### PR TITLE
feat(htmx): HTMX header-helpers package

### DIFF
--- a/htmx/doc.go
+++ b/htmx/doc.go
@@ -1,0 +1,29 @@
+// Package htmx provides small, stateless helpers for the HTMX HTTP header
+// contract: reading HX-* request headers (IsRequest, IsBoosted, Target,
+// TriggerID, ...) and writing HX-* response directives (Redirect, Location,
+// Refresh, PushURL, Reswap, Retarget, Reselect, and the Trigger family).
+//
+// The helpers are free functions — there is no constructor, options object, or
+// global state. HTML output is not this package's concern; render the body with
+// the render package (or any handler) after setting the htmx headers:
+//
+//	if htmx.IsRequest(r) {
+//		htmx.Retarget(w, "#cart")
+//		htmx.Trigger(w, "cart:updated")
+//		_ = render.Templ(r.Context(), w, http.StatusOK, views.CartFragment(item))
+//		return
+//	}
+//	_ = render.Templ(r.Context(), w, http.StatusOK, views.CartPage(item))
+//
+// Most directives only set a response header and must be called before the body
+// is written. The redirect helpers (Redirect, Location, LocationWith) are the
+// exception: they branch on whether the request came from HTMX — setting the
+// HX-Redirect / HX-Location header and a 200 for HTMX requests, or falling back
+// to a standard http.Redirect (3xx) for everyone else — and they commit the
+// response, so call them last.
+//
+// When one URL serves both an HTMX partial and a full page, add
+// Vary: HX-Request so shared caches do not cross-serve the two variants.
+//
+// htmx depends only on the standard library; it does not import render.
+package htmx

--- a/htmx/example_test.go
+++ b/htmx/example_test.go
@@ -32,7 +32,7 @@ func ExampleRedirect() {
 	rec := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/login", nil) // non-HTMX request
 
-	htmx.Redirect(rec, r, http.StatusSeeOther, "/dashboard")
+	htmx.Redirect(rec, r, "/dashboard") // fallback status defaults to 303 See Other
 
 	fmt.Println(rec.Code)
 	fmt.Println(rec.Header().Get("Location"))

--- a/htmx/example_test.go
+++ b/htmx/example_test.go
@@ -1,0 +1,42 @@
+package htmx_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/dmitrymomot/forge/htmx"
+)
+
+func ExampleIsRequest() {
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cart", nil)
+	r.Header.Set("HX-Request", "true")
+
+	if htmx.IsRequest(r) {
+		htmx.Retarget(rec, "#cart")
+		htmx.Trigger(rec, "cart:updated")
+		// then render the partial, e.g. render.Templ(r.Context(), rec, 200, fragment)
+	}
+
+	fmt.Println(htmx.IsRequest(r))
+	fmt.Println(rec.Header().Get("HX-Retarget"))
+	fmt.Println(rec.Header().Get("HX-Trigger"))
+	// Output:
+	// true
+	// #cart
+	// cart:updated
+}
+
+func ExampleRedirect() {
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/login", nil) // non-HTMX request
+
+	htmx.Redirect(rec, r, http.StatusSeeOther, "/dashboard")
+
+	fmt.Println(rec.Code)
+	fmt.Println(rec.Header().Get("Location"))
+	// Output:
+	// 303
+	// /dashboard
+}

--- a/htmx/headers.go
+++ b/htmx/headers.go
@@ -1,0 +1,13 @@
+package htmx
+
+// Request header names. hdrTrigger is reused by the response-side Trigger.
+const (
+	hdrRequest        = "HX-Request"
+	hdrBoosted        = "HX-Boosted"
+	hdrHistoryRestore = "HX-History-Restore-Request"
+	hdrCurrentURL     = "HX-Current-URL"
+	hdrPrompt         = "HX-Prompt"
+	hdrTarget         = "HX-Target"
+	hdrTrigger        = "HX-Trigger" // request: triggering element id; response: events
+	hdrTriggerName    = "HX-Trigger-Name"
+)

--- a/htmx/headers.go
+++ b/htmx/headers.go
@@ -11,3 +11,13 @@ const (
 	hdrTrigger        = "HX-Trigger" // request: triggering element id; response: events
 	hdrTriggerName    = "HX-Trigger-Name"
 )
+
+// Response header names: history, refresh, and swap controls.
+const (
+	hdrPushURL    = "HX-Push-Url"
+	hdrReplaceURL = "HX-Replace-Url"
+	hdrRefresh    = "HX-Refresh"
+	hdrReswap     = "HX-Reswap"
+	hdrRetarget   = "HX-Retarget"
+	hdrReselect   = "HX-Reselect"
+)

--- a/htmx/headers.go
+++ b/htmx/headers.go
@@ -1,5 +1,12 @@
 package htmx
 
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
 // Request header names. hdrTrigger is reused by the response-side Trigger.
 const (
 	hdrRequest        = "HX-Request"
@@ -21,3 +28,32 @@ const (
 	hdrRetarget   = "HX-Retarget"
 	hdrReselect   = "HX-Reselect"
 )
+
+// Response header names: client-side event triggers.
+const (
+	hdrTriggerAfterSettle = "HX-Trigger-After-Settle"
+	hdrTriggerAfterSwap   = "HX-Trigger-After-Swap"
+)
+
+// setEventNames writes a bare comma-joined event-name list (the HX-Trigger
+// family's name form). No names is a no-op.
+func setEventNames(w http.ResponseWriter, header string, names []string) {
+	if len(names) == 0 {
+		return
+	}
+	w.Header().Set(header, strings.Join(names, ", "))
+}
+
+// setEventDetail writes the JSON {"name": detail, ...} form. An empty map is a
+// no-op; a marshal failure returns a wrapped error with no header written.
+func setEventDetail(w http.ResponseWriter, header string, events map[string]any) error {
+	if len(events) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(events)
+	if err != nil {
+		return fmt.Errorf("htmx: marshal %s: %w", header, err)
+	}
+	w.Header().Set(header, string(b))
+	return nil
+}

--- a/htmx/headers.go
+++ b/htmx/headers.go
@@ -35,6 +35,12 @@ const (
 	hdrTriggerAfterSwap   = "HX-Trigger-After-Swap"
 )
 
+// Response header names: client-side redirects.
+const (
+	hdrRedirect = "HX-Redirect"
+	hdrLocation = "HX-Location"
+)
+
 // setEventNames writes a bare comma-joined event-name list (the HX-Trigger
 // family's name form). No names is a no-op.
 func setEventNames(w http.ResponseWriter, header string, names []string) {

--- a/htmx/request.go
+++ b/htmx/request.go
@@ -1,0 +1,46 @@
+package htmx
+
+import "net/http"
+
+// IsRequest reports whether r was issued by HTMX (HX-Request: true).
+func IsRequest(r *http.Request) bool {
+	return r.Header.Get(hdrRequest) == "true"
+}
+
+// IsBoosted reports whether r came from an hx-boost'd element (HX-Boosted: true).
+func IsBoosted(r *http.Request) bool {
+	return r.Header.Get(hdrBoosted) == "true"
+}
+
+// IsHistoryRestore reports whether r is an HTMX history-restoration request
+// (HX-History-Restore-Request: true).
+func IsHistoryRestore(r *http.Request) bool {
+	return r.Header.Get(hdrHistoryRestore) == "true"
+}
+
+// CurrentURL returns the browser's current URL (HX-Current-URL), or "" if absent.
+func CurrentURL(r *http.Request) string {
+	return r.Header.Get(hdrCurrentURL)
+}
+
+// Prompt returns the user's response to an hx-prompt (HX-Prompt), or "" if absent.
+func Prompt(r *http.Request) string {
+	return r.Header.Get(hdrPrompt)
+}
+
+// Target returns the id of the target element (HX-Target), or "" if absent.
+func Target(r *http.Request) string {
+	return r.Header.Get(hdrTarget)
+}
+
+// TriggerID returns the id of the element that triggered the request
+// (HX-Trigger), or "" if absent. Named TriggerID, not Trigger, to avoid
+// confusion with the response-side Trigger (which fires client-side events).
+func TriggerID(r *http.Request) string {
+	return r.Header.Get(hdrTrigger)
+}
+
+// TriggerName returns the name of the triggering element (HX-Trigger-Name), or "".
+func TriggerName(r *http.Request) string {
+	return r.Header.Get(hdrTriggerName)
+}

--- a/htmx/request_test.go
+++ b/htmx/request_test.go
@@ -5,8 +5,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dmitrymomot/forge/htmx"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/htmx"
 )
 
 func TestRequestBooleans(t *testing.T) {

--- a/htmx/request_test.go
+++ b/htmx/request_test.go
@@ -1,0 +1,70 @@
+package htmx_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/htmx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestBooleans(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		header string
+		value  string
+		fn     func(*http.Request) bool
+		want   bool
+	}{
+		{"IsRequest true", "HX-Request", "true", htmx.IsRequest, true},
+		{"IsRequest false value", "HX-Request", "false", htmx.IsRequest, false},
+		{"IsRequest absent", "", "", htmx.IsRequest, false},
+		{"IsBoosted true", "HX-Boosted", "true", htmx.IsBoosted, true},
+		{"IsBoosted absent", "", "", htmx.IsBoosted, false},
+		{"IsHistoryRestore true", "HX-History-Restore-Request", "true", htmx.IsHistoryRestore, true},
+		{"IsHistoryRestore absent", "", "", htmx.IsHistoryRestore, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.header != "" {
+				r.Header.Set(tc.header, tc.value)
+			}
+			assert.Equal(t, tc.want, tc.fn(r))
+		})
+	}
+}
+
+func TestRequestStrings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		header string
+		value  string
+		fn     func(*http.Request) string
+	}{
+		{"CurrentURL", "HX-Current-URL", "https://example.com/x", htmx.CurrentURL},
+		{"Prompt", "HX-Prompt", "yes", htmx.Prompt},
+		{"Target", "HX-Target", "#main", htmx.Target},
+		{"TriggerID", "HX-Trigger", "save-btn", htmx.TriggerID},
+		{"TriggerName", "HX-Trigger-Name", "save", htmx.TriggerName},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.Header.Set(tc.header, tc.value)
+			assert.Equal(t, tc.value, tc.fn(r))
+
+			absent := httptest.NewRequest(http.MethodGet, "/", nil)
+			assert.Empty(t, tc.fn(absent))
+		})
+	}
+}

--- a/htmx/response.go
+++ b/htmx/response.go
@@ -1,6 +1,10 @@
 package htmx
 
-import "net/http"
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
 
 // Swap styles for Reswap and LocationOptions.Swap (the hx-swap values).
 const (
@@ -85,4 +89,86 @@ func TriggerAfterSwap(w http.ResponseWriter, names ...string) {
 // TriggerAfterSwapWith fires events with JSON detail after the swap step.
 func TriggerAfterSwapWith(w http.ResponseWriter, events map[string]any) error {
 	return setEventDetail(w, hdrTriggerAfterSwap, events)
+}
+
+// LocationOptions is the optional AJAX context for LocationWith. Zero-value
+// fields are omitted from the emitted JSON. It is a plain options struct
+// (cf. http.Cookie), not functional options and not a builder.
+type LocationOptions struct {
+	Source  string            // CSS selector of the element issuing the request
+	Event   string            // event that triggered the request
+	Handler string            // callback that handles the response
+	Target  string            // CSS selector to swap into
+	Swap    string            // how to swap (a Swap* value)
+	Select  string            // CSS selector of the response subset to swap
+	Values  map[string]any    // values submitted with the request
+	Headers map[string]string // headers submitted with the request
+}
+
+// locationPayload is the JSON shape HX-Location expects: the required path plus
+// the set LocationOptions fields.
+type locationPayload struct {
+	Path    string            `json:"path"`
+	Source  string            `json:"source,omitempty"`
+	Event   string            `json:"event,omitempty"`
+	Handler string            `json:"handler,omitempty"`
+	Target  string            `json:"target,omitempty"`
+	Swap    string            `json:"swap,omitempty"`
+	Select  string            `json:"select,omitempty"`
+	Values  map[string]any    `json:"values,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+// Redirect performs a client-side redirect. For HTMX requests it sets
+// HX-Redirect (a full-page client navigation) and writes 200; otherwise it falls
+// back to http.Redirect with status (a 3xx, e.g. http.StatusSeeOther). It commits
+// the response — call it last.
+func Redirect(w http.ResponseWriter, r *http.Request, status int, url string) {
+	if IsRequest(r) {
+		w.Header().Set(hdrRedirect, url)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	http.Redirect(w, r, url, status)
+}
+
+// Location performs a client-side redirect without a full page reload. For HTMX
+// requests it sets HX-Location to url and writes 200; otherwise it falls back to
+// http.Redirect with status. Terminal.
+func Location(w http.ResponseWriter, r *http.Request, status int, url string) {
+	if IsRequest(r) {
+		w.Header().Set(hdrLocation, url)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	http.Redirect(w, r, url, status)
+}
+
+// LocationWith is Location with an AJAX context object (target, swap, values, ...).
+// For HTMX requests it sets HX-Location to the JSON form {"path":path, ...opts}
+// and writes 200; a marshal failure returns a wrapped error with nothing written.
+// For non-HTMX requests it falls back to http.Redirect(w, r, status, path),
+// dropping the context. Terminal.
+func LocationWith(w http.ResponseWriter, r *http.Request, status int, path string, opts LocationOptions) error {
+	if !IsRequest(r) {
+		http.Redirect(w, r, path, status)
+		return nil
+	}
+	b, err := json.Marshal(locationPayload{
+		Path:    path,
+		Source:  opts.Source,
+		Event:   opts.Event,
+		Handler: opts.Handler,
+		Target:  opts.Target,
+		Swap:    opts.Swap,
+		Select:  opts.Select,
+		Values:  opts.Values,
+		Headers: opts.Headers,
+	})
+	if err != nil {
+		return fmt.Errorf("htmx: marshal HX-Location: %w", err)
+	}
+	w.Header().Set(hdrLocation, string(b))
+	w.WriteHeader(http.StatusOK)
+	return nil
 }

--- a/htmx/response.go
+++ b/htmx/response.go
@@ -147,7 +147,7 @@ func Location(w http.ResponseWriter, r *http.Request, status int, url string) {
 // LocationWith is Location with an AJAX context object (target, swap, values, ...).
 // For HTMX requests it sets HX-Location to the JSON form {"path":path, ...opts}
 // and writes 200; a marshal failure returns a wrapped error with nothing written.
-// For non-HTMX requests it falls back to http.Redirect(w, r, status, path),
+// For non-HTMX requests it falls back to http.Redirect(w, r, path, status),
 // dropping the context. Terminal.
 func LocationWith(w http.ResponseWriter, r *http.Request, status int, path string, opts LocationOptions) error {
 	if !IsRequest(r) {

--- a/htmx/response.go
+++ b/htmx/response.go
@@ -95,19 +95,21 @@ func TriggerAfterSwapWith(w http.ResponseWriter, events map[string]any) error {
 // fields are omitted from the emitted JSON. It is a plain options struct
 // (cf. http.Cookie), not functional options and not a builder.
 type LocationOptions struct {
+	Values  map[string]any    // values submitted with the request
+	Headers map[string]string // headers submitted with the request
 	Source  string            // CSS selector of the element issuing the request
 	Event   string            // event that triggered the request
 	Handler string            // callback that handles the response
 	Target  string            // CSS selector to swap into
 	Swap    string            // how to swap (a Swap* value)
 	Select  string            // CSS selector of the response subset to swap
-	Values  map[string]any    // values submitted with the request
-	Headers map[string]string // headers submitted with the request
 }
 
 // locationPayload is the JSON shape HX-Location expects: the required path plus
 // the set LocationOptions fields.
 type locationPayload struct {
+	Values  map[string]any    `json:"values,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
 	Path    string            `json:"path"`
 	Source  string            `json:"source,omitempty"`
 	Event   string            `json:"event,omitempty"`
@@ -115,8 +117,6 @@ type locationPayload struct {
 	Target  string            `json:"target,omitempty"`
 	Swap    string            `json:"swap,omitempty"`
 	Select  string            `json:"select,omitempty"`
-	Values  map[string]any    `json:"values,omitempty"`
-	Headers map[string]string `json:"headers,omitempty"`
 }
 
 // Redirect performs a client-side redirect. For HTMX requests it sets

--- a/htmx/response.go
+++ b/htmx/response.go
@@ -1,0 +1,55 @@
+package htmx
+
+import "net/http"
+
+// Swap styles for Reswap and LocationOptions.Swap (the hx-swap values).
+const (
+	SwapInnerHTML   = "innerHTML"
+	SwapOuterHTML   = "outerHTML"
+	SwapTextContent = "textContent"
+	SwapBeforeBegin = "beforebegin"
+	SwapAfterBegin  = "afterbegin"
+	SwapBeforeEnd   = "beforeend"
+	SwapAfterEnd    = "afterend"
+	SwapDelete      = "delete"
+	SwapNone        = "none"
+)
+
+// PreventHistory, passed to PushURL or ReplaceURL, suppresses HTMX's history
+// update (the literal "false" HTMX expects).
+const PreventHistory = "false"
+
+// PushURL pushes url into the browser history (HX-Push-Url). Pass PreventHistory
+// to suppress HTMX's default history update.
+func PushURL(w http.ResponseWriter, url string) {
+	w.Header().Set(hdrPushURL, url)
+}
+
+// ReplaceURL replaces the current browser URL (HX-Replace-Url). Pass
+// PreventHistory to suppress the default replacement.
+func ReplaceURL(w http.ResponseWriter, url string) {
+	w.Header().Set(hdrReplaceURL, url)
+}
+
+// Refresh tells the client to do a full page refresh (HX-Refresh: true).
+func Refresh(w http.ResponseWriter) {
+	w.Header().Set(hdrRefresh, "true")
+}
+
+// Reswap overrides how the response is swapped in (HX-Reswap). swap is a Swap*
+// value, optionally with modifiers (e.g. "innerHTML swap:1s").
+func Reswap(w http.ResponseWriter, swap string) {
+	w.Header().Set(hdrReswap, swap)
+}
+
+// Retarget changes the element the response is swapped into (HX-Retarget);
+// selector is a CSS selector.
+func Retarget(w http.ResponseWriter, selector string) {
+	w.Header().Set(hdrRetarget, selector)
+}
+
+// Reselect chooses which part of the response is swapped in (HX-Reselect),
+// overriding hx-select on the triggering element; selector is a CSS selector.
+func Reselect(w http.ResponseWriter, selector string) {
+	w.Header().Set(hdrReselect, selector)
+}

--- a/htmx/response.go
+++ b/htmx/response.go
@@ -79,6 +79,8 @@ func TriggerAfterSettle(w http.ResponseWriter, names ...string) {
 }
 
 // TriggerAfterSettleWith fires events with JSON detail after the settle step.
+// An empty map is a no-op; a marshal failure returns a wrapped error with no
+// header written.
 func TriggerAfterSettleWith(w http.ResponseWriter, events map[string]any) error {
 	return setEventDetail(w, hdrTriggerAfterSettle, events)
 }
@@ -89,6 +91,8 @@ func TriggerAfterSwap(w http.ResponseWriter, names ...string) {
 }
 
 // TriggerAfterSwapWith fires events with JSON detail after the swap step.
+// An empty map is a no-op; a marshal failure returns a wrapped error with no
+// header written.
 func TriggerAfterSwapWith(w http.ResponseWriter, events map[string]any) error {
 	return setEventDetail(w, hdrTriggerAfterSwap, events)
 }

--- a/htmx/response.go
+++ b/htmx/response.go
@@ -59,7 +59,9 @@ func Reselect(w http.ResponseWriter, selector string) {
 }
 
 // Trigger fires client-side events by name (HX-Trigger: "a, b"). No names is a
-// no-op. For events carrying detail, use TriggerWith.
+// no-op. Each Trigger function sets a single header, so calling any of them more
+// than once for the same header overwrites the previous value (last write wins) —
+// pass every event name in one call. For events carrying detail, use TriggerWith.
 func Trigger(w http.ResponseWriter, names ...string) {
 	setEventNames(w, hdrTrigger, names)
 }
@@ -119,39 +121,52 @@ type locationPayload struct {
 	Select  string            `json:"select,omitempty"`
 }
 
+// fallbackStatus returns the non-HTMX redirect status: the first value supplied
+// to the redirect helpers, or http.StatusSeeOther (303) when none is given.
+func fallbackStatus(status []int) int {
+	if len(status) > 0 {
+		return status[0]
+	}
+	return http.StatusSeeOther
+}
+
 // Redirect performs a client-side redirect. For HTMX requests it sets
-// HX-Redirect (a full-page client navigation) and writes 200; otherwise it falls
-// back to http.Redirect with status (a 3xx, e.g. http.StatusSeeOther). It commits
-// the response — call it last.
-func Redirect(w http.ResponseWriter, r *http.Request, status int, url string) {
+// HX-Redirect (a full-page client navigation) and writes 200. For non-HTMX
+// requests it falls back to http.Redirect; the optional status sets that fallback
+// code (only the first value is used), defaulting to http.StatusSeeOther (303).
+// status never applies to HTMX requests, which always get 200. It commits the
+// response — call it last.
+func Redirect(w http.ResponseWriter, r *http.Request, url string, status ...int) {
 	if IsRequest(r) {
 		w.Header().Set(hdrRedirect, url)
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	http.Redirect(w, r, url, status)
+	http.Redirect(w, r, url, fallbackStatus(status))
 }
 
 // Location performs a client-side redirect without a full page reload. For HTMX
-// requests it sets HX-Location to url and writes 200; otherwise it falls back to
-// http.Redirect with status. Terminal.
-func Location(w http.ResponseWriter, r *http.Request, status int, url string) {
+// requests it sets HX-Location to url and writes 200. For non-HTMX requests it
+// falls back to http.Redirect; the optional status sets that fallback code (only
+// the first value is used), defaulting to http.StatusSeeOther (303). Terminal.
+func Location(w http.ResponseWriter, r *http.Request, url string, status ...int) {
 	if IsRequest(r) {
 		w.Header().Set(hdrLocation, url)
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	http.Redirect(w, r, url, status)
+	http.Redirect(w, r, url, fallbackStatus(status))
 }
 
 // LocationWith is Location with an AJAX context object (target, swap, values, ...).
 // For HTMX requests it sets HX-Location to the JSON form {"path":path, ...opts}
 // and writes 200; a marshal failure returns a wrapped error with nothing written.
-// For non-HTMX requests it falls back to http.Redirect(w, r, path, status),
-// dropping the context. Terminal.
-func LocationWith(w http.ResponseWriter, r *http.Request, status int, path string, opts LocationOptions) error {
+// For non-HTMX requests it falls back to http.Redirect — the optional status sets
+// that fallback code (only the first value is used), defaulting to
+// http.StatusSeeOther (303) — dropping the context. Terminal.
+func LocationWith(w http.ResponseWriter, r *http.Request, path string, opts LocationOptions, status ...int) error {
 	if !IsRequest(r) {
-		http.Redirect(w, r, path, status)
+		http.Redirect(w, r, path, fallbackStatus(status))
 		return nil
 	}
 	b, err := json.Marshal(locationPayload{

--- a/htmx/response.go
+++ b/htmx/response.go
@@ -53,3 +53,36 @@ func Retarget(w http.ResponseWriter, selector string) {
 func Reselect(w http.ResponseWriter, selector string) {
 	w.Header().Set(hdrReselect, selector)
 }
+
+// Trigger fires client-side events by name (HX-Trigger: "a, b"). No names is a
+// no-op. For events carrying detail, use TriggerWith.
+func Trigger(w http.ResponseWriter, names ...string) {
+	setEventNames(w, hdrTrigger, names)
+}
+
+// TriggerWith fires client-side events with JSON detail
+// (HX-Trigger: {"name": detail, ...}). An empty map is a no-op; a marshal
+// failure returns a wrapped error with no header written.
+func TriggerWith(w http.ResponseWriter, events map[string]any) error {
+	return setEventDetail(w, hdrTrigger, events)
+}
+
+// TriggerAfterSettle fires events after the settle step (HX-Trigger-After-Settle).
+func TriggerAfterSettle(w http.ResponseWriter, names ...string) {
+	setEventNames(w, hdrTriggerAfterSettle, names)
+}
+
+// TriggerAfterSettleWith fires events with JSON detail after the settle step.
+func TriggerAfterSettleWith(w http.ResponseWriter, events map[string]any) error {
+	return setEventDetail(w, hdrTriggerAfterSettle, events)
+}
+
+// TriggerAfterSwap fires events after the swap step (HX-Trigger-After-Swap).
+func TriggerAfterSwap(w http.ResponseWriter, names ...string) {
+	setEventNames(w, hdrTriggerAfterSwap, names)
+}
+
+// TriggerAfterSwapWith fires events with JSON detail after the swap step.
+func TriggerAfterSwapWith(w http.ResponseWriter, events map[string]any) error {
+	return setEventDetail(w, hdrTriggerAfterSwap, events)
+}

--- a/htmx/response_test.go
+++ b/htmx/response_test.go
@@ -85,18 +85,50 @@ func TestTriggerWithMarshalError(t *testing.T) {
 	assert.Empty(t, rec.Header().Get("HX-Trigger")) // nothing written on marshal failure
 }
 
-func TestTriggerAfterVariants(t *testing.T) {
+func TestTriggerAfterSettle(t *testing.T) {
 	t.Parallel()
 
 	rec := httptest.NewRecorder()
 	htmx.TriggerAfterSettle(rec, "settled")
-	htmx.TriggerAfterSwap(rec, "swapped")
 	assert.Equal(t, "settled", rec.Header().Get("HX-Trigger-After-Settle"))
+}
+
+func TestTriggerAfterSwap(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	htmx.TriggerAfterSwap(rec, "swapped")
 	assert.Equal(t, "swapped", rec.Header().Get("HX-Trigger-After-Swap"))
+}
+
+func TestTriggerAfterSettleWith(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, htmx.TriggerAfterSettleWith(rec, map[string]any{"toast": map[string]any{"level": "info"}}))
+
+	var got map[string]map[string]string
+	require.NoError(t, json.Unmarshal([]byte(rec.Header().Get("HX-Trigger-After-Settle")), &got))
+	assert.Equal(t, "info", got["toast"]["level"])
 
 	bad := httptest.NewRecorder()
 	require.Error(t, htmx.TriggerAfterSettleWith(bad, map[string]any{"x": make(chan int)}))
-	require.NoError(t, htmx.TriggerAfterSwapWith(httptest.NewRecorder(), map[string]any{"y": 1}))
+	assert.Empty(t, bad.Header().Get("HX-Trigger-After-Settle")) // nothing written on marshal failure
+}
+
+func TestTriggerAfterSwapWith(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, htmx.TriggerAfterSwapWith(rec, map[string]any{"y": 1}))
+
+	var got map[string]int
+	require.NoError(t, json.Unmarshal([]byte(rec.Header().Get("HX-Trigger-After-Swap")), &got))
+	assert.Equal(t, 1, got["y"])
+
+	bad := httptest.NewRecorder()
+	require.Error(t, htmx.TriggerAfterSwapWith(bad, map[string]any{"x": make(chan int)}))
+	assert.Empty(t, bad.Header().Get("HX-Trigger-After-Swap")) // nothing written on marshal failure
 }
 
 func htmxRequest() *http.Request {
@@ -109,7 +141,7 @@ func TestRedirectHTMX(t *testing.T) {
 	t.Parallel()
 
 	rec := httptest.NewRecorder()
-	htmx.Redirect(rec, htmxRequest(), http.StatusSeeOther, "/dashboard")
+	htmx.Redirect(rec, htmxRequest(), "/dashboard") // status omitted — HTMX ignores it
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "/dashboard", rec.Header().Get("HX-Redirect"))
@@ -121,9 +153,9 @@ func TestRedirectNonHTMX(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	htmx.Redirect(rec, r, http.StatusSeeOther, "/dashboard")
+	htmx.Redirect(rec, r, "/dashboard", http.StatusTemporaryRedirect) // explicit fallback status
 
-	assert.Equal(t, http.StatusSeeOther, rec.Code)
+	assert.Equal(t, http.StatusTemporaryRedirect, rec.Code)
 	assert.Equal(t, "/dashboard", rec.Header().Get("Location"))
 	assert.Empty(t, rec.Header().Get("HX-Redirect"))
 }
@@ -132,7 +164,7 @@ func TestLocationHTMX(t *testing.T) {
 	t.Parallel()
 
 	rec := httptest.NewRecorder()
-	htmx.Location(rec, htmxRequest(), http.StatusSeeOther, "/dashboard")
+	htmx.Location(rec, htmxRequest(), "/dashboard") // status omitted — HTMX ignores it
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "/dashboard", rec.Header().Get("HX-Location"))
@@ -143,7 +175,7 @@ func TestLocationNonHTMX(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	htmx.Location(rec, r, http.StatusSeeOther, "/dashboard")
+	htmx.Location(rec, r, "/dashboard") // status omitted — defaults to 303 See Other
 
 	assert.Equal(t, http.StatusSeeOther, rec.Code)
 	assert.Equal(t, "/dashboard", rec.Header().Get("Location"))
@@ -154,8 +186,8 @@ func TestLocationWithHTMX(t *testing.T) {
 	t.Parallel()
 
 	rec := httptest.NewRecorder()
-	err := htmx.LocationWith(rec, htmxRequest(), http.StatusSeeOther, "/dashboard",
-		htmx.LocationOptions{Target: "#main", Swap: htmx.SwapInnerHTML})
+	err := htmx.LocationWith(rec, htmxRequest(), "/dashboard",
+		htmx.LocationOptions{Target: "#main", Swap: htmx.SwapInnerHTML}) // status omitted — HTMX ignores it
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -175,8 +207,8 @@ func TestLocationWithNonHTMX(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	err := htmx.LocationWith(rec, r, http.StatusSeeOther, "/dashboard",
-		htmx.LocationOptions{Target: "#main"})
+	err := htmx.LocationWith(rec, r, "/dashboard",
+		htmx.LocationOptions{Target: "#main"}) // status omitted — defaults to 303 See Other
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusSeeOther, rec.Code)
@@ -188,7 +220,7 @@ func TestLocationWithMarshalError(t *testing.T) {
 	t.Parallel()
 
 	rec := httptest.NewRecorder()
-	err := htmx.LocationWith(rec, htmxRequest(), http.StatusSeeOther, "/dashboard",
+	err := htmx.LocationWith(rec, htmxRequest(), "/dashboard",
 		htmx.LocationOptions{Values: map[string]any{"bad": make(chan int)}})
 	require.Error(t, err)
 	assert.Empty(t, rec.Header().Get("HX-Location")) // nothing written

--- a/htmx/response_test.go
+++ b/htmx/response_test.go
@@ -110,10 +110,23 @@ func TestTriggerAfterSettleWith(t *testing.T) {
 	var got map[string]map[string]string
 	require.NoError(t, json.Unmarshal([]byte(rec.Header().Get("HX-Trigger-After-Settle")), &got))
 	assert.Equal(t, "info", got["toast"]["level"])
+}
 
-	bad := httptest.NewRecorder()
-	require.Error(t, htmx.TriggerAfterSettleWith(bad, map[string]any{"x": make(chan int)}))
-	assert.Empty(t, bad.Header().Get("HX-Trigger-After-Settle")) // nothing written on marshal failure
+func TestTriggerAfterSettleWithEmptyIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, htmx.TriggerAfterSettleWith(rec, map[string]any{}))
+	assert.Empty(t, rec.Header().Get("HX-Trigger-After-Settle"))
+}
+
+func TestTriggerAfterSettleWithMarshalError(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	err := htmx.TriggerAfterSettleWith(rec, map[string]any{"bad": make(chan int)})
+	require.Error(t, err)
+	assert.Empty(t, rec.Header().Get("HX-Trigger-After-Settle")) // nothing written on marshal failure
 }
 
 func TestTriggerAfterSwapWith(t *testing.T) {
@@ -125,10 +138,23 @@ func TestTriggerAfterSwapWith(t *testing.T) {
 	var got map[string]int
 	require.NoError(t, json.Unmarshal([]byte(rec.Header().Get("HX-Trigger-After-Swap")), &got))
 	assert.Equal(t, 1, got["y"])
+}
 
-	bad := httptest.NewRecorder()
-	require.Error(t, htmx.TriggerAfterSwapWith(bad, map[string]any{"x": make(chan int)}))
-	assert.Empty(t, bad.Header().Get("HX-Trigger-After-Swap")) // nothing written on marshal failure
+func TestTriggerAfterSwapWithEmptyIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, htmx.TriggerAfterSwapWith(rec, map[string]any{}))
+	assert.Empty(t, rec.Header().Get("HX-Trigger-After-Swap"))
+}
+
+func TestTriggerAfterSwapWithMarshalError(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	err := htmx.TriggerAfterSwapWith(rec, map[string]any{"bad": make(chan int)})
+	require.Error(t, err)
+	assert.Empty(t, rec.Header().Get("HX-Trigger-After-Swap")) // nothing written on marshal failure
 }
 
 func htmxRequest() *http.Request {

--- a/htmx/response_test.go
+++ b/htmx/response_test.go
@@ -1,0 +1,38 @@
+package htmx_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/htmx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimpleSetters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		apply  func(http.ResponseWriter)
+		header string
+		want   string
+	}{
+		{"PushURL", func(w http.ResponseWriter) { htmx.PushURL(w, "/items/42") }, "HX-Push-Url", "/items/42"},
+		{"PushURL prevent", func(w http.ResponseWriter) { htmx.PushURL(w, htmx.PreventHistory) }, "HX-Push-Url", "false"},
+		{"ReplaceURL", func(w http.ResponseWriter) { htmx.ReplaceURL(w, "/x") }, "HX-Replace-Url", "/x"},
+		{"Refresh", func(w http.ResponseWriter) { htmx.Refresh(w) }, "HX-Refresh", "true"},
+		{"Reswap", func(w http.ResponseWriter) { htmx.Reswap(w, htmx.SwapOuterHTML) }, "HX-Reswap", "outerHTML"},
+		{"Retarget", func(w http.ResponseWriter) { htmx.Retarget(w, "#cart") }, "HX-Retarget", "#cart"},
+		{"Reselect", func(w http.ResponseWriter) { htmx.Reselect(w, "#rows") }, "HX-Reselect", "#rows"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := httptest.NewRecorder()
+			tc.apply(rec)
+			assert.Equal(t, tc.want, rec.Header().Get(tc.header))
+		})
+	}
+}

--- a/htmx/response_test.go
+++ b/htmx/response_test.go
@@ -1,12 +1,15 @@
 package htmx_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dmitrymomot/forge/htmx"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/htmx"
 )
 
 func TestSimpleSetters(t *testing.T) {
@@ -35,4 +38,63 @@ func TestSimpleSetters(t *testing.T) {
 			assert.Equal(t, tc.want, rec.Header().Get(tc.header))
 		})
 	}
+}
+
+func TestTriggerNames(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	htmx.Trigger(rec, "cart:updated", "toast")
+	assert.Equal(t, "cart:updated, toast", rec.Header().Get("HX-Trigger"))
+}
+
+func TestTriggerNoNamesIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	htmx.Trigger(rec)
+	assert.Empty(t, rec.Header().Get("HX-Trigger"))
+}
+
+func TestTriggerWith(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	err := htmx.TriggerWith(rec, map[string]any{"toast": map[string]any{"level": "info"}})
+	require.NoError(t, err)
+
+	var got map[string]map[string]string
+	require.NoError(t, json.Unmarshal([]byte(rec.Header().Get("HX-Trigger")), &got))
+	assert.Equal(t, "info", got["toast"]["level"])
+}
+
+func TestTriggerWithEmptyIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, htmx.TriggerWith(rec, map[string]any{}))
+	assert.Empty(t, rec.Header().Get("HX-Trigger"))
+}
+
+func TestTriggerWithMarshalError(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	err := htmx.TriggerWith(rec, map[string]any{"bad": make(chan int)})
+	require.Error(t, err)
+	assert.Empty(t, rec.Header().Get("HX-Trigger")) // nothing written on marshal failure
+}
+
+func TestTriggerAfterVariants(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	htmx.TriggerAfterSettle(rec, "settled")
+	htmx.TriggerAfterSwap(rec, "swapped")
+	assert.Equal(t, "settled", rec.Header().Get("HX-Trigger-After-Settle"))
+	assert.Equal(t, "swapped", rec.Header().Get("HX-Trigger-After-Swap"))
+
+	bad := httptest.NewRecorder()
+	require.Error(t, htmx.TriggerAfterSettleWith(bad, map[string]any{"x": make(chan int)}))
+	require.NoError(t, htmx.TriggerAfterSwapWith(httptest.NewRecorder(), map[string]any{"y": 1}))
 }

--- a/htmx/response_test.go
+++ b/htmx/response_test.go
@@ -98,3 +98,98 @@ func TestTriggerAfterVariants(t *testing.T) {
 	require.Error(t, htmx.TriggerAfterSettleWith(bad, map[string]any{"x": make(chan int)}))
 	require.NoError(t, htmx.TriggerAfterSwapWith(httptest.NewRecorder(), map[string]any{"y": 1}))
 }
+
+func htmxRequest() *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("HX-Request", "true")
+	return r
+}
+
+func TestRedirectHTMX(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	htmx.Redirect(rec, htmxRequest(), http.StatusSeeOther, "/dashboard")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "/dashboard", rec.Header().Get("HX-Redirect"))
+	assert.Empty(t, rec.Header().Get("Location"))
+}
+
+func TestRedirectNonHTMX(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	htmx.Redirect(rec, r, http.StatusSeeOther, "/dashboard")
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code)
+	assert.Equal(t, "/dashboard", rec.Header().Get("Location"))
+	assert.Empty(t, rec.Header().Get("HX-Redirect"))
+}
+
+func TestLocationHTMX(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	htmx.Location(rec, htmxRequest(), http.StatusSeeOther, "/dashboard")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "/dashboard", rec.Header().Get("HX-Location"))
+}
+
+func TestLocationNonHTMX(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	htmx.Location(rec, r, http.StatusSeeOther, "/dashboard")
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code)
+	assert.Equal(t, "/dashboard", rec.Header().Get("Location"))
+	assert.Empty(t, rec.Header().Get("HX-Location"))
+}
+
+func TestLocationWithHTMX(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	err := htmx.LocationWith(rec, htmxRequest(), http.StatusSeeOther, "/dashboard",
+		htmx.LocationOptions{Target: "#main", Swap: htmx.SwapInnerHTML})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var got struct {
+		Path   string `json:"path"`
+		Target string `json:"target"`
+		Swap   string `json:"swap"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(rec.Header().Get("HX-Location")), &got))
+	assert.Equal(t, "/dashboard", got.Path)
+	assert.Equal(t, "#main", got.Target)
+	assert.Equal(t, "innerHTML", got.Swap)
+}
+
+func TestLocationWithNonHTMX(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	err := htmx.LocationWith(rec, r, http.StatusSeeOther, "/dashboard",
+		htmx.LocationOptions{Target: "#main"})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code)
+	assert.Equal(t, "/dashboard", rec.Header().Get("Location"))
+	assert.Empty(t, rec.Header().Get("HX-Location"))
+}
+
+func TestLocationWithMarshalError(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	err := htmx.LocationWith(rec, htmxRequest(), http.StatusSeeOther, "/dashboard",
+		htmx.LocationOptions{Values: map[string]any{"bad": make(chan int)}})
+	require.Error(t, err)
+	assert.Empty(t, rec.Header().Get("HX-Location")) // nothing written
+}


### PR DESCRIPTION
## Summary

New standalone `htmx` package — stateless free functions mapping the HTMX HTTP header contract. Free functions over `*http.Request` (readers) and `http.ResponseWriter` (writers), mirroring the `render` package's style. **Stdlib only**; does not import `render`.

Implements [docs/superpowers/plans/2026-06-26-htmx-package.md](docs/superpowers/plans/2026-06-26-htmx-package.md) (spec: [design doc](docs/superpowers/specs/2026-06-26-htmx-package-design.md)).

## What's included

- **Request introspection** (`request.go`): `IsRequest`, `IsBoosted`, `IsHistoryRestore`, `CurrentURL`, `Prompt`, `Target`, `TriggerID`, `TriggerName`.
- **Response directives** (`response.go`): `PushURL`, `ReplaceURL`, `Refresh`, `Reswap`, `Retarget`, `Reselect`, plus `Swap*` and `PreventHistory` constants.
- **Trigger family**: `Trigger` / `TriggerWith` / `TriggerAfterSettle(With)` / `TriggerAfterSwap(With)` — bare-name and JSON-detail forms; no-op on empty input; transactional (no header written on marshal failure).
- **HTMX-aware redirects**: `Redirect`, `Location`, `LocationWith` (+ `LocationOptions`). Branch on `IsRequest` — set `HX-Redirect`/`HX-Location` + 200 for HTMX requests, fall back to a real `http.Redirect` (3xx) otherwise. Terminal (commit the response).
- **Docs**: package overview with the `Vary: HX-Request` caching note; runnable godoc examples.

## Quality

- Built task-by-task with TDD (failing test → implement → green) via subagent-driven development; each task spec/quality-reviewed, plus a final whole-branch review.
- **Black-box tests only** (`package htmx_test`), `httptest`-driven; covers absent headers, no-op cases, marshal errors, and both redirect branches.
- `just check` passes fully clean (go vet, golangci-lint, nilaway, betteralign, modernize, race tests); **htmx at 100% statement coverage**.
- Stdlib only in package code; `testify` confined to tests. Flat layout, no builder pattern, single-line `htmx:`-prefixed wrapped errors on the `*With` marshal paths only.

## Notes

- One deviation from the plan's literal test code: the no-op Trigger assertions use `rec.Header().Get(...)` instead of a raw `rec.Header()["HX-Trigger"]` map index — `http.Header` canonicalizes keys, so the plan's literal form failed staticcheck SA1008 and couldn't detect a regression. Approved during implementation.