### PR TITLE
feat(request): HTTP request-reading helpers (input-side counterpart to render)

### DIFF
--- a/docs/superpowers/plans/2026-06-26-request-package.md
+++ b/docs/superpowers/plans/2026-06-26-request-package.md
@@ -1,0 +1,2072 @@
+# request Package Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone `request` package of stateless, reflection-free free functions that read data off an `*http.Request` into Go values — typed accessors, strict body decoding, and focused readers (BearerToken, ClientIP, pagination).
+
+**Architecture:** Every typed accessor funnels a raw string through one private generic engine (`parse[T]`: scalar type-switch → `time.Duration` → `encoding.TextUnmarshaler`) and a shared `resolve` helper that applies the missing/default/malformed contract. Per-source wrappers (`Query`, `Path`, `Header`, `Cookie`, `FormValue`) differ only in how they pull the raw string. Body decoding, ClientIP, and pagination each carry their own concern-scoped functional-option type. Failures are one typed `*Error{Source, Key, Kind, Err}`; `StatusCode` maps it to 400/413/415.
+
+**Tech Stack:** Go 1.26 standard library (`encoding`, `encoding/json`, `errors`, `fmt`, `mime`, `mime/multipart`, `net`, `net/http`, `net/netip`, `strconv`, `strings`, `time`); `testify` in tests only; `just` task runner.
+
+**Spec:** [docs/superpowers/specs/2026-06-26-request-package-design.md](../specs/2026-06-26-request-package-design.md)
+
+## Global Constraints
+
+- **Go 1.26**, module `github.com/dmitrymomot/forge`; new package import path `github.com/dmitrymomot/forge/request`.
+- **Stdlib only** in package code — no external dependencies. `testify` (already a module dep) allowed in tests only.
+- **Black-box tests ONLY** — every `*_test.go` declares `package request_test` and imports the package.
+- **Flat layout** — files live directly under `request/`, no subfolders.
+- **No reflection, no struct tags, no `init()`, no global mutable state** — interface assertions only (`encoding.TextUnmarshaler`).
+- **No builder pattern** — options are functional, split into three concern-scoped types: `BodyOption`, `ClientIPOption`, `PageOption`.
+- **Single-line errors**, prefixed `request:` and `%w`-wrapped; the wrapped cause stays reachable via `Unwrap`. No embedded stacks/blobs.
+- **Use `just` recipes** — `just test ./request/` to run; `just check` (fmt + lint + test) before finishing.
+- The accessor contract: absent/empty value ⇒ `def[0]` or the zero value with nil error; present-but-unparseable ⇒ `(zero, *Error{Kind: Malformed})`.
+
+---
+
+### Task 1: Error model and package doc
+
+**Files:**
+- Create: `request/doc.go`
+- Create: `request/errors.go`
+- Test: `request/errors_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type Source string` with `SourceQuery`, `SourcePath`, `SourceHeader`, `SourceCookie`, `SourceForm`, `SourceBody`.
+  - `type Kind int` with `KindMalformed`, `KindTooLarge`, `KindUnsupportedMediaType`, `KindInvalidBody`; `func (Kind) String() string`.
+  - `type Error struct { Source Source; Key string; Kind Kind; Err error }`; `func (*Error) Error() string`; `func (*Error) Unwrap() error`.
+  - `func StatusCode(err error) int` — used by every later task's tests and consumers.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `request/errors_test.go`:
+
+```go
+package request_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/dmitrymomot/forge/request"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil is 200", nil, http.StatusOK},
+		{"malformed is 400", &request.Error{Source: request.SourceQuery, Key: "p", Kind: request.KindMalformed}, http.StatusBadRequest},
+		{"too large is 413", &request.Error{Source: request.SourceBody, Kind: request.KindTooLarge}, http.StatusRequestEntityTooLarge},
+		{"unsupported media is 415", &request.Error{Source: request.SourceBody, Kind: request.KindUnsupportedMediaType}, http.StatusUnsupportedMediaType},
+		{"invalid body is 400", &request.Error{Source: request.SourceBody, Kind: request.KindInvalidBody}, http.StatusBadRequest},
+		{"plain error is 400", errors.New("other"), http.StatusBadRequest},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, request.StatusCode(tc.err))
+		})
+	}
+}
+
+func TestErrorStringAndUnwrap(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("boom")
+	e := &request.Error{Source: request.SourceQuery, Key: "page", Kind: request.KindMalformed, Err: cause}
+
+	assert.ErrorIs(t, e, cause)
+	assert.Contains(t, e.Error(), "request:")
+	assert.Contains(t, e.Error(), "query")
+	assert.Contains(t, e.Error(), "page")
+	assert.Contains(t, e.Error(), "malformed")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test ./request/`
+Expected: FAIL — build error (`no non-test Go files`, or `undefined: request.Error`).
+
+- [ ] **Step 3: Write the package doc and the error model**
+
+Create `request/doc.go`:
+
+```go
+// Package request provides small, stateless, reflection-free helpers for reading
+// data off an *http.Request into Go values: typed accessors for query, path,
+// header, cookie, and form values (Query, Path, Header, Cookie, FormValue and
+// their Func/Slice/Split variants), strict body decoding (DecodeJSON, RawBody,
+// multipart File/Files), and focused readers (BearerToken, ClientIP, presence
+// predicates, QueryPage/QueryCursor).
+//
+// The helpers are free functions — no constructor, no binder, no struct tags, no
+// global state. Each typed accessor returns the zero value of T and a nil error
+// when the key is absent, and a *request.Error only when a present value fails to
+// parse. request.StatusCode maps that error to the right HTTP status (400/413/415):
+//
+//	page, err := request.Query[int](r, "page", 1)
+//	if err != nil {
+//		render.JSON(w, request.StatusCode(err), apiErr{err.Error()})
+//		return
+//	}
+//
+// Custom types parse with no reflection: any type whose pointer implements
+// encoding.TextUnmarshaler (uuid.UUID, netip.Addr, time.Time, custom enums) works
+// through the generic engine; anything else can use the Func variants.
+//
+// request reads; the render package writes; the htmx package handles HX-* headers.
+// None imports another. Stdlib only.
+package request
+```
+
+Create `request/errors.go`:
+
+```go
+package request
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Source identifies which part of the request a value came from.
+type Source string
+
+const (
+	SourceQuery  Source = "query"
+	SourcePath   Source = "path"
+	SourceHeader Source = "header"
+	SourceCookie Source = "cookie"
+	SourceForm   Source = "form"
+	SourceBody   Source = "body"
+)
+
+// Kind classifies a request-reading failure so handlers can map it to a status.
+type Kind int
+
+const (
+	KindMalformed            Kind = iota // unparseable value           -> 400
+	KindTooLarge                         // body exceeded the size cap   -> 413
+	KindUnsupportedMediaType             // wrong/absent Content-Type    -> 415
+	KindInvalidBody                      // malformed/unknown-field JSON -> 400
+)
+
+// String returns a short human label for k.
+func (k Kind) String() string {
+	switch k {
+	case KindMalformed:
+		return "malformed"
+	case KindTooLarge:
+		return "too large"
+	case KindUnsupportedMediaType:
+		return "unsupported media type"
+	case KindInvalidBody:
+		return "invalid body"
+	default:
+		return "unknown"
+	}
+}
+
+// Error is the single error type returned by every request-reading helper. Source
+// and Key name the offending input; Kind drives StatusCode; Err is the cause.
+type Error struct {
+	Source Source
+	Key    string
+	Kind   Kind
+	Err    error
+}
+
+// Error returns a single-line description; the wrapped cause is reached via Unwrap.
+func (e *Error) Error() string {
+	loc := string(e.Source)
+	if e.Key != "" {
+		loc = fmt.Sprintf("%s %q", e.Source, e.Key)
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("request: %s: %s: %v", loc, e.Kind, e.Err)
+	}
+	return fmt.Sprintf("request: %s: %s", loc, e.Kind)
+}
+
+// Unwrap returns the wrapped cause so errors.Is/As reach it.
+func (e *Error) Unwrap() error { return e.Err }
+
+// StatusCode reports the HTTP status for err: a *Error maps by Kind
+// (400/413/415); any other non-nil error is 400; nil is 200.
+func StatusCode(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+	var e *Error
+	if errors.As(err, &e) {
+		switch e.Kind {
+		case KindTooLarge:
+			return http.StatusRequestEntityTooLarge
+		case KindUnsupportedMediaType:
+			return http.StatusUnsupportedMediaType
+		default:
+			return http.StatusBadRequest
+		}
+	}
+	return http.StatusBadRequest
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `just test ./request/`
+Expected: PASS — `ok  github.com/dmitrymomot/forge/request`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add request/doc.go request/errors.go request/errors_test.go
+git commit -m "feat(request): typed error model and StatusCode mapper"
+```
+
+---
+
+### Task 2: Generic parse engine and the Query accessor family
+
+**Files:**
+- Create: `request/parse.go`
+- Create: `request/query.go`
+- Test: `request/query_test.go`
+
+**Interfaces:**
+- Consumes: `Source`, `Error`, `KindMalformed` (Task 1).
+- Produces:
+  - Internal `func parse[T any](raw string) (T, error)`; internal `resolve`, `resolveSlice`, `resolveSplit` — reused by Tasks 3 and 4.
+  - `func Query[T any](r *http.Request, key string, def ...T) (T, error)`
+  - `func QueryFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error)`
+  - `func QuerySlice[T any](r *http.Request, key string, def ...[]T) ([]T, error)`
+  - `func QuerySliceFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...[]T) ([]T, error)`
+  - `func QuerySplit[T any](r *http.Request, key, sep string, def ...[]T) ([]T, error)`
+  - `func QuerySplitFunc[T any](r *http.Request, key, sep string, parse func(string) (T, error), def ...[]T) ([]T, error)`
+  - `func HasQuery(r *http.Request, key string) bool`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `request/query_test.go`:
+
+```go
+package request_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// color is a local TextUnmarshaler type — proves custom types parse with no
+// external dependency and no reflection.
+type color struct{ name string }
+
+func (c *color) UnmarshalText(b []byte) error {
+	switch s := string(b); s {
+	case "red", "green", "blue":
+		c.name = s
+		return nil
+	default:
+		return fmt.Errorf("bad color %q", s)
+	}
+}
+
+func TestQueryScalars(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?n=42&ok=true&f=3.5&s=hi&d=1500ms", nil)
+
+	n, err := request.Query[int](r, "n")
+	require.NoError(t, err)
+	assert.Equal(t, 42, n)
+
+	ok, err := request.Query[bool](r, "ok")
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	f, err := request.Query[float64](r, "f")
+	require.NoError(t, err)
+	assert.InEpsilon(t, 3.5, f, 1e-9)
+
+	s, err := request.Query[string](r, "s")
+	require.NoError(t, err)
+	assert.Equal(t, "hi", s)
+
+	d, err := request.Query[time.Duration](r, "d")
+	require.NoError(t, err)
+	assert.Equal(t, 1500*time.Millisecond, d)
+}
+
+func TestQueryTextUnmarshaler(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?c=blue", nil)
+	c, err := request.Query[color](r, "c")
+	require.NoError(t, err)
+	assert.Equal(t, "blue", c.name)
+}
+
+func TestQueryMalformed(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?n=oops", nil)
+
+	_, err := request.Query[int](r, "n")
+	require.Error(t, err)
+
+	var re *request.Error
+	require.ErrorAs(t, err, &re)
+	assert.Equal(t, request.SourceQuery, re.Source)
+	assert.Equal(t, request.KindMalformed, re.Kind)
+	assert.Equal(t, "n", re.Key)
+}
+
+func TestQueryAbsentAndDefault(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	n, err := request.Query[int](r, "n")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	n2, err := request.Query[int](r, "n", 7)
+	require.NoError(t, err)
+	assert.Equal(t, 7, n2)
+}
+
+func TestQueryFunc(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?hex=ff", nil)
+	v, err := request.QueryFunc(r, "hex", func(s string) (int64, error) {
+		return strconv.ParseInt(s, 16, 64)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(255), v)
+}
+
+func TestQuerySlice(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?id=1&id=2&id=3", nil)
+	ids, err := request.QuerySlice[int](r, "id")
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3}, ids)
+}
+
+func TestQuerySplit(t *testing.T) {
+	t.Parallel()
+	// decodes to: filter=orange, blue ,gray,
+	r := httptest.NewRequest(http.MethodGet, "/?filter=orange,%20blue%20,gray,", nil)
+	got, err := request.QuerySplit[string](r, "filter", ",")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"orange", "blue", "gray"}, got)
+}
+
+func TestHasQuery(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?x=", nil)
+	assert.True(t, request.HasQuery(r, "x"))
+	assert.False(t, request.HasQuery(r, "y"))
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test ./request/`
+Expected: FAIL — build error (`undefined: request.Query`).
+
+- [ ] **Step 3: Write the parse engine and shared resolvers**
+
+Create `request/parse.go`:
+
+```go
+package request
+
+import (
+	"encoding"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// parse converts a single non-empty raw string into T. Resolution order: built-in
+// scalars via a type switch on any(&v); *time.Duration via time.ParseDuration; then
+// any type whose pointer implements encoding.TextUnmarshaler (time.Time, uuid.UUID,
+// netip.Addr, custom enums). No reflect package: interface assertions only.
+func parse[T any](raw string) (T, error) {
+	var v T
+	switch p := any(&v).(type) {
+	case *string:
+		*p = raw
+	case *bool:
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return v, err
+		}
+		*p = b
+	case *int:
+		n, err := strconv.ParseInt(raw, 10, strconv.IntSize)
+		if err != nil {
+			return v, err
+		}
+		*p = int(n)
+	case *int8:
+		n, err := strconv.ParseInt(raw, 10, 8)
+		if err != nil {
+			return v, err
+		}
+		*p = int8(n)
+	case *int16:
+		n, err := strconv.ParseInt(raw, 10, 16)
+		if err != nil {
+			return v, err
+		}
+		*p = int16(n)
+	case *int32:
+		n, err := strconv.ParseInt(raw, 10, 32)
+		if err != nil {
+			return v, err
+		}
+		*p = int32(n)
+	case *int64:
+		n, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return v, err
+		}
+		*p = n
+	case *uint:
+		n, err := strconv.ParseUint(raw, 10, strconv.IntSize)
+		if err != nil {
+			return v, err
+		}
+		*p = uint(n)
+	case *uint8:
+		n, err := strconv.ParseUint(raw, 10, 8)
+		if err != nil {
+			return v, err
+		}
+		*p = uint8(n)
+	case *uint16:
+		n, err := strconv.ParseUint(raw, 10, 16)
+		if err != nil {
+			return v, err
+		}
+		*p = uint16(n)
+	case *uint32:
+		n, err := strconv.ParseUint(raw, 10, 32)
+		if err != nil {
+			return v, err
+		}
+		*p = uint32(n)
+	case *uint64:
+		n, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			return v, err
+		}
+		*p = n
+	case *float32:
+		f, err := strconv.ParseFloat(raw, 32)
+		if err != nil {
+			return v, err
+		}
+		*p = float32(f)
+	case *float64:
+		f, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return v, err
+		}
+		*p = f
+	case *time.Duration:
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return v, err
+		}
+		*p = d
+	default:
+		if tu, ok := any(&v).(encoding.TextUnmarshaler); ok {
+			if err := tu.UnmarshalText([]byte(raw)); err != nil {
+				return v, err
+			}
+			return v, nil
+		}
+		return v, fmt.Errorf("unsupported type %T", v)
+	}
+	return v, nil
+}
+
+// resolve applies the missing/default/malformed contract for a single value: an
+// empty raw string yields def[0] (or the zero value) and a nil error; a non-empty
+// value is parsed by p and any failure is wrapped as *Error.
+func resolve[T any](src Source, key, raw string, p func(string) (T, error), def []T) (T, error) {
+	if raw == "" {
+		if len(def) > 0 {
+			return def[0], nil
+		}
+		var zero T
+		return zero, nil
+	}
+	v, err := p(raw)
+	if err != nil {
+		var zero T
+		return zero, &Error{Source: src, Key: key, Kind: KindMalformed, Err: err}
+	}
+	return v, nil
+}
+
+// resolveSlice parses each non-empty element of raws with p. Any failure wraps as
+// *Error; an all-empty result falls back to def[0] (or nil).
+func resolveSlice[T any](src Source, key string, raws []string, p func(string) (T, error), def [][]T) ([]T, error) {
+	out := make([]T, 0, len(raws))
+	for _, raw := range raws {
+		if raw == "" {
+			continue
+		}
+		v, err := p(raw)
+		if err != nil {
+			return nil, &Error{Source: src, Key: key, Kind: KindMalformed, Err: err}
+		}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		if len(def) > 0 {
+			return def[0], nil
+		}
+		return nil, nil
+	}
+	return out, nil
+}
+
+// resolveSplit splits raw on sep, trims and skips empty elements, then parses each
+// with p. An empty raw falls back to def[0] (or nil).
+func resolveSplit[T any](src Source, key, raw, sep string, p func(string) (T, error), def [][]T) ([]T, error) {
+	if raw == "" {
+		if len(def) > 0 {
+			return def[0], nil
+		}
+		return nil, nil
+	}
+	var out []T
+	for _, part := range strings.Split(raw, sep) {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		v, err := p(part)
+		if err != nil {
+			return nil, &Error{Source: src, Key: key, Kind: KindMalformed, Err: err}
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+```
+
+Create `request/query.go`:
+
+```go
+package request
+
+import "net/http"
+
+// Query reads URL query parameter key and converts it to T. Absent/empty yields
+// def[0] (or the zero value) with a nil error; a present unparseable value returns
+// a *Error with Kind Malformed.
+func Query[T any](r *http.Request, key string, def ...T) (T, error) {
+	return resolve(SourceQuery, key, r.URL.Query().Get(key), parse[T], def)
+}
+
+// QueryFunc is Query with a caller-supplied parser instead of the built-in engine.
+func QueryFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error) {
+	return resolve(SourceQuery, key, r.URL.Query().Get(key), parse, def)
+}
+
+// QuerySlice reads every repeated value of key (?id=1&id=2) and parses each into T.
+func QuerySlice[T any](r *http.Request, key string, def ...[]T) ([]T, error) {
+	return resolveSlice(SourceQuery, key, r.URL.Query()[key], parse[T], def)
+}
+
+// QuerySliceFunc is QuerySlice with a caller-supplied element parser.
+func QuerySliceFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...[]T) ([]T, error) {
+	return resolveSlice(SourceQuery, key, r.URL.Query()[key], parse, def)
+}
+
+// QuerySplit reads a single delimited value (?filter=a,b,c), splitting on sep.
+func QuerySplit[T any](r *http.Request, key, sep string, def ...[]T) ([]T, error) {
+	return resolveSplit(SourceQuery, key, r.URL.Query().Get(key), sep, parse[T], def)
+}
+
+// QuerySplitFunc is QuerySplit with a caller-supplied element parser.
+func QuerySplitFunc[T any](r *http.Request, key, sep string, parse func(string) (T, error), def ...[]T) ([]T, error) {
+	return resolveSplit(SourceQuery, key, r.URL.Query().Get(key), sep, parse, def)
+}
+
+// HasQuery reports whether key is present in the URL query (even with an empty value).
+func HasQuery(r *http.Request, key string) bool {
+	return r.URL.Query().Has(key)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `just test ./request/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add request/parse.go request/query.go request/query_test.go
+git commit -m "feat(request): generic parse engine and Query accessor family"
+```
+
+---
+
+### Task 3: Path, Header (+BearerToken), and Cookie families
+
+**Files:**
+- Create: `request/path.go`
+- Create: `request/header.go`
+- Create: `request/cookie.go`
+- Test: `request/parts_test.go`
+
+**Interfaces:**
+- Consumes: `resolve`, `parse` (Task 2); `SourcePath`/`SourceHeader`/`SourceCookie` (Task 1).
+- Produces:
+  - `Path`, `PathFunc`, `HasPath`
+  - `Header`, `HeaderFunc`, `HasHeader`, `func BearerToken(r *http.Request) (string, bool)`
+  - `Cookie`, `CookieFunc`, `HasCookie`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `request/parts_test.go`:
+
+```go
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPath(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/u/42", nil)
+	r.SetPathValue("id", "42")
+
+	v, err := request.Path[int](r, "id")
+	require.NoError(t, err)
+	assert.Equal(t, 42, v)
+	assert.True(t, request.HasPath(r, "id"))
+	assert.False(t, request.HasPath(r, "missing"))
+}
+
+func TestHeader(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Count", "5")
+
+	v, err := request.Header[int](r, "X-Count")
+	require.NoError(t, err)
+	assert.Equal(t, 5, v)
+	assert.True(t, request.HasHeader(r, "X-Count"))
+	assert.False(t, request.HasHeader(r, "X-Absent"))
+}
+
+func TestBearerToken(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer abc.def")
+	tok, ok := request.BearerToken(r)
+	assert.True(t, ok)
+	assert.Equal(t, "abc.def", tok)
+
+	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2.Header.Set("Authorization", "Basic xxx")
+	_, ok2 := request.BearerToken(r2)
+	assert.False(t, ok2)
+
+	r3 := httptest.NewRequest(http.MethodGet, "/", nil)
+	_, ok3 := request.BearerToken(r3)
+	assert.False(t, ok3)
+}
+
+func TestCookie(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.AddCookie(&http.Cookie{Name: "sid", Value: "xyz"})
+
+	v, err := request.Cookie[string](r, "sid")
+	require.NoError(t, err)
+	assert.Equal(t, "xyz", v)
+	assert.True(t, request.HasCookie(r, "sid"))
+	assert.False(t, request.HasCookie(r, "nope"))
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test ./request/`
+Expected: FAIL — build error (`undefined: request.Path`, `request.BearerToken`).
+
+- [ ] **Step 3: Write the three source families**
+
+Create `request/path.go`:
+
+```go
+package request
+
+import "net/http"
+
+// Path reads path wildcard key (r.PathValue) and converts it to T. Requires a
+// Go 1.22+ ServeMux pattern that defines key.
+func Path[T any](r *http.Request, key string, def ...T) (T, error) {
+	return resolve(SourcePath, key, r.PathValue(key), parse[T], def)
+}
+
+// PathFunc is Path with a caller-supplied parser.
+func PathFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error) {
+	return resolve(SourcePath, key, r.PathValue(key), parse, def)
+}
+
+// HasPath reports whether the path wildcard key is set and non-empty.
+func HasPath(r *http.Request, key string) bool {
+	return r.PathValue(key) != ""
+}
+```
+
+Create `request/header.go`:
+
+```go
+package request
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Header reads request header key and converts it to T.
+func Header[T any](r *http.Request, key string, def ...T) (T, error) {
+	return resolve(SourceHeader, key, r.Header.Get(key), parse[T], def)
+}
+
+// HeaderFunc is Header with a caller-supplied parser.
+func HeaderFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error) {
+	return resolve(SourceHeader, key, r.Header.Get(key), parse, def)
+}
+
+// HasHeader reports whether header key is present and non-empty.
+func HasHeader(r *http.Request, key string) bool {
+	return r.Header.Get(key) != ""
+}
+
+// BearerToken returns the token from an Authorization: Bearer <token> header, or
+// "" and false if the header is absent or not a Bearer credential.
+func BearerToken(r *http.Request) (string, bool) {
+	const prefix = "Bearer "
+	auth := r.Header.Get("Authorization")
+	if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+		return "", false
+	}
+	token := strings.TrimSpace(auth[len(prefix):])
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+```
+
+Create `request/cookie.go`:
+
+```go
+package request
+
+import "net/http"
+
+// Cookie reads cookie key's value and converts it to T. A missing cookie is treated
+// as absent (zero value / default).
+func Cookie[T any](r *http.Request, key string, def ...T) (T, error) {
+	return resolve(SourceCookie, key, cookieValue(r, key), parse[T], def)
+}
+
+// CookieFunc is Cookie with a caller-supplied parser.
+func CookieFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error) {
+	return resolve(SourceCookie, key, cookieValue(r, key), parse, def)
+}
+
+// HasCookie reports whether cookie key is present.
+func HasCookie(r *http.Request, key string) bool {
+	_, err := r.Cookie(key)
+	return err == nil
+}
+
+func cookieValue(r *http.Request, key string) string {
+	c, err := r.Cookie(key)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `just test ./request/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add request/path.go request/header.go request/cookie.go request/parts_test.go
+git commit -m "feat(request): path, header (with BearerToken), and cookie accessors"
+```
+
+---
+
+### Task 4: Form accessor family
+
+**Files:**
+- Create: `request/form.go`
+- Test: `request/form_test.go`
+
+**Interfaces:**
+- Consumes: `resolve`, `resolveSlice`, `resolveSplit`, `parse` (Task 2); `SourceForm` (Task 1).
+- Produces:
+  - `FormValue`, `FormValueFunc`, `FormSlice`, `FormSliceFunc`, `FormSplit`, `FormSplitFunc`, `HasForm`. All read the **body** form (POST/PUT/PATCH), never the URL query.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `request/form_test.go`:
+
+```go
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func formReq(values url.Values) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(values.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return r
+}
+
+func TestFormValue(t *testing.T) {
+	t.Parallel()
+	r := formReq(url.Values{"age": {"30"}})
+
+	v, err := request.FormValue[int](r, "age")
+	require.NoError(t, err)
+	assert.Equal(t, 30, v)
+	assert.True(t, request.HasForm(r, "age"))
+	assert.False(t, request.HasForm(r, "missing"))
+}
+
+func TestFormSlice(t *testing.T) {
+	t.Parallel()
+	r := formReq(url.Values{"tag": {"a", "b"}})
+
+	v, err := request.FormSlice[string](r, "tag")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, v)
+}
+
+func TestFormSplit(t *testing.T) {
+	t.Parallel()
+	r := formReq(url.Values{"ids": {"1, 2 ,3"}})
+
+	v, err := request.FormSplit[int](r, "ids", ",")
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3}, v)
+}
+
+func TestFormNotMergedWithQuery(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/?age=99",
+		strings.NewReader(url.Values{"age": {"30"}}.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	v, err := request.FormValue[int](r, "age")
+	require.NoError(t, err)
+	assert.Equal(t, 30, v) // body value, not the query's 99
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test ./request/`
+Expected: FAIL — build error (`undefined: request.FormValue`).
+
+- [ ] **Step 3: Write the form family**
+
+Create `request/form.go`:
+
+```go
+package request
+
+import "net/http"
+
+// FormValue reads body form field key (POST/PUT/PATCH) and converts it to T. It
+// reads only the request body, never the URL query.
+func FormValue[T any](r *http.Request, key string, def ...T) (T, error) {
+	return resolve(SourceForm, key, r.PostFormValue(key), parse[T], def)
+}
+
+// FormValueFunc is FormValue with a caller-supplied parser.
+func FormValueFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error) {
+	return resolve(SourceForm, key, r.PostFormValue(key), parse, def)
+}
+
+// FormSlice reads every repeated body value of key and parses each into T.
+func FormSlice[T any](r *http.Request, key string, def ...[]T) ([]T, error) {
+	_ = r.ParseForm()
+	return resolveSlice(SourceForm, key, r.PostForm[key], parse[T], def)
+}
+
+// FormSliceFunc is FormSlice with a caller-supplied element parser.
+func FormSliceFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...[]T) ([]T, error) {
+	_ = r.ParseForm()
+	return resolveSlice(SourceForm, key, r.PostForm[key], parse, def)
+}
+
+// FormSplit reads a single delimited body value, splitting on sep.
+func FormSplit[T any](r *http.Request, key, sep string, def ...[]T) ([]T, error) {
+	return resolveSplit(SourceForm, key, r.PostFormValue(key), sep, parse[T], def)
+}
+
+// FormSplitFunc is FormSplit with a caller-supplied element parser.
+func FormSplitFunc[T any](r *http.Request, key, sep string, parse func(string) (T, error), def ...[]T) ([]T, error) {
+	return resolveSplit(SourceForm, key, r.PostFormValue(key), sep, parse, def)
+}
+
+// HasForm reports whether body form field key is present.
+func HasForm(r *http.Request, key string) bool {
+	_ = r.ParseForm()
+	return r.PostForm.Has(key)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `just test ./request/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add request/form.go request/form_test.go
+git commit -m "feat(request): body form accessor family"
+```
+
+---
+
+### Task 5: Body options, DecodeJSON, and IsContentType
+
+**Files:**
+- Create: `request/body.go`
+- Test: `request/body_test.go`
+
+**Interfaces:**
+- Consumes: `Error`, `SourceBody`, `KindTooLarge`, `KindUnsupportedMediaType`, `KindInvalidBody` (Task 1).
+- Produces:
+  - `type BodyOption func(*bodyConfig)`; `WithMaxBytes(int64)`, `AllowUnknownFields()`, `SkipContentType()`.
+  - Internal `bodyConfig`, `newBodyConfig`, `limitedBody`, `matchesMediaType`, `decodeError`, and consts `defaultMaxBytes`/`defaultMultipartMemory` — reused by Task 6.
+  - `func DecodeJSON(r *http.Request, dst any, opts ...BodyOption) error`
+  - `func IsContentType(r *http.Request, media string) bool`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `request/body_test.go`:
+
+```go
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type payload struct {
+	Name string `json:"name"`
+}
+
+func jsonReq(body string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}
+
+func TestDecodeJSONHappy(t *testing.T) {
+	t.Parallel()
+	var p payload
+	require.NoError(t, request.DecodeJSON(jsonReq(`{"name":"ada"}`), &p))
+	assert.Equal(t, "ada", p.Name)
+}
+
+func TestDecodeJSONUnknownField(t *testing.T) {
+	t.Parallel()
+	var p payload
+	err := request.DecodeJSON(jsonReq(`{"name":"ada","extra":1}`), &p)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestDecodeJSONAllowUnknown(t *testing.T) {
+	t.Parallel()
+	var p payload
+	require.NoError(t, request.DecodeJSON(jsonReq(`{"name":"ada","extra":1}`), &p, request.AllowUnknownFields()))
+	assert.Equal(t, "ada", p.Name)
+}
+
+func TestDecodeJSONWrongContentType(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	r.Header.Set("Content-Type", "text/plain")
+	var p payload
+	err := request.DecodeJSON(r, &p)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnsupportedMediaType, request.StatusCode(err))
+}
+
+func TestDecodeJSONSkipContentType(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"x"}`))
+	// no Content-Type set
+	var p payload
+	require.NoError(t, request.DecodeJSON(r, &p, request.SkipContentType()))
+	assert.Equal(t, "x", p.Name)
+}
+
+func TestDecodeJSONTooLarge(t *testing.T) {
+	t.Parallel()
+	var p payload
+	big := `{"name":"` + strings.Repeat("x", 2000) + `"}`
+	err := request.DecodeJSON(jsonReq(big), &p, request.WithMaxBytes(100))
+	require.Error(t, err)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, request.StatusCode(err))
+}
+
+func TestDecodeJSONTrailingData(t *testing.T) {
+	t.Parallel()
+	var p payload
+	err := request.DecodeJSON(jsonReq(`{"name":"a"}{"name":"b"}`), &p)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestDecodeJSONEmpty(t *testing.T) {
+	t.Parallel()
+	var p payload
+	err := request.DecodeJSON(jsonReq(``), &p)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestIsContentType(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
+	r.Header.Set("Content-Type", "Application/JSON; charset=utf-8")
+	assert.True(t, request.IsContentType(r, "application/json"))
+	assert.False(t, request.IsContentType(r, "text/plain"))
+
+	bare := httptest.NewRequest(http.MethodGet, "/", nil)
+	assert.False(t, request.IsContentType(bare, "application/json"))
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test ./request/`
+Expected: FAIL — build error (`undefined: request.DecodeJSON`).
+
+- [ ] **Step 3: Write the body options, decoder, and predicate**
+
+Create `request/body.go`:
+
+```go
+package request
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+const (
+	defaultMaxBytes        = 1 << 20  // 1 MiB — DecodeJSON / RawBody body cap
+	defaultMultipartMemory = 32 << 20 // 32 MiB — File / Files in-memory cap
+)
+
+type bodyConfig struct {
+	maxBytes     int64
+	maxBytesSet  bool
+	allowUnknown bool
+	skipCType    bool
+}
+
+// BodyOption configures DecodeJSON, RawBody, File, and Files.
+type BodyOption func(*bodyConfig)
+
+// WithMaxBytes sets the body size cap for every body reader; n <= 0 disables the
+// limit for DecodeJSON/RawBody (and falls back to 32 MiB for File/Files memory).
+func WithMaxBytes(n int64) BodyOption {
+	return func(c *bodyConfig) { c.maxBytes = n; c.maxBytesSet = true }
+}
+
+// AllowUnknownFields turns off DisallowUnknownFields (DecodeJSON only).
+func AllowUnknownFields() BodyOption {
+	return func(c *bodyConfig) { c.allowUnknown = true }
+}
+
+// SkipContentType accepts any/absent Content-Type (DecodeJSON only).
+func SkipContentType() BodyOption {
+	return func(c *bodyConfig) { c.skipCType = true }
+}
+
+func newBodyConfig(opts []BodyOption) bodyConfig {
+	var c bodyConfig
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// limitedBody wraps r.Body in a MaxBytesReader using the config's cap (default
+// 1 MiB; a non-positive explicit cap disables the limit). The nil ResponseWriter
+// is fine: MaxBytesReader only type-asserts w to signal the server, which we don't
+// need here.
+func limitedBody(r *http.Request, c bodyConfig) io.ReadCloser {
+	limit := int64(defaultMaxBytes)
+	if c.maxBytesSet {
+		limit = c.maxBytes
+	}
+	if limit <= 0 {
+		return r.Body
+	}
+	return http.MaxBytesReader(nil, r.Body, limit)
+}
+
+// matchesMediaType reports whether header's media type equals media
+// (case-insensitive, parameters ignored).
+func matchesMediaType(header, media string) bool {
+	if header == "" {
+		return false
+	}
+	got, _, err := mime.ParseMediaType(header)
+	if err != nil {
+		return false
+	}
+	want, _, err := mime.ParseMediaType(media)
+	if err != nil {
+		want = media
+	}
+	return strings.EqualFold(got, want)
+}
+
+// decodeError classifies a body read/decode failure: an *http.MaxBytesError maps
+// to KindTooLarge, anything else to KindInvalidBody.
+func decodeError(err error) error {
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) {
+		return &Error{Source: SourceBody, Kind: KindTooLarge, Err: err}
+	}
+	return &Error{Source: SourceBody, Kind: KindInvalidBody, Err: err}
+}
+
+// DecodeJSON strictly decodes the JSON request body into dst. Defaults: 1 MiB cap
+// (-> 413), require Content-Type application/json (-> 415), DisallowUnknownFields
+// and reject trailing data and empty bodies (-> 400). Override with options.
+func DecodeJSON(r *http.Request, dst any, opts ...BodyOption) error {
+	c := newBodyConfig(opts)
+
+	if !c.skipCType && !matchesMediaType(r.Header.Get("Content-Type"), "application/json") {
+		return &Error{
+			Source: SourceBody,
+			Kind:   KindUnsupportedMediaType,
+			Err:    fmt.Errorf("content-type %q is not application/json", r.Header.Get("Content-Type")),
+		}
+	}
+
+	dec := json.NewDecoder(limitedBody(r, c))
+	if !c.allowUnknown {
+		dec.DisallowUnknownFields()
+	}
+	if err := dec.Decode(dst); err != nil {
+		return decodeError(err)
+	}
+	if dec.More() {
+		return &Error{Source: SourceBody, Kind: KindInvalidBody, Err: errors.New("unexpected data after JSON value")}
+	}
+	return nil
+}
+
+// IsContentType reports whether the request's Content-Type media type equals media
+// (case-insensitive, parameters ignored). It inspects the request's own
+// Content-Type, not the Accept header — it is not content negotiation.
+func IsContentType(r *http.Request, media string) bool {
+	return matchesMediaType(r.Header.Get("Content-Type"), media)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `just test ./request/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add request/body.go request/body_test.go
+git commit -m "feat(request): strict DecodeJSON, body options, and IsContentType"
+```
+
+---
+
+### Task 6: RawBody and multipart File / Files
+
+**Files:**
+- Modify: `request/body.go` (replace the import block; append `RawBody`, `File`, `Files`, `parseMultipart`)
+- Test: `request/body_files_test.go`
+
+**Interfaces:**
+- Consumes: `newBodyConfig`, `limitedBody`, `decodeError`, `defaultMultipartMemory` (Task 5); `Error`, `SourceBody`, `SourceForm`, `KindMalformed`, `KindUnsupportedMediaType`, `KindInvalidBody` (Tasks 1, 5).
+- Produces:
+  - `func RawBody(r *http.Request, opts ...BodyOption) ([]byte, error)`
+  - `func File(r *http.Request, key string, opts ...BodyOption) (multipart.File, *multipart.FileHeader, error)`
+  - `func Files(r *http.Request, key string, opts ...BodyOption) ([]*multipart.FileHeader, error)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `request/body_files_test.go`:
+
+```go
+package request_test
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func multipartReq(t *testing.T, field, filename, content string) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile(field, filename)
+	require.NoError(t, err)
+	_, err = fw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
+
+	r := httptest.NewRequest(http.MethodPost, "/", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	return r
+}
+
+func TestRawBody(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("hello"))
+	b, err := request.RawBody(r)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(b))
+}
+
+func TestRawBodyTooLarge(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("0123456789"))
+	_, err := request.RawBody(r, request.WithMaxBytes(4))
+	require.Error(t, err)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, request.StatusCode(err))
+}
+
+func TestFile(t *testing.T) {
+	t.Parallel()
+	r := multipartReq(t, "doc", "a.txt", "filedata")
+
+	f, h, err := request.File(r, "doc")
+	require.NoError(t, err)
+	defer f.Close()
+
+	assert.Equal(t, "a.txt", h.Filename)
+	data, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, "filedata", string(data))
+}
+
+func TestFileMissing(t *testing.T) {
+	t.Parallel()
+	r := multipartReq(t, "other", "x.txt", "x")
+	_, _, err := request.File(r, "doc")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestFileNonMultipart(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("x"))
+	r.Header.Set("Content-Type", "application/json")
+	_, _, err := request.File(r, "doc")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnsupportedMediaType, request.StatusCode(err))
+}
+
+func TestFiles(t *testing.T) {
+	t.Parallel()
+	r := multipartReq(t, "doc", "a.txt", "data")
+	headers, err := request.Files(r, "doc")
+	require.NoError(t, err)
+	require.Len(t, headers, 1)
+	assert.Equal(t, "a.txt", headers[0].Filename)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test ./request/`
+Expected: FAIL — build error (`undefined: request.RawBody`, `request.File`).
+
+- [ ] **Step 3: Add the multipart import and the three functions**
+
+Replace the import block at the top of `request/body.go` with (adds `mime/multipart`):
+
+```go
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strings"
+)
+```
+
+Append to `request/body.go`:
+
+```go
+// RawBody reads the entire request body into a byte slice under the configured
+// size cap (default 1 MiB; overflow -> 413). For webhook HMAC verification and
+// arbitrary payloads. No Content-Type check.
+func RawBody(r *http.Request, opts ...BodyOption) ([]byte, error) {
+	c := newBodyConfig(opts)
+	b, err := io.ReadAll(limitedBody(r, c))
+	if err != nil {
+		return nil, decodeError(err)
+	}
+	return b, nil
+}
+
+// File returns the first uploaded file for key. The caller must Close the returned
+// multipart.File. A non-multipart request -> 415; a missing file -> 400.
+func File(r *http.Request, key string, opts ...BodyOption) (multipart.File, *multipart.FileHeader, error) {
+	if err := parseMultipart(r, opts); err != nil {
+		return nil, nil, err
+	}
+	f, h, err := r.FormFile(key)
+	if err != nil {
+		return nil, nil, &Error{Source: SourceForm, Key: key, Kind: KindMalformed, Err: err}
+	}
+	return f, h, nil
+}
+
+// Files returns every uploaded file header for key (open each via fh.Open()).
+func Files(r *http.Request, key string, opts ...BodyOption) ([]*multipart.FileHeader, error) {
+	if err := parseMultipart(r, opts); err != nil {
+		return nil, err
+	}
+	var headers []*multipart.FileHeader
+	if r.MultipartForm != nil && r.MultipartForm.File != nil {
+		headers = r.MultipartForm.File[key]
+	}
+	if len(headers) == 0 {
+		return nil, &Error{Source: SourceForm, Key: key, Kind: KindMalformed, Err: errors.New("no file for key")}
+	}
+	return headers, nil
+}
+
+// parseMultipart parses the multipart form, using the configured in-memory cap
+// (default 32 MiB). A non-multipart body maps to KindUnsupportedMediaType.
+func parseMultipart(r *http.Request, opts []BodyOption) error {
+	c := newBodyConfig(opts)
+	mem := int64(defaultMultipartMemory)
+	if c.maxBytesSet && c.maxBytes > 0 {
+		mem = c.maxBytes
+	}
+	if err := r.ParseMultipartForm(mem); err != nil {
+		kind := KindInvalidBody
+		if errors.Is(err, http.ErrNotMultipart) {
+			kind = KindUnsupportedMediaType
+		}
+		return &Error{Source: SourceBody, Kind: kind, Err: err}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `just test ./request/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add request/body.go request/body_files_test.go
+git commit -m "feat(request): RawBody and multipart File/Files readers"
+```
+
+---
+
+### Task 7: ClientIP — real-client-IP resolution
+
+**Files:**
+- Create: `request/clientip.go`
+- Test: `request/clientip_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (uses `net`, `net/http`, `net/netip`, `strings`).
+- Produces:
+  - `type ClientIPOption func(*clientIPConfig)`; `WithClientIPHeaders(names ...string)`, `WithTrustedProxies(prefixes ...netip.Prefix)`.
+  - `func ClientIP(r *http.Request, opts ...ClientIPOption) string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `request/clientip_test.go`:
+
+```go
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+
+	"github.com/dmitrymomot/forge/request"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientIPPriority(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1234"
+	r.Header.Set("X-Real-IP", "203.0.113.5")
+	r.Header.Set("CF-Connecting-IP", "198.51.100.7")
+	assert.Equal(t, "198.51.100.7", request.ClientIP(r)) // CF outranks X-Real-IP
+}
+
+func TestClientIPFallbackRemoteAddr(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "192.0.2.9:5555"
+	assert.Equal(t, "192.0.2.9", request.ClientIP(r))
+}
+
+func TestClientIPXFFFirstValid(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1"
+	r.Header.Set("X-Forwarded-For", "garbage, 203.0.113.5, 70.41.3.18")
+	assert.Equal(t, "203.0.113.5", request.ClientIP(r))
+}
+
+func TestClientIPForwarded(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1"
+	r.Header.Set("Forwarded", `for=192.0.2.60;proto=http, for=198.51.100.17`)
+	assert.Equal(t, "192.0.2.60", request.ClientIP(r))
+}
+
+func TestClientIPPinnedHeader(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1"
+	r.Header.Set("X-Forwarded-For", "1.2.3.4")
+	r.Header.Set("CF-Connecting-IP", "9.9.9.9")
+	// pin to a header that is absent -> ignore XFF/CF, fall back to RemoteAddr
+	assert.Equal(t, "10.0.0.1", request.ClientIP(r, request.WithClientIPHeaders("X-Real-IP")))
+}
+
+func TestClientIPTrustedProxies(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1" // trusted hop
+	r.Header.Set("X-Forwarded-For", "203.0.113.5, 10.0.0.2")
+	trusted := netip.MustParsePrefix("10.0.0.0/8")
+	assert.Equal(t, "203.0.113.5", request.ClientIP(r, request.WithTrustedProxies(trusted)))
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test ./request/`
+Expected: FAIL — build error (`undefined: request.ClientIP`).
+
+- [ ] **Step 3: Write the resolver**
+
+Create `request/clientip.go`:
+
+```go
+package request
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+type clientIPConfig struct {
+	headers    []string
+	trusted    []netip.Prefix
+	useTrusted bool
+}
+
+// ClientIPOption configures ClientIP.
+type ClientIPOption func(*clientIPConfig)
+
+// WithClientIPHeaders replaces the header priority list scanned in best-effort
+// mode. The secure pattern for a known CDN is to pin the single header the edge
+// always sets and strips on ingress, e.g. WithClientIPHeaders("CF-Connecting-IP").
+func WithClientIPHeaders(names ...string) ClientIPOption {
+	return func(c *clientIPConfig) { c.headers = names }
+}
+
+// WithTrustedProxies switches to spoof-resistant X-Forwarded-For resolution: the
+// chain (XFF entries plus RemoteAddr) is walked right-to-left, trusted hops are
+// skipped, and the first untrusted address is returned.
+func WithTrustedProxies(prefixes ...netip.Prefix) ClientIPOption {
+	return func(c *clientIPConfig) { c.trusted = prefixes; c.useTrusted = true }
+}
+
+// defaultClientIPHeaders is the best-effort scan order. Note: trusting these is
+// spoofable unless the service sits behind a proxy that overwrites them.
+var defaultClientIPHeaders = []string{
+	"CF-Connecting-IP",
+	"True-Client-IP",
+	"Fastly-Client-IP",
+	"X-Real-IP",
+	"Forwarded",
+	"X-Forwarded-For",
+}
+
+// ClientIP returns the best guess at the originating client IP, or "" if nothing
+// parses. By default it scans well-known CDN/proxy headers in priority order and
+// falls back to RemoteAddr. The default mode trusts client-supplied headers and is
+// spoofable; use WithTrustedProxies or a pinned header for auth/rate-limiting.
+func ClientIP(r *http.Request, opts ...ClientIPOption) string {
+	c := clientIPConfig{headers: defaultClientIPHeaders}
+	for _, o := range opts {
+		o(&c)
+	}
+
+	if c.useTrusted {
+		return clientIPTrusted(r, c.trusted)
+	}
+	for _, name := range c.headers {
+		if ip := headerIP(r, name); ip != "" {
+			return ip
+		}
+	}
+	return remoteHost(r.RemoteAddr)
+}
+
+// headerIP extracts the first valid IP from header name. Forwarded uses RFC 7239
+// for= parsing; every other header is treated as a comma list, first valid wins.
+func headerIP(r *http.Request, name string) string {
+	raw := r.Header.Get(name)
+	if raw == "" {
+		return ""
+	}
+	if strings.EqualFold(name, "Forwarded") {
+		return forwardedFor(raw)
+	}
+	for _, part := range strings.Split(raw, ",") {
+		if ip := validIP(part); ip != "" {
+			return ip
+		}
+	}
+	return ""
+}
+
+// clientIPTrusted walks the XFF chain (then RemoteAddr) right-to-left and returns
+// the first address not inside a trusted prefix. If all hops are trusted, the
+// left-most chain entry (closest to the originating client) is returned.
+func clientIPTrusted(r *http.Request, trusted []netip.Prefix) string {
+	var chain []string
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		chain = strings.Split(xff, ",")
+	}
+	chain = append(chain, r.RemoteAddr)
+
+	for i := len(chain) - 1; i >= 0; i-- {
+		ip := validIP(chain[i])
+		if ip == "" {
+			continue
+		}
+		addr, err := netip.ParseAddr(ip)
+		if err != nil {
+			continue
+		}
+		if isTrusted(addr, trusted) {
+			continue
+		}
+		return ip
+	}
+	if len(chain) > 0 {
+		if ip := validIP(chain[0]); ip != "" {
+			return ip
+		}
+	}
+	return remoteHost(r.RemoteAddr)
+}
+
+func isTrusted(addr netip.Addr, trusted []netip.Prefix) bool {
+	for _, p := range trusted {
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// forwardedFor returns the IP from the first "for=" directive of a Forwarded header.
+func forwardedFor(v string) string {
+	first := v
+	if i := strings.IndexByte(v, ','); i >= 0 {
+		first = v[:i]
+	}
+	for _, kv := range strings.Split(first, ";") {
+		key, val, ok := strings.Cut(strings.TrimSpace(kv), "=")
+		if !ok || !strings.EqualFold(strings.TrimSpace(key), "for") {
+			continue
+		}
+		return validIP(strings.Trim(strings.TrimSpace(val), `"`))
+	}
+	return ""
+}
+
+// validIP normalizes s (which may carry a port or brackets) to a bare IP string,
+// or "" if it is not a valid address.
+func validIP(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(s); err == nil {
+		s = host
+	}
+	s = strings.Trim(s, "[]")
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return ""
+	}
+	return addr.String()
+}
+
+// remoteHost returns the host portion of a RemoteAddr ("ip:port" or bare ip).
+func remoteHost(addr string) string {
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		if a, err := netip.ParseAddr(host); err == nil {
+			return a.String()
+		}
+		return host
+	}
+	if a, err := netip.ParseAddr(addr); err == nil {
+		return a.String()
+	}
+	return addr
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `just test ./request/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add request/clientip.go request/clientip_test.go
+git commit -m "feat(request): ClientIP with CDN/proxy header resolution"
+```
+
+---
+
+### Task 8: Pagination — page and cursor
+
+**Files:**
+- Create: `request/pagination.go`
+- Test: `request/pagination_test.go`
+
+**Interfaces:**
+- Consumes: `Query` (Task 2) for reading and malformed-error propagation.
+- Produces:
+  - `type Page struct { Number, Size, Offset int }`; `type Cursor struct { Value string; Limit int }`.
+  - `type PageOption func(*pageConfig)`; `WithPageParams(pageKey, sizeKey string)`, `WithDefaultPageSize(n int)`, `WithMaxPageSize(n int)`, `WithCursorParams(cursorKey, limitKey string)`.
+  - `func QueryPage(r *http.Request, opts ...PageOption) (Page, error)`
+  - `func QueryCursor(r *http.Request, opts ...PageOption) (Cursor, error)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `request/pagination_test.go`:
+
+```go
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryPageDefaults(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	p, err := request.QueryPage(r)
+	require.NoError(t, err)
+	assert.Equal(t, 1, p.Number)
+	assert.Equal(t, 20, p.Size)
+	assert.Equal(t, 0, p.Offset)
+}
+
+func TestQueryPageValues(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?page=3&per_page=10", nil)
+	p, err := request.QueryPage(r)
+	require.NoError(t, err)
+	assert.Equal(t, 3, p.Number)
+	assert.Equal(t, 10, p.Size)
+	assert.Equal(t, 20, p.Offset)
+}
+
+func TestQueryPageClamp(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?page=0&per_page=9999", nil)
+	p, err := request.QueryPage(r, request.WithMaxPageSize(100))
+	require.NoError(t, err)
+	assert.Equal(t, 1, p.Number)   // clamped up to 1
+	assert.Equal(t, 100, p.Size)   // clamped down to max
+}
+
+func TestQueryPageMalformed(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?page=abc", nil)
+	_, err := request.QueryPage(r)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestQueryPageCustomParams(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?p=2&size=5", nil)
+	p, err := request.QueryPage(r, request.WithPageParams("p", "size"))
+	require.NoError(t, err)
+	assert.Equal(t, 2, p.Number)
+	assert.Equal(t, 5, p.Size)
+}
+
+func TestQueryCursor(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?cursor=abc123&limit=5", nil)
+	c, err := request.QueryCursor(r)
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", c.Value)
+	assert.Equal(t, 5, c.Limit)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test ./request/`
+Expected: FAIL — build error (`undefined: request.QueryPage`).
+
+- [ ] **Step 3: Write the pagination readers**
+
+Create `request/pagination.go`:
+
+```go
+package request
+
+import "net/http"
+
+// Page is offset-based pagination input. Offset is derived as (Number-1)*Size.
+type Page struct {
+	Number int
+	Size   int
+	Offset int
+}
+
+// Cursor is cursor-based pagination input. Value is an opaque token passed through
+// verbatim; decoding its payload is the caller's job.
+type Cursor struct {
+	Value string
+	Limit int
+}
+
+type pageConfig struct {
+	pageKey     string
+	sizeKey     string
+	cursorKey   string
+	limitKey    string
+	defaultSize int
+	maxSize     int
+}
+
+// PageOption configures QueryPage and QueryCursor.
+type PageOption func(*pageConfig)
+
+// WithPageParams sets the query parameter names for page number and size.
+func WithPageParams(pageKey, sizeKey string) PageOption {
+	return func(c *pageConfig) { c.pageKey = pageKey; c.sizeKey = sizeKey }
+}
+
+// WithCursorParams sets the query parameter names for cursor and limit.
+func WithCursorParams(cursorKey, limitKey string) PageOption {
+	return func(c *pageConfig) { c.cursorKey = cursorKey; c.limitKey = limitKey }
+}
+
+// WithDefaultPageSize sets the size/limit used when the parameter is absent.
+func WithDefaultPageSize(n int) PageOption {
+	return func(c *pageConfig) { c.defaultSize = n }
+}
+
+// WithMaxPageSize sets the upper bound that size/limit is clamped to.
+func WithMaxPageSize(n int) PageOption {
+	return func(c *pageConfig) { c.maxSize = n }
+}
+
+func newPageConfig(opts []PageOption) pageConfig {
+	c := pageConfig{
+		pageKey:     "page",
+		sizeKey:     "per_page",
+		cursorKey:   "cursor",
+		limitKey:    "limit",
+		defaultSize: 20,
+		maxSize:     100,
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// QueryPage reads offset-based pagination from the query. A non-numeric value is a
+// Malformed error (-> 400); a valid out-of-range value is clamped (page >= 1,
+// 1 <= size <= max).
+func QueryPage(r *http.Request, opts ...PageOption) (Page, error) {
+	c := newPageConfig(opts)
+
+	number, err := Query[int](r, c.pageKey, 1)
+	if err != nil {
+		return Page{}, err
+	}
+	size, err := Query[int](r, c.sizeKey, c.defaultSize)
+	if err != nil {
+		return Page{}, err
+	}
+	number = clampMin(number, 1)
+	size = clampRange(size, 1, c.maxSize)
+	return Page{Number: number, Size: size, Offset: (number - 1) * size}, nil
+}
+
+// QueryCursor reads cursor-based pagination from the query. The cursor is opaque;
+// limit shares the same default/max bounds as page size.
+func QueryCursor(r *http.Request, opts ...PageOption) (Cursor, error) {
+	c := newPageConfig(opts)
+
+	limit, err := Query[int](r, c.limitKey, c.defaultSize)
+	if err != nil {
+		return Cursor{}, err
+	}
+	value, err := Query[string](r, c.cursorKey)
+	if err != nil {
+		return Cursor{}, err
+	}
+	return Cursor{Value: value, Limit: clampRange(limit, 1, c.maxSize)}, nil
+}
+
+func clampMin(v, min int) int {
+	if v < min {
+		return min
+	}
+	return v
+}
+
+func clampRange(v, min, max int) int {
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `just test ./request/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add request/pagination.go request/pagination_test.go
+git commit -m "feat(request): page and cursor pagination readers"
+```
+
+---
+
+### Task 9: Runnable examples, benchmark, and final verification
+
+**Files:**
+- Create: `request/example_test.go`
+
+**Interfaces:**
+- Consumes: `Query`, `DecodeJSON`, `StatusCode` (Tasks 1, 2, 5).
+- Produces: nothing (godoc examples + benchmark only).
+
+- [ ] **Step 1: Write the examples and benchmark**
+
+Create `request/example_test.go`:
+
+```go
+package request_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/request"
+)
+
+func ExampleQuery() {
+	r := httptest.NewRequest(http.MethodGet, "/search?page=2", nil)
+	page, _ := request.Query[int](r, "page", 1)
+	fmt.Println(page)
+	// Output: 2
+}
+
+func ExampleDecodeJSON() {
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"ada"}`))
+	r.Header.Set("Content-Type", "application/json")
+
+	var v struct {
+		Name string `json:"name"`
+	}
+	if err := request.DecodeJSON(r, &v); err != nil {
+		fmt.Println("status:", request.StatusCode(err))
+		return
+	}
+	fmt.Println(v.Name)
+	// Output: ada
+}
+
+func BenchmarkQueryInt(b *testing.B) {
+	r := httptest.NewRequest(http.MethodGet, "/?n=12345", nil)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = request.Query[int](r, "n")
+	}
+}
+```
+
+- [ ] **Step 2: Run the examples to verify they pass**
+
+Run: `just test ./request/`
+Expected: PASS (Go runs `Example*` functions and checks their `// Output:` blocks).
+
+- [ ] **Step 3: Run the full check (fmt + lint + test)**
+
+Run: `just check`
+Expected: `go fmt`/`goimports`/`betteralign` make no changes; `go vet`, `golangci-lint`, `nilaway`, `betteralign`, `modernize` report nothing; all tests pass. If `betteralign -apply` (run by `just fmt`) reorders any struct field (e.g. in `bodyConfig`, `clientIPConfig`, `pageConfig`, `Error`), re-run `just test ./request/` — all struct literals in the package use named fields, so reordering is safe — and include the change in the commit below.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add request/example_test.go
+git commit -m "docs(request): runnable examples and parse benchmark"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** — every spec section maps to a task:
+
+- Generic `parse[T]` engine (scalars + `time.Duration` + `TextUnmarshaler`) → Task 2 (`parse.go`).
+- Missing/default/malformed contract (`resolve`, `resolveSlice`, `resolveSplit`) → Task 2; reused by Tasks 3–4.
+- Scalar accessors + `…Func` + `…Slice` + `…Split` for Query → Task 2; Form → Task 4; scalar-only Path/Header/Cookie → Task 3.
+- Presence predicates (`HasQuery`/`HasPath`/`HasHeader`/`HasCookie`/`HasForm`) → Tasks 2–4 (one per source file).
+- `BearerToken` → Task 3 (`header.go`).
+- Strict `DecodeJSON` (1 MiB→413, Content-Type→415, unknown-field/trailing/empty→400) + `BodyOption`/`WithMaxBytes`/`AllowUnknownFields`/`SkipContentType` → Task 5.
+- `IsContentType` → Task 5.
+- `RawBody` + multipart `File`/`Files` → Task 6.
+- `ClientIP` best-effort priority scan + `WithClientIPHeaders` pin + `WithTrustedProxies` right-to-left → Task 7.
+- Pagination `Page`/`Cursor`/`QueryPage`/`QueryCursor` + `PageOption` family, clamp-vs-malformed → Task 8.
+- Error model (`Source`/`Kind`/`*Error`/`StatusCode`) → Task 1.
+- `doc.go` package overview → Task 1; runnable Examples + `parse` benchmark → Task 9.
+- Black-box `package request_test`, `httptest`-driven, testify → all tasks.
+
+**2. Placeholder scan** — no TBD/TODO/"add error handling"/"similar to Task N"; every code step shows complete code. ✔
+
+**3. Type consistency** — the option types match their consumers: `BodyOption` (Tasks 5–6), `ClientIPOption` (Task 7), `PageOption` (Task 8). `*Error{Source, Key, Kind, Err}` field names are identical across `errors.go`, the resolvers, and every accessor. The generic accessor signature `[T any](r *http.Request, key string, def ...T) (T, error)` and the `…Func` shape `(…, parse func(string) (T, error), …)` are uniform across `query.go`/`path.go`/`header.go`/`cookie.go`/`form.go`. `resolve`/`resolveSlice`/`resolveSplit` signatures match their call sites in Tasks 2–4. ✔
+

--- a/docs/superpowers/plans/2026-06-26-request-package.md
+++ b/docs/superpowers/plans/2026-06-26-request-package.md
@@ -1698,10 +1698,7 @@ func isTrusted(addr netip.Addr, trusted []netip.Prefix) bool {
 
 // forwardedFor returns the IP from the first "for=" directive of a Forwarded header.
 func forwardedFor(v string) string {
-	first := v
-	if i := strings.IndexByte(v, ','); i >= 0 {
-		first = v[:i]
-	}
+	first, _, _ := strings.Cut(v, ",")
 	for kv := range strings.SplitSeq(first, ";") {
 		key, val, ok := strings.Cut(strings.TrimSpace(kv), "=")
 		if !ok || !strings.EqualFold(strings.TrimSpace(key), "for") {

--- a/docs/superpowers/plans/2026-06-26-request-package.md
+++ b/docs/superpowers/plans/2026-06-26-request-package.md
@@ -332,9 +332,12 @@ func TestQueryMalformed(t *testing.T) {
 
 	var re *request.Error
 	require.ErrorAs(t, err, &re)
-	assert.Equal(t, request.SourceQuery, re.Source)
-	assert.Equal(t, request.KindMalformed, re.Kind)
-	assert.Equal(t, "n", re.Key)
+	require.NotNil(t, re)
+	if re != nil { // nil-guard so nilaway can follow the deref
+		assert.Equal(t, request.SourceQuery, re.Source)
+		assert.Equal(t, request.KindMalformed, re.Kind)
+		assert.Equal(t, "n", re.Key)
+	}
 }
 
 func TestQueryAbsentAndDefault(t *testing.T) {

--- a/docs/superpowers/plans/2026-06-26-request-package.md
+++ b/docs/superpowers/plans/2026-06-26-request-package.md
@@ -1367,6 +1367,23 @@ func TestFiles(t *testing.T) {
 	require.Len(t, headers, 1)
 	assert.Equal(t, "a.txt", headers[0].Filename)
 }
+
+func TestFilesMissing(t *testing.T) {
+	t.Parallel()
+	r := multipartReq(t, "other", "x.txt", "x")
+	_, err := request.Files(r, "doc")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestFilesNonMultipart(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("x"))
+	r.Header.Set("Content-Type", "application/json")
+	_, err := request.Files(r, "doc")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnsupportedMediaType, request.StatusCode(err))
+}
 ```
 
 - [ ] **Step 2: Run the test to verify it fails**

--- a/docs/superpowers/plans/2026-06-26-request-package.md
+++ b/docs/superpowers/plans/2026-06-26-request-package.md
@@ -209,8 +209,7 @@ func StatusCode(err error) int {
 	if err == nil {
 		return http.StatusOK
 	}
-	var e *Error
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[*Error](err); ok {
 		switch e.Kind {
 		case KindTooLarge:
 			return http.StatusRequestEntityTooLarge
@@ -563,7 +562,7 @@ func resolveSplit[T any](src Source, key, raw, sep string, p func(string) (T, er
 		return nil, nil
 	}
 	var out []T
-	for _, part := range strings.Split(raw, sep) {
+	for part := range strings.SplitSeq(raw, sep) {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue
@@ -1206,8 +1205,7 @@ func matchesMediaType(header, media string) bool {
 // decodeError classifies a body read/decode failure: an *http.MaxBytesError maps
 // to KindTooLarge, anything else to KindInvalidBody.
 func decodeError(err error) error {
-	var maxErr *http.MaxBytesError
-	if errors.As(err, &maxErr) {
+	if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 		return &Error{Source: SourceBody, Kind: KindTooLarge, Err: err}
 	}
 	return &Error{Source: SourceBody, Kind: KindInvalidBody, Err: err}
@@ -1589,23 +1587,21 @@ func WithTrustedProxies(prefixes ...netip.Prefix) ClientIPOption {
 	return func(c *clientIPConfig) { c.trusted = prefixes; c.useTrusted = true }
 }
 
-// defaultClientIPHeaders is the best-effort scan order. Note: trusting these is
-// spoofable unless the service sits behind a proxy that overwrites them.
-var defaultClientIPHeaders = []string{
-	"CF-Connecting-IP",
-	"True-Client-IP",
-	"Fastly-Client-IP",
-	"X-Real-IP",
-	"Forwarded",
-	"X-Forwarded-For",
-}
-
 // ClientIP returns the best guess at the originating client IP, or "" if nothing
 // parses. By default it scans well-known CDN/proxy headers in priority order and
 // falls back to RemoteAddr. The default mode trusts client-supplied headers and is
 // spoofable; use WithTrustedProxies or a pinned header for auth/rate-limiting.
 func ClientIP(r *http.Request, opts ...ClientIPOption) string {
-	c := clientIPConfig{headers: defaultClientIPHeaders}
+	// Best-effort scan order. Trusting these is spoofable unless the service sits
+	// behind a proxy that overwrites them.
+	c := clientIPConfig{headers: []string{
+		"CF-Connecting-IP",
+		"True-Client-IP",
+		"Fastly-Client-IP",
+		"X-Real-IP",
+		"Forwarded",
+		"X-Forwarded-For",
+	}}
 	for _, o := range opts {
 		o(&c)
 	}
@@ -1631,7 +1627,7 @@ func headerIP(r *http.Request, name string) string {
 	if strings.EqualFold(name, "Forwarded") {
 		return forwardedFor(raw)
 	}
-	for _, part := range strings.Split(raw, ",") {
+	for part := range strings.SplitSeq(raw, ",") {
 		if ip := validIP(part); ip != "" {
 			return ip
 		}
@@ -1686,7 +1682,7 @@ func forwardedFor(v string) string {
 	if i := strings.IndexByte(v, ','); i >= 0 {
 		first = v[:i]
 	}
-	for _, kv := range strings.Split(first, ";") {
+	for kv := range strings.SplitSeq(first, ";") {
 		key, val, ok := strings.Cut(strings.TrimSpace(kv), "=")
 		if !ok || !strings.EqualFold(strings.TrimSpace(key), "for") {
 			continue
@@ -1919,8 +1915,8 @@ func QueryPage(r *http.Request, opts ...PageOption) (Page, error) {
 	if err != nil {
 		return Page{}, err
 	}
-	number = clampMin(number, 1)
-	size = clampRange(size, 1, c.maxSize)
+	number = max(number, 1)
+	size = min(max(size, 1), c.maxSize)
 	return Page{Number: number, Size: size, Offset: (number - 1) * size}, nil
 }
 
@@ -1937,24 +1933,7 @@ func QueryCursor(r *http.Request, opts ...PageOption) (Cursor, error) {
 	if err != nil {
 		return Cursor{}, err
 	}
-	return Cursor{Value: value, Limit: clampRange(limit, 1, c.maxSize)}, nil
-}
-
-func clampMin(v, min int) int {
-	if v < min {
-		return min
-	}
-	return v
-}
-
-func clampRange(v, min, max int) int {
-	if v < min {
-		return min
-	}
-	if v > max {
-		return max
-	}
-	return v
+	return Cursor{Value: value, Limit: min(max(limit, 1), c.maxSize)}, nil
 }
 ```
 
@@ -2023,7 +2002,7 @@ func ExampleDecodeJSON() {
 func BenchmarkQueryInt(b *testing.B) {
 	r := httptest.NewRequest(http.MethodGet, "/?n=12345", nil)
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = request.Query[int](r, "n")
 	}
 }

--- a/docs/superpowers/plans/2026-06-26-request-package.md
+++ b/docs/superpowers/plans/2026-06-26-request-package.md
@@ -1581,6 +1581,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"slices"
 	"strings"
 )
 
@@ -1665,8 +1666,8 @@ func clientIPTrusted(r *http.Request, trusted []netip.Prefix) string {
 	}
 	chain = append(chain, r.RemoteAddr)
 
-	for i := len(chain) - 1; i >= 0; i-- {
-		ip := validIP(chain[i])
+	for _, hop := range slices.Backward(chain) {
+		ip := validIP(hop)
 		if ip == "" {
 			continue
 		}

--- a/docs/superpowers/plans/2026-06-26-request-package.md
+++ b/docs/superpowers/plans/2026-06-26-request-package.md
@@ -1334,7 +1334,7 @@ func TestFile(t *testing.T) {
 
 	f, h, err := request.File(r, "doc")
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	assert.Equal(t, "a.txt", h.Filename)
 	data, err := io.ReadAll(f)

--- a/docs/superpowers/plans/2026-06-26-request-package.md
+++ b/docs/superpowers/plans/2026-06-26-request-package.md
@@ -1563,6 +1563,13 @@ func TestClientIPTrustedProxies(t *testing.T) {
 	trusted := netip.MustParsePrefix("10.0.0.0/8")
 	assert.Equal(t, "203.0.113.5", request.ClientIP(r, request.WithTrustedProxies(trusted)))
 }
+
+func TestClientIPMalformedRemoteAddr(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "not-an-ip" // no usable headers, unparseable peer
+	assert.Equal(t, "", request.ClientIP(r))
+}
 ```
 
 - [ ] **Step 2: Run the test to verify it fails**
@@ -1728,18 +1735,17 @@ func validIP(s string) string {
 	return addr.String()
 }
 
-// remoteHost returns the host portion of a RemoteAddr ("ip:port" or bare ip).
+// remoteHost returns the IP from a RemoteAddr ("ip:port" or bare ip), or "" if it
+// does not parse as an IP.
 func remoteHost(addr string) string {
-	if host, _, err := net.SplitHostPort(addr); err == nil {
-		if a, err := netip.ParseAddr(host); err == nil {
-			return a.String()
-		}
-		return host
+	host := addr
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		host = h
 	}
-	if a, err := netip.ParseAddr(addr); err == nil {
+	if a, err := netip.ParseAddr(host); err == nil {
 		return a.String()
 	}
-	return addr
+	return ""
 }
 ```
 

--- a/docs/superpowers/specs/2026-06-26-request-package-design.md
+++ b/docs/superpowers/specs/2026-06-26-request-package-design.md
@@ -1,0 +1,475 @@
+# Design: `request` — HTTP request-reading helpers (free functions)
+
+- **Date:** 2026-06-26
+- **Status:** Draft for review
+- **Scope:** A new standalone `request` package of stateless, reflection-free helpers
+  that read data off an `*http.Request` into Go values — typed part accessors
+  (`Query`/`Path`/`Header`/`Cookie`/`FormValue`, their `…Func`/`…Slice`/`…Split`
+  variants), strict body decoding (`DecodeJSON`, `RawBody`, multipart `File`/`Files`),
+  and a handful of focused readers (`BearerToken`, `ClientIP`, presence predicates,
+  `QueryPage`/`QueryCursor`). No constructor, no options object except where there is
+  real policy to configure (`DecodeJSON`/`RawBody`/`ClientIP`/pagination), no global
+  state, no struct-tag binding, no reflection. It is the input-side counterpart to
+  `render`; stdlib only; the rest of the framework is untouched.
+
+## Overview
+
+`request` is a thin, opinion-light layer over `*http.Request`. Each accessor pulls one
+named value out of one part of the request and converts it to the Go type the caller
+asks for, so handlers stop hand-repeating
+`strconv.Atoi(r.URL.Query().Get("page"))` and the fiddly parts (transactional strict
+JSON decoding, `Content-Type`/size guards, `TextUnmarshaler` parsing, real-client-IP
+resolution) get one consistent, tested place.
+
+It is deliberately **free functions, not a binder or a request-scoped wrapper type**.
+There is nothing to hold and nothing to register — the handler owns its `r` and calls
+a function. This matches the framework's "no magic" stance and composes with stdlib
+handlers, `render`, and `htmx` directly:
+
+```go
+mux.HandleFunc("POST /orgs/{org}/reports", func(w http.ResponseWriter, r *http.Request) {
+	org, _ := request.Path[uuid.UUID](r, "org")            // TextUnmarshaler — for free
+	page, err := request.Query[int](r, "page", 1)          // default 1 when absent
+	if err != nil {
+		render.JSON(w, request.StatusCode(err), apiErr{err.Error()}) // 400
+		return
+	}
+	tags, _ := request.QuerySplit[string](r, "filter", ",") // ?filter=orange,blue,gray
+
+	var body createReport
+	if err := request.DecodeJSON(r, &body); err != nil {    // 413 / 415 / 400 by Kind
+		render.JSON(w, request.StatusCode(err), apiErr{err.Error()})
+		return
+	}
+	// org, page, tags, body are ready; the handler owns the rest.
+})
+```
+
+**Why a package and not just `strconv` + `r.URL.Query().Get`?** Things stdlib makes you
+re-solve at every call site: (1) **typed conversion** with a uniform missing-vs-malformed
+contract across query/path/header/cookie/form; (2) **custom-type parsing** without
+reflection (`uuid.UUID`, `netip.Addr`, custom enums via `encoding.TextUnmarshaler`);
+(3) **strict, transactional JSON decoding** (size cap → `413`, wrong `Content-Type` →
+`415`, unknown field / trailing data → `400`); (4) **real-client-IP resolution** across
+the CDN/proxy headers, with a clear spoofing caveat; (5) the small but real risk of
+**typos and inconsistent error handling** in repeated `strconv` plumbing. `request`
+solves each once, with stdlib only.
+
+**Relationship to `render` and `htmx` (one-way, and standalone).** `request` reads;
+`render` writes; `htmx` handles `HX-*` headers. `request` imports none of them and
+none of them import `request`. A handler typically uses `request` to read input and
+`render` to write output, and the typed `*request.Error` plus `request.StatusCode`
+hand the right status straight to a `render.JSON` error body — but the three packages
+stay fully independent and any one can be used alone.
+
+## The central contract: missing vs malformed
+
+This is the behavioral spine of the accessor family, decided during design.
+
+- **Single accessor, zero on missing.** `Query[T](r, key) (T, error)` returns the
+  **zero value of `T` and a nil error** when the key is absent, and returns
+  `(zero, *Error{Kind: Malformed})` only when the key is **present but unparseable**.
+  There is no separate "required" function; absence is not an error. The caller decides
+  whether absence matters.
+
+- **Optional default via variadic.** `Query[int](r, "page", 1)` returns `1` when the
+  key is absent. Only the first `def` is consulted; any further values are ignored
+  (documented). The default is used **only** for absence — a present-but-malformed
+  value still returns an error, never the default, so bad client input is never
+  silently swallowed.
+
+- **Presence is a separate question.** Because zero and absent collapse to the same
+  return when no default is given, presence predicates (`HasQuery`, …) exist to
+  distinguish `?count=0` from "count absent" when that distinction matters. This keeps
+  the common call site a clean two-value unpack while still answering "was it there?"
+  on demand.
+
+Rule of thumb: **absent ⇒ zero/default, nil error; present-but-bad ⇒ zero, typed
+error.**
+
+## Goals
+
+- One stateless free function per (source, shape); consistent signature shape
+  `(r, key, def …) (T, error)` for the typed accessors.
+- Reflection-free in package code: built-in scalars via a type switch,
+  `encoding.TextUnmarshaler` for custom types, and `…Func` variants for a
+  caller-supplied parser. No `reflect`, no struct tags, no `init()`.
+- Strict, transactional `DecodeJSON` (size/`Content-Type`/unknown-field/trailing-data
+  guards) with functional options to relax per endpoint.
+- A typed `*Error` carrying `Source`, `Key`, and `Kind`, plus a `StatusCode` mapper, so
+  handlers map failures to `400`/`413`/`415` and name the offending field.
+- Focused convenience readers that are otherwise re-written everywhere: `BearerToken`,
+  `RawBody`, `ClientIP` (real-IP across CDN/proxy headers), page/cursor pagination.
+- Stdlib only; testify in tests only; black-box tests (`package request_test`).
+
+## Non-goals
+
+- **No validation rules engine.** No required/min/max/regex DSL and no field-error
+  collection. Absence and range are the handler's call; `*Error` already exposes
+  `Source`+`Key` if the caller wants to build a field-keyed response. (Validation may
+  be a future sibling package, not part of `request`.)
+- **No struct binding / reflection / tags.** Accessors only; whole structs arrive via
+  `DecodeJSON`. There is no `Bind(r, &dto)` pulling from multiple sources by tag.
+- **No content negotiation.** `DecodeJSON` is JSON; there is no `Accept`-driven decoder
+  selection. (`DecodeXML` may be added later as a peer free function; `IsContentType`
+  is a possible light predicate — neither is in this scope.)
+- **No query/form merge.** `Query` reads the URL query; `FormValue` reads the body
+  form. They stay separate (stdlib's `r.FormValue` merges the two; `request` does not),
+  so the caller is explicit about which it wants.
+- **No signed/encrypted cookies, CSRF, or sessions.** Those are a separate
+  security/`cookie` sibling package; `request` only reads the raw cookie value.
+- **No global state, middleware, or context plumbing.** Every function is a pure
+  function of its arguments.
+
+## Package & module
+
+- Import path: `github.com/dmitrymomot/forge/request`, package `request`.
+- Flat top-level layout alongside `httpserver`/`hostrouter`/`render`/`htmx`.
+- Stdlib only: `encoding`, `encoding/json`, `errors`, `fmt`, `mime`, `mime/multipart`,
+  `net/http`, `net/netip`, `strconv`, `strings`, `time`. testify in tests only.
+- No constructor and no package-level mutable state. Functional options exist only for
+  `DecodeJSON`, `RawBody`, `File`/`Files`, `ClientIP`, and the pagination readers.
+
+### Files (one concern each)
+
+| File | Contents |
+|---|---|
+| `parse.go` | the private generic `parse[T]` conversion engine |
+| `query.go` | `Query`, `QueryFunc`, `QuerySlice`/`Func`, `QuerySplit`/`Func`, `HasQuery` |
+| `path.go` | `Path`, `PathFunc`, `HasPath` |
+| `header.go` | `Header`, `HeaderFunc`, `HasHeader`, `BearerToken` |
+| `cookie.go` | `Cookie`, `CookieFunc`, `HasCookie` |
+| `form.go` | `FormValue`, `FormValueFunc`, `FormSlice`/`Func`, `FormSplit`/`Func`, `HasForm` |
+| `body.go` | `DecodeJSON`, `RawBody`, `File`, `Files`, the `Option` type and option funcs |
+| `clientip.go` | `ClientIP` and its options |
+| `pagination.go` | `Page`, `Cursor`, `QueryPage`, `QueryCursor` and their options |
+| `errors.go` | `Source`, `Kind`, `*Error`, `StatusCode` |
+| `doc.go` | package documentation |
+
+## The generic core
+
+Every typed accessor funnels through one private function:
+
+```go
+// parse converts a single raw string into T. Resolution order:
+//   1. built-in scalars via a type switch on any(&v): *string, *bool,
+//      *int/int8/16/32/64, *uint/uint8/16/32/64, *float32/64;
+//   2. *time.Duration via time.ParseDuration;
+//   3. any type whose pointer implements encoding.TextUnmarshaler —
+//      time.Time (RFC 3339), uuid.UUID, netip.Addr, custom enums.
+// No reflect package: interface assertions only. Returns the parse cause on
+// failure; the calling accessor wraps it in *Error with Source/Key.
+func parse[T any](raw string) (T, error)
+```
+
+`time.Time` needs no special case — `*time.Time` already implements
+`encoding.TextUnmarshaler` (RFC 3339), so it falls out of branch 3. The `…Func`
+variants bypass `parse` entirely and call the caller's `func(string) (T, error)`, so
+genuinely exotic types never touch the engine.
+
+## The accessor API
+
+### Scalar accessors (one family per source)
+
+```go
+func Query[T any]    (r *http.Request, key string, def ...T) (T, error)
+func Path[T any]     (r *http.Request, key string, def ...T) (T, error)
+func Header[T any]   (r *http.Request, key string, def ...T) (T, error)
+func Cookie[T any]   (r *http.Request, key string, def ...T) (T, error)
+func FormValue[T any](r *http.Request, key string, def ...T) (T, error)
+```
+
+Semantics for every family: absent key → `def[0]` if supplied, else the zero value of
+`T`, with a nil error; present-but-unparseable → `(zero, *Error{Kind: Malformed})`.
+
+### `…Func` escape-hatch variants
+
+Same five sources, caller supplies the parser; the built-in engine is bypassed:
+
+```go
+func QueryFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error)
+// PathFunc, HeaderFunc, CookieFunc, FormValueFunc — identical shape
+```
+
+### Slice accessors — two distinct shapes
+
+**Repeated keys** (`?id=1&id=2&id=3`), for the two sources where repetition is
+idiomatic:
+
+```go
+func QuerySlice[T any](r *http.Request, key string, def ...[]T) ([]T, error)
+func FormSlice[T any] (r *http.Request, key string, def ...[]T) ([]T, error)
+```
+
+**Single delimited value** (`?filter=orange,blue,gray`):
+
+```go
+func QuerySplit[T any](r *http.Request, key, sep string, def ...[]T) ([]T, error)
+func FormSplit[T any] (r *http.Request, key, sep string, def ...[]T) ([]T, error)
+```
+
+`…Split` behavior: split the single value on the **explicit** `sep` (`","`, `" "`,
+`"|"`, …; no hidden default), `strings.TrimSpace` each element, **skip empty elements**
+(so `orange, blue, gray` and a trailing `a,b,` behave sensibly), then run each element
+through `parse[T]`. Absent key → default (or nil slice) + nil error; any element
+unparseable → `*Error{Kind: Malformed, Key: key}` naming the offending value.
+
+Both slice shapes get `…Func` peers (`QuerySliceFunc`, `QuerySplitFunc`, `FormSliceFunc`,
+`FormSplitFunc`) for custom element parsers.
+
+### Presence predicates
+
+```go
+func HasQuery(r *http.Request, key string) bool
+func HasPath(r *http.Request, key string) bool
+func HasHeader(r *http.Request, key string) bool
+func HasCookie(r *http.Request, key string) bool
+func HasForm(r *http.Request, key string) bool
+```
+
+These close the "zero vs absent" gap left by the zero-on-missing contract: a caller
+that must distinguish `?count=0` from a missing `count` checks `HasQuery` first.
+
+### Per-source lookup mechanics
+
+| Source | Backing read | Notes |
+|---|---|---|
+| `Query` | `r.URL.Query().Get` / `[key]` for slices | parses the raw query string per call |
+| `Path` | `r.PathValue(key)` | needs a Go 1.22+ `ServeMux` pattern; no slice form |
+| `Header` | `r.Header.Get(key)` | canonicalized key |
+| `Cookie` | `r.Cookie(key)`; `http.ErrNoCookie` → absent | uses `cookie.Value` |
+| `FormValue` | `r.PostFormValue(key)`; `…Slice` uses `r.PostForm[key]` | body form only (POST/PUT/PATCH); triggers stdlib form parsing |
+
+`FormValue` reads the **body** form, not the query string, so query and form stay
+distinct — to read either, the caller calls both explicitly.
+
+## Body decoding & multipart
+
+### `DecodeJSON`
+
+```go
+func DecodeJSON(r *http.Request, dst any, opts ...Option) error
+```
+
+Strict-by-default policy, each guard independently overridable:
+
+| Guard | Default | On violation |
+|---|---|---|
+| Body size | `http.MaxBytesReader`, **1 MiB** | `*Error{Kind: TooLarge}` → `413` |
+| Content-Type | require `application/json` (params allowed) | `*Error{Kind: UnsupportedMediaType}` → `415` |
+| Unknown fields | `DisallowUnknownFields` | `*Error{Kind: InvalidBody}` → `400` |
+| Trailing data | reject anything after the first JSON value | `*Error{Kind: InvalidBody}` → `400` |
+| Empty body | rejected (EOF) | `*Error{Kind: InvalidBody}` → `400` |
+
+`Content-Type` is matched with `mime.ParseMediaType` (robust to casing/params). The
+too-large case is detected via `errors.As` on `*http.MaxBytesError`, so it maps to
+`413` rather than a generic `400`.
+
+### `RawBody`
+
+```go
+func RawBody(r *http.Request, opts ...Option) ([]byte, error)
+```
+
+Reads the full body into a byte slice under the **same** `MaxBytes` cap as `DecodeJSON`
+(`WithMaxBytes` applies; overflow → `*Error{Kind: TooLarge}` → `413`). For webhook HMAC
+verification and arbitrary payloads — the one body shape `DecodeJSON` can't return. No
+`Content-Type` check by default.
+
+### Multipart files
+
+```go
+func File(r *http.Request, key string, opts ...Option) (multipart.File, *multipart.FileHeader, error)
+func Files(r *http.Request, key string, opts ...Option) ([]*multipart.FileHeader, error)
+```
+
+`File` returns the first uploaded file for `key` (caller `defer`s `Close()`); `Files`
+returns every header for repeated file inputs (open lazily via `fh.Open()`). Both
+trigger `r.ParseMultipartForm`; `WithMaxBytes` caps the in-memory portion (stdlib
+default 32 MiB spills to temp files otherwise). A missing file → `*Error{Kind:
+Malformed}`; a non-multipart request → `*Error{Kind: UnsupportedMediaType}` → `415`.
+Multipart **field** values are already covered by `FormValue`/`FormSlice`, so
+`File`/`Files` handle only the file parts — no overlap.
+
+### Options
+
+There is **one** `Option` type and one internal `config`, shared by every
+option-taking function (`DecodeJSON`, `RawBody`, `File`/`Files`, `ClientIP`,
+`QueryPage`, `QueryCursor`). Each such function starts from its own per-function
+defaults, applies the supplied options, and reads only the fields it cares about, so an
+option that doesn't apply to a given function (e.g. `AllowUnknownFields` on `RawBody`)
+is a harmless no-op. The accessor families (`Query`, `Path`, …) take no options.
+
+```go
+type Option func(*config)
+
+// Body (DecodeJSON / RawBody / File / Files)
+func WithMaxBytes(n int64) Option   // raise/lower the cap; n <= 0 disables the limit
+func AllowUnknownFields() Option    // turn off DisallowUnknownFields (DecodeJSON)
+func SkipContentType() Option       // accept any/absent Content-Type (DecodeJSON)
+
+// ClientIP
+func WithClientIPHeaders(names ...string) Option
+func WithTrustedProxies(prefixes ...netip.Prefix) Option
+
+// Pagination
+func WithPageParams(pageKey, sizeKey string) Option
+func WithDefaultPageSize(n int) Option
+func WithMaxPageSize(n int) Option
+func WithCursorParams(cursorKey, limitKey string) Option
+```
+
+Functional options, no builder (per project convention).
+
+## `ClientIP` — real-client-IP resolution
+
+```go
+func ClientIP(r *http.Request, opts ...Option) string   // "" if nothing parses
+```
+
+**Default (best-effort):** scan well-known headers in priority order, take the first
+value that parses as an IP (`netip.ParseAddr`), else fall back to the host of
+`r.RemoteAddr`:
+
+`CF-Connecting-IP` → `True-Client-IP` → `Fastly-Client-IP` → `X-Real-IP` →
+`Forwarded` (RFC 7239 `for=`) → `X-Forwarded-For` (first valid) → `RemoteAddr`.
+
+**Options:**
+
+```go
+func WithClientIPHeaders(names ...string) Option        // replace the priority list
+func WithTrustedProxies(prefixes ...netip.Prefix) Option // correct XFF resolution
+```
+
+- `WithClientIPHeaders` is the **secure pattern for a known CDN**: pin to exactly the
+  one header your edge always sets and strips on ingress (e.g.
+  `WithClientIPHeaders("CF-Connecting-IP")`), so a client can't forge it.
+- `WithTrustedProxies` switches to spoof-resistant `X-Forwarded-For` resolution: walk
+  the chain right-to-left, skip trusted hops, return the first **untrusted** address.
+
+**Security note (stated plainly in the doc):** the default best-effort mode trusts
+client-supplied headers and is **spoofable** unless the service sits behind a proxy
+that overwrites them. Do not use the raw result for auth or rate-limiting without
+`WithTrustedProxies` or a pinned header. CDN IP ranges are not hardcoded (they change);
+that allowlist is the caller's to supply.
+
+## Pagination
+
+```go
+type Page struct {
+	Number int // 1-based page number
+	Size   int // page size
+	Offset int // derived: (Number - 1) * Size
+}
+func QueryPage(r *http.Request, opts ...Option) (Page, error)
+
+type Cursor struct {
+	Value string // opaque token, passed through verbatim
+	Limit int
+}
+func QueryCursor(r *http.Request, opts ...Option) (Cursor, error)
+```
+
+- `QueryPage` reads `page` + `per_page`; defaults: page 1, size 20. Options:
+  `WithPageParams(pageKey, sizeKey)`, `WithDefaultPageSize(n)`, `WithMaxPageSize(n)`.
+- `QueryCursor` reads `cursor` + `limit` (param names via `WithCursorParams`); the
+  cursor stays an **opaque string** — encoding/decoding its payload is the app's job (a
+  codec would be a sibling concern). `limit` shares the same default/max bounds as page
+  size (`WithDefaultPageSize`/`WithMaxPageSize`).
+- **Behavior split:** a *non-numeric* `page`/`size`/`limit` → `*Error{Kind: Malformed}`
+  → `400`. A *valid but out-of-range* value (page < 1, size > max) is **clamped** to the
+  bound — the conventional, less hostile pagination behavior — rather than rejected.
+
+## Error model
+
+```go
+type Source string
+const (
+	SourceQuery  Source = "query"
+	SourcePath   Source = "path"
+	SourceHeader Source = "header"
+	SourceCookie Source = "cookie"
+	SourceForm   Source = "form"
+	SourceBody   Source = "body"
+)
+
+type Kind int
+const (
+	KindMalformed            Kind = iota // unparseable value           → 400
+	KindTooLarge                         // body exceeded the size cap   → 413
+	KindUnsupportedMediaType             // wrong/absent Content-Type    → 415
+	KindInvalidBody                      // malformed/unknown-field JSON → 400
+)
+func (k Kind) String() string
+
+type Error struct {
+	Source Source // which part of the request
+	Key    string // param/field/cookie name ("" for whole-body errors)
+	Kind   Kind
+	Err    error  // wrapped cause (strconv error, json error, *MaxBytesError, …)
+}
+func (e *Error) Error() string  // single line, e.g. `request: query "page": malformed: ...`
+func (e *Error) Unwrap() error  // returns Err — errors.Is/As reach the cause
+
+// StatusCode reports the HTTP status for err: a *request.Error maps by Kind
+// (400/413/415); any other non-nil error is 400; nil is 200.
+func StatusCode(err error) int
+```
+
+Design notes:
+
+- **One `*Error` type, not a tree.** `errors.As(err, &reqErr)` then switch on
+  `reqErr.Kind`. `Source`+`Key` are right there for building a field-keyed response.
+- **Single-line `Error()` strings** (no embedded blobs/stacks), matching the project's
+  structured-logging rule. The wrapped `Err` stays reachable via `Unwrap` for
+  `errors.Is`/`errors.As`.
+- A handler stays three lines and never re-derives status logic:
+
+  ```go
+  page, err := request.Query[int](r, "page", 1)
+  if err != nil {
+  	render.JSON(w, request.StatusCode(err), apiErr{Message: err.Error()})
+  	return
+  }
+  ```
+
+## Data flow
+
+- **Accessor:** `accessor → raw string from r → parse[T] (scalar switch → Duration →
+  TextUnmarshaler, or the Func) → (value, nil) | (zero, *Error{Source, Key, Kind})`.
+- **`DecodeJSON`:** `MaxBytesReader → Content-Type check → strict json.Decoder → reject
+  trailing → (nil | *Error)`.
+- No shared state between calls; each function is independent and idempotent.
+
+## Testing
+
+Black-box only (`package request_test`, per project convention; testify for assertions):
+
+- Per source × type matrix: present/valid, present/malformed (→ `*Error` with the right
+  `Kind`/`Source`/`Key`), absent (→ zero), absent-with-default, `…Func`, `…Slice`
+  (repeated keys), `…Split` (delimited: separator, trim, skipped empties).
+- `TextUnmarshaler` path via a tiny local custom type (no external dependency) plus
+  `time.Time` and `time.Duration`.
+- `DecodeJSON`: happy path, oversize → 413, wrong/missing `Content-Type` → 415, unknown
+  field → 400, trailing data → 400, empty → 400, and each option
+  (`WithMaxBytes`/`AllowUnknownFields`/`SkipContentType`) flipping the outcome.
+- `RawBody`: happy path and oversize → 413.
+- Multipart `File`/`Files`: present, absent, non-multipart → 415, in-memory cap.
+- `ClientIP`: header priority order, first-valid selection, `WithClientIPHeaders`
+  pinning, `WithTrustedProxies` right-to-left resolution, `RemoteAddr` fallback,
+  unparseable candidates skipped.
+- `QueryPage`/`QueryCursor`: defaults, custom param names, clamping vs malformed error,
+  opaque cursor passthrough.
+- Presence predicates across all sources; `StatusCode` mapping table; `errors.Is`/`As`
+  reach the wrapped cause.
+- `example_test.go` (compiles, doubles as documentation); allocation-sensitive
+  benchmarks for the `parse` hot path.
+
+## Future fit
+
+- `DecodeXML` (`encoding/xml`) can be added later as a peer body decoder without
+  touching the existing functions.
+- A lightweight `IsContentType(r, media string) bool` predicate is addable if content
+  branching is ever wanted (full `Accept` negotiation stays out of scope).
+- A validation sibling package can consume `*Error`'s `Source`/`Key` to assemble
+  field-keyed error responses, without `request` itself growing a rules engine.

--- a/docs/superpowers/specs/2026-06-26-request-package-design.md
+++ b/docs/superpowers/specs/2026-06-26-request-package-design.md
@@ -288,7 +288,9 @@ func Files(r *http.Request, key string, opts ...BodyOption) ([]*multipart.FileHe
 returns every header for repeated file inputs (open lazily via `fh.Open()`). Both
 trigger `r.ParseMultipartForm`; `WithMaxBytes` caps the in-memory portion (stdlib
 default 32 MiB spills to temp files otherwise). A missing file → `*Error{Kind:
-Malformed}`; a non-multipart request → `*Error{Kind: UnsupportedMediaType}` → `415`.
+Missing, Err: http.ErrMissingFile}` (so `errors.Is(err, http.ErrMissingFile)`
+distinguishes absence from a bad upload); a non-multipart request → `*Error{Kind:
+UnsupportedMediaType}` → `415`.
 Multipart **field** values are already covered by `FormValue`/`FormSlice`, so
 `File`/`Files` handle only the file parts — no overlap.
 
@@ -418,6 +420,7 @@ const (
 	KindTooLarge                         // body exceeded the size cap   → 413
 	KindUnsupportedMediaType             // wrong/absent Content-Type    → 415
 	KindInvalidBody                      // malformed/unknown-field JSON → 400
+	KindMissing                          // required input absent        → 400
 )
 func (k Kind) String() string
 

--- a/docs/superpowers/specs/2026-06-26-request-package-design.md
+++ b/docs/superpowers/specs/2026-06-26-request-package-design.md
@@ -110,9 +110,10 @@ error.**
   be a future sibling package, not part of `request`.)
 - **No struct binding / reflection / tags.** Accessors only; whole structs arrive via
   `DecodeJSON`. There is no `Bind(r, &dto)` pulling from multiple sources by tag.
-- **No content negotiation.** `DecodeJSON` is JSON; there is no `Accept`-driven decoder
-  selection. (`DecodeXML` may be added later as a peer free function; `IsContentType`
-  is a possible light predicate — neither is in this scope.)
+- **No content negotiation.** There is no `Accept`-driven decoder selection.
+  `DecodeJSON` is JSON; `IsContentType` inspects the request's own `Content-Type`, not
+  `Accept`. (`DecodeXML` may be added later as a peer free function; it is not in this
+  scope.)
 - **No query/form merge.** `Query` reads the URL query; `FormValue` reads the body
   form. They stay separate (stdlib's `r.FormValue` merges the two; `request` does not),
   so the caller is explicit about which it wants.
@@ -140,7 +141,7 @@ error.**
 | `header.go` | `Header`, `HeaderFunc`, `HasHeader`, `BearerToken` |
 | `cookie.go` | `Cookie`, `CookieFunc`, `HasCookie` |
 | `form.go` | `FormValue`, `FormValueFunc`, `FormSlice`/`Func`, `FormSplit`/`Func`, `HasForm` |
-| `body.go` | `DecodeJSON`, `RawBody`, `File`, `Files`, the `Option` type and option funcs |
+| `body.go` | `DecodeJSON`, `RawBody`, `File`, `Files`, `IsContentType`, the `Option` type and option funcs |
 | `clientip.go` | `ClientIP` and its options |
 | `pagination.go` | `Page`, `Cursor`, `QueryPage`, `QueryCursor` and their options |
 | `errors.go` | `Source`, `Kind`, `*Error`, `StatusCode` |
@@ -290,6 +291,18 @@ default 32 MiB spills to temp files otherwise). A missing file → `*Error{Kind:
 Malformed}`; a non-multipart request → `*Error{Kind: UnsupportedMediaType}` → `415`.
 Multipart **field** values are already covered by `FormValue`/`FormSlice`, so
 `File`/`Files` handle only the file parts — no overlap.
+
+### `IsContentType`
+
+```go
+func IsContentType(r *http.Request, media string) bool
+```
+
+Reports whether the request's `Content-Type` media type equals `media`, compared via
+`mime.ParseMediaType` (case-insensitive, parameters like `; charset=utf-8` ignored) —
+the same matcher `DecodeJSON` uses. A lightweight predicate for branching on body
+format (e.g. `if request.IsContentType(r, "application/json")`); it is **not** content
+negotiation — it inspects the request's own `Content-Type`, never the `Accept` header.
 
 ### Options
 
@@ -454,6 +467,7 @@ Black-box only (`package request_test`, per project convention; testify for asse
   field → 400, trailing data → 400, empty → 400, and each option
   (`WithMaxBytes`/`AllowUnknownFields`/`SkipContentType`) flipping the outcome.
 - `RawBody`: happy path and oversize → 413.
+- `IsContentType`: exact match, case/parameter insensitivity, mismatch, absent header.
 - Multipart `File`/`Files`: present, absent, non-multipart → 415, in-memory cap.
 - `ClientIP`: header priority order, first-valid selection, `WithClientIPHeaders`
   pinning, `WithTrustedProxies` right-to-left resolution, `RemoteAddr` fallback,
@@ -469,7 +483,5 @@ Black-box only (`package request_test`, per project convention; testify for asse
 
 - `DecodeXML` (`encoding/xml`) can be added later as a peer body decoder without
   touching the existing functions.
-- A lightweight `IsContentType(r, media string) bool` predicate is addable if content
-  branching is ever wanted (full `Accept` negotiation stays out of scope).
 - A validation sibling package can consume `*Error`'s `Source`/`Key` to assemble
   field-keyed error responses, without `request` itself growing a rules engine.

--- a/docs/superpowers/specs/2026-06-26-request-package-design.md
+++ b/docs/superpowers/specs/2026-06-26-request-package-design.md
@@ -141,9 +141,9 @@ error.**
 | `header.go` | `Header`, `HeaderFunc`, `HasHeader`, `BearerToken` |
 | `cookie.go` | `Cookie`, `CookieFunc`, `HasCookie` |
 | `form.go` | `FormValue`, `FormValueFunc`, `FormSlice`/`Func`, `FormSplit`/`Func`, `HasForm` |
-| `body.go` | `DecodeJSON`, `RawBody`, `File`, `Files`, `IsContentType`, the `Option` type and option funcs |
-| `clientip.go` | `ClientIP` and its options |
-| `pagination.go` | `Page`, `Cursor`, `QueryPage`, `QueryCursor` and their options |
+| `body.go` | `DecodeJSON`, `RawBody`, `File`, `Files`, `IsContentType`, `BodyOption` + funcs |
+| `clientip.go` | `ClientIP`, `ClientIPOption` + funcs |
+| `pagination.go` | `Page`, `Cursor`, `QueryPage`, `QueryCursor`, `PageOption` + funcs |
 | `errors.go` | `Source`, `Kind`, `*Error`, `StatusCode` |
 | `doc.go` | package documentation |
 
@@ -249,7 +249,7 @@ distinct — to read either, the caller calls both explicitly.
 ### `DecodeJSON`
 
 ```go
-func DecodeJSON(r *http.Request, dst any, opts ...Option) error
+func DecodeJSON(r *http.Request, dst any, opts ...BodyOption) error
 ```
 
 Strict-by-default policy, each guard independently overridable:
@@ -269,7 +269,7 @@ too-large case is detected via `errors.As` on `*http.MaxBytesError`, so it maps 
 ### `RawBody`
 
 ```go
-func RawBody(r *http.Request, opts ...Option) ([]byte, error)
+func RawBody(r *http.Request, opts ...BodyOption) ([]byte, error)
 ```
 
 Reads the full body into a byte slice under the **same** `MaxBytes` cap as `DecodeJSON`
@@ -280,8 +280,8 @@ verification and arbitrary payloads — the one body shape `DecodeJSON` can't re
 ### Multipart files
 
 ```go
-func File(r *http.Request, key string, opts ...Option) (multipart.File, *multipart.FileHeader, error)
-func Files(r *http.Request, key string, opts ...Option) ([]*multipart.FileHeader, error)
+func File(r *http.Request, key string, opts ...BodyOption) (multipart.File, *multipart.FileHeader, error)
+func Files(r *http.Request, key string, opts ...BodyOption) ([]*multipart.FileHeader, error)
 ```
 
 `File` returns the first uploaded file for `key` (caller `defer`s `Close()`); `Files`
@@ -306,38 +306,44 @@ negotiation — it inspects the request's own `Content-Type`, never the `Accept`
 
 ### Options
 
-There is **one** `Option` type and one internal `config`, shared by every
-option-taking function (`DecodeJSON`, `RawBody`, `File`/`Files`, `ClientIP`,
-`QueryPage`, `QueryCursor`). Each such function starts from its own per-function
-defaults, applies the supplied options, and reads only the fields it cares about, so an
-option that doesn't apply to a given function (e.g. `AllowUnknownFields` on `RawBody`)
-is a harmless no-op. The accessor families (`Query`, `Path`, …) take no options.
+Options are **split by concern into three types**, each with its own internal config,
+so a function accepts only the options that apply to it — passing a pagination option to
+`DecodeJSON` is a **compile error**, not a silent no-op:
 
 ```go
-type Option func(*config)
+type BodyOption     func(*bodyConfig)     // DecodeJSON, RawBody, File, Files
+type ClientIPOption func(*clientIPConfig) // ClientIP
+type PageOption     func(*pageConfig)     // QueryPage, QueryCursor
 
-// Body (DecodeJSON / RawBody / File / Files)
-func WithMaxBytes(n int64) Option   // raise/lower the cap; n <= 0 disables the limit
-func AllowUnknownFields() Option    // turn off DisallowUnknownFields (DecodeJSON)
-func SkipContentType() Option       // accept any/absent Content-Type (DecodeJSON)
+// BodyOption
+func WithMaxBytes(n int64) BodyOption    // all body readers; n <= 0 disables the limit
+func AllowUnknownFields() BodyOption     // DecodeJSON only
+func SkipContentType() BodyOption        // DecodeJSON only
 
-// ClientIP
-func WithClientIPHeaders(names ...string) Option
-func WithTrustedProxies(prefixes ...netip.Prefix) Option
+// ClientIPOption
+func WithClientIPHeaders(names ...string) ClientIPOption
+func WithTrustedProxies(prefixes ...netip.Prefix) ClientIPOption
 
-// Pagination
-func WithPageParams(pageKey, sizeKey string) Option
-func WithDefaultPageSize(n int) Option
-func WithMaxPageSize(n int) Option
-func WithCursorParams(cursorKey, limitKey string) Option
+// PageOption
+func WithPageParams(pageKey, sizeKey string) PageOption
+func WithDefaultPageSize(n int) PageOption
+func WithMaxPageSize(n int) PageOption
+func WithCursorParams(cursorKey, limitKey string) PageOption
 ```
 
-Functional options, no builder (per project convention).
+Each function applies its options to a fresh per-call config seeded with that
+function's defaults. Functional options, no builder (per project convention). The
+accessor families (`Query`, `Path`, …) take no options.
+
+`WithMaxBytes` applies to every body reader; `AllowUnknownFields` and `SkipContentType`
+are `BodyOption`s that only `DecodeJSON` consults (`RawBody`/`File` read the size cap
+and ignore the rest — the one residual no-op left inside the body group, which is the
+reason these three share `BodyOption` rather than splitting further per body function).
 
 ## `ClientIP` — real-client-IP resolution
 
 ```go
-func ClientIP(r *http.Request, opts ...Option) string   // "" if nothing parses
+func ClientIP(r *http.Request, opts ...ClientIPOption) string   // "" if nothing parses
 ```
 
 **Default (best-effort):** scan well-known headers in priority order, take the first
@@ -350,8 +356,8 @@ value that parses as an IP (`netip.ParseAddr`), else fall back to the host of
 **Options:**
 
 ```go
-func WithClientIPHeaders(names ...string) Option        // replace the priority list
-func WithTrustedProxies(prefixes ...netip.Prefix) Option // correct XFF resolution
+func WithClientIPHeaders(names ...string) ClientIPOption        // replace the priority list
+func WithTrustedProxies(prefixes ...netip.Prefix) ClientIPOption // correct XFF resolution
 ```
 
 - `WithClientIPHeaders` is the **secure pattern for a known CDN**: pin to exactly the
@@ -374,13 +380,13 @@ type Page struct {
 	Size   int // page size
 	Offset int // derived: (Number - 1) * Size
 }
-func QueryPage(r *http.Request, opts ...Option) (Page, error)
+func QueryPage(r *http.Request, opts ...PageOption) (Page, error)
 
 type Cursor struct {
 	Value string // opaque token, passed through verbatim
 	Limit int
 }
-func QueryCursor(r *http.Request, opts ...Option) (Cursor, error)
+func QueryCursor(r *http.Request, opts ...PageOption) (Cursor, error)
 ```
 
 - `QueryPage` reads `page` + `per_page`; defaults: page 1, size 20. Options:

--- a/request/body.go
+++ b/request/body.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"mime/multipart"
 	"net/http"
 	"strings"
 )
@@ -122,4 +123,62 @@ func DecodeJSON(r *http.Request, dst any, opts ...BodyOption) error {
 // Content-Type, not the Accept header — it is not content negotiation.
 func IsContentType(r *http.Request, media string) bool {
 	return matchesMediaType(r.Header.Get("Content-Type"), media)
+}
+
+// RawBody reads the entire request body into a byte slice under the configured
+// size cap (default 1 MiB; overflow -> 413). For webhook HMAC verification and
+// arbitrary payloads. No Content-Type check.
+func RawBody(r *http.Request, opts ...BodyOption) ([]byte, error) {
+	c := newBodyConfig(opts)
+	b, err := io.ReadAll(limitedBody(r, c))
+	if err != nil {
+		return nil, decodeError(err)
+	}
+	return b, nil
+}
+
+// File returns the first uploaded file for key. The caller must Close the returned
+// multipart.File. A non-multipart request -> 415; a missing file -> 400.
+func File(r *http.Request, key string, opts ...BodyOption) (multipart.File, *multipart.FileHeader, error) {
+	if err := parseMultipart(r, opts); err != nil {
+		return nil, nil, err
+	}
+	f, h, err := r.FormFile(key)
+	if err != nil {
+		return nil, nil, &Error{Source: SourceForm, Key: key, Kind: KindMalformed, Err: err}
+	}
+	return f, h, nil
+}
+
+// Files returns every uploaded file header for key (open each via fh.Open()).
+func Files(r *http.Request, key string, opts ...BodyOption) ([]*multipart.FileHeader, error) {
+	if err := parseMultipart(r, opts); err != nil {
+		return nil, err
+	}
+	var headers []*multipart.FileHeader
+	if r.MultipartForm != nil && r.MultipartForm.File != nil {
+		headers = r.MultipartForm.File[key]
+	}
+	if len(headers) == 0 {
+		return nil, &Error{Source: SourceForm, Key: key, Kind: KindMalformed, Err: errors.New("no file for key")}
+	}
+	return headers, nil
+}
+
+// parseMultipart parses the multipart form, using the configured in-memory cap
+// (default 32 MiB). A non-multipart body maps to KindUnsupportedMediaType.
+func parseMultipart(r *http.Request, opts []BodyOption) error {
+	c := newBodyConfig(opts)
+	mem := int64(defaultMultipartMemory)
+	if c.maxBytesSet && c.maxBytes > 0 {
+		mem = c.maxBytes
+	}
+	if err := r.ParseMultipartForm(mem); err != nil {
+		kind := KindInvalidBody
+		if errors.Is(err, http.ErrNotMultipart) {
+			kind = KindUnsupportedMediaType
+		}
+		return &Error{Source: SourceBody, Kind: kind, Err: err}
+	}
+	return nil
 }

--- a/request/body.go
+++ b/request/body.go
@@ -97,11 +97,13 @@ func decodeError(err error) error {
 func DecodeJSON(r *http.Request, dst any, opts ...BodyOption) error {
 	c := newBodyConfig(opts)
 
-	if !c.skipCType && !matchesMediaType(r.Header.Get("Content-Type"), "application/json") {
-		return &Error{
-			Source: SourceBody,
-			Kind:   KindUnsupportedMediaType,
-			Err:    fmt.Errorf("content-type %q is not application/json", r.Header.Get("Content-Type")),
+	if !c.skipCType {
+		if ct := r.Header.Get("Content-Type"); !matchesMediaType(ct, "application/json") {
+			return &Error{
+				Source: SourceBody,
+				Kind:   KindUnsupportedMediaType,
+				Err:    fmt.Errorf("content-type %q is not application/json", ct),
+			}
 		}
 	}
 
@@ -160,7 +162,9 @@ func Files(r *http.Request, key string, opts ...BodyOption) ([]*multipart.FileHe
 		headers = r.MultipartForm.File[key]
 	}
 	if len(headers) == 0 {
-		return nil, &Error{Source: SourceForm, Key: key, Kind: KindMalformed, Err: errors.New("no file for key")}
+		// http.ErrMissingFile mirrors what File (via r.FormFile) returns, so callers
+		// can errors.Is(err, http.ErrMissingFile) for either.
+		return nil, &Error{Source: SourceForm, Key: key, Kind: KindMalformed, Err: http.ErrMissingFile}
 	}
 	return headers, nil
 }

--- a/request/body.go
+++ b/request/body.go
@@ -140,19 +140,27 @@ func RawBody(r *http.Request, opts ...BodyOption) ([]byte, error) {
 }
 
 // File returns the first uploaded file for key. The caller must Close the returned
-// multipart.File. A non-multipart request -> 415; a missing file -> 400.
+// multipart.File. A non-multipart request -> 415. An absent key -> 400 with Kind
+// KindMissing and Err http.ErrMissingFile (use errors.Is(err, http.ErrMissingFile)
+// to distinguish absence from a bad upload, which is KindMalformed).
 func File(r *http.Request, key string, opts ...BodyOption) (multipart.File, *multipart.FileHeader, error) {
 	if err := parseMultipart(r, opts); err != nil {
 		return nil, nil, err
 	}
 	f, h, err := r.FormFile(key)
 	if err != nil {
-		return nil, nil, &Error{Source: SourceForm, Key: key, Kind: KindMalformed, Err: err}
+		kind := KindMalformed
+		if errors.Is(err, http.ErrMissingFile) {
+			kind = KindMissing // absent key, not an unparseable value
+		}
+		return nil, nil, &Error{Source: SourceForm, Key: key, Kind: kind, Err: err}
 	}
 	return f, h, nil
 }
 
-// Files returns every uploaded file header for key (open each via fh.Open()).
+// Files returns every uploaded file header for key (open each via fh.Open()). An
+// absent key -> 400 with Kind KindMissing and Err http.ErrMissingFile, mirroring
+// File so callers can errors.Is(err, http.ErrMissingFile) for either.
 func Files(r *http.Request, key string, opts ...BodyOption) ([]*multipart.FileHeader, error) {
 	if err := parseMultipart(r, opts); err != nil {
 		return nil, err
@@ -162,9 +170,7 @@ func Files(r *http.Request, key string, opts ...BodyOption) ([]*multipart.FileHe
 		headers = r.MultipartForm.File[key]
 	}
 	if len(headers) == 0 {
-		// http.ErrMissingFile mirrors what File (via r.FormFile) returns, so callers
-		// can errors.Is(err, http.ErrMissingFile) for either.
-		return nil, &Error{Source: SourceForm, Key: key, Kind: KindMalformed, Err: http.ErrMissingFile}
+		return nil, &Error{Source: SourceForm, Key: key, Kind: KindMissing, Err: http.ErrMissingFile}
 	}
 	return headers, nil
 }

--- a/request/body.go
+++ b/request/body.go
@@ -1,0 +1,125 @@
+package request
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+const (
+	defaultMaxBytes        = 1 << 20  // 1 MiB — DecodeJSON / RawBody body cap
+	defaultMultipartMemory = 32 << 20 // 32 MiB — File / Files in-memory cap
+)
+
+type bodyConfig struct {
+	maxBytes     int64
+	maxBytesSet  bool
+	allowUnknown bool
+	skipCType    bool
+}
+
+// BodyOption configures DecodeJSON, RawBody, File, and Files.
+type BodyOption func(*bodyConfig)
+
+// WithMaxBytes sets the body size cap for every body reader; n <= 0 disables the
+// limit for DecodeJSON/RawBody (and falls back to 32 MiB for File/Files memory).
+func WithMaxBytes(n int64) BodyOption {
+	return func(c *bodyConfig) { c.maxBytes = n; c.maxBytesSet = true }
+}
+
+// AllowUnknownFields turns off DisallowUnknownFields (DecodeJSON only).
+func AllowUnknownFields() BodyOption {
+	return func(c *bodyConfig) { c.allowUnknown = true }
+}
+
+// SkipContentType accepts any/absent Content-Type (DecodeJSON only).
+func SkipContentType() BodyOption {
+	return func(c *bodyConfig) { c.skipCType = true }
+}
+
+func newBodyConfig(opts []BodyOption) bodyConfig {
+	var c bodyConfig
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// limitedBody wraps r.Body in a MaxBytesReader using the config's cap (default
+// 1 MiB; a non-positive explicit cap disables the limit). The nil ResponseWriter
+// is fine: MaxBytesReader only type-asserts w to signal the server, which we don't
+// need here.
+func limitedBody(r *http.Request, c bodyConfig) io.ReadCloser {
+	limit := int64(defaultMaxBytes)
+	if c.maxBytesSet {
+		limit = c.maxBytes
+	}
+	if limit <= 0 {
+		return r.Body
+	}
+	return http.MaxBytesReader(nil, r.Body, limit)
+}
+
+// matchesMediaType reports whether header's media type equals media
+// (case-insensitive, parameters ignored).
+func matchesMediaType(header, media string) bool {
+	if header == "" {
+		return false
+	}
+	got, _, err := mime.ParseMediaType(header)
+	if err != nil {
+		return false
+	}
+	want, _, err := mime.ParseMediaType(media)
+	if err != nil {
+		want = media
+	}
+	return strings.EqualFold(got, want)
+}
+
+// decodeError classifies a body read/decode failure: an *http.MaxBytesError maps
+// to KindTooLarge, anything else to KindInvalidBody.
+func decodeError(err error) error {
+	if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+		return &Error{Source: SourceBody, Kind: KindTooLarge, Err: err}
+	}
+	return &Error{Source: SourceBody, Kind: KindInvalidBody, Err: err}
+}
+
+// DecodeJSON strictly decodes the JSON request body into dst. Defaults: 1 MiB cap
+// (-> 413), require Content-Type application/json (-> 415), DisallowUnknownFields
+// and reject trailing data and empty bodies (-> 400). Override with options.
+func DecodeJSON(r *http.Request, dst any, opts ...BodyOption) error {
+	c := newBodyConfig(opts)
+
+	if !c.skipCType && !matchesMediaType(r.Header.Get("Content-Type"), "application/json") {
+		return &Error{
+			Source: SourceBody,
+			Kind:   KindUnsupportedMediaType,
+			Err:    fmt.Errorf("content-type %q is not application/json", r.Header.Get("Content-Type")),
+		}
+	}
+
+	dec := json.NewDecoder(limitedBody(r, c))
+	if !c.allowUnknown {
+		dec.DisallowUnknownFields()
+	}
+	if err := dec.Decode(dst); err != nil {
+		return decodeError(err)
+	}
+	if dec.More() {
+		return &Error{Source: SourceBody, Kind: KindInvalidBody, Err: errors.New("unexpected data after JSON value")}
+	}
+	return nil
+}
+
+// IsContentType reports whether the request's Content-Type media type equals media
+// (case-insensitive, parameters ignored). It inspects the request's own
+// Content-Type, not the Accept header — it is not content negotiation.
+func IsContentType(r *http.Request, media string) bool {
+	return matchesMediaType(r.Header.Get("Content-Type"), media)
+}

--- a/request/body_files_test.go
+++ b/request/body_files_test.go
@@ -1,0 +1,87 @@
+package request_test
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/request"
+)
+
+func multipartReq(t *testing.T, field, filename, content string) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile(field, filename)
+	require.NoError(t, err)
+	_, err = fw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
+
+	r := httptest.NewRequest(http.MethodPost, "/", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	return r
+}
+
+func TestRawBody(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("hello"))
+	b, err := request.RawBody(r)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(b))
+}
+
+func TestRawBodyTooLarge(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("0123456789"))
+	_, err := request.RawBody(r, request.WithMaxBytes(4))
+	require.Error(t, err)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, request.StatusCode(err))
+}
+
+func TestFile(t *testing.T) {
+	t.Parallel()
+	r := multipartReq(t, "doc", "a.txt", "filedata")
+
+	f, h, err := request.File(r, "doc")
+	require.NoError(t, err)
+	defer f.Close()
+
+	assert.Equal(t, "a.txt", h.Filename)
+	data, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, "filedata", string(data))
+}
+
+func TestFileMissing(t *testing.T) {
+	t.Parallel()
+	r := multipartReq(t, "other", "x.txt", "x")
+	_, _, err := request.File(r, "doc")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestFileNonMultipart(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("x"))
+	r.Header.Set("Content-Type", "application/json")
+	_, _, err := request.File(r, "doc")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnsupportedMediaType, request.StatusCode(err))
+}
+
+func TestFiles(t *testing.T) {
+	t.Parallel()
+	r := multipartReq(t, "doc", "a.txt", "data")
+	headers, err := request.Files(r, "doc")
+	require.NoError(t, err)
+	require.Len(t, headers, 1)
+	assert.Equal(t, "a.txt", headers[0].Filename)
+}

--- a/request/body_files_test.go
+++ b/request/body_files_test.go
@@ -102,3 +102,15 @@ func TestFilesNonMultipart(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, http.StatusUnsupportedMediaType, request.StatusCode(err))
 }
+
+func TestFileFilesMissingSentinel(t *testing.T) {
+	t.Parallel()
+	// Both File and Files surface http.ErrMissingFile for a missing key.
+	r1 := multipartReq(t, "other", "x.txt", "x")
+	_, _, err := request.File(r1, "doc")
+	assert.ErrorIs(t, err, http.ErrMissingFile)
+
+	r2 := multipartReq(t, "other", "x.txt", "x")
+	_, err = request.Files(r2, "doc")
+	assert.ErrorIs(t, err, http.ErrMissingFile)
+}

--- a/request/body_files_test.go
+++ b/request/body_files_test.go
@@ -85,3 +85,20 @@ func TestFiles(t *testing.T) {
 	require.Len(t, headers, 1)
 	assert.Equal(t, "a.txt", headers[0].Filename)
 }
+
+func TestFilesMissing(t *testing.T) {
+	t.Parallel()
+	r := multipartReq(t, "other", "x.txt", "x")
+	_, err := request.Files(r, "doc")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestFilesNonMultipart(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("x"))
+	r.Header.Set("Content-Type", "application/json")
+	_, err := request.Files(r, "doc")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnsupportedMediaType, request.StatusCode(err))
+}

--- a/request/body_files_test.go
+++ b/request/body_files_test.go
@@ -114,3 +114,16 @@ func TestFileFilesMissingSentinel(t *testing.T) {
 	_, err = request.Files(r2, "doc")
 	assert.ErrorIs(t, err, http.ErrMissingFile)
 }
+
+func TestFileMissingKind(t *testing.T) {
+	t.Parallel()
+	r := multipartReq(t, "other", "x.txt", "x")
+	_, _, err := request.File(r, "doc")
+
+	var re *request.Error
+	require.ErrorAs(t, err, &re)
+	require.NotNil(t, re)
+	if re != nil {
+		assert.Equal(t, request.KindMissing, re.Kind) // absent, not malformed
+	}
+}

--- a/request/body_files_test.go
+++ b/request/body_files_test.go
@@ -52,7 +52,7 @@ func TestFile(t *testing.T) {
 
 	f, h, err := request.File(r, "doc")
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	assert.Equal(t, "a.txt", h.Filename)
 	data, err := io.ReadAll(f)

--- a/request/body_test.go
+++ b/request/body_test.go
@@ -1,0 +1,101 @@
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/request"
+)
+
+type payload struct {
+	Name string `json:"name"`
+}
+
+func jsonReq(body string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}
+
+func TestDecodeJSONHappy(t *testing.T) {
+	t.Parallel()
+	var p payload
+	require.NoError(t, request.DecodeJSON(jsonReq(`{"name":"ada"}`), &p))
+	assert.Equal(t, "ada", p.Name)
+}
+
+func TestDecodeJSONUnknownField(t *testing.T) {
+	t.Parallel()
+	var p payload
+	err := request.DecodeJSON(jsonReq(`{"name":"ada","extra":1}`), &p)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestDecodeJSONAllowUnknown(t *testing.T) {
+	t.Parallel()
+	var p payload
+	require.NoError(t, request.DecodeJSON(jsonReq(`{"name":"ada","extra":1}`), &p, request.AllowUnknownFields()))
+	assert.Equal(t, "ada", p.Name)
+}
+
+func TestDecodeJSONWrongContentType(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	r.Header.Set("Content-Type", "text/plain")
+	var p payload
+	err := request.DecodeJSON(r, &p)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnsupportedMediaType, request.StatusCode(err))
+}
+
+func TestDecodeJSONSkipContentType(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"x"}`))
+	// no Content-Type set
+	var p payload
+	require.NoError(t, request.DecodeJSON(r, &p, request.SkipContentType()))
+	assert.Equal(t, "x", p.Name)
+}
+
+func TestDecodeJSONTooLarge(t *testing.T) {
+	t.Parallel()
+	var p payload
+	big := `{"name":"` + strings.Repeat("x", 2000) + `"}`
+	err := request.DecodeJSON(jsonReq(big), &p, request.WithMaxBytes(100))
+	require.Error(t, err)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, request.StatusCode(err))
+}
+
+func TestDecodeJSONTrailingData(t *testing.T) {
+	t.Parallel()
+	var p payload
+	err := request.DecodeJSON(jsonReq(`{"name":"a"}{"name":"b"}`), &p)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestDecodeJSONEmpty(t *testing.T) {
+	t.Parallel()
+	var p payload
+	err := request.DecodeJSON(jsonReq(``), &p)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestIsContentType(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
+	r.Header.Set("Content-Type", "Application/JSON; charset=utf-8")
+	assert.True(t, request.IsContentType(r, "application/json"))
+	assert.False(t, request.IsContentType(r, "text/plain"))
+
+	bare := httptest.NewRequest(http.MethodGet, "/", nil)
+	assert.False(t, request.IsContentType(bare, "application/json"))
+}

--- a/request/body_test.go
+++ b/request/body_test.go
@@ -99,3 +99,11 @@ func TestIsContentType(t *testing.T) {
 	bare := httptest.NewRequest(http.MethodGet, "/", nil)
 	assert.False(t, request.IsContentType(bare, "application/json"))
 }
+
+func TestDecodeJSONMaxBytesZeroDisablesLimit(t *testing.T) {
+	t.Parallel()
+	var p payload
+	big := `{"name":"` + strings.Repeat("x", (1<<20)+1) + `"}` // exceeds the default 1 MiB cap
+	require.NoError(t, request.DecodeJSON(jsonReq(big), &p, request.WithMaxBytes(0)))
+	assert.Len(t, p.Name, (1<<20)+1)
+}

--- a/request/clientip.go
+++ b/request/clientip.go
@@ -151,16 +151,15 @@ func validIP(s string) string {
 	return addr.String()
 }
 
-// remoteHost returns the host portion of a RemoteAddr ("ip:port" or bare ip).
+// remoteHost returns the IP from a RemoteAddr ("ip:port" or bare ip), or "" if it
+// does not parse as an IP.
 func remoteHost(addr string) string {
-	if host, _, err := net.SplitHostPort(addr); err == nil {
-		if a, err := netip.ParseAddr(host); err == nil {
-			return a.String()
-		}
-		return host
+	host := addr
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		host = h
 	}
-	if a, err := netip.ParseAddr(addr); err == nil {
+	if a, err := netip.ParseAddr(host); err == nil {
 		return a.String()
 	}
-	return addr
+	return ""
 }

--- a/request/clientip.go
+++ b/request/clientip.go
@@ -26,7 +26,8 @@ func WithClientIPHeaders(names ...string) ClientIPOption {
 
 // WithTrustedProxies switches to spoof-resistant X-Forwarded-For resolution: the
 // chain (XFF entries plus RemoteAddr) is walked right-to-left, trusted hops are
-// skipped, and the first untrusted address is returned.
+// skipped, and the first untrusted address is returned. Only X-Forwarded-For is
+// consulted in this mode; the RFC 7239 Forwarded header is not parsed here.
 func WithTrustedProxies(prefixes ...netip.Prefix) ClientIPOption {
 	return func(c *clientIPConfig) { c.trusted = prefixes; c.useTrusted = true }
 }

--- a/request/clientip.go
+++ b/request/clientip.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"slices"
 	"strings"
 )
 
@@ -88,8 +89,8 @@ func clientIPTrusted(r *http.Request, trusted []netip.Prefix) string {
 	}
 	chain = append(chain, r.RemoteAddr)
 
-	for i := len(chain) - 1; i >= 0; i-- {
-		ip := validIP(chain[i])
+	for _, hop := range slices.Backward(chain) {
+		ip := validIP(hop)
 		if ip == "" {
 			continue
 		}

--- a/request/clientip.go
+++ b/request/clientip.go
@@ -121,10 +121,7 @@ func isTrusted(addr netip.Addr, trusted []netip.Prefix) bool {
 
 // forwardedFor returns the IP from the first "for=" directive of a Forwarded header.
 func forwardedFor(v string) string {
-	first := v
-	if i := strings.IndexByte(v, ','); i >= 0 {
-		first = v[:i]
-	}
+	first, _, _ := strings.Cut(v, ",")
 	for kv := range strings.SplitSeq(first, ";") {
 		key, val, ok := strings.Cut(strings.TrimSpace(kv), "=")
 		if !ok || !strings.EqualFold(strings.TrimSpace(key), "for") {

--- a/request/clientip.go
+++ b/request/clientip.go
@@ -1,0 +1,168 @@
+package request
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+type clientIPConfig struct {
+	headers    []string
+	trusted    []netip.Prefix
+	useTrusted bool
+}
+
+// ClientIPOption configures ClientIP.
+type ClientIPOption func(*clientIPConfig)
+
+// WithClientIPHeaders replaces the header priority list scanned in best-effort
+// mode. The secure pattern for a known CDN is to pin the single header the edge
+// always sets and strips on ingress, e.g. WithClientIPHeaders("CF-Connecting-IP").
+func WithClientIPHeaders(names ...string) ClientIPOption {
+	return func(c *clientIPConfig) { c.headers = names }
+}
+
+// WithTrustedProxies switches to spoof-resistant X-Forwarded-For resolution: the
+// chain (XFF entries plus RemoteAddr) is walked right-to-left, trusted hops are
+// skipped, and the first untrusted address is returned.
+func WithTrustedProxies(prefixes ...netip.Prefix) ClientIPOption {
+	return func(c *clientIPConfig) { c.trusted = prefixes; c.useTrusted = true }
+}
+
+// ClientIP returns the best guess at the originating client IP, or "" if nothing
+// parses. By default it scans well-known CDN/proxy headers in priority order and
+// falls back to RemoteAddr. The default mode trusts client-supplied headers and is
+// spoofable; use WithTrustedProxies or a pinned header for auth/rate-limiting.
+func ClientIP(r *http.Request, opts ...ClientIPOption) string {
+	// Best-effort scan order. Trusting these is spoofable unless the service sits
+	// behind a proxy that overwrites them.
+	c := clientIPConfig{headers: []string{
+		"CF-Connecting-IP",
+		"True-Client-IP",
+		"Fastly-Client-IP",
+		"X-Real-IP",
+		"Forwarded",
+		"X-Forwarded-For",
+	}}
+	for _, o := range opts {
+		o(&c)
+	}
+
+	if c.useTrusted {
+		return clientIPTrusted(r, c.trusted)
+	}
+	for _, name := range c.headers {
+		if ip := headerIP(r, name); ip != "" {
+			return ip
+		}
+	}
+	return remoteHost(r.RemoteAddr)
+}
+
+// headerIP extracts the first valid IP from header name. Forwarded uses RFC 7239
+// for= parsing; every other header is treated as a comma list, first valid wins.
+func headerIP(r *http.Request, name string) string {
+	raw := r.Header.Get(name)
+	if raw == "" {
+		return ""
+	}
+	if strings.EqualFold(name, "Forwarded") {
+		return forwardedFor(raw)
+	}
+	for part := range strings.SplitSeq(raw, ",") {
+		if ip := validIP(part); ip != "" {
+			return ip
+		}
+	}
+	return ""
+}
+
+// clientIPTrusted walks the XFF chain (then RemoteAddr) right-to-left and returns
+// the first address not inside a trusted prefix. If all hops are trusted, the
+// left-most chain entry (closest to the originating client) is returned.
+func clientIPTrusted(r *http.Request, trusted []netip.Prefix) string {
+	var chain []string
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		chain = strings.Split(xff, ",")
+	}
+	chain = append(chain, r.RemoteAddr)
+
+	for i := len(chain) - 1; i >= 0; i-- {
+		ip := validIP(chain[i])
+		if ip == "" {
+			continue
+		}
+		addr, err := netip.ParseAddr(ip)
+		if err != nil {
+			continue
+		}
+		if isTrusted(addr, trusted) {
+			continue
+		}
+		return ip
+	}
+	if len(chain) > 0 {
+		if ip := validIP(chain[0]); ip != "" {
+			return ip
+		}
+	}
+	return remoteHost(r.RemoteAddr)
+}
+
+func isTrusted(addr netip.Addr, trusted []netip.Prefix) bool {
+	for _, p := range trusted {
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// forwardedFor returns the IP from the first "for=" directive of a Forwarded header.
+func forwardedFor(v string) string {
+	first := v
+	if i := strings.IndexByte(v, ','); i >= 0 {
+		first = v[:i]
+	}
+	for kv := range strings.SplitSeq(first, ";") {
+		key, val, ok := strings.Cut(strings.TrimSpace(kv), "=")
+		if !ok || !strings.EqualFold(strings.TrimSpace(key), "for") {
+			continue
+		}
+		return validIP(strings.Trim(strings.TrimSpace(val), `"`))
+	}
+	return ""
+}
+
+// validIP normalizes s (which may carry a port or brackets) to a bare IP string,
+// or "" if it is not a valid address.
+func validIP(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(s); err == nil {
+		s = host
+	}
+	s = strings.Trim(s, "[]")
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return ""
+	}
+	return addr.String()
+}
+
+// remoteHost returns the host portion of a RemoteAddr ("ip:port" or bare ip).
+func remoteHost(addr string) string {
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		if a, err := netip.ParseAddr(host); err == nil {
+			return a.String()
+		}
+		return host
+	}
+	if a, err := netip.ParseAddr(addr); err == nil {
+		return a.String()
+	}
+	return addr
+}

--- a/request/clientip.go
+++ b/request/clientip.go
@@ -149,7 +149,10 @@ func validIP(s string) string {
 	if err != nil {
 		return ""
 	}
-	return addr.String()
+	// Unmap normalizes an IPv4-mapped IPv6 address (::ffff:a.b.c.d, as a dual-stack
+	// listener reports IPv4 peers) to plain IPv4, so the string is clean and IPv4
+	// trusted-proxy prefixes match.
+	return addr.Unmap().String()
 }
 
 // remoteHost returns the IP from a RemoteAddr ("ip:port" or bare ip), or "" if it
@@ -160,7 +163,7 @@ func remoteHost(addr string) string {
 		host = h
 	}
 	if a, err := netip.ParseAddr(host); err == nil {
-		return a.String()
+		return a.Unmap().String()
 	}
 	return ""
 }

--- a/request/clientip_test.go
+++ b/request/clientip_test.go
@@ -1,0 +1,63 @@
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/request"
+)
+
+func TestClientIPPriority(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1234"
+	r.Header.Set("X-Real-IP", "203.0.113.5")
+	r.Header.Set("CF-Connecting-IP", "198.51.100.7")
+	assert.Equal(t, "198.51.100.7", request.ClientIP(r)) // CF outranks X-Real-IP
+}
+
+func TestClientIPFallbackRemoteAddr(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "192.0.2.9:5555"
+	assert.Equal(t, "192.0.2.9", request.ClientIP(r))
+}
+
+func TestClientIPXFFFirstValid(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1"
+	r.Header.Set("X-Forwarded-For", "garbage, 203.0.113.5, 70.41.3.18")
+	assert.Equal(t, "203.0.113.5", request.ClientIP(r))
+}
+
+func TestClientIPForwarded(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1"
+	r.Header.Set("Forwarded", `for=192.0.2.60;proto=http, for=198.51.100.17`)
+	assert.Equal(t, "192.0.2.60", request.ClientIP(r))
+}
+
+func TestClientIPPinnedHeader(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1"
+	r.Header.Set("X-Forwarded-For", "1.2.3.4")
+	r.Header.Set("CF-Connecting-IP", "9.9.9.9")
+	// pin to a header that is absent -> ignore XFF/CF, fall back to RemoteAddr
+	assert.Equal(t, "10.0.0.1", request.ClientIP(r, request.WithClientIPHeaders("X-Real-IP")))
+}
+
+func TestClientIPTrustedProxies(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1" // trusted hop
+	r.Header.Set("X-Forwarded-For", "203.0.113.5, 10.0.0.2")
+	trusted := netip.MustParsePrefix("10.0.0.0/8")
+	assert.Equal(t, "203.0.113.5", request.ClientIP(r, request.WithTrustedProxies(trusted)))
+}

--- a/request/clientip_test.go
+++ b/request/clientip_test.go
@@ -78,3 +78,13 @@ func TestClientIPAllTrusted(t *testing.T) {
 	// every hop is trusted -> fall back to the left-most (original client)
 	assert.Equal(t, "10.1.1.1", request.ClientIP(r, request.WithTrustedProxies(trusted)))
 }
+
+func TestClientIPTrustedIgnoresForwarded(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "203.0.113.9:443"
+	r.Header.Set("Forwarded", "for=198.51.100.1") // not consulted in trusted mode
+	trusted := netip.MustParsePrefix("10.0.0.0/8")
+	// no XFF; chain is just RemoteAddr (untrusted) -> returned, Forwarded ignored
+	assert.Equal(t, "203.0.113.9", request.ClientIP(r, request.WithTrustedProxies(trusted)))
+}

--- a/request/clientip_test.go
+++ b/request/clientip_test.go
@@ -68,3 +68,13 @@ func TestClientIPMalformedRemoteAddr(t *testing.T) {
 	r.RemoteAddr = "not-an-ip" // no usable headers, unparseable peer
 	assert.Equal(t, "", request.ClientIP(r))
 }
+
+func TestClientIPAllTrusted(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:1"
+	r.Header.Set("X-Forwarded-For", "10.1.1.1, 10.2.2.2")
+	trusted := netip.MustParsePrefix("10.0.0.0/8")
+	// every hop is trusted -> fall back to the left-most (original client)
+	assert.Equal(t, "10.1.1.1", request.ClientIP(r, request.WithTrustedProxies(trusted)))
+}

--- a/request/clientip_test.go
+++ b/request/clientip_test.go
@@ -61,3 +61,10 @@ func TestClientIPTrustedProxies(t *testing.T) {
 	trusted := netip.MustParsePrefix("10.0.0.0/8")
 	assert.Equal(t, "203.0.113.5", request.ClientIP(r, request.WithTrustedProxies(trusted)))
 }
+
+func TestClientIPMalformedRemoteAddr(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "not-an-ip" // no usable headers, unparseable peer
+	assert.Equal(t, "", request.ClientIP(r))
+}

--- a/request/clientip_test.go
+++ b/request/clientip_test.go
@@ -79,6 +79,45 @@ func TestClientIPAllTrusted(t *testing.T) {
 	assert.Equal(t, "10.1.1.1", request.ClientIP(r, request.WithTrustedProxies(trusted)))
 }
 
+func TestClientIPv6(t *testing.T) {
+	t.Parallel()
+
+	// RemoteAddr fallback: bracketed IPv6 + port.
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "[2001:db8::1]:443"
+	assert.Equal(t, "2001:db8::1", request.ClientIP(r))
+
+	// Bare IPv6 in a CDN header.
+	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2.RemoteAddr = "10.0.0.1:1"
+	r2.Header.Set("CF-Connecting-IP", "2001:db8::2")
+	assert.Equal(t, "2001:db8::2", request.ClientIP(r2))
+
+	// RFC 7239 Forwarded with a quoted, bracketed IPv6 + port.
+	r3 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r3.RemoteAddr = "10.0.0.1:1"
+	r3.Header.Set("Forwarded", `for="[2001:db8::3]:8080"`)
+	assert.Equal(t, "2001:db8::3", request.ClientIP(r3))
+
+	// Trusted-proxy walk with an IPv6 client behind an IPv6 proxy prefix.
+	r4 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r4.RemoteAddr = "[2001:db8:1::1]:1" // trusted proxy
+	r4.Header.Set("X-Forwarded-For", "2001:db8:abcd::5, 2001:db8:1::2")
+	trusted := netip.MustParsePrefix("2001:db8:1::/48")
+	assert.Equal(t, "2001:db8:abcd::5", request.ClientIP(r4, request.WithTrustedProxies(trusted)))
+
+	// IPv4-mapped IPv6 (dual-stack listener) normalizes to plain IPv4.
+	r5 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r5.RemoteAddr = "[::ffff:192.0.2.7]:443"
+	assert.Equal(t, "192.0.2.7", request.ClientIP(r5))
+
+	// ...and a v4-mapped proxy hop matches an IPv4 trusted prefix.
+	r6 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r6.RemoteAddr = "[::ffff:10.0.0.9]:1"
+	r6.Header.Set("X-Forwarded-For", "203.0.113.5, ::ffff:10.0.0.8")
+	assert.Equal(t, "203.0.113.5", request.ClientIP(r6, request.WithTrustedProxies(netip.MustParsePrefix("10.0.0.0/8"))))
+}
+
 func TestClientIPTrustedIgnoresForwarded(t *testing.T) {
 	t.Parallel()
 	r := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/request/cookie.go
+++ b/request/cookie.go
@@ -1,0 +1,28 @@
+package request
+
+import "net/http"
+
+// Cookie reads cookie key's value and converts it to T. A missing cookie is treated
+// as absent (zero value / default).
+func Cookie[T any](r *http.Request, key string, def ...T) (T, error) {
+	return resolve(SourceCookie, key, cookieValue(r, key), parse[T], def)
+}
+
+// CookieFunc is Cookie with a caller-supplied parser.
+func CookieFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error) {
+	return resolve(SourceCookie, key, cookieValue(r, key), parse, def)
+}
+
+// HasCookie reports whether cookie key is present.
+func HasCookie(r *http.Request, key string) bool {
+	_, err := r.Cookie(key)
+	return err == nil
+}
+
+func cookieValue(r *http.Request, key string) string {
+	c, err := r.Cookie(key)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}

--- a/request/doc.go
+++ b/request/doc.go
@@ -1,0 +1,25 @@
+// Package request provides small, stateless, reflection-free helpers for reading
+// data off an *http.Request into Go values: typed accessors for query, path,
+// header, cookie, and form values (Query, Path, Header, Cookie, FormValue and
+// their Func/Slice/Split variants), strict body decoding (DecodeJSON, RawBody,
+// multipart File/Files), and focused readers (BearerToken, ClientIP, presence
+// predicates, QueryPage/QueryCursor).
+//
+// The helpers are free functions — no constructor, no binder, no struct tags, no
+// global state. Each typed accessor returns the zero value of T and a nil error
+// when the key is absent, and a *request.Error only when a present value fails to
+// parse. request.StatusCode maps that error to the right HTTP status (400/413/415):
+//
+//	page, err := request.Query[int](r, "page", 1)
+//	if err != nil {
+//		render.JSON(w, request.StatusCode(err), apiErr{err.Error()})
+//		return
+//	}
+//
+// Custom types parse with no reflection: any type whose pointer implements
+// encoding.TextUnmarshaler (uuid.UUID, netip.Addr, time.Time, custom enums) works
+// through the generic engine; anything else can use the Func variants.
+//
+// request reads; the render package writes; the htmx package handles HX-* headers.
+// None imports another. Stdlib only.
+package request

--- a/request/errors.go
+++ b/request/errors.go
@@ -47,10 +47,10 @@ func (k Kind) String() string {
 // Error is the single error type returned by every request-reading helper. Source
 // and Key name the offending input; Kind drives StatusCode; Err is the cause.
 type Error struct {
+	Err    error
 	Source Source
 	Key    string
 	Kind   Kind
-	Err    error
 }
 
 // Error returns a single-line description; the wrapped cause is reached via Unwrap.

--- a/request/errors.go
+++ b/request/errors.go
@@ -1,0 +1,89 @@
+package request
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Source identifies which part of the request a value came from.
+type Source string
+
+const (
+	SourceQuery  Source = "query"
+	SourcePath   Source = "path"
+	SourceHeader Source = "header"
+	SourceCookie Source = "cookie"
+	SourceForm   Source = "form"
+	SourceBody   Source = "body"
+)
+
+// Kind classifies a request-reading failure so handlers can map it to a status.
+type Kind int
+
+const (
+	KindMalformed            Kind = iota // unparseable value           -> 400
+	KindTooLarge                         // body exceeded the size cap   -> 413
+	KindUnsupportedMediaType             // wrong/absent Content-Type    -> 415
+	KindInvalidBody                      // malformed/unknown-field JSON -> 400
+)
+
+// String returns a short human label for k.
+func (k Kind) String() string {
+	switch k {
+	case KindMalformed:
+		return "malformed"
+	case KindTooLarge:
+		return "too large"
+	case KindUnsupportedMediaType:
+		return "unsupported media type"
+	case KindInvalidBody:
+		return "invalid body"
+	default:
+		return "unknown"
+	}
+}
+
+// Error is the single error type returned by every request-reading helper. Source
+// and Key name the offending input; Kind drives StatusCode; Err is the cause.
+type Error struct {
+	Source Source
+	Key    string
+	Kind   Kind
+	Err    error
+}
+
+// Error returns a single-line description; the wrapped cause is reached via Unwrap.
+func (e *Error) Error() string {
+	loc := string(e.Source)
+	if e.Key != "" {
+		loc = fmt.Sprintf("%s %q", e.Source, e.Key)
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("request: %s: %s: %v", loc, e.Kind, e.Err)
+	}
+	return fmt.Sprintf("request: %s: %s", loc, e.Kind)
+}
+
+// Unwrap returns the wrapped cause so errors.Is/As reach it.
+func (e *Error) Unwrap() error { return e.Err }
+
+// StatusCode reports the HTTP status for err: a *Error maps by Kind
+// (400/413/415); any other non-nil error is 400; nil is 200.
+func StatusCode(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+	var e *Error
+	if errors.As(err, &e) {
+		switch e.Kind {
+		case KindTooLarge:
+			return http.StatusRequestEntityTooLarge
+		case KindUnsupportedMediaType:
+			return http.StatusUnsupportedMediaType
+		default:
+			return http.StatusBadRequest
+		}
+	}
+	return http.StatusBadRequest
+}

--- a/request/errors.go
+++ b/request/errors.go
@@ -26,6 +26,7 @@ const (
 	KindTooLarge                         // body exceeded the size cap   -> 413
 	KindUnsupportedMediaType             // wrong/absent Content-Type    -> 415
 	KindInvalidBody                      // malformed/unknown-field JSON -> 400
+	KindMissing                          // required input absent        -> 400
 )
 
 // String returns a short human label for k.
@@ -39,6 +40,8 @@ func (k Kind) String() string {
 		return "unsupported media type"
 	case KindInvalidBody:
 		return "invalid body"
+	case KindMissing:
+		return "missing"
 	default:
 		return "unknown"
 	}

--- a/request/errors.go
+++ b/request/errors.go
@@ -74,8 +74,7 @@ func StatusCode(err error) int {
 	if err == nil {
 		return http.StatusOK
 	}
-	var e *Error
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[*Error](err); ok {
 		switch e.Kind {
 		case KindTooLarge:
 			return http.StatusRequestEntityTooLarge

--- a/request/errors_test.go
+++ b/request/errors_test.go
@@ -46,3 +46,20 @@ func TestErrorStringAndUnwrap(t *testing.T) {
 	assert.Contains(t, e.Error(), "page")
 	assert.Contains(t, e.Error(), "malformed")
 }
+
+func TestErrorStringAllKinds(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		kind request.Kind
+		want string
+	}{
+		{request.KindMalformed, "malformed"},
+		{request.KindTooLarge, "too large"},
+		{request.KindUnsupportedMediaType, "unsupported media type"},
+		{request.KindInvalidBody, "invalid body"},
+	}
+	for _, tc := range cases {
+		e := &request.Error{Source: request.SourceBody, Kind: tc.kind, Err: errors.New("x")}
+		assert.Contains(t, e.Error(), tc.want)
+	}
+}

--- a/request/errors_test.go
+++ b/request/errors_test.go
@@ -5,8 +5,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/dmitrymomot/forge/request"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/request"
 )
 
 func TestStatusCode(t *testing.T) {

--- a/request/errors_test.go
+++ b/request/errors_test.go
@@ -23,6 +23,7 @@ func TestStatusCode(t *testing.T) {
 		{"too large is 413", &request.Error{Source: request.SourceBody, Kind: request.KindTooLarge}, http.StatusRequestEntityTooLarge},
 		{"unsupported media is 415", &request.Error{Source: request.SourceBody, Kind: request.KindUnsupportedMediaType}, http.StatusUnsupportedMediaType},
 		{"invalid body is 400", &request.Error{Source: request.SourceBody, Kind: request.KindInvalidBody}, http.StatusBadRequest},
+		{"missing is 400", &request.Error{Source: request.SourceForm, Key: "f", Kind: request.KindMissing}, http.StatusBadRequest},
 		{"plain error is 400", errors.New("other"), http.StatusBadRequest},
 	}
 
@@ -57,6 +58,7 @@ func TestErrorStringAllKinds(t *testing.T) {
 		{request.KindTooLarge, "too large"},
 		{request.KindUnsupportedMediaType, "unsupported media type"},
 		{request.KindInvalidBody, "invalid body"},
+		{request.KindMissing, "missing"},
 	}
 	for _, tc := range cases {
 		e := &request.Error{Source: request.SourceBody, Kind: tc.kind, Err: errors.New("x")}

--- a/request/errors_test.go
+++ b/request/errors_test.go
@@ -63,3 +63,9 @@ func TestErrorStringAllKinds(t *testing.T) {
 		assert.Contains(t, e.Error(), tc.want)
 	}
 }
+
+func TestErrorStringNoCause(t *testing.T) {
+	t.Parallel()
+	e := &request.Error{Source: request.SourcePath, Key: "id", Kind: request.KindMalformed}
+	assert.Equal(t, `request: path "id": malformed`, e.Error())
+}

--- a/request/errors_test.go
+++ b/request/errors_test.go
@@ -1,0 +1,47 @@
+package request_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/dmitrymomot/forge/request"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil is 200", nil, http.StatusOK},
+		{"malformed is 400", &request.Error{Source: request.SourceQuery, Key: "p", Kind: request.KindMalformed}, http.StatusBadRequest},
+		{"too large is 413", &request.Error{Source: request.SourceBody, Kind: request.KindTooLarge}, http.StatusRequestEntityTooLarge},
+		{"unsupported media is 415", &request.Error{Source: request.SourceBody, Kind: request.KindUnsupportedMediaType}, http.StatusUnsupportedMediaType},
+		{"invalid body is 400", &request.Error{Source: request.SourceBody, Kind: request.KindInvalidBody}, http.StatusBadRequest},
+		{"plain error is 400", errors.New("other"), http.StatusBadRequest},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, request.StatusCode(tc.err))
+		})
+	}
+}
+
+func TestErrorStringAndUnwrap(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("boom")
+	e := &request.Error{Source: request.SourceQuery, Key: "page", Kind: request.KindMalformed, Err: cause}
+
+	assert.ErrorIs(t, e, cause)
+	assert.Contains(t, e.Error(), "request:")
+	assert.Contains(t, e.Error(), "query")
+	assert.Contains(t, e.Error(), "page")
+	assert.Contains(t, e.Error(), "malformed")
+}

--- a/request/example_test.go
+++ b/request/example_test.go
@@ -1,0 +1,41 @@
+package request_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/request"
+)
+
+func ExampleQuery() {
+	r := httptest.NewRequest(http.MethodGet, "/search?page=2", nil)
+	page, _ := request.Query[int](r, "page", 1)
+	fmt.Println(page)
+	// Output: 2
+}
+
+func ExampleDecodeJSON() {
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"ada"}`))
+	r.Header.Set("Content-Type", "application/json")
+
+	var v struct {
+		Name string `json:"name"`
+	}
+	if err := request.DecodeJSON(r, &v); err != nil {
+		fmt.Println("status:", request.StatusCode(err))
+		return
+	}
+	fmt.Println(v.Name)
+	// Output: ada
+}
+
+func BenchmarkQueryInt(b *testing.B) {
+	r := httptest.NewRequest(http.MethodGet, "/?n=12345", nil)
+	b.ReportAllocs()
+	for range b.N {
+		_, _ = request.Query[int](r, "n")
+	}
+}

--- a/request/form.go
+++ b/request/form.go
@@ -1,0 +1,42 @@
+package request
+
+import "net/http"
+
+// FormValue reads body form field key (POST/PUT/PATCH) and converts it to T. It
+// reads only the request body, never the URL query.
+func FormValue[T any](r *http.Request, key string, def ...T) (T, error) {
+	return resolve(SourceForm, key, r.PostFormValue(key), parse[T], def)
+}
+
+// FormValueFunc is FormValue with a caller-supplied parser.
+func FormValueFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error) {
+	return resolve(SourceForm, key, r.PostFormValue(key), parse, def)
+}
+
+// FormSlice reads every repeated body value of key and parses each into T.
+func FormSlice[T any](r *http.Request, key string, def ...[]T) ([]T, error) {
+	_ = r.ParseForm()
+	return resolveSlice(SourceForm, key, r.PostForm[key], parse[T], def)
+}
+
+// FormSliceFunc is FormSlice with a caller-supplied element parser.
+func FormSliceFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...[]T) ([]T, error) {
+	_ = r.ParseForm()
+	return resolveSlice(SourceForm, key, r.PostForm[key], parse, def)
+}
+
+// FormSplit reads a single delimited body value, splitting on sep.
+func FormSplit[T any](r *http.Request, key, sep string, def ...[]T) ([]T, error) {
+	return resolveSplit(SourceForm, key, r.PostFormValue(key), sep, parse[T], def)
+}
+
+// FormSplitFunc is FormSplit with a caller-supplied element parser.
+func FormSplitFunc[T any](r *http.Request, key, sep string, parse func(string) (T, error), def ...[]T) ([]T, error) {
+	return resolveSplit(SourceForm, key, r.PostFormValue(key), sep, parse, def)
+}
+
+// HasForm reports whether body form field key is present.
+func HasForm(r *http.Request, key string) bool {
+	_ = r.ParseForm()
+	return r.PostForm.Has(key)
+}

--- a/request/form.go
+++ b/request/form.go
@@ -15,13 +15,13 @@ func FormValueFunc[T any](r *http.Request, key string, parse func(string) (T, er
 
 // FormSlice reads every repeated body value of key and parses each into T.
 func FormSlice[T any](r *http.Request, key string, def ...[]T) ([]T, error) {
-	_ = r.ParseForm()
+	_ = r.ParseForm() // best-effort: a broken/absent body reads as no values (like net/http)
 	return resolveSlice(SourceForm, key, r.PostForm[key], parse[T], def)
 }
 
 // FormSliceFunc is FormSlice with a caller-supplied element parser.
 func FormSliceFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...[]T) ([]T, error) {
-	_ = r.ParseForm()
+	_ = r.ParseForm() // best-effort: a broken/absent body reads as no values (like net/http)
 	return resolveSlice(SourceForm, key, r.PostForm[key], parse, def)
 }
 
@@ -37,6 +37,6 @@ func FormSplitFunc[T any](r *http.Request, key, sep string, parse func(string) (
 
 // HasForm reports whether body form field key is present.
 func HasForm(r *http.Request, key string) bool {
-	_ = r.ParseForm()
+	_ = r.ParseForm() // best-effort: a broken/absent body reads as no values (like net/http)
 	return r.PostForm.Has(key)
 }

--- a/request/form_test.go
+++ b/request/form_test.go
@@ -1,0 +1,60 @@
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/request"
+)
+
+func formReq(values url.Values) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(values.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return r
+}
+
+func TestFormValue(t *testing.T) {
+	t.Parallel()
+	r := formReq(url.Values{"age": {"30"}})
+
+	v, err := request.FormValue[int](r, "age")
+	require.NoError(t, err)
+	assert.Equal(t, 30, v)
+	assert.True(t, request.HasForm(r, "age"))
+	assert.False(t, request.HasForm(r, "missing"))
+}
+
+func TestFormSlice(t *testing.T) {
+	t.Parallel()
+	r := formReq(url.Values{"tag": {"a", "b"}})
+
+	v, err := request.FormSlice[string](r, "tag")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, v)
+}
+
+func TestFormSplit(t *testing.T) {
+	t.Parallel()
+	r := formReq(url.Values{"ids": {"1, 2 ,3"}})
+
+	v, err := request.FormSplit[int](r, "ids", ",")
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3}, v)
+}
+
+func TestFormNotMergedWithQuery(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "/?age=99",
+		strings.NewReader(url.Values{"age": {"30"}}.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	v, err := request.FormValue[int](r, "age")
+	require.NoError(t, err)
+	assert.Equal(t, 30, v) // body value, not the query's 99
+}

--- a/request/form_test.go
+++ b/request/form_test.go
@@ -58,3 +58,29 @@ func TestFormNotMergedWithQuery(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 30, v) // body value, not the query's 99
 }
+
+func TestFormValueMalformed(t *testing.T) {
+	t.Parallel()
+	r := formReq(url.Values{"age": {"not-a-number"}})
+
+	_, err := request.FormValue[int](r, "age")
+	require.Error(t, err)
+
+	var re *request.Error
+	require.ErrorAs(t, err, &re)
+	require.NotNil(t, re)
+	if re != nil {
+		assert.Equal(t, request.SourceForm, re.Source)
+		assert.Equal(t, request.KindMalformed, re.Kind)
+		assert.Equal(t, "age", re.Key)
+	}
+}
+
+func TestFormValueAbsentDefault(t *testing.T) {
+	t.Parallel()
+	r := formReq(url.Values{})
+
+	v, err := request.FormValue[int](r, "age", 9)
+	require.NoError(t, err)
+	assert.Equal(t, 9, v)
+}

--- a/request/header.go
+++ b/request/header.go
@@ -21,7 +21,8 @@ func HasHeader(r *http.Request, key string) bool {
 }
 
 // BearerToken returns the token from an Authorization: Bearer <token> header, or
-// "" and false if the header is absent or not a Bearer credential.
+// "" and false if the header is absent or not a Bearer credential. The scheme is
+// matched case-insensitively and surrounding whitespace is trimmed from the token.
 func BearerToken(r *http.Request) (string, bool) {
 	const prefix = "Bearer "
 	auth := r.Header.Get("Authorization")

--- a/request/header.go
+++ b/request/header.go
@@ -15,9 +15,10 @@ func HeaderFunc[T any](r *http.Request, key string, parse func(string) (T, error
 	return resolve(SourceHeader, key, r.Header.Get(key), parse, def)
 }
 
-// HasHeader reports whether header key is present and non-empty.
+// HasHeader reports whether header key is present (even with an empty value),
+// consistent with HasQuery/HasForm.
 func HasHeader(r *http.Request, key string) bool {
-	return r.Header.Get(key) != ""
+	return len(r.Header.Values(key)) > 0
 }
 
 // BearerToken returns the token from an Authorization: Bearer <token> header, or

--- a/request/header.go
+++ b/request/header.go
@@ -1,0 +1,36 @@
+package request
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Header reads request header key and converts it to T.
+func Header[T any](r *http.Request, key string, def ...T) (T, error) {
+	return resolve(SourceHeader, key, r.Header.Get(key), parse[T], def)
+}
+
+// HeaderFunc is Header with a caller-supplied parser.
+func HeaderFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error) {
+	return resolve(SourceHeader, key, r.Header.Get(key), parse, def)
+}
+
+// HasHeader reports whether header key is present and non-empty.
+func HasHeader(r *http.Request, key string) bool {
+	return r.Header.Get(key) != ""
+}
+
+// BearerToken returns the token from an Authorization: Bearer <token> header, or
+// "" and false if the header is absent or not a Bearer credential.
+func BearerToken(r *http.Request) (string, bool) {
+	const prefix = "Bearer "
+	auth := r.Header.Get("Authorization")
+	if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+		return "", false
+	}
+	token := strings.TrimSpace(auth[len(prefix):])
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}

--- a/request/pagination.go
+++ b/request/pagination.go
@@ -1,0 +1,99 @@
+package request
+
+import "net/http"
+
+// Page is offset-based pagination input. Offset is derived as (Number-1)*Size.
+type Page struct {
+	Number int
+	Size   int
+	Offset int
+}
+
+// Cursor is cursor-based pagination input. Value is an opaque token passed through
+// verbatim; decoding its payload is the caller's job.
+type Cursor struct {
+	Value string
+	Limit int
+}
+
+type pageConfig struct {
+	pageKey     string
+	sizeKey     string
+	cursorKey   string
+	limitKey    string
+	defaultSize int
+	maxSize     int
+}
+
+// PageOption configures QueryPage and QueryCursor.
+type PageOption func(*pageConfig)
+
+// WithPageParams sets the query parameter names for page number and size.
+func WithPageParams(pageKey, sizeKey string) PageOption {
+	return func(c *pageConfig) { c.pageKey = pageKey; c.sizeKey = sizeKey }
+}
+
+// WithCursorParams sets the query parameter names for cursor and limit.
+func WithCursorParams(cursorKey, limitKey string) PageOption {
+	return func(c *pageConfig) { c.cursorKey = cursorKey; c.limitKey = limitKey }
+}
+
+// WithDefaultPageSize sets the size/limit used when the parameter is absent.
+func WithDefaultPageSize(n int) PageOption {
+	return func(c *pageConfig) { c.defaultSize = n }
+}
+
+// WithMaxPageSize sets the upper bound that size/limit is clamped to.
+func WithMaxPageSize(n int) PageOption {
+	return func(c *pageConfig) { c.maxSize = n }
+}
+
+func newPageConfig(opts []PageOption) pageConfig {
+	c := pageConfig{
+		pageKey:     "page",
+		sizeKey:     "per_page",
+		cursorKey:   "cursor",
+		limitKey:    "limit",
+		defaultSize: 20,
+		maxSize:     100,
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// QueryPage reads offset-based pagination from the query. A non-numeric value is a
+// Malformed error (-> 400); a valid out-of-range value is clamped (page >= 1,
+// 1 <= size <= max).
+func QueryPage(r *http.Request, opts ...PageOption) (Page, error) {
+	c := newPageConfig(opts)
+
+	number, err := Query[int](r, c.pageKey, 1)
+	if err != nil {
+		return Page{}, err
+	}
+	size, err := Query[int](r, c.sizeKey, c.defaultSize)
+	if err != nil {
+		return Page{}, err
+	}
+	number = max(number, 1)
+	size = min(max(size, 1), c.maxSize)
+	return Page{Number: number, Size: size, Offset: (number - 1) * size}, nil
+}
+
+// QueryCursor reads cursor-based pagination from the query. The cursor is opaque;
+// limit shares the same default/max bounds as page size.
+func QueryCursor(r *http.Request, opts ...PageOption) (Cursor, error) {
+	c := newPageConfig(opts)
+
+	limit, err := Query[int](r, c.limitKey, c.defaultSize)
+	if err != nil {
+		return Cursor{}, err
+	}
+	value, err := Query[string](r, c.cursorKey)
+	if err != nil {
+		return Cursor{}, err
+	}
+	return Cursor{Value: value, Limit: min(max(limit, 1), c.maxSize)}, nil
+}

--- a/request/pagination_test.go
+++ b/request/pagination_test.go
@@ -1,0 +1,67 @@
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/request"
+)
+
+func TestQueryPageDefaults(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	p, err := request.QueryPage(r)
+	require.NoError(t, err)
+	assert.Equal(t, 1, p.Number)
+	assert.Equal(t, 20, p.Size)
+	assert.Equal(t, 0, p.Offset)
+}
+
+func TestQueryPageValues(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?page=3&per_page=10", nil)
+	p, err := request.QueryPage(r)
+	require.NoError(t, err)
+	assert.Equal(t, 3, p.Number)
+	assert.Equal(t, 10, p.Size)
+	assert.Equal(t, 20, p.Offset)
+}
+
+func TestQueryPageClamp(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?page=0&per_page=9999", nil)
+	p, err := request.QueryPage(r, request.WithMaxPageSize(100))
+	require.NoError(t, err)
+	assert.Equal(t, 1, p.Number) // clamped up to 1
+	assert.Equal(t, 100, p.Size) // clamped down to max
+}
+
+func TestQueryPageMalformed(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?page=abc", nil)
+	_, err := request.QueryPage(r)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestQueryPageCustomParams(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?p=2&size=5", nil)
+	p, err := request.QueryPage(r, request.WithPageParams("p", "size"))
+	require.NoError(t, err)
+	assert.Equal(t, 2, p.Number)
+	assert.Equal(t, 5, p.Size)
+}
+
+func TestQueryCursor(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?cursor=abc123&limit=5", nil)
+	c, err := request.QueryCursor(r)
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", c.Value)
+	assert.Equal(t, 5, c.Limit)
+}

--- a/request/pagination_test.go
+++ b/request/pagination_test.go
@@ -38,6 +38,7 @@ func TestQueryPageClamp(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, p.Number) // clamped up to 1
 	assert.Equal(t, 100, p.Size) // clamped down to max
+	assert.Equal(t, 0, p.Offset) // (1-1)*100
 }
 
 func TestQueryPageMalformed(t *testing.T) {
@@ -63,5 +64,39 @@ func TestQueryCursor(t *testing.T) {
 	c, err := request.QueryCursor(r)
 	require.NoError(t, err)
 	assert.Equal(t, "abc123", c.Value)
+	assert.Equal(t, 5, c.Limit)
+}
+
+func TestQueryCursorDefaults(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	c, err := request.QueryCursor(r)
+	require.NoError(t, err)
+	assert.Equal(t, "", c.Value)
+	assert.Equal(t, 20, c.Limit)
+}
+
+func TestQueryCursorMalformedLimit(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?limit=abc", nil)
+	_, err := request.QueryCursor(r)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+
+func TestQueryCursorLimitClamp(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?limit=9999", nil)
+	c, err := request.QueryCursor(r, request.WithMaxPageSize(100))
+	require.NoError(t, err)
+	assert.Equal(t, 100, c.Limit)
+}
+
+func TestQueryCursorCustomParams(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?c=tok&n=5", nil)
+	c, err := request.QueryCursor(r, request.WithCursorParams("c", "n"))
+	require.NoError(t, err)
+	assert.Equal(t, "tok", c.Value)
 	assert.Equal(t, 5, c.Limit)
 }

--- a/request/parse.go
+++ b/request/parse.go
@@ -1,0 +1,180 @@
+package request
+
+import (
+	"encoding"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// parse converts a single non-empty raw string into T. Resolution order: built-in
+// scalars via a type switch on any(&v); *time.Duration via time.ParseDuration; then
+// any type whose pointer implements encoding.TextUnmarshaler (time.Time, uuid.UUID,
+// netip.Addr, custom enums). No reflect package: interface assertions only.
+func parse[T any](raw string) (T, error) {
+	var v T
+	switch p := any(&v).(type) {
+	case *string:
+		*p = raw
+	case *bool:
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return v, err
+		}
+		*p = b
+	case *int:
+		n, err := strconv.ParseInt(raw, 10, strconv.IntSize)
+		if err != nil {
+			return v, err
+		}
+		*p = int(n)
+	case *int8:
+		n, err := strconv.ParseInt(raw, 10, 8)
+		if err != nil {
+			return v, err
+		}
+		*p = int8(n)
+	case *int16:
+		n, err := strconv.ParseInt(raw, 10, 16)
+		if err != nil {
+			return v, err
+		}
+		*p = int16(n)
+	case *int32:
+		n, err := strconv.ParseInt(raw, 10, 32)
+		if err != nil {
+			return v, err
+		}
+		*p = int32(n)
+	case *int64:
+		n, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return v, err
+		}
+		*p = n
+	case *uint:
+		n, err := strconv.ParseUint(raw, 10, strconv.IntSize)
+		if err != nil {
+			return v, err
+		}
+		*p = uint(n)
+	case *uint8:
+		n, err := strconv.ParseUint(raw, 10, 8)
+		if err != nil {
+			return v, err
+		}
+		*p = uint8(n)
+	case *uint16:
+		n, err := strconv.ParseUint(raw, 10, 16)
+		if err != nil {
+			return v, err
+		}
+		*p = uint16(n)
+	case *uint32:
+		n, err := strconv.ParseUint(raw, 10, 32)
+		if err != nil {
+			return v, err
+		}
+		*p = uint32(n)
+	case *uint64:
+		n, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			return v, err
+		}
+		*p = n
+	case *float32:
+		f, err := strconv.ParseFloat(raw, 32)
+		if err != nil {
+			return v, err
+		}
+		*p = float32(f)
+	case *float64:
+		f, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return v, err
+		}
+		*p = f
+	case *time.Duration:
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return v, err
+		}
+		*p = d
+	default:
+		if tu, ok := any(&v).(encoding.TextUnmarshaler); ok {
+			if err := tu.UnmarshalText([]byte(raw)); err != nil {
+				return v, err
+			}
+			return v, nil
+		}
+		return v, fmt.Errorf("unsupported type %T", v)
+	}
+	return v, nil
+}
+
+// resolve applies the missing/default/malformed contract for a single value: an
+// empty raw string yields def[0] (or the zero value) and a nil error; a non-empty
+// value is parsed by p and any failure is wrapped as *Error.
+func resolve[T any](src Source, key, raw string, p func(string) (T, error), def []T) (T, error) {
+	if raw == "" {
+		if len(def) > 0 {
+			return def[0], nil
+		}
+		var zero T
+		return zero, nil
+	}
+	v, err := p(raw)
+	if err != nil {
+		var zero T
+		return zero, &Error{Source: src, Key: key, Kind: KindMalformed, Err: err}
+	}
+	return v, nil
+}
+
+// resolveSlice parses each non-empty element of raws with p. Any failure wraps as
+// *Error; an all-empty result falls back to def[0] (or nil).
+func resolveSlice[T any](src Source, key string, raws []string, p func(string) (T, error), def [][]T) ([]T, error) {
+	out := make([]T, 0, len(raws))
+	for _, raw := range raws {
+		if raw == "" {
+			continue
+		}
+		v, err := p(raw)
+		if err != nil {
+			return nil, &Error{Source: src, Key: key, Kind: KindMalformed, Err: err}
+		}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		if len(def) > 0 {
+			return def[0], nil
+		}
+		return nil, nil
+	}
+	return out, nil
+}
+
+// resolveSplit splits raw on sep, trims and skips empty elements, then parses each
+// with p. An empty raw falls back to def[0] (or nil).
+func resolveSplit[T any](src Source, key, raw, sep string, p func(string) (T, error), def [][]T) ([]T, error) {
+	if raw == "" {
+		if len(def) > 0 {
+			return def[0], nil
+		}
+		return nil, nil
+	}
+	var out []T
+	for _, part := range strings.Split(raw, sep) {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		v, err := p(part)
+		if err != nil {
+			return nil, &Error{Source: src, Key: key, Kind: KindMalformed, Err: err}
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}

--- a/request/parse.go
+++ b/request/parse.go
@@ -165,7 +165,7 @@ func resolveSplit[T any](src Source, key, raw, sep string, p func(string) (T, er
 		return nil, nil
 	}
 	var out []T
-	for _, part := range strings.Split(raw, sep) {
+	for part := range strings.SplitSeq(raw, sep) {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue

--- a/request/parse.go
+++ b/request/parse.go
@@ -176,5 +176,11 @@ func resolveSplit[T any](src Source, key, raw, sep string, p func(string) (T, er
 		}
 		out = append(out, v)
 	}
+	if len(out) == 0 {
+		if len(def) > 0 {
+			return def[0], nil
+		}
+		return nil, nil
+	}
 	return out, nil
 }

--- a/request/parts_test.go
+++ b/request/parts_test.go
@@ -97,3 +97,11 @@ func TestPartFuncVariants(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(26), c)
 }
+
+func TestHasHeaderEmptyValue(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Flag", "")
+	assert.True(t, request.HasHeader(r, "X-Flag")) // present, even though empty
+	assert.False(t, request.HasHeader(r, "X-Absent"))
+}

--- a/request/parts_test.go
+++ b/request/parts_test.go
@@ -3,6 +3,7 @@ package request_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,4 +65,35 @@ func TestCookie(t *testing.T) {
 	assert.Equal(t, "xyz", v)
 	assert.True(t, request.HasCookie(r, "sid"))
 	assert.False(t, request.HasCookie(r, "nope"))
+}
+
+func TestBearerTokenCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "BEARER abc.def")
+	tok, ok := request.BearerToken(r)
+	assert.True(t, ok)
+	assert.Equal(t, "abc.def", tok)
+}
+
+func TestPartFuncVariants(t *testing.T) {
+	t.Parallel()
+	hexParse := func(s string) (int64, error) { return strconv.ParseInt(s, 16, 64) }
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.SetPathValue("id", "ff")
+	r.Header.Set("X-Hex", "10")
+	r.AddCookie(&http.Cookie{Name: "c", Value: "1a"})
+
+	p, err := request.PathFunc(r, "id", hexParse)
+	require.NoError(t, err)
+	assert.Equal(t, int64(255), p)
+
+	h, err := request.HeaderFunc(r, "X-Hex", hexParse)
+	require.NoError(t, err)
+	assert.Equal(t, int64(16), h)
+
+	c, err := request.CookieFunc(r, "c", hexParse)
+	require.NoError(t, err)
+	assert.Equal(t, int64(26), c)
 }

--- a/request/parts_test.go
+++ b/request/parts_test.go
@@ -5,9 +5,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dmitrymomot/forge/request"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/request"
 )
 
 func TestPath(t *testing.T) {

--- a/request/parts_test.go
+++ b/request/parts_test.go
@@ -1,0 +1,66 @@
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPath(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/u/42", nil)
+	r.SetPathValue("id", "42")
+
+	v, err := request.Path[int](r, "id")
+	require.NoError(t, err)
+	assert.Equal(t, 42, v)
+	assert.True(t, request.HasPath(r, "id"))
+	assert.False(t, request.HasPath(r, "missing"))
+}
+
+func TestHeader(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Count", "5")
+
+	v, err := request.Header[int](r, "X-Count")
+	require.NoError(t, err)
+	assert.Equal(t, 5, v)
+	assert.True(t, request.HasHeader(r, "X-Count"))
+	assert.False(t, request.HasHeader(r, "X-Absent"))
+}
+
+func TestBearerToken(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer abc.def")
+	tok, ok := request.BearerToken(r)
+	assert.True(t, ok)
+	assert.Equal(t, "abc.def", tok)
+
+	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2.Header.Set("Authorization", "Basic xxx")
+	_, ok2 := request.BearerToken(r2)
+	assert.False(t, ok2)
+
+	r3 := httptest.NewRequest(http.MethodGet, "/", nil)
+	_, ok3 := request.BearerToken(r3)
+	assert.False(t, ok3)
+}
+
+func TestCookie(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.AddCookie(&http.Cookie{Name: "sid", Value: "xyz"})
+
+	v, err := request.Cookie[string](r, "sid")
+	require.NoError(t, err)
+	assert.Equal(t, "xyz", v)
+	assert.True(t, request.HasCookie(r, "sid"))
+	assert.False(t, request.HasCookie(r, "nope"))
+}

--- a/request/path.go
+++ b/request/path.go
@@ -1,0 +1,19 @@
+package request
+
+import "net/http"
+
+// Path reads path wildcard key (r.PathValue) and converts it to T. Requires a
+// Go 1.22+ ServeMux pattern that defines key.
+func Path[T any](r *http.Request, key string, def ...T) (T, error) {
+	return resolve(SourcePath, key, r.PathValue(key), parse[T], def)
+}
+
+// PathFunc is Path with a caller-supplied parser.
+func PathFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error) {
+	return resolve(SourcePath, key, r.PathValue(key), parse, def)
+}
+
+// HasPath reports whether the path wildcard key is set and non-empty.
+func HasPath(r *http.Request, key string) bool {
+	return r.PathValue(key) != ""
+}

--- a/request/query.go
+++ b/request/query.go
@@ -1,0 +1,40 @@
+package request
+
+import "net/http"
+
+// Query reads URL query parameter key and converts it to T. Absent/empty yields
+// def[0] (or the zero value) with a nil error; a present unparseable value returns
+// a *Error with Kind Malformed.
+func Query[T any](r *http.Request, key string, def ...T) (T, error) {
+	return resolve(SourceQuery, key, r.URL.Query().Get(key), parse[T], def)
+}
+
+// QueryFunc is Query with a caller-supplied parser instead of the built-in engine.
+func QueryFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error) {
+	return resolve(SourceQuery, key, r.URL.Query().Get(key), parse, def)
+}
+
+// QuerySlice reads every repeated value of key (?id=1&id=2) and parses each into T.
+func QuerySlice[T any](r *http.Request, key string, def ...[]T) ([]T, error) {
+	return resolveSlice(SourceQuery, key, r.URL.Query()[key], parse[T], def)
+}
+
+// QuerySliceFunc is QuerySlice with a caller-supplied element parser.
+func QuerySliceFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...[]T) ([]T, error) {
+	return resolveSlice(SourceQuery, key, r.URL.Query()[key], parse, def)
+}
+
+// QuerySplit reads a single delimited value (?filter=a,b,c), splitting on sep.
+func QuerySplit[T any](r *http.Request, key, sep string, def ...[]T) ([]T, error) {
+	return resolveSplit(SourceQuery, key, r.URL.Query().Get(key), sep, parse[T], def)
+}
+
+// QuerySplitFunc is QuerySplit with a caller-supplied element parser.
+func QuerySplitFunc[T any](r *http.Request, key, sep string, parse func(string) (T, error), def ...[]T) ([]T, error) {
+	return resolveSplit(SourceQuery, key, r.URL.Query().Get(key), sep, parse, def)
+}
+
+// HasQuery reports whether key is present in the URL query (even with an empty value).
+func HasQuery(r *http.Request, key string) bool {
+	return r.URL.Query().Has(key)
+}

--- a/request/query_test.go
+++ b/request/query_test.go
@@ -1,0 +1,122 @@
+package request_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// color is a local TextUnmarshaler type — proves custom types parse with no
+// external dependency and no reflection.
+type color struct{ name string }
+
+func (c *color) UnmarshalText(b []byte) error {
+	switch s := string(b); s {
+	case "red", "green", "blue":
+		c.name = s
+		return nil
+	default:
+		return fmt.Errorf("bad color %q", s)
+	}
+}
+
+func TestQueryScalars(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?n=42&ok=true&f=3.5&s=hi&d=1500ms", nil)
+
+	n, err := request.Query[int](r, "n")
+	require.NoError(t, err)
+	assert.Equal(t, 42, n)
+
+	ok, err := request.Query[bool](r, "ok")
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	f, err := request.Query[float64](r, "f")
+	require.NoError(t, err)
+	assert.InEpsilon(t, 3.5, f, 1e-9)
+
+	s, err := request.Query[string](r, "s")
+	require.NoError(t, err)
+	assert.Equal(t, "hi", s)
+
+	d, err := request.Query[time.Duration](r, "d")
+	require.NoError(t, err)
+	assert.Equal(t, 1500*time.Millisecond, d)
+}
+
+func TestQueryTextUnmarshaler(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?c=blue", nil)
+	c, err := request.Query[color](r, "c")
+	require.NoError(t, err)
+	assert.Equal(t, "blue", c.name)
+}
+
+func TestQueryMalformed(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?n=oops", nil)
+
+	_, err := request.Query[int](r, "n")
+	require.Error(t, err)
+
+	var re *request.Error
+	require.ErrorAs(t, err, &re)
+	assert.Equal(t, request.SourceQuery, re.Source)
+	assert.Equal(t, request.KindMalformed, re.Kind)
+	assert.Equal(t, "n", re.Key)
+}
+
+func TestQueryAbsentAndDefault(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	n, err := request.Query[int](r, "n")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	n2, err := request.Query[int](r, "n", 7)
+	require.NoError(t, err)
+	assert.Equal(t, 7, n2)
+}
+
+func TestQueryFunc(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?hex=ff", nil)
+	v, err := request.QueryFunc(r, "hex", func(s string) (int64, error) {
+		return strconv.ParseInt(s, 16, 64)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(255), v)
+}
+
+func TestQuerySlice(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?id=1&id=2&id=3", nil)
+	ids, err := request.QuerySlice[int](r, "id")
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3}, ids)
+}
+
+func TestQuerySplit(t *testing.T) {
+	t.Parallel()
+	// decodes to: filter=orange, blue ,gray,
+	r := httptest.NewRequest(http.MethodGet, "/?filter=orange,%20blue%20,gray,", nil)
+	got, err := request.QuerySplit[string](r, "filter", ",")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"orange", "blue", "gray"}, got)
+}
+
+func TestHasQuery(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?x=", nil)
+	assert.True(t, request.HasQuery(r, "x"))
+	assert.False(t, request.HasQuery(r, "y"))
+}

--- a/request/query_test.go
+++ b/request/query_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dmitrymomot/forge/request"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/request"
 )
 
 // color is a local TextUnmarshaler type — proves custom types parse with no

--- a/request/query_test.go
+++ b/request/query_test.go
@@ -70,9 +70,12 @@ func TestQueryMalformed(t *testing.T) {
 
 	var re *request.Error
 	require.ErrorAs(t, err, &re)
-	assert.Equal(t, request.SourceQuery, re.Source)
-	assert.Equal(t, request.KindMalformed, re.Kind)
-	assert.Equal(t, "n", re.Key)
+	require.NotNil(t, re)
+	if re != nil {
+		assert.Equal(t, request.SourceQuery, re.Source)
+		assert.Equal(t, request.KindMalformed, re.Kind)
+		assert.Equal(t, "n", re.Key)
+	}
 }
 
 func TestQueryAbsentAndDefault(t *testing.T) {

--- a/request/query_test.go
+++ b/request/query_test.go
@@ -171,3 +171,11 @@ func TestQueryUnsupportedType(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
 }
+
+func TestQuerySplitAllEmptyUsesDefault(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?tags=,,", nil) // every part empty after split
+	got, err := request.QuerySplit[string](r, "tags", ",", []string{"all"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"all"}, got)
+}

--- a/request/query_test.go
+++ b/request/query_test.go
@@ -124,3 +124,50 @@ func TestHasQuery(t *testing.T) {
 	assert.True(t, request.HasQuery(r, "x"))
 	assert.False(t, request.HasQuery(r, "y"))
 }
+
+type noParse struct{ X int } // pointer does NOT implement encoding.TextUnmarshaler
+
+func TestQueryScalarWidths(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet,
+		"/?i8=12&i16=300&i32=70000&i64=5000000000&u=7&u8=200&u16=40000&u32=3000000000&u64=10000000000&f32=1.5", nil)
+
+	i8, err := request.Query[int8](r, "i8")
+	require.NoError(t, err)
+	assert.Equal(t, int8(12), i8)
+	i16, err := request.Query[int16](r, "i16")
+	require.NoError(t, err)
+	assert.Equal(t, int16(300), i16)
+	i32, err := request.Query[int32](r, "i32")
+	require.NoError(t, err)
+	assert.Equal(t, int32(70000), i32)
+	i64, err := request.Query[int64](r, "i64")
+	require.NoError(t, err)
+	assert.Equal(t, int64(5000000000), i64)
+	u, err := request.Query[uint](r, "u")
+	require.NoError(t, err)
+	assert.Equal(t, uint(7), u)
+	u8, err := request.Query[uint8](r, "u8")
+	require.NoError(t, err)
+	assert.Equal(t, uint8(200), u8)
+	u16, err := request.Query[uint16](r, "u16")
+	require.NoError(t, err)
+	assert.Equal(t, uint16(40000), u16)
+	u32, err := request.Query[uint32](r, "u32")
+	require.NoError(t, err)
+	assert.Equal(t, uint32(3000000000), u32)
+	u64, err := request.Query[uint64](r, "u64")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(10000000000), u64)
+	f32, err := request.Query[float32](r, "f32")
+	require.NoError(t, err)
+	assert.InEpsilon(t, float32(1.5), f32, 1e-6)
+}
+
+func TestQueryUnsupportedType(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/?v=anything", nil)
+	_, err := request.Query[noParse](r, "v")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}


### PR DESCRIPTION
## Summary

New standalone `request` package — the input-side counterpart to `render`. Stateless, **reflection-free** free functions that read data off an `*http.Request` into Go values. Stdlib only; flat layout; black-box tests.

Design spec and plan are included in the branch:
- `docs/superpowers/specs/2026-06-26-request-package-design.md`
- `docs/superpowers/plans/2026-06-26-request-package.md`

## What's included

- **Typed accessors** `Query` / `Path` / `Header` / `Cookie` / `FormValue`, each with `…Func` (custom-parser) variants, plus `…Slice` (repeated keys) and `…Split` (delimited) for query/form. One generic `parse[T]` engine: scalar type-switch → `time.Duration` → `encoding.TextUnmarshaler` (so `uuid.UUID`, `netip.Addr`, `time.Time`, custom enums work with **no `reflect`**).
- **Contract:** absent/empty ⇒ default or zero value + nil error; present-but-unparseable ⇒ `*request.Error{Kind: Malformed}`. Optional variadic default. `Has*` presence predicates close the zero-vs-absent gap.
- **Body decoding:** strict `DecodeJSON` (1 MiB cap → 413, `Content-Type` → 415, unknown-field/trailing/empty → 400) with `BodyOption` (`WithMaxBytes` / `AllowUnknownFields` / `SkipContentType`); `RawBody`; multipart `File` / `Files`; `IsContentType`.
- **`ClientIP`** — best-effort CDN/proxy header resolution (CF-Connecting-IP → True-Client-IP → Fastly → X-Real-IP → Forwarded → X-Forwarded-For → RemoteAddr), with `WithClientIPHeaders` (pin a header) and `WithTrustedProxies` (spoof-resistant right-to-left XFF walk). Default mode is documented as spoofable.
- **Pagination** — `QueryPage` (offset) / `QueryCursor` (opaque token) with `PageOption`; non-numeric → 400, out-of-range → clamped.
- **Errors:** one `*Error{Source, Key, Kind, Err}` + `StatusCode(err)` → 400/413/415. Options are split into three concern-scoped types (`BodyOption` / `ClientIPOption` / `PageOption`) so an irrelevant option is a compile error.

## Testing & quality

- Black-box tests (`package request_test`), `httptest`-driven; runnable godoc examples; a `parse` benchmark.
- `just check` (go fmt, goimports, betteralign, go vet, golangci-lint, nilaway, modernize, `go test -race`) is **green across the whole module**.
- Package coverage **84.6%**.
- Built task-by-task with a per-task review on each, plus a final whole-package review: **no Critical findings, no security issues**; all flagged items addressed.

## Non-goals (deliberate)

No validation-rules engine, no struct-tag binding/reflection, no content negotiation, no query/form merge, no signed cookies/CSRF/sessions.