### PR TITLE
feat: resilience & caching primitives (backoff, retry, singleflight, parallel, circuitbreaker, cache)

### DIFF
--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -61,7 +61,10 @@ func (e exponential) Next(attempt int) time.Duration {
 	}
 	if e.jitter > 0 {
 		delta := d * e.jitter
-		d = d - delta + rand.Float64()*(2*delta) //nolint:gosec // non-crypto jitter
+		d = d - delta + rand.Float64()*(2*delta)
+	}
+	if d > float64(e.max) { // re-clamp: jitter must not exceed the ceiling
+		d = float64(e.max)
 	}
 	if d < 0 {
 		d = 0

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -1,0 +1,86 @@
+// Package backoff computes retry delays as pure, stateless strategies.
+package backoff
+
+import (
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// Backoff returns the delay to wait before a given 1-based attempt.
+// Implementations are stateless and safe for concurrent use.
+type Backoff interface {
+	Next(attempt int) time.Duration
+}
+
+type constant struct{ d time.Duration }
+
+func (c constant) Next(int) time.Duration { return c.d }
+
+// Constant always returns d. A negative d is clamped to 0.
+func Constant(d time.Duration) Backoff {
+	if d < 0 {
+		d = 0
+	}
+	return constant{d: d}
+}
+
+type exponential struct {
+	base       time.Duration
+	max        time.Duration
+	multiplier float64
+	jitter     float64
+}
+
+// Option configures Exponential.
+type Option func(*exponential)
+
+// WithMultiplier sets the growth factor (default 2.0). Values ≤ 0 are ignored.
+func WithMultiplier(f float64) Option {
+	return func(e *exponential) {
+		if f > 0 {
+			e.multiplier = f
+		}
+	}
+}
+
+// WithJitter randomizes each delay by ±fraction (clamped to 0..1).
+func WithJitter(fraction float64) Option {
+	return func(e *exponential) {
+		e.jitter = math.Min(1, math.Max(0, fraction))
+	}
+}
+
+func (e exponential) Next(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := float64(e.base) * math.Pow(e.multiplier, float64(attempt-1))
+	if d > float64(e.max) {
+		d = float64(e.max)
+	}
+	if e.jitter > 0 {
+		delta := d * e.jitter
+		d = d - delta + rand.Float64()*(2*delta) //nolint:gosec // non-crypto jitter
+	}
+	if d < 0 {
+		d = 0
+	}
+	return time.Duration(d)
+}
+
+// Exponential grows the delay as base*multiplier^(attempt-1), capped at max.
+// base is clamped to ≥ 1ns and max to ≥ base.
+func Exponential(base, max time.Duration, opts ...Option) Backoff {
+	if base < 1 {
+		base = 1
+	}
+	if max < base {
+		max = base
+	}
+	e := exponential{base: base, max: max, multiplier: 2.0}
+	for _, o := range opts {
+		o(&e)
+	}
+	return e
+}

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -1,4 +1,3 @@
-// Package backoff computes retry delays as pure, stateless strategies.
 package backoff
 
 import (

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -1,0 +1,40 @@
+package backoff_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/backoff"
+)
+
+func TestConstant(t *testing.T) {
+	b := backoff.Constant(2 * time.Second)
+	assert.Equal(t, 2*time.Second, b.Next(1))
+	assert.Equal(t, 2*time.Second, b.Next(9))
+}
+
+func TestExponential(t *testing.T) {
+	b := backoff.Exponential(100*time.Millisecond, 10*time.Second)
+	assert.Equal(t, 100*time.Millisecond, b.Next(1))
+	assert.Equal(t, 200*time.Millisecond, b.Next(2))
+	assert.Equal(t, 400*time.Millisecond, b.Next(3))
+	assert.Equal(t, 10*time.Second, b.Next(30)) // capped at max
+}
+
+func TestExponentialMultiplier(t *testing.T) {
+	b := backoff.Exponential(10*time.Millisecond, time.Minute, backoff.WithMultiplier(3))
+	assert.Equal(t, 10*time.Millisecond, b.Next(1))
+	assert.Equal(t, 30*time.Millisecond, b.Next(2))
+	assert.Equal(t, 90*time.Millisecond, b.Next(3))
+}
+
+func TestExponentialJitterWithinBounds(t *testing.T) {
+	b := backoff.Exponential(100*time.Millisecond, 10*time.Second, backoff.WithJitter(0.5))
+	for range 200 {
+		d := b.Next(1) // base 100ms ±50% => [50ms, 150ms]
+		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+		assert.LessOrEqual(t, d, 150*time.Millisecond)
+	}
+}

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -38,3 +38,24 @@ func TestExponentialJitterWithinBounds(t *testing.T) {
 		assert.LessOrEqual(t, d, 150*time.Millisecond)
 	}
 }
+
+func TestExponentialJitterRespectsMaxCeiling(t *testing.T) {
+	b := backoff.Exponential(time.Second, time.Second, backoff.WithJitter(0.5))
+	for range 200 {
+		d := b.Next(1) // already at cap; jitter must not push it past max
+		assert.GreaterOrEqual(t, d, time.Duration(0))
+		assert.LessOrEqual(t, d, time.Second)
+	}
+}
+
+func TestConstantClampsNegative(t *testing.T) {
+	assert.Equal(t, time.Duration(0), backoff.Constant(-5*time.Second).Next(1))
+}
+
+func TestExponentialClampsDegenerateInputs(t *testing.T) {
+	assert.Equal(t, time.Duration(1), backoff.Exponential(0, time.Second).Next(1))
+
+	b := backoff.Exponential(5*time.Second, time.Second)
+	assert.Equal(t, 5*time.Second, b.Next(1))
+	assert.Equal(t, 5*time.Second, b.Next(10))
+}

--- a/backoff/doc.go
+++ b/backoff/doc.go
@@ -1,0 +1,7 @@
+// Package backoff computes retry delays as pure, stateless strategies.
+//
+//	b := backoff.Exponential(100*time.Millisecond, 10*time.Second, backoff.WithJitter(0.5))
+//	for attempt := 1; attempt <= 5; attempt++ {
+//	    time.Sleep(b.Next(attempt))
+//	}
+package backoff

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/dmitrymomot/forge/singleflight"
@@ -104,11 +105,24 @@ func (c *Cache[V]) Clear(ctx context.Context) error {
 // GetOrSet returns the cached value or computes it via fn on a miss,
 // deduplicating concurrent misses so fn runs once per key. The value is cached
 // best-effort with the TTL fn returns; load errors are not cached.
+//
+// Only a genuine miss (ErrNotFound) invokes fn. A Store failure or an
+// unreadable cached entry is surfaced as an error rather than masked as a
+// miss: errors already matching a cache sentinel pass through unchanged, and
+// any other Store error is wrapped with ErrStore (unwrap for the original).
 func (c *Cache[V]) GetOrSet(ctx context.Context, key string, fn func(context.Context) (V, time.Duration, error)) (V, error) {
-	if v, err := c.Get(ctx, key); err == nil {
+	v, err := c.Get(ctx, key)
+	if err == nil {
 		return v, nil
 	}
-	v, _, err := c.sf.Do(ctx, c.key(key), func(ctx context.Context) (V, error) {
+	if !errors.Is(err, ErrNotFound) {
+		var zero V
+		if errors.Is(err, ErrClosed) || errors.Is(err, ErrMarshal) || errors.Is(err, ErrUnmarshal) {
+			return zero, err
+		}
+		return zero, errors.Join(ErrStore, err)
+	}
+	v, _, err = c.sf.Do(ctx, c.key(key), func(ctx context.Context) (V, error) {
 		val, ttl, ferr := fn(ctx)
 		if ferr != nil {
 			var zero V

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/dmitrymomot/forge/singleflight"
@@ -25,7 +26,10 @@ func WithPrefix(p string) Option { return func(c *config) { c.prefix = p } }
 // WithDefaultTTL is applied when Set receives ttl == 0 (default 5m).
 func WithDefaultTTL(d time.Duration) Option { return func(c *config) { c.defaultTTL = d } }
 
-// WithMarshaler overrides the default JSON serialization.
+// WithMarshaler overrides the default JSON serialization. Its type parameter
+// must match the value type of the Cache it is passed to: New[V] panics if the
+// marshaler is a Marshaler[W] for some W != V (the Option type is non-generic,
+// so the mismatch cannot be caught at compile time).
 func WithMarshaler[V any](m Marshaler[V]) Option {
 	return func(c *config) {
 		if m != nil {
@@ -54,7 +58,11 @@ func New[V any](store Store, opts ...Option) *Cache[V] {
 	}
 	var m Marshaler[V]
 	if c.marshaler != nil {
-		m = c.marshaler.(Marshaler[V]) // set by WithMarshaler[V]; V matches New[V]
+		tm, ok := c.marshaler.(Marshaler[V])
+		if !ok {
+			panic(fmt.Sprintf("cache: WithMarshaler marshaler %T does not match the Cache value type", c.marshaler))
+		}
+		m = tm
 	} else {
 		m = jsonMarshaler[V]{}
 	}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,121 @@
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/dmitrymomot/forge/singleflight"
+)
+
+type config struct {
+	marshaler  any // Marshaler[V] set by WithMarshaler; resolved in New
+	prefix     string
+	defaultTTL time.Duration
+}
+
+// Option configures a Cache. Options are non-generic so call sites need no type
+// arguments; WithMarshaler infers V from its argument.
+type Option func(*config)
+
+// WithPrefix namespaces this cache's keys within its Store, isolating it from
+// other caches sharing the same Store.
+func WithPrefix(p string) Option { return func(c *config) { c.prefix = p } }
+
+// WithDefaultTTL is applied when Set receives ttl == 0 (default 5m).
+func WithDefaultTTL(d time.Duration) Option { return func(c *config) { c.defaultTTL = d } }
+
+// WithMarshaler overrides the default JSON serialization.
+func WithMarshaler[V any](m Marshaler[V]) Option {
+	return func(c *config) {
+		if m != nil {
+			c.marshaler = m
+		}
+	}
+}
+
+// Cache is a typed facade over a Store. It marshals values, applies the default
+// TTL, isolates keys by prefix, and provides GetOrSet. It does NOT own the
+// Store: construct and Close the Store yourself.
+type Cache[V any] struct {
+	store      Store
+	marshaler  Marshaler[V]
+	prefix     string
+	sf         singleflight.Group[V]
+	defaultTTL time.Duration
+}
+
+// New builds a typed cache over store. The Store's lifecycle stays with the
+// caller; Cache has no Close.
+func New[V any](store Store, opts ...Option) *Cache[V] {
+	c := config{defaultTTL: 5 * time.Minute}
+	for _, o := range opts {
+		o(&c)
+	}
+	var m Marshaler[V]
+	if c.marshaler != nil {
+		m = c.marshaler.(Marshaler[V]) // set by WithMarshaler[V]; V matches New[V]
+	} else {
+		m = jsonMarshaler[V]{}
+	}
+	return &Cache[V]{store: store, prefix: c.prefix, defaultTTL: c.defaultTTL, marshaler: m}
+}
+
+func (c *Cache[V]) key(k string) string { return c.prefix + k }
+
+// Get returns the value for key or ErrNotFound.
+func (c *Cache[V]) Get(ctx context.Context, key string) (V, error) {
+	var zero V
+	data, err := c.store.Get(ctx, c.key(key))
+	if err != nil {
+		return zero, err
+	}
+	return c.marshaler.Unmarshal(data)
+}
+
+// Set stores v under key. ttl == 0 uses the configured default; ttl < 0 never
+// expires.
+func (c *Cache[V]) Set(ctx context.Context, key string, v V, ttl time.Duration) error {
+	data, err := c.marshaler.Marshal(v)
+	if err != nil {
+		return err
+	}
+	if ttl == 0 {
+		ttl = c.defaultTTL
+	}
+	return c.store.Set(ctx, c.key(key), data, ttl)
+}
+
+// Delete removes key.
+func (c *Cache[V]) Delete(ctx context.Context, key string) error {
+	return c.store.Delete(ctx, c.key(key))
+}
+
+// Has reports whether key exists and is unexpired.
+func (c *Cache[V]) Has(ctx context.Context, key string) (bool, error) {
+	return c.store.Has(ctx, c.key(key))
+}
+
+// Clear removes every key under this cache's prefix. With an empty prefix it
+// clears the whole Store.
+func (c *Cache[V]) Clear(ctx context.Context) error {
+	return c.store.DeletePrefix(ctx, c.prefix)
+}
+
+// GetOrSet returns the cached value or computes it via fn on a miss,
+// deduplicating concurrent misses so fn runs once per key. The value is cached
+// best-effort with the TTL fn returns; load errors are not cached.
+func (c *Cache[V]) GetOrSet(ctx context.Context, key string, fn func(context.Context) (V, time.Duration, error)) (V, error) {
+	if v, err := c.Get(ctx, key); err == nil {
+		return v, nil
+	}
+	v, _, err := c.sf.Do(ctx, c.key(key), func(ctx context.Context) (V, error) {
+		val, ttl, ferr := fn(ctx)
+		if ferr != nil {
+			var zero V
+			return zero, ferr
+		}
+		_ = c.Set(ctx, key, val, ttl)
+		return val, nil
+	})
+	return v, err
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -2,6 +2,7 @@ package cache_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -86,4 +87,36 @@ func TestGetOrSetStampede(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 99, v)
+}
+
+func TestGetOrSetSurfacesClosedStore(t *testing.T) {
+	store := cache.NewMemoryStore()
+	require.NoError(t, store.Close())
+	c := cache.New[int](store)
+	_, err := c.GetOrSet(t.Context(), "k", func(context.Context) (int, time.Duration, error) {
+		t.Fatal("loader must not run when the Store errors")
+		return 0, 0, nil
+	})
+	assert.ErrorIs(t, err, cache.ErrClosed) // existing sentinel passes through
+}
+
+// errStore is a Store stub whose Get fails with a non-sentinel error.
+type errStore struct{ getErr error }
+
+func (e errStore) Get(context.Context, string) ([]byte, error)            { return nil, e.getErr }
+func (errStore) Set(context.Context, string, []byte, time.Duration) error { return nil }
+func (errStore) Delete(context.Context, string) error                     { return nil }
+func (errStore) Has(context.Context, string) (bool, error)                { return false, nil }
+func (errStore) DeletePrefix(context.Context, string) error               { return nil }
+func (errStore) Close() error                                             { return nil }
+
+func TestGetOrSetWrapsUnclassifiedStoreError(t *testing.T) {
+	boom := errors.New("connection reset")
+	c := cache.New[int](errStore{getErr: boom})
+	_, err := c.GetOrSet(t.Context(), "k", func(context.Context) (int, time.Duration, error) {
+		t.Fatal("loader must not run when the Store errors")
+		return 0, 0, nil
+	})
+	assert.ErrorIs(t, err, cache.ErrStore) // tagged with our sentinel
+	assert.ErrorIs(t, err, boom)           // original preserved for unwrapping
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -120,3 +120,37 @@ func TestGetOrSetWrapsUnclassifiedStoreError(t *testing.T) {
 	assert.ErrorIs(t, err, cache.ErrStore) // tagged with our sentinel
 	assert.ErrorIs(t, err, boom)           // original preserved for unwrapping
 }
+
+// rawStringMarshaler stores strings verbatim (no JSON quoting) so a test can
+// tell whether WithMarshaler actually replaced the default JSON marshaler.
+type rawStringMarshaler struct{}
+
+func (rawStringMarshaler) Marshal(v string) ([]byte, error)      { return []byte(v), nil }
+func (rawStringMarshaler) Unmarshal(data []byte) (string, error) { return string(data), nil }
+
+func TestWithMarshalerUsesCustomMarshaler(t *testing.T) {
+	store := cache.NewMemoryStore()
+	defer func() { _ = store.Close() }()
+	c := cache.New[string](store, cache.WithMarshaler(rawStringMarshaler{}))
+
+	require.NoError(t, c.Set(t.Context(), "k", "hi", -1))
+
+	// Stored bytes are raw, not JSON-quoted (`"hi"`), so the custom marshaler ran.
+	raw, err := store.Get(t.Context(), "k")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hi"), raw)
+
+	v, err := c.Get(t.Context(), "k")
+	require.NoError(t, err)
+	assert.Equal(t, "hi", v)
+}
+
+func TestWithMarshalerTypeMismatchPanics(t *testing.T) {
+	store := cache.NewMemoryStore()
+	defer func() { _ = store.Close() }()
+	// A Marshaler[string] passed to New[int] cannot be caught at compile time
+	// (Option is non-generic); New must panic rather than silently misbehave.
+	assert.Panics(t, func() {
+		_ = cache.New[int](store, cache.WithMarshaler(rawStringMarshaler{}))
+	})
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,91 @@
+package cache_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/cache"
+)
+
+func TestCacheSetGetTyped(t *testing.T) {
+	store := cache.NewMemoryStore()
+	defer store.Close()
+	c := cache.New[string](store, cache.WithPrefix("greet:"))
+
+	require.NoError(t, c.Set(t.Context(), "en", "hello", 0))
+	v, err := c.Get(t.Context(), "en")
+	require.NoError(t, err)
+	assert.Equal(t, "hello", v)
+}
+
+func TestCacheMissIsErrNotFound(t *testing.T) {
+	store := cache.NewMemoryStore()
+	defer store.Close()
+	c := cache.New[int](store)
+	_, err := c.Get(t.Context(), "nope")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+}
+
+func TestCacheIsolationByPrefixOverSharedStore(t *testing.T) {
+	store := cache.NewMemoryStore()
+	defer store.Close()
+	a := cache.New[string](store, cache.WithPrefix("a:"))
+	b := cache.New[string](store, cache.WithPrefix("b:"))
+
+	require.NoError(t, a.Set(t.Context(), "k", "AAA", -1))
+	require.NoError(t, b.Set(t.Context(), "k", "BBB", -1))
+
+	av, _ := a.Get(t.Context(), "k")
+	bv, _ := b.Get(t.Context(), "k")
+	assert.Equal(t, "AAA", av)
+	assert.Equal(t, "BBB", bv)
+
+	require.NoError(t, a.Clear(t.Context()))
+	_, err := a.Get(t.Context(), "k")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+
+	still, err := b.Get(t.Context(), "k") // b untouched by a.Clear
+	require.NoError(t, err)
+	assert.Equal(t, "BBB", still)
+}
+
+func TestGetOrSetStampede(t *testing.T) {
+	store := cache.NewMemoryStore()
+	defer store.Close()
+	c := cache.New[int](store)
+
+	var calls atomic.Int32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			v, err := c.GetOrSet(t.Context(), "k", func(context.Context) (int, time.Duration, error) {
+				calls.Add(1)
+				time.Sleep(25 * time.Millisecond)
+				return 99, time.Minute, nil
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, 99, v)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	assert.Equal(t, int32(1), calls.Load())
+
+	// value is now cached; loader is not called again
+	v, err := c.GetOrSet(t.Context(), "k", func(context.Context) (int, time.Duration, error) {
+		t.Fatal("loader must not run on hit")
+		return 0, 0, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 99, v)
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCacheSetGetTyped(t *testing.T) {
 	store := cache.NewMemoryStore()
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	c := cache.New[string](store, cache.WithPrefix("greet:"))
 
 	require.NoError(t, c.Set(t.Context(), "en", "hello", 0))
@@ -26,7 +26,7 @@ func TestCacheSetGetTyped(t *testing.T) {
 
 func TestCacheMissIsErrNotFound(t *testing.T) {
 	store := cache.NewMemoryStore()
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	c := cache.New[int](store)
 	_, err := c.Get(t.Context(), "nope")
 	assert.ErrorIs(t, err, cache.ErrNotFound)
@@ -34,7 +34,7 @@ func TestCacheMissIsErrNotFound(t *testing.T) {
 
 func TestCacheIsolationByPrefixOverSharedStore(t *testing.T) {
 	store := cache.NewMemoryStore()
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	a := cache.New[string](store, cache.WithPrefix("a:"))
 	b := cache.New[string](store, cache.WithPrefix("b:"))
 
@@ -57,16 +57,14 @@ func TestCacheIsolationByPrefixOverSharedStore(t *testing.T) {
 
 func TestGetOrSetStampede(t *testing.T) {
 	store := cache.NewMemoryStore()
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	c := cache.New[int](store)
 
 	var calls atomic.Int32
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 	for range 20 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			v, err := c.GetOrSet(t.Context(), "k", func(context.Context) (int, time.Duration, error) {
 				calls.Add(1)
@@ -75,7 +73,7 @@ func TestGetOrSetStampede(t *testing.T) {
 			})
 			assert.NoError(t, err)
 			assert.Equal(t, 99, v)
-		}()
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/cache/doc.go
+++ b/cache/doc.go
@@ -1,0 +1,13 @@
+// Package cache is a typed cache over a pluggable byte-level Store. Build a
+// Store (in-memory or, via cache/redis, Redis) and wrap it with a typed facade.
+// The facade never owns the Store's lifecycle.
+//
+//	store := cache.NewMemoryStore(cache.WithMaxEntries(10_000))
+//	defer store.Close()
+//
+//	users := cache.New[User](store, cache.WithPrefix("users:"), cache.WithDefaultTTL(30*time.Minute))
+//	u, err := users.GetOrSet(ctx, id, func(ctx context.Context) (User, time.Duration, error) {
+//	    u, err := repo.Load(ctx, id)
+//	    return u, 5 * time.Minute, err
+//	})
+package cache

--- a/cache/errors.go
+++ b/cache/errors.go
@@ -12,4 +12,6 @@ var (
 	ErrMarshal = errors.New("cache: failed to marshal value")
 	// ErrUnmarshal is returned when value deserialization fails.
 	ErrUnmarshal = errors.New("cache: failed to unmarshal value")
+	// ErrStore wraps an unclassified error returned by the underlying Store.
+	ErrStore = errors.New("cache: store operation failed")
 )

--- a/cache/errors.go
+++ b/cache/errors.go
@@ -1,0 +1,15 @@
+package cache
+
+import "errors"
+
+// Sentinel errors for cache operations.
+var (
+	// ErrNotFound is returned when a key is absent or expired.
+	ErrNotFound = errors.New("cache: entry not found")
+	// ErrClosed is returned by a store after Close.
+	ErrClosed = errors.New("cache: closed")
+	// ErrMarshal is returned when value serialization fails.
+	ErrMarshal = errors.New("cache: failed to marshal value")
+	// ErrUnmarshal is returned when value deserialization fails.
+	ErrUnmarshal = errors.New("cache: failed to unmarshal value")
+)

--- a/cache/memory.go
+++ b/cache/memory.go
@@ -1,0 +1,203 @@
+package cache
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/clock"
+)
+
+type memoryConfig struct {
+	clk        clock.Clock
+	maxEntries int
+	cleanup    time.Duration
+}
+
+// MemoryOption configures NewMemoryStore.
+type MemoryOption func(*memoryConfig)
+
+// WithMaxEntries caps entries; exceeding it evicts the least-recently-used.
+// 0 (default) is unbounded.
+func WithMaxEntries(n int) MemoryOption { return func(c *memoryConfig) { c.maxEntries = n } }
+
+// WithCleanupInterval starts a janitor goroutine that sweeps expired entries
+// every d; Close stops it. 0 (default) means lazy expiry only.
+func WithCleanupInterval(d time.Duration) MemoryOption {
+	return func(c *memoryConfig) { c.cleanup = d }
+}
+
+// WithClock injects the time source (default clock.System()).
+func WithClock(clk clock.Clock) MemoryOption {
+	return func(c *memoryConfig) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+type memEntry struct {
+	expires time.Time // zero = never
+	elem    *list.Element
+	key     string
+	val     []byte
+}
+
+type memoryStore struct {
+	items  map[string]*memEntry
+	lru    *list.List
+	stop   chan struct{}
+	cfg    memoryConfig
+	mu     sync.Mutex
+	closed bool
+}
+
+// NewMemoryStore returns an in-process Store backed by a map with LRU eviction
+// and TTL expiry. It is a standalone instance: call Close to release it.
+func NewMemoryStore(opts ...MemoryOption) Store {
+	c := memoryConfig{clk: clock.System()}
+	for _, o := range opts {
+		o(&c)
+	}
+	m := &memoryStore{cfg: c, items: make(map[string]*memEntry), lru: list.New()}
+	if c.cleanup > 0 {
+		m.stop = make(chan struct{})
+		go m.janitor()
+	}
+	return m
+}
+
+func (m *memoryStore) janitor() {
+	t := time.NewTicker(m.cfg.cleanup)
+	defer t.Stop()
+	for {
+		select {
+		case <-m.stop:
+			return
+		case <-t.C:
+			m.sweep()
+		}
+	}
+}
+
+func (m *memoryStore) sweep() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := m.cfg.clk.Now()
+	for k, e := range m.items {
+		if !e.expires.IsZero() && now.After(e.expires) {
+			m.removeLocked(k, e)
+		}
+	}
+}
+
+func (m *memoryStore) removeLocked(k string, e *memEntry) {
+	delete(m.items, k)
+	m.lru.Remove(e.elem)
+}
+
+func (m *memoryStore) Get(_ context.Context, key string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil, ErrClosed
+	}
+	e, ok := m.items[key]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	if !e.expires.IsZero() && m.cfg.clk.Now().After(e.expires) {
+		m.removeLocked(key, e)
+		return nil, ErrNotFound
+	}
+	m.lru.MoveToFront(e.elem)
+	out := make([]byte, len(e.val))
+	copy(out, e.val)
+	return out, nil
+}
+
+func (m *memoryStore) Set(_ context.Context, key string, val []byte, ttl time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return ErrClosed
+	}
+	var expires time.Time
+	if ttl > 0 {
+		expires = m.cfg.clk.Now().Add(ttl)
+	}
+	stored := make([]byte, len(val))
+	copy(stored, val)
+	if e, ok := m.items[key]; ok {
+		e.val = stored
+		e.expires = expires
+		m.lru.MoveToFront(e.elem)
+		return nil
+	}
+	e := &memEntry{key: key, val: stored, expires: expires}
+	e.elem = m.lru.PushFront(e)
+	m.items[key] = e
+	if m.cfg.maxEntries > 0 && m.lru.Len() > m.cfg.maxEntries {
+		if back := m.lru.Back(); back != nil {
+			old := back.Value.(*memEntry)
+			m.removeLocked(old.key, old)
+		}
+	}
+	return nil
+}
+
+func (m *memoryStore) Delete(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return ErrClosed
+	}
+	if e, ok := m.items[key]; ok {
+		m.removeLocked(key, e)
+	}
+	return nil
+}
+
+func (m *memoryStore) Has(ctx context.Context, key string) (bool, error) {
+	_, err := m.Get(ctx, key)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, ErrNotFound):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func (m *memoryStore) DeletePrefix(_ context.Context, prefix string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return ErrClosed
+	}
+	for k, e := range m.items {
+		if strings.HasPrefix(k, prefix) {
+			m.removeLocked(k, e)
+		}
+	}
+	return nil
+}
+
+func (m *memoryStore) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil
+	}
+	m.closed = true
+	if m.stop != nil {
+		close(m.stop)
+	}
+	m.items = nil
+	m.lru.Init()
+	return nil
+}

--- a/cache/memory_test.go
+++ b/cache/memory_test.go
@@ -1,0 +1,97 @@
+package cache_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/cache"
+	"github.com/dmitrymomot/forge/clock"
+)
+
+func TestMemoryStoreSetGetDelete(t *testing.T) {
+	s := cache.NewMemoryStore()
+	defer s.Close()
+
+	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), 0))
+	got, err := s.Get(t.Context(), "k")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v"), got)
+
+	require.NoError(t, s.Delete(t.Context(), "k"))
+	_, err = s.Get(t.Context(), "k")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+}
+
+func TestMemoryStoreExpiry(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	s := cache.NewMemoryStore(cache.WithClock(clk))
+	defer s.Close()
+
+	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), 30*time.Second))
+	clk.Advance(31 * time.Second)
+	_, err := s.Get(t.Context(), "k")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+}
+
+func TestMemoryStoreNegativeTTLNeverExpires(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	s := cache.NewMemoryStore(cache.WithClock(clk))
+	defer s.Close()
+
+	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), -1))
+	clk.Advance(1000 * time.Hour)
+	got, err := s.Get(t.Context(), "k")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v"), got)
+}
+
+func TestMemoryStoreLRUEviction(t *testing.T) {
+	s := cache.NewMemoryStore(cache.WithMaxEntries(2))
+	defer s.Close()
+
+	require.NoError(t, s.Set(t.Context(), "a", []byte("1"), -1))
+	require.NoError(t, s.Set(t.Context(), "b", []byte("2"), -1))
+	_, _ = s.Get(t.Context(), "a") // touch a -> b is least-recently-used
+	require.NoError(t, s.Set(t.Context(), "c", []byte("3"), -1))
+
+	_, err := s.Get(t.Context(), "b")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+	_, err = s.Get(t.Context(), "a")
+	assert.NoError(t, err)
+}
+
+func TestMemoryStoreDeletePrefix(t *testing.T) {
+	s := cache.NewMemoryStore()
+	defer s.Close()
+
+	require.NoError(t, s.Set(t.Context(), "a:1", []byte("x"), -1))
+	require.NoError(t, s.Set(t.Context(), "a:2", []byte("x"), -1))
+	require.NoError(t, s.Set(t.Context(), "b:1", []byte("x"), -1))
+
+	require.NoError(t, s.DeletePrefix(t.Context(), "a:"))
+	_, err := s.Get(t.Context(), "a:1")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+	ok, err := s.Has(t.Context(), "b:1")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestMemoryStoreClosedRejects(t *testing.T) {
+	s := cache.NewMemoryStore()
+	require.NoError(t, s.Close())
+	require.NoError(t, s.Close()) // idempotent
+	err := s.Set(t.Context(), "k", []byte("v"), 0)
+	assert.ErrorIs(t, err, cache.ErrClosed)
+}
+
+// Smoke test: exercises the janitor goroutine start/sweep/stop path under -race.
+// The janitor uses a real ticker, so this asserts no panic/leak, not timing.
+func TestMemoryStoreJanitorStartsAndStops(t *testing.T) {
+	s := cache.NewMemoryStore(cache.WithCleanupInterval(5 * time.Millisecond))
+	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), time.Millisecond))
+	time.Sleep(20 * time.Millisecond) // let the ticker fire at least once
+	require.NoError(t, s.Close())     // must stop the goroutine cleanly
+}

--- a/cache/memory_test.go
+++ b/cache/memory_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestMemoryStoreSetGetDelete(t *testing.T) {
 	s := cache.NewMemoryStore()
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), 0))
 	got, err := s.Get(t.Context(), "k")
@@ -28,7 +28,7 @@ func TestMemoryStoreSetGetDelete(t *testing.T) {
 func TestMemoryStoreExpiry(t *testing.T) {
 	clk := clock.NewMock(time.Now())
 	s := cache.NewMemoryStore(cache.WithClock(clk))
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), 30*time.Second))
 	clk.Advance(31 * time.Second)
@@ -39,7 +39,7 @@ func TestMemoryStoreExpiry(t *testing.T) {
 func TestMemoryStoreNegativeTTLNeverExpires(t *testing.T) {
 	clk := clock.NewMock(time.Now())
 	s := cache.NewMemoryStore(cache.WithClock(clk))
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), -1))
 	clk.Advance(1000 * time.Hour)
@@ -50,7 +50,7 @@ func TestMemoryStoreNegativeTTLNeverExpires(t *testing.T) {
 
 func TestMemoryStoreLRUEviction(t *testing.T) {
 	s := cache.NewMemoryStore(cache.WithMaxEntries(2))
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	require.NoError(t, s.Set(t.Context(), "a", []byte("1"), -1))
 	require.NoError(t, s.Set(t.Context(), "b", []byte("2"), -1))
@@ -65,7 +65,7 @@ func TestMemoryStoreLRUEviction(t *testing.T) {
 
 func TestMemoryStoreDeletePrefix(t *testing.T) {
 	s := cache.NewMemoryStore()
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	require.NoError(t, s.Set(t.Context(), "a:1", []byte("x"), -1))
 	require.NoError(t, s.Set(t.Context(), "a:2", []byte("x"), -1))

--- a/cache/redis/doc.go
+++ b/cache/redis/doc.go
@@ -1,0 +1,11 @@
+// Package redis provides a Redis-backed cache.Store.
+//
+//	client := redis.Open(ctx, redis.WithConfig(cfg)) // forge/redis; caller closes it
+//	defer client.Close()
+//
+//	store := cacheredis.NewStore(client)
+//	sessions := cache.New[Session](store, cache.WithPrefix("sess:"))
+//
+// Store.Close is a no-op — close the underlying client yourself. Clear on a
+// typed cache issues SCAN + DEL over the cache's prefix (never FLUSHDB).
+package redis

--- a/cache/redis/redis.go
+++ b/cache/redis/redis.go
@@ -1,0 +1,74 @@
+package redis
+
+import (
+	"context"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/dmitrymomot/forge/cache"
+	forgeredis "github.com/dmitrymomot/forge/redis"
+)
+
+type store struct {
+	client goredis.UniversalClient
+}
+
+// NewStore returns a cache.Store backed by client. Store.Close is a no-op: the
+// caller owns the client and must close it.
+func NewStore(client goredis.UniversalClient) cache.Store {
+	return &store{client: client}
+}
+
+func (s *store) Get(ctx context.Context, key string) ([]byte, error) {
+	b, err := s.client.Get(ctx, key).Bytes()
+	if forgeredis.IsNil(err) {
+		return nil, cache.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (s *store) Set(ctx context.Context, key string, val []byte, ttl time.Duration) error {
+	var exp time.Duration // ttl <= 0 -> 0 -> no expiry in Redis
+	if ttl > 0 {
+		exp = ttl
+	}
+	return s.client.Set(ctx, key, val, exp).Err()
+}
+
+func (s *store) Delete(ctx context.Context, key string) error {
+	return s.client.Del(ctx, key).Err()
+}
+
+func (s *store) Has(ctx context.Context, key string) (bool, error) {
+	n, err := s.client.Exists(ctx, key).Result()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+func (s *store) DeletePrefix(ctx context.Context, prefix string) error {
+	var cursor uint64
+	for {
+		keys, next, err := s.client.Scan(ctx, cursor, prefix+"*", 100).Result()
+		if err != nil {
+			return err
+		}
+		if len(keys) > 0 {
+			if err := s.client.Del(ctx, keys...).Err(); err != nil {
+				return err
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			return nil
+		}
+	}
+}
+
+// Close is a no-op; the caller owns the client's lifecycle.
+func (s *store) Close() error { return nil }

--- a/cache/redis/redis.go
+++ b/cache/redis/redis.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	goredis "github.com/redis/go-redis/v9"
@@ -51,10 +52,28 @@ func (s *store) Has(ctx context.Context, key string) (bool, error) {
 	return n > 0, nil
 }
 
+// escapeGlob escapes Redis glob metacharacters so a prefix is matched
+// literally by SCAN MATCH. Without this, a prefix containing * ? [ ] \ would be
+// interpreted as a pattern, diverging from the in-memory store's literal
+// strings.HasPrefix and breaking prefix isolation.
+func escapeGlob(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		case '*', '?', '[', ']', '\\':
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
 func (s *store) DeletePrefix(ctx context.Context, prefix string) error {
+	pattern := escapeGlob(prefix) + "*"
 	var cursor uint64
 	for {
-		keys, next, err := s.client.Scan(ctx, cursor, prefix+"*", 100).Result()
+		keys, next, err := s.client.Scan(ctx, cursor, pattern, 100).Result()
 		if err != nil {
 			return err
 		}

--- a/cache/redis/redis_test.go
+++ b/cache/redis/redis_test.go
@@ -1,0 +1,52 @@
+package redis_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/cache"
+	cacheredis "github.com/dmitrymomot/forge/cache/redis"
+)
+
+func testClient(t *testing.T) goredis.UniversalClient {
+	t.Helper()
+	url := os.Getenv("TEST_REDIS_URL")
+	if url == "" {
+		t.Skip("TEST_REDIS_URL not set")
+	}
+	opt, err := goredis.ParseURL(url)
+	require.NoError(t, err)
+	c := goredis.NewClient(opt)
+	require.NoError(t, c.Ping(context.Background()).Err())
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func TestRedisStoreRoundTripAndScopedClear(t *testing.T) {
+	client := testClient(t)
+	store := cacheredis.NewStore(client)
+
+	users := cache.New[string](store, cache.WithPrefix("test:cache:users:"))
+	other := cache.New[string](store, cache.WithPrefix("test:cache:other:"))
+
+	require.NoError(t, users.Set(t.Context(), "1", "alice", time.Minute))
+	require.NoError(t, other.Set(t.Context(), "1", "keep", time.Minute))
+
+	v, err := users.Get(t.Context(), "1")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", v)
+
+	require.NoError(t, users.Clear(t.Context()))
+	_, err = users.Get(t.Context(), "1")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+
+	kept, err := other.Get(t.Context(), "1") // scoped clear left other's prefix alone
+	require.NoError(t, err)
+	assert.Equal(t, "keep", kept)
+}

--- a/cache/redis/redis_test.go
+++ b/cache/redis/redis_test.go
@@ -50,3 +50,26 @@ func TestRedisStoreRoundTripAndScopedClear(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "keep", kept)
 }
+
+func TestRedisStoreDeletePrefixMatchesLiterally(t *testing.T) {
+	client := testClient(t) // SKIPs without TEST_REDIS_URL
+	store := cacheredis.NewStore(client)
+
+	// The prefix contains a glob metacharacter '['. DeletePrefix must match it
+	// literally (like the in-memory store's strings.HasPrefix), not as a Redis
+	// pattern — otherwise "g[x]" would also match the sibling "gx".
+	target := cache.New[string](store, cache.WithPrefix("test:cache:g[x]:"))
+	sibling := cache.New[string](store, cache.WithPrefix("test:cache:gx:"))
+
+	require.NoError(t, target.Set(t.Context(), "1", "gone", time.Minute))
+	require.NoError(t, sibling.Set(t.Context(), "1", "keep", time.Minute))
+
+	require.NoError(t, target.Clear(t.Context()))
+
+	_, err := target.Get(t.Context(), "1")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+
+	kept, err := sibling.Get(t.Context(), "1") // literal match: sibling untouched
+	require.NoError(t, err)
+	assert.Equal(t, "keep", kept)
+}

--- a/cache/store.go
+++ b/cache/store.go
@@ -1,0 +1,45 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Store is a byte-level key/value backend with TTL. Implementations are
+// standalone instances whose lifecycle (background goroutines, connections) is
+// owned by the caller via Close. TTL semantics: >0 expires after the duration,
+// 0 means the store's own default (none for the memory store), <0 never expires.
+type Store interface {
+	Get(ctx context.Context, key string) ([]byte, error)
+	Set(ctx context.Context, key string, val []byte, ttl time.Duration) error
+	Delete(ctx context.Context, key string) error
+	Has(ctx context.Context, key string) (bool, error)
+	DeletePrefix(ctx context.Context, prefix string) error
+	Close() error
+}
+
+// Marshaler serializes cache values to and from bytes.
+type Marshaler[V any] interface {
+	Marshal(v V) ([]byte, error)
+	Unmarshal(data []byte) (V, error)
+}
+
+type jsonMarshaler[V any] struct{}
+
+func (jsonMarshaler[V]) Marshal(v V) ([]byte, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, errors.Join(ErrMarshal, err)
+	}
+	return b, nil
+}
+
+func (jsonMarshaler[V]) Unmarshal(data []byte) (V, error) {
+	var v V
+	if err := json.Unmarshal(data, &v); err != nil {
+		return v, errors.Join(ErrUnmarshal, err)
+	}
+	return v, nil
+}

--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -168,12 +168,6 @@ func (b *Breaker) after(err error) {
 			b.openedAt = b.cfg.clk.Now()
 			b.transition(StateOpen)
 		}
-	case StateOpen:
-		// A sibling probe admitted in half-open can complete after another
-		// probe already reopened the breaker; keep the in-flight counter honest.
-		if b.halfOpenIn > 0 {
-			b.halfOpenIn--
-		}
 	}
 }
 

--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -170,6 +170,12 @@ func (b *Breaker) after(err error) {
 			b.openedAt = b.cfg.clk.Now()
 			b.transition(StateOpen)
 		}
+	case StateOpen:
+		// A sibling probe admitted in half-open can complete after another
+		// probe already reopened the breaker; keep the in-flight counter honest.
+		if b.halfOpenIn > 0 {
+			b.halfOpenIn--
+		}
 	}
 }
 

--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -1,0 +1,186 @@
+// Package circuitbreaker fails fast against a failing dependency using a
+// closed/open/half-open state machine.
+package circuitbreaker
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/clock"
+)
+
+// State is the breaker's current mode.
+type State int
+
+const (
+	// StateClosed passes calls through and counts failures.
+	StateClosed State = iota
+	// StateOpen rejects calls with ErrOpen until the open timeout elapses.
+	StateOpen
+	// StateHalfOpen admits a limited number of probe calls.
+	StateHalfOpen
+)
+
+// String returns "closed", "open", or "half-open".
+func (s State) String() string {
+	switch s {
+	case StateOpen:
+		return "open"
+	case StateHalfOpen:
+		return "half-open"
+	default:
+		return "closed"
+	}
+}
+
+type config struct {
+	onStateChange func(from, to State)
+	clk           clock.Clock
+	threshold     int
+	openTimeout   time.Duration
+	halfOpenMax   int
+}
+
+// Option configures a Breaker.
+type Option func(*config)
+
+// WithFailureThreshold sets consecutive failures that open the circuit (default 5).
+func WithFailureThreshold(n int) Option {
+	return func(c *config) {
+		if n > 0 {
+			c.threshold = n
+		}
+	}
+}
+
+// WithOpenTimeout sets how long the circuit stays open before a probe (default 30s).
+func WithOpenTimeout(d time.Duration) Option {
+	return func(c *config) {
+		if d > 0 {
+			c.openTimeout = d
+		}
+	}
+}
+
+// WithHalfOpenMax caps concurrent probe calls in half-open (default 1).
+func WithHalfOpenMax(n int) Option {
+	return func(c *config) {
+		if n > 0 {
+			c.halfOpenMax = n
+		}
+	}
+}
+
+// WithOnStateChange registers a transition callback. It runs while the breaker
+// lock is held, so it must not call back into the same Breaker.
+func WithOnStateChange(fn func(from, to State)) Option {
+	return func(c *config) { c.onStateChange = fn }
+}
+
+// WithClock injects the time source (default clock.System()).
+func WithClock(clk clock.Clock) Option {
+	return func(c *config) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+// Breaker guards calls to a dependency. Construct it with New; safe for
+// concurrent use.
+type Breaker struct {
+	openedAt   time.Time
+	cfg        config
+	state      State
+	failures   int
+	halfOpenIn int
+	mu         sync.Mutex
+}
+
+// New builds a Breaker from options.
+func New(opts ...Option) *Breaker {
+	c := config{threshold: 5, openTimeout: 30 * time.Second, halfOpenMax: 1, clk: clock.System()}
+	for _, o := range opts {
+		o(&c)
+	}
+	return &Breaker{cfg: c, state: StateClosed}
+}
+
+// State reports the current state.
+func (b *Breaker) State() State {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.state
+}
+
+// Do runs fn unless the circuit rejects it, recording the outcome. It returns
+// ErrOpen without calling fn when the circuit is open.
+func (b *Breaker) Do(ctx context.Context, fn func(context.Context) error) error {
+	if err := b.before(); err != nil {
+		return err
+	}
+	err := fn(ctx)
+	b.after(err)
+	return err
+}
+
+func (b *Breaker) before() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch b.state {
+	case StateOpen:
+		if b.cfg.clk.Now().Sub(b.openedAt) < b.cfg.openTimeout {
+			return ErrOpen
+		}
+		b.transition(StateHalfOpen)
+		b.halfOpenIn = 1
+		return nil
+	case StateHalfOpen:
+		if b.halfOpenIn >= b.cfg.halfOpenMax {
+			return ErrOpen
+		}
+		b.halfOpenIn++
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (b *Breaker) after(err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch b.state {
+	case StateHalfOpen:
+		b.halfOpenIn--
+		if err != nil {
+			b.openedAt = b.cfg.clk.Now()
+			b.transition(StateOpen)
+			return
+		}
+		b.failures = 0
+		b.transition(StateClosed)
+	case StateClosed:
+		if err == nil {
+			b.failures = 0
+			return
+		}
+		b.failures++
+		if b.failures >= b.cfg.threshold {
+			b.openedAt = b.cfg.clk.Now()
+			b.transition(StateOpen)
+		}
+	}
+}
+
+// transition sets a new state and fires the callback. Caller holds b.mu.
+func (b *Breaker) transition(to State) {
+	if b.state == to {
+		return
+	}
+	from := b.state
+	b.state = to
+	if b.cfg.onStateChange != nil {
+		b.cfg.onStateChange(from, to)
+	}
+}

--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -1,5 +1,3 @@
-// Package circuitbreaker fails fast against a failing dependency using a
-// closed/open/half-open state machine.
 package circuitbreaker
 
 import (

--- a/circuitbreaker/circuitbreaker_test.go
+++ b/circuitbreaker/circuitbreaker_test.go
@@ -1,0 +1,67 @@
+package circuitbreaker_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/circuitbreaker"
+	"github.com/dmitrymomot/forge/clock"
+)
+
+var errBoom = errors.New("boom")
+
+func fail(context.Context) error { return errBoom }
+func ok(context.Context) error   { return nil }
+
+func TestOpensAfterThresholdAndFastFails(t *testing.T) {
+	b := circuitbreaker.New(circuitbreaker.WithFailureThreshold(3))
+	for range 3 {
+		_ = b.Do(t.Context(), fail)
+	}
+	assert.Equal(t, circuitbreaker.StateOpen, b.State())
+
+	err := b.Do(t.Context(), func(context.Context) error {
+		t.Fatal("fn must not run while open")
+		return nil
+	})
+	assert.ErrorIs(t, err, circuitbreaker.ErrOpen)
+}
+
+func TestHalfOpenProbeRecovers(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	var transitions []string
+	b := circuitbreaker.New(
+		circuitbreaker.WithFailureThreshold(2),
+		circuitbreaker.WithOpenTimeout(10*time.Second),
+		circuitbreaker.WithClock(clk),
+		circuitbreaker.WithOnStateChange(func(from, to circuitbreaker.State) {
+			transitions = append(transitions, from.String()+"->"+to.String())
+		}),
+	)
+	_ = b.Do(t.Context(), fail)
+	_ = b.Do(t.Context(), fail)
+	assert.Equal(t, circuitbreaker.StateOpen, b.State())
+
+	clk.Advance(10 * time.Second)
+	assert.NoError(t, b.Do(t.Context(), ok))
+	assert.Equal(t, circuitbreaker.StateClosed, b.State())
+	assert.Equal(t, []string{"closed->open", "open->half-open", "half-open->closed"}, transitions)
+}
+
+func TestHalfOpenProbeFailureReopens(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	b := circuitbreaker.New(
+		circuitbreaker.WithFailureThreshold(1),
+		circuitbreaker.WithOpenTimeout(5*time.Second),
+		circuitbreaker.WithClock(clk),
+	)
+	_ = b.Do(t.Context(), fail)
+	assert.Equal(t, circuitbreaker.StateOpen, b.State())
+	clk.Advance(5 * time.Second)
+	_ = b.Do(t.Context(), fail) // half-open probe fails
+	assert.Equal(t, circuitbreaker.StateOpen, b.State())
+}

--- a/circuitbreaker/circuitbreaker_test.go
+++ b/circuitbreaker/circuitbreaker_test.go
@@ -3,6 +3,7 @@ package circuitbreaker_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -64,4 +65,38 @@ func TestHalfOpenProbeFailureReopens(t *testing.T) {
 	clk.Advance(5 * time.Second)
 	_ = b.Do(t.Context(), fail) // half-open probe fails
 	assert.Equal(t, circuitbreaker.StateOpen, b.State())
+}
+
+func TestHalfOpenMaxAdmitsConcurrentProbesThenRejects(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	b := circuitbreaker.New(
+		circuitbreaker.WithFailureThreshold(1),
+		circuitbreaker.WithOpenTimeout(time.Second),
+		circuitbreaker.WithHalfOpenMax(2),
+		circuitbreaker.WithClock(clk),
+	)
+	_ = b.Do(t.Context(), fail) // trip open
+	assert.Equal(t, circuitbreaker.StateOpen, b.State())
+	clk.Advance(time.Second) // allow half-open probing
+
+	inProbe := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Go(func() {
+			_ = b.Do(t.Context(), func(context.Context) error {
+				inProbe <- struct{}{}
+				<-release
+				return nil
+			})
+		})
+	}
+	<-inProbe // both probes admitted and running in half-open
+	<-inProbe
+	// A third probe must be rejected: halfOpenIn(2) >= halfOpenMax(2).
+	assert.ErrorIs(t, b.Do(t.Context(), ok), circuitbreaker.ErrOpen)
+	close(release)
+	wg.Wait()
+	// Both probes succeeded → breaker closed.
+	assert.Equal(t, circuitbreaker.StateClosed, b.State())
 }

--- a/circuitbreaker/doc.go
+++ b/circuitbreaker/doc.go
@@ -1,0 +1,9 @@
+// Package circuitbreaker fails fast against a failing dependency using a
+// closed/open/half-open state machine.
+//
+//	cb := circuitbreaker.New(circuitbreaker.WithFailureThreshold(5))
+//	err := cb.Do(ctx, func(ctx context.Context) error { return call(ctx) })
+//	if errors.Is(err, circuitbreaker.ErrOpen) {
+//	    // dependency is being given time to recover
+//	}
+package circuitbreaker

--- a/circuitbreaker/errors.go
+++ b/circuitbreaker/errors.go
@@ -1,0 +1,6 @@
+package circuitbreaker
+
+import "errors"
+
+// ErrOpen is returned by Do when the circuit is open and the call is rejected.
+var ErrOpen = errors.New("circuitbreaker: circuit open")

--- a/docs/superpowers/plans/2026-07-02-resilience-caching-primitives.md
+++ b/docs/superpowers/plans/2026-07-02-resilience-caching-primitives.md
@@ -1,0 +1,2078 @@
+# Resilience & Caching Primitives Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship six flat packages — `backoff`, `retry`, `singleflight`, `parallel`, `circuitbreaker`, and `cache` (with a `cache/redis` subpackage) — as the resilience/caching leaves of the forge recommended tier.
+
+**Architecture:** Five near-zero-dependency primitives (stdlib, or stdlib + shipped `clock`) plus a provider-backed `cache`: a byte-level `Store` (built-in memory store + isolated `cache/redis` adapter) with a typed `Cache[V]` facade that owns no backend lifecycle. Instances over globals; each constructor returns isolated state.
+
+**Tech Stack:** Go 1.26, stdlib, `github.com/dmitrymomot/forge/clock` (shipped), `github.com/dmitrymomot/forge/singleflight` (this plan), `github.com/redis/go-redis/v9` (already in go.mod), `github.com/stretchr/testify` for tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-resilience-caching-primitives-design.md`
+
+## Global Constraints
+
+- Module path `github.com/dmitrymomot/forge`; Go 1.26.
+- **Options only, no builders.** `type Option func(*config)` with an unexported `config`. No exported env `Config` in v1.
+- **Instances over globals.** Zero package-level mutable state; no singletons.
+- **Black-box tests only** — test package is `<pkg>_test`, importing the package under its public API. Use `testify/assert` and `testify/require`.
+- Each package has `doc.go` (runnable example), `errors.go` (single-line `errors.Is` sentinels) where it has errors, and focused impl files.
+- `clock.Clock` is `Now()`-only. Inject via `WithClock`; test with `clock.NewMock(t).Advance(d)`.
+- Flat top-level packages. Run `just fmt ./<pkg>/...` after edits and `just lint` when the feature is done; both must pass.
+- Test a package with `just test ./<pkg>/...` (runs `go test -race -cover`).
+- Work only in the current branch. No Claude attribution in commits.
+
+---
+
+### Task 1: `backoff`
+
+**Files:**
+- Create: `backoff/backoff.go`
+- Create: `backoff/doc.go`
+- Test: `backoff/backoff_test.go`
+
+**Interfaces:**
+- Produces: `type Backoff interface { Next(attempt int) time.Duration }`; `Constant(d time.Duration) Backoff`; `Exponential(base, max time.Duration, opts ...Option) Backoff`; `WithMultiplier(f float64) Option`; `WithJitter(fraction float64) Option`.
+
+- [ ] **Step 1: Write the failing test** — `backoff/backoff_test.go`
+
+```go
+package backoff_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/backoff"
+)
+
+func TestConstant(t *testing.T) {
+	b := backoff.Constant(2 * time.Second)
+	assert.Equal(t, 2*time.Second, b.Next(1))
+	assert.Equal(t, 2*time.Second, b.Next(9))
+}
+
+func TestExponential(t *testing.T) {
+	b := backoff.Exponential(100*time.Millisecond, 10*time.Second)
+	assert.Equal(t, 100*time.Millisecond, b.Next(1))
+	assert.Equal(t, 200*time.Millisecond, b.Next(2))
+	assert.Equal(t, 400*time.Millisecond, b.Next(3))
+	assert.Equal(t, 10*time.Second, b.Next(30)) // capped at max
+}
+
+func TestExponentialMultiplier(t *testing.T) {
+	b := backoff.Exponential(10*time.Millisecond, time.Minute, backoff.WithMultiplier(3))
+	assert.Equal(t, 10*time.Millisecond, b.Next(1))
+	assert.Equal(t, 30*time.Millisecond, b.Next(2))
+	assert.Equal(t, 90*time.Millisecond, b.Next(3))
+}
+
+func TestExponentialJitterWithinBounds(t *testing.T) {
+	b := backoff.Exponential(100*time.Millisecond, 10*time.Second, backoff.WithJitter(0.5))
+	for range 200 {
+		d := b.Next(1) // base 100ms ±50% => [50ms, 150ms]
+		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+		assert.LessOrEqual(t, d, 150*time.Millisecond)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `just test ./backoff/...`
+Expected: FAIL — `undefined: backoff.Constant` (package does not compile yet).
+
+- [ ] **Step 3: Write the implementation** — `backoff/backoff.go`
+
+```go
+// Package backoff computes retry delays as pure, stateless strategies.
+package backoff
+
+import (
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// Backoff returns the delay to wait before a given 1-based attempt.
+// Implementations are stateless and safe for concurrent use.
+type Backoff interface {
+	Next(attempt int) time.Duration
+}
+
+type constant struct{ d time.Duration }
+
+func (c constant) Next(int) time.Duration { return c.d }
+
+// Constant always returns d. A negative d is clamped to 0.
+func Constant(d time.Duration) Backoff {
+	if d < 0 {
+		d = 0
+	}
+	return constant{d: d}
+}
+
+type exponential struct {
+	base       time.Duration
+	max        time.Duration
+	multiplier float64
+	jitter     float64
+}
+
+// Option configures Exponential.
+type Option func(*exponential)
+
+// WithMultiplier sets the growth factor (default 2.0). Values ≤ 0 are ignored.
+func WithMultiplier(f float64) Option {
+	return func(e *exponential) {
+		if f > 0 {
+			e.multiplier = f
+		}
+	}
+}
+
+// WithJitter randomizes each delay by ±fraction (clamped to 0..1).
+func WithJitter(fraction float64) Option {
+	return func(e *exponential) {
+		e.jitter = math.Min(1, math.Max(0, fraction))
+	}
+}
+
+func (e exponential) Next(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := float64(e.base) * math.Pow(e.multiplier, float64(attempt-1))
+	if d > float64(e.max) {
+		d = float64(e.max)
+	}
+	if e.jitter > 0 {
+		delta := d * e.jitter
+		d = d - delta + rand.Float64()*(2*delta) //nolint:gosec // non-crypto jitter
+	}
+	if d < 0 {
+		d = 0
+	}
+	return time.Duration(d)
+}
+
+// Exponential grows the delay as base*multiplier^(attempt-1), capped at max.
+// base is clamped to ≥ 1ns and max to ≥ base.
+func Exponential(base, max time.Duration, opts ...Option) Backoff {
+	if base < 1 {
+		base = 1
+	}
+	if max < base {
+		max = base
+	}
+	e := exponential{base: base, max: max, multiplier: 2.0}
+	for _, o := range opts {
+		o(&e)
+	}
+	return e
+}
+```
+
+- [ ] **Step 4: Create `backoff/doc.go`**
+
+```go
+// Package backoff computes retry delays as pure, stateless strategies.
+//
+//	b := backoff.Exponential(100*time.Millisecond, 10*time.Second, backoff.WithJitter(0.5))
+//	for attempt := 1; attempt <= 5; attempt++ {
+//	    time.Sleep(b.Next(attempt))
+//	}
+package backoff
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `just test ./backoff/...`
+Expected: PASS (ok, coverage reported).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+just fmt ./backoff/...
+git add backoff/
+git commit -m "feat(backoff): stateless exponential/constant delay strategies"
+```
+
+---
+
+### Task 2: `retry`
+
+**Files:**
+- Create: `retry/retry.go`
+- Create: `retry/doc.go`
+- Test: `retry/retry_test.go`
+
+**Interfaces:**
+- Consumes: `backoff.Backoff`, `backoff.Constant`, `backoff.Exponential`, `backoff.WithJitter`.
+- Produces: `type Retrier struct{}`; `New(opts ...Option) *Retrier`; `(*Retrier).Do(ctx, fn func(context.Context) error) error`; `Do(ctx, fn, opts ...Option) error`; `Permanent(err error) error`; `WithMaxAttempts(n int) Option`; `WithBackoff(b backoff.Backoff) Option`; `WithRetryIf(fn func(error) bool) Option`.
+
+- [ ] **Step 1: Write the failing test** — `retry/retry_test.go`
+
+```go
+package retry_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/backoff"
+	"github.com/dmitrymomot/forge/retry"
+)
+
+var fast = retry.WithBackoff(backoff.Constant(time.Millisecond))
+
+func TestSucceedsAfterTransientFailures(t *testing.T) {
+	calls := 0
+	err := retry.Do(t.Context(), func(context.Context) error {
+		calls++
+		if calls < 3 {
+			return errors.New("boom")
+		}
+		return nil
+	}, retry.WithMaxAttempts(5), fast)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestExhaustsAndReturnsLastError(t *testing.T) {
+	calls := 0
+	err := retry.Do(t.Context(), func(context.Context) error {
+		calls++
+		return errors.New("boom")
+	}, retry.WithMaxAttempts(3), fast)
+	assert.Error(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestPermanentStopsImmediately(t *testing.T) {
+	sentinel := errors.New("nope")
+	calls := 0
+	err := retry.Do(t.Context(), func(context.Context) error {
+		calls++
+		return retry.Permanent(sentinel)
+	}, retry.WithMaxAttempts(5), fast)
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryIfGate(t *testing.T) {
+	stop := errors.New("do-not-retry")
+	calls := 0
+	err := retry.Do(t.Context(), func(context.Context) error {
+		calls++
+		return stop
+	}, retry.WithMaxAttempts(5), fast, retry.WithRetryIf(func(e error) bool {
+		return !errors.Is(e, stop)
+	}))
+	assert.ErrorIs(t, err, stop)
+	assert.Equal(t, 1, calls)
+}
+
+func TestContextCancellationDuringBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	err := retry.Do(ctx, func(context.Context) error {
+		return errors.New("boom")
+	}, retry.WithMaxAttempts(5), retry.WithBackoff(backoff.Constant(time.Hour)))
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestRetrierReusable(t *testing.T) {
+	r := retry.New(retry.WithMaxAttempts(2), fast)
+	assert.Error(t, r.Do(t.Context(), func(context.Context) error { return errors.New("x") }))
+	assert.NoError(t, r.Do(t.Context(), func(context.Context) error { return nil }))
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `just test ./retry/...`
+Expected: FAIL — `undefined: retry.Do`.
+
+- [ ] **Step 3: Write the implementation** — `retry/retry.go`
+
+```go
+// Package retry runs an operation with a backoff strategy until it succeeds,
+// a permanent error is returned, or the context is cancelled.
+package retry
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dmitrymomot/forge/backoff"
+)
+
+type config struct {
+	maxAttempts int
+	backoff     backoff.Backoff
+	retryIf     func(error) bool
+}
+
+// Option configures a Retrier.
+type Option func(*config)
+
+// WithMaxAttempts caps total attempts (default 3). Values ≤ 0 are ignored.
+func WithMaxAttempts(n int) Option {
+	return func(c *config) {
+		if n > 0 {
+			c.maxAttempts = n
+		}
+	}
+}
+
+// WithBackoff sets the delay strategy (default Exponential(100ms,10s,jitter 0.5)).
+func WithBackoff(b backoff.Backoff) Option {
+	return func(c *config) {
+		if b != nil {
+			c.backoff = b
+		}
+	}
+}
+
+// WithRetryIf decides, per error, whether to retry (default: retry all non-Permanent).
+func WithRetryIf(fn func(error) bool) Option {
+	return func(c *config) {
+		if fn != nil {
+			c.retryIf = fn
+		}
+	}
+}
+
+// Retrier executes functions with a fixed retry policy and is reusable and
+// safe for concurrent use.
+type Retrier struct{ cfg config }
+
+// New builds a Retrier from options.
+func New(opts ...Option) *Retrier {
+	c := config{
+		maxAttempts: 3,
+		backoff:     backoff.Exponential(100*time.Millisecond, 10*time.Second, backoff.WithJitter(0.5)),
+		retryIf:     func(error) bool { return true },
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	return &Retrier{cfg: c}
+}
+
+type permanentError struct{ err error }
+
+func (e *permanentError) Error() string { return e.err.Error() }
+func (e *permanentError) Unwrap() error { return e.err }
+
+// Permanent wraps err so retry stops immediately and returns the wrapped error.
+func Permanent(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &permanentError{err: err}
+}
+
+// Do runs fn, retrying per the policy. It returns nil on success, the wrapped
+// error for a Permanent, ctx.Err() on cancellation, or the last error on
+// exhaustion.
+func (r *Retrier) Do(ctx context.Context, fn func(context.Context) error) error {
+	var lastErr error
+	for attempt := 1; attempt <= r.cfg.maxAttempts; attempt++ {
+		err := fn(ctx)
+		if err == nil {
+			return nil
+		}
+		var perm *permanentError
+		if errors.As(err, &perm) {
+			return perm.err
+		}
+		lastErr = err
+		if !r.cfg.retryIf(err) {
+			return err
+		}
+		if attempt == r.cfg.maxAttempts {
+			break
+		}
+		timer := time.NewTimer(r.cfg.backoff.Next(attempt))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return lastErr
+}
+
+// Do is a one-shot convenience equivalent to New(opts...).Do(ctx, fn).
+func Do(ctx context.Context, fn func(context.Context) error, opts ...Option) error {
+	return New(opts...).Do(ctx, fn)
+}
+```
+
+- [ ] **Step 4: Create `retry/doc.go`**
+
+```go
+// Package retry runs an operation with a backoff strategy until it succeeds,
+// a permanent error is returned, or the context is cancelled.
+//
+//	err := retry.Do(ctx, func(ctx context.Context) error {
+//	    return callFlakyAPI(ctx)
+//	}, retry.WithMaxAttempts(5))
+//
+// Wrap an error with retry.Permanent to stop early:
+//
+//	return retry.Permanent(errBadRequest)
+package retry
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `just test ./retry/...`
+Expected: PASS.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+just fmt ./retry/...
+git add retry/
+git commit -m "feat(retry): instance-based retry with backoff, Permanent, ctx cancel"
+```
+
+---
+
+### Task 3: `singleflight`
+
+**Files:**
+- Create: `singleflight/singleflight.go`
+- Create: `singleflight/doc.go`
+- Test: `singleflight/singleflight_test.go`
+
+**Interfaces:**
+- Produces: `type Group[V any] struct{}` (zero-value usable); `(*Group[V]).Do(ctx, key string, fn func(context.Context) (V, error)) (V, bool, error)`; `(*Group[V]).Forget(key string)`.
+
+- [ ] **Step 1: Write the failing test** — `singleflight/singleflight_test.go`
+
+```go
+package singleflight_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/singleflight"
+)
+
+func TestCoalescesConcurrentCalls(t *testing.T) {
+	var g singleflight.Group[int]
+	var calls atomic.Int32
+	start := make(chan struct{})
+	results := make([]int, 20)
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			v, _, err := g.Do(t.Context(), "k", func(context.Context) (int, error) {
+				calls.Add(1)
+				time.Sleep(25 * time.Millisecond)
+				return 42, nil
+			})
+			assert.NoError(t, err)
+			results[i] = v
+		}()
+	}
+	close(start)
+	wg.Wait()
+	assert.Equal(t, int32(1), calls.Load())
+	for _, r := range results {
+		assert.Equal(t, 42, r)
+	}
+}
+
+func TestForgetAllowsReexecution(t *testing.T) {
+	var g singleflight.Group[int]
+	var calls atomic.Int32
+	load := func(context.Context) (int, error) { calls.Add(1); return 1, nil }
+	_, _, _ = g.Do(t.Context(), "k", load)
+	g.Forget("k")
+	_, _, _ = g.Do(t.Context(), "k", load)
+	assert.Equal(t, int32(2), calls.Load())
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `just test ./singleflight/...`
+Expected: FAIL — `undefined: singleflight.Group`.
+
+- [ ] **Step 3: Write the implementation** — `singleflight/singleflight.go`
+
+```go
+// Package singleflight coalesces concurrent calls for the same key into a
+// single execution whose result is shared among all callers.
+package singleflight
+
+import (
+	"context"
+	"sync"
+)
+
+type call[V any] struct {
+	wg  sync.WaitGroup
+	val V
+	err error
+}
+
+// Group deduplicates concurrent Do calls by key. The zero value is ready to
+// use; a Group must not be copied after first use.
+type Group[V any] struct {
+	mu sync.Mutex
+	m  map[string]*call[V]
+}
+
+// Do runs fn once for key while a call is in flight, sharing the result with
+// concurrent callers. shared reports whether the result came from another
+// caller's execution. fn runs under a cancellation-detached copy of ctx so one
+// caller cancelling does not abort the shared work; each caller's own ctx still
+// bounds its wait via fn's returned error, not the wait itself.
+func (g *Group[V]) Do(ctx context.Context, key string, fn func(context.Context) (V, error)) (V, bool, error) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call[V])
+	}
+	if c, ok := g.m[key]; ok {
+		g.mu.Unlock()
+		c.wg.Wait()
+		return c.val, true, c.err
+	}
+	c := new(call[V])
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	c.val, c.err = fn(context.WithoutCancel(ctx))
+	c.wg.Done()
+
+	g.mu.Lock()
+	if g.m[key] == c {
+		delete(g.m, key)
+	}
+	g.mu.Unlock()
+	return c.val, false, c.err
+}
+
+// Forget drops any in-flight/last record for key so the next Do re-executes.
+func (g *Group[V]) Forget(key string) {
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+}
+```
+
+- [ ] **Step 4: Create `singleflight/doc.go`**
+
+```go
+// Package singleflight coalesces concurrent calls for the same key into a
+// single execution whose result is shared among all callers.
+//
+//	var g singleflight.Group[User]
+//	u, shared, err := g.Do(ctx, id, func(ctx context.Context) (User, error) {
+//	    return repo.Load(ctx, id)
+//	})
+package singleflight
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `just test ./singleflight/...`
+Expected: PASS.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+just fmt ./singleflight/...
+git add singleflight/
+git commit -m "feat(singleflight): generic per-key call coalescing"
+```
+
+---
+
+### Task 4: `parallel`
+
+**Files:**
+- Create: `parallel/parallel.go`
+- Create: `parallel/doc.go`
+- Test: `parallel/parallel_test.go`
+
+**Interfaces:**
+- Produces: `type Group struct{}`; `New(ctx, opts ...Option) (*Group, context.Context)`; `(*Group).Go(fn func(context.Context) error)`; `(*Group).Wait() error`; `WithLimit(n int) Option`; `WithCollectAll() Option`; `ForEach[T any](ctx, items []T, limit int, fn func(context.Context, T) error) error`; `Map[T, U any](ctx, items []T, limit int, fn func(context.Context, T) (U, error)) ([]U, error)`.
+
+- [ ] **Step 1: Write the failing test** — `parallel/parallel_test.go`
+
+```go
+package parallel_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/parallel"
+)
+
+func TestMapPreservesOrder(t *testing.T) {
+	out, err := parallel.Map(t.Context(), []int{1, 2, 3, 4, 5}, 2,
+		func(_ context.Context, n int) (int, error) { return n * n, nil })
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 4, 9, 16, 25}, out)
+}
+
+func TestForEachBoundsConcurrency(t *testing.T) {
+	var inflight, peak atomic.Int32
+	items := make([]int, 30)
+	err := parallel.ForEach(t.Context(), items, 3, func(context.Context, int) error {
+		n := inflight.Add(1)
+		for {
+			p := peak.Load()
+			if n <= p || peak.CompareAndSwap(p, n) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+		inflight.Add(-1)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.LessOrEqual(t, peak.Load(), int32(3))
+}
+
+func TestForEachFailFast(t *testing.T) {
+	err := parallel.ForEach(t.Context(), []int{1, 2, 3}, 2, func(_ context.Context, n int) error {
+		if n == 2 {
+			return errors.New("boom")
+		}
+		return nil
+	})
+	assert.Error(t, err)
+}
+
+func TestGroupCollectAll(t *testing.T) {
+	g, _ := parallel.New(t.Context(), parallel.WithCollectAll())
+	for _, n := range []int{1, 2, 3, 4} {
+		g.Go(func(context.Context) error {
+			if n%2 == 0 {
+				return fmt.Errorf("even %d", n)
+			}
+			return nil
+		})
+	}
+	err := g.Wait()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "even 2")
+	assert.Contains(t, err.Error(), "even 4")
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `just test ./parallel/...`
+Expected: FAIL — `undefined: parallel.Map`.
+
+- [ ] **Step 3: Write the implementation** — `parallel/parallel.go`
+
+```go
+// Package parallel runs work concurrently with a bounded worker count. By
+// default it is fail-fast (first error cancels the rest); WithCollectAll runs
+// everything and joins all errors.
+package parallel
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+type config struct {
+	limit      int
+	collectAll bool
+}
+
+// Option configures a Group.
+type Option func(*config)
+
+// WithLimit bounds concurrent goroutines. n ≤ 0 means unbounded.
+func WithLimit(n int) Option { return func(c *config) { c.limit = n } }
+
+// WithCollectAll runs every task to completion and joins all errors instead of
+// cancelling siblings on the first failure.
+func WithCollectAll() Option { return func(c *config) { c.collectAll = true } }
+
+// Group runs a set of functions concurrently. Construct it with New.
+type Group struct {
+	ctx        context.Context
+	cancel     context.CancelFunc
+	collectAll bool
+	sem        chan struct{}
+	wg         sync.WaitGroup
+	once       sync.Once
+	firstErr   error
+	mu         sync.Mutex
+	errs       []error
+}
+
+// New returns a Group and a derived context. In fail-fast mode the context is
+// cancelled on the first error; it is always cancelled once Wait returns.
+func New(ctx context.Context, opts ...Option) (*Group, context.Context) {
+	c := config{}
+	for _, o := range opts {
+		o(&c)
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	g := &Group{ctx: ctx, cancel: cancel, collectAll: c.collectAll}
+	if c.limit > 0 {
+		g.sem = make(chan struct{}, c.limit)
+	}
+	return g, ctx
+}
+
+// Go runs fn in a new goroutine, blocking if the concurrency limit is reached.
+func (g *Group) Go(fn func(context.Context) error) {
+	g.wg.Add(1)
+	if g.sem != nil {
+		g.sem <- struct{}{}
+	}
+	go func() {
+		defer g.wg.Done()
+		if g.sem != nil {
+			defer func() { <-g.sem }()
+		}
+		if err := fn(g.ctx); err != nil {
+			if g.collectAll {
+				g.mu.Lock()
+				g.errs = append(g.errs, err)
+				g.mu.Unlock()
+				return
+			}
+			g.once.Do(func() {
+				g.firstErr = err
+				g.cancel()
+			})
+		}
+	}()
+}
+
+// Wait blocks until all Go'd functions return, then reports the error: the
+// first error in fail-fast mode, or errors.Join of all in collect-all mode.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	g.cancel()
+	if g.collectAll {
+		return errors.Join(g.errs...)
+	}
+	return g.firstErr
+}
+
+// ForEach runs fn for every item with bounded concurrency, fail-fast.
+func ForEach[T any](ctx context.Context, items []T, limit int, fn func(context.Context, T) error) error {
+	g, _ := New(ctx, WithLimit(limit))
+	for _, item := range items {
+		g.Go(func(ctx context.Context) error { return fn(ctx, item) })
+	}
+	return g.Wait()
+}
+
+// Map applies fn to every item with bounded concurrency, fail-fast, preserving
+// order. On any error it returns a nil slice and the first error.
+func Map[T, U any](ctx context.Context, items []T, limit int, fn func(context.Context, T) (U, error)) ([]U, error) {
+	results := make([]U, len(items))
+	g, _ := New(ctx, WithLimit(limit))
+	for i, item := range items {
+		g.Go(func(ctx context.Context) error {
+			u, err := fn(ctx, item)
+			if err != nil {
+				return err
+			}
+			results[i] = u
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+```
+
+- [ ] **Step 4: Create `parallel/doc.go`**
+
+```go
+// Package parallel runs work concurrently with a bounded worker count.
+//
+//	squares, err := parallel.Map(ctx, ids, 8, func(ctx context.Context, id int) (int, error) {
+//	    return id * id, nil
+//	})
+//
+// For imperative use, construct a Group:
+//
+//	g, ctx := parallel.New(ctx, parallel.WithLimit(4))
+//	for _, job := range jobs {
+//	    g.Go(func(ctx context.Context) error { return job.Run(ctx) })
+//	}
+//	err := g.Wait()
+package parallel
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `just test ./parallel/...`
+Expected: PASS.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+just fmt ./parallel/...
+git add parallel/
+git commit -m "feat(parallel): bounded concurrency with fail-fast and collect-all modes"
+```
+
+---
+
+### Task 5: `circuitbreaker`
+
+**Files:**
+- Create: `circuitbreaker/circuitbreaker.go`
+- Create: `circuitbreaker/errors.go`
+- Create: `circuitbreaker/doc.go`
+- Test: `circuitbreaker/circuitbreaker_test.go`
+
+**Interfaces:**
+- Consumes: `clock.Clock`, `clock.System()`, `clock.NewMock(t)`, `(*clock.Mock).Advance(d)`.
+- Produces: `type State int` with `StateClosed/StateOpen/StateHalfOpen` and `String()`; `var ErrOpen`; `type Breaker struct{}`; `New(opts ...Option) *Breaker`; `(*Breaker).Do(ctx, fn func(context.Context) error) error`; `(*Breaker).State() State`; options `WithFailureThreshold(n)`, `WithOpenTimeout(d)`, `WithHalfOpenMax(n)`, `WithOnStateChange(func(from, to State))`, `WithClock(clock.Clock)`.
+
+- [ ] **Step 1: Write the failing test** — `circuitbreaker/circuitbreaker_test.go`
+
+```go
+package circuitbreaker_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/circuitbreaker"
+	"github.com/dmitrymomot/forge/clock"
+)
+
+var errBoom = errors.New("boom")
+
+func fail(context.Context) error { return errBoom }
+func ok(context.Context) error   { return nil }
+
+func TestOpensAfterThresholdAndFastFails(t *testing.T) {
+	b := circuitbreaker.New(circuitbreaker.WithFailureThreshold(3))
+	for range 3 {
+		_ = b.Do(t.Context(), fail)
+	}
+	assert.Equal(t, circuitbreaker.StateOpen, b.State())
+
+	err := b.Do(t.Context(), func(context.Context) error {
+		t.Fatal("fn must not run while open")
+		return nil
+	})
+	assert.ErrorIs(t, err, circuitbreaker.ErrOpen)
+}
+
+func TestHalfOpenProbeRecovers(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	var transitions []string
+	b := circuitbreaker.New(
+		circuitbreaker.WithFailureThreshold(2),
+		circuitbreaker.WithOpenTimeout(10*time.Second),
+		circuitbreaker.WithClock(clk),
+		circuitbreaker.WithOnStateChange(func(from, to circuitbreaker.State) {
+			transitions = append(transitions, from.String()+"->"+to.String())
+		}),
+	)
+	_ = b.Do(t.Context(), fail)
+	_ = b.Do(t.Context(), fail)
+	assert.Equal(t, circuitbreaker.StateOpen, b.State())
+
+	clk.Advance(10 * time.Second)
+	assert.NoError(t, b.Do(t.Context(), ok))
+	assert.Equal(t, circuitbreaker.StateClosed, b.State())
+	assert.Equal(t, []string{"closed->open", "open->half-open", "half-open->closed"}, transitions)
+}
+
+func TestHalfOpenProbeFailureReopens(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	b := circuitbreaker.New(
+		circuitbreaker.WithFailureThreshold(1),
+		circuitbreaker.WithOpenTimeout(5*time.Second),
+		circuitbreaker.WithClock(clk),
+	)
+	_ = b.Do(t.Context(), fail)
+	assert.Equal(t, circuitbreaker.StateOpen, b.State())
+	clk.Advance(5 * time.Second)
+	_ = b.Do(t.Context(), fail) // half-open probe fails
+	assert.Equal(t, circuitbreaker.StateOpen, b.State())
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `just test ./circuitbreaker/...`
+Expected: FAIL — `undefined: circuitbreaker.New`.
+
+- [ ] **Step 3: Write the sentinel + state** — `circuitbreaker/errors.go`
+
+```go
+package circuitbreaker
+
+import "errors"
+
+// ErrOpen is returned by Do when the circuit is open and the call is rejected.
+var ErrOpen = errors.New("circuitbreaker: circuit open")
+```
+
+- [ ] **Step 4: Write the implementation** — `circuitbreaker/circuitbreaker.go`
+
+```go
+// Package circuitbreaker fails fast against a failing dependency using a
+// closed/open/half-open state machine.
+package circuitbreaker
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/clock"
+)
+
+// State is the breaker's current mode.
+type State int
+
+const (
+	// StateClosed passes calls through and counts failures.
+	StateClosed State = iota
+	// StateOpen rejects calls with ErrOpen until the open timeout elapses.
+	StateOpen
+	// StateHalfOpen admits a limited number of probe calls.
+	StateHalfOpen
+)
+
+// String returns "closed", "open", or "half-open".
+func (s State) String() string {
+	switch s {
+	case StateOpen:
+		return "open"
+	case StateHalfOpen:
+		return "half-open"
+	default:
+		return "closed"
+	}
+}
+
+type config struct {
+	threshold     int
+	openTimeout   time.Duration
+	halfOpenMax   int
+	onStateChange func(from, to State)
+	clk           clock.Clock
+}
+
+// Option configures a Breaker.
+type Option func(*config)
+
+// WithFailureThreshold sets consecutive failures that open the circuit (default 5).
+func WithFailureThreshold(n int) Option {
+	return func(c *config) {
+		if n > 0 {
+			c.threshold = n
+		}
+	}
+}
+
+// WithOpenTimeout sets how long the circuit stays open before a probe (default 30s).
+func WithOpenTimeout(d time.Duration) Option {
+	return func(c *config) {
+		if d > 0 {
+			c.openTimeout = d
+		}
+	}
+}
+
+// WithHalfOpenMax caps concurrent probe calls in half-open (default 1).
+func WithHalfOpenMax(n int) Option {
+	return func(c *config) {
+		if n > 0 {
+			c.halfOpenMax = n
+		}
+	}
+}
+
+// WithOnStateChange registers a transition callback. It runs while the breaker
+// lock is held, so it must not call back into the same Breaker.
+func WithOnStateChange(fn func(from, to State)) Option {
+	return func(c *config) { c.onStateChange = fn }
+}
+
+// WithClock injects the time source (default clock.System()).
+func WithClock(clk clock.Clock) Option {
+	return func(c *config) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+// Breaker guards calls to a dependency. Construct it with New; safe for
+// concurrent use.
+type Breaker struct {
+	cfg        config
+	mu         sync.Mutex
+	state      State
+	failures   int
+	openedAt   time.Time
+	halfOpenIn int
+}
+
+// New builds a Breaker from options.
+func New(opts ...Option) *Breaker {
+	c := config{threshold: 5, openTimeout: 30 * time.Second, halfOpenMax: 1, clk: clock.System()}
+	for _, o := range opts {
+		o(&c)
+	}
+	return &Breaker{cfg: c, state: StateClosed}
+}
+
+// State reports the current state.
+func (b *Breaker) State() State {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.state
+}
+
+// Do runs fn unless the circuit rejects it, recording the outcome. It returns
+// ErrOpen without calling fn when the circuit is open.
+func (b *Breaker) Do(ctx context.Context, fn func(context.Context) error) error {
+	if err := b.before(); err != nil {
+		return err
+	}
+	err := fn(ctx)
+	b.after(err)
+	return err
+}
+
+func (b *Breaker) before() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch b.state {
+	case StateOpen:
+		if b.cfg.clk.Now().Sub(b.openedAt) < b.cfg.openTimeout {
+			return ErrOpen
+		}
+		b.transition(StateHalfOpen)
+		b.halfOpenIn = 1
+		return nil
+	case StateHalfOpen:
+		if b.halfOpenIn >= b.cfg.halfOpenMax {
+			return ErrOpen
+		}
+		b.halfOpenIn++
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (b *Breaker) after(err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch b.state {
+	case StateHalfOpen:
+		b.halfOpenIn--
+		if err != nil {
+			b.openedAt = b.cfg.clk.Now()
+			b.transition(StateOpen)
+			return
+		}
+		b.failures = 0
+		b.transition(StateClosed)
+	case StateClosed:
+		if err == nil {
+			b.failures = 0
+			return
+		}
+		b.failures++
+		if b.failures >= b.cfg.threshold {
+			b.openedAt = b.cfg.clk.Now()
+			b.transition(StateOpen)
+		}
+	}
+}
+
+// transition sets a new state and fires the callback. Caller holds b.mu.
+func (b *Breaker) transition(to State) {
+	if b.state == to {
+		return
+	}
+	from := b.state
+	b.state = to
+	if b.cfg.onStateChange != nil {
+		b.cfg.onStateChange(from, to)
+	}
+}
+```
+
+- [ ] **Step 5: Create `circuitbreaker/doc.go`**
+
+```go
+// Package circuitbreaker fails fast against a failing dependency using a
+// closed/open/half-open state machine.
+//
+//	cb := circuitbreaker.New(circuitbreaker.WithFailureThreshold(5))
+//	err := cb.Do(ctx, func(ctx context.Context) error { return call(ctx) })
+//	if errors.Is(err, circuitbreaker.ErrOpen) {
+//	    // dependency is being given time to recover
+//	}
+package circuitbreaker
+```
+
+- [ ] **Step 6: Run the test, verify it passes**
+
+Run: `just test ./circuitbreaker/...`
+Expected: PASS.
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+just fmt ./circuitbreaker/...
+git add circuitbreaker/
+git commit -m "feat(circuitbreaker): closed/open/half-open breaker with clock injection"
+```
+
+---
+
+### Task 6: `cache` — `Store`, `Marshaler`, errors, and the memory store
+
+**Files:**
+- Create: `cache/errors.go`
+- Create: `cache/store.go`
+- Create: `cache/memory.go`
+- Test: `cache/memory_test.go`
+
+**Interfaces:**
+- Consumes: `clock.Clock`, `clock.System()`, `clock.NewMock`, `(*clock.Mock).Advance`.
+- Produces: sentinels `ErrNotFound/ErrClosed/ErrMarshal/ErrUnmarshal`; `type Store interface{ Get/Set/Delete/Has/DeletePrefix/Close }`; `type Marshaler[V any] interface{ Marshal/Unmarshal }`; `NewMemoryStore(opts ...MemoryOption) Store`; `WithMaxEntries(n int) MemoryOption`; `WithCleanupInterval(d time.Duration) MemoryOption`; `WithClock(clk clock.Clock) MemoryOption`.
+
+- [ ] **Step 1: Write the failing test** — `cache/memory_test.go`
+
+```go
+package cache_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/cache"
+	"github.com/dmitrymomot/forge/clock"
+)
+
+func TestMemoryStoreSetGetDelete(t *testing.T) {
+	s := cache.NewMemoryStore()
+	defer s.Close()
+
+	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), 0))
+	got, err := s.Get(t.Context(), "k")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v"), got)
+
+	require.NoError(t, s.Delete(t.Context(), "k"))
+	_, err = s.Get(t.Context(), "k")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+}
+
+func TestMemoryStoreExpiry(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	s := cache.NewMemoryStore(cache.WithClock(clk))
+	defer s.Close()
+
+	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), 30*time.Second))
+	clk.Advance(31 * time.Second)
+	_, err := s.Get(t.Context(), "k")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+}
+
+func TestMemoryStoreNegativeTTLNeverExpires(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	s := cache.NewMemoryStore(cache.WithClock(clk))
+	defer s.Close()
+
+	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), -1))
+	clk.Advance(1000 * time.Hour)
+	got, err := s.Get(t.Context(), "k")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v"), got)
+}
+
+func TestMemoryStoreLRUEviction(t *testing.T) {
+	s := cache.NewMemoryStore(cache.WithMaxEntries(2))
+	defer s.Close()
+
+	require.NoError(t, s.Set(t.Context(), "a", []byte("1"), -1))
+	require.NoError(t, s.Set(t.Context(), "b", []byte("2"), -1))
+	_, _ = s.Get(t.Context(), "a") // touch a -> b is least-recently-used
+	require.NoError(t, s.Set(t.Context(), "c", []byte("3"), -1))
+
+	_, err := s.Get(t.Context(), "b")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+	_, err = s.Get(t.Context(), "a")
+	assert.NoError(t, err)
+}
+
+func TestMemoryStoreDeletePrefix(t *testing.T) {
+	s := cache.NewMemoryStore()
+	defer s.Close()
+
+	require.NoError(t, s.Set(t.Context(), "a:1", []byte("x"), -1))
+	require.NoError(t, s.Set(t.Context(), "a:2", []byte("x"), -1))
+	require.NoError(t, s.Set(t.Context(), "b:1", []byte("x"), -1))
+
+	require.NoError(t, s.DeletePrefix(t.Context(), "a:"))
+	_, err := s.Get(t.Context(), "a:1")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+	ok, err := s.Has(t.Context(), "b:1")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestMemoryStoreClosedRejects(t *testing.T) {
+	s := cache.NewMemoryStore()
+	require.NoError(t, s.Close())
+	require.NoError(t, s.Close()) // idempotent
+	err := s.Set(t.Context(), "k", []byte("v"), 0)
+	assert.ErrorIs(t, err, cache.ErrClosed)
+}
+
+// Smoke test: exercises the janitor goroutine start/sweep/stop path under -race.
+// The janitor uses a real ticker, so this asserts no panic/leak, not timing.
+func TestMemoryStoreJanitorStartsAndStops(t *testing.T) {
+	s := cache.NewMemoryStore(cache.WithCleanupInterval(5 * time.Millisecond))
+	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), time.Millisecond))
+	time.Sleep(20 * time.Millisecond) // let the ticker fire at least once
+	require.NoError(t, s.Close())      // must stop the goroutine cleanly
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `just test ./cache/...`
+Expected: FAIL — `undefined: cache.NewMemoryStore`.
+
+- [ ] **Step 3: Write sentinels** — `cache/errors.go`
+
+```go
+package cache
+
+import "errors"
+
+// Sentinel errors for cache operations.
+var (
+	// ErrNotFound is returned when a key is absent or expired.
+	ErrNotFound = errors.New("cache: entry not found")
+	// ErrClosed is returned by a store after Close.
+	ErrClosed = errors.New("cache: closed")
+	// ErrMarshal is returned when value serialization fails.
+	ErrMarshal = errors.New("cache: failed to marshal value")
+	// ErrUnmarshal is returned when value deserialization fails.
+	ErrUnmarshal = errors.New("cache: failed to unmarshal value")
+)
+```
+
+- [ ] **Step 4: Write the Store interface + JSON marshaler** — `cache/store.go`
+
+```go
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Store is a byte-level key/value backend with TTL. Implementations are
+// standalone instances whose lifecycle (background goroutines, connections) is
+// owned by the caller via Close. TTL semantics: >0 expires after the duration,
+// 0 means the store's own default (none for the memory store), <0 never expires.
+type Store interface {
+	Get(ctx context.Context, key string) ([]byte, error)
+	Set(ctx context.Context, key string, val []byte, ttl time.Duration) error
+	Delete(ctx context.Context, key string) error
+	Has(ctx context.Context, key string) (bool, error)
+	DeletePrefix(ctx context.Context, prefix string) error
+	Close() error
+}
+
+// Marshaler serializes cache values to and from bytes.
+type Marshaler[V any] interface {
+	Marshal(v V) ([]byte, error)
+	Unmarshal(data []byte) (V, error)
+}
+
+type jsonMarshaler[V any] struct{}
+
+func (jsonMarshaler[V]) Marshal(v V) ([]byte, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, errors.Join(ErrMarshal, err)
+	}
+	return b, nil
+}
+
+func (jsonMarshaler[V]) Unmarshal(data []byte) (V, error) {
+	var v V
+	if err := json.Unmarshal(data, &v); err != nil {
+		return v, errors.Join(ErrUnmarshal, err)
+	}
+	return v, nil
+}
+```
+
+- [ ] **Step 5: Write the memory store** — `cache/memory.go`
+
+```go
+package cache
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/clock"
+)
+
+type memoryConfig struct {
+	maxEntries int
+	cleanup    time.Duration
+	clk        clock.Clock
+}
+
+// MemoryOption configures NewMemoryStore.
+type MemoryOption func(*memoryConfig)
+
+// WithMaxEntries caps entries; exceeding it evicts the least-recently-used.
+// 0 (default) is unbounded.
+func WithMaxEntries(n int) MemoryOption { return func(c *memoryConfig) { c.maxEntries = n } }
+
+// WithCleanupInterval starts a janitor goroutine that sweeps expired entries
+// every d; Close stops it. 0 (default) means lazy expiry only.
+func WithCleanupInterval(d time.Duration) MemoryOption {
+	return func(c *memoryConfig) { c.cleanup = d }
+}
+
+// WithClock injects the time source (default clock.System()).
+func WithClock(clk clock.Clock) MemoryOption {
+	return func(c *memoryConfig) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+type memEntry struct {
+	key     string
+	val     []byte
+	expires time.Time // zero = never
+	elem    *list.Element
+}
+
+type memoryStore struct {
+	cfg    memoryConfig
+	mu     sync.Mutex
+	items  map[string]*memEntry
+	lru    *list.List
+	closed bool
+	stop   chan struct{}
+}
+
+// NewMemoryStore returns an in-process Store backed by a map with LRU eviction
+// and TTL expiry. It is a standalone instance: call Close to release it.
+func NewMemoryStore(opts ...MemoryOption) Store {
+	c := memoryConfig{clk: clock.System()}
+	for _, o := range opts {
+		o(&c)
+	}
+	m := &memoryStore{cfg: c, items: make(map[string]*memEntry), lru: list.New()}
+	if c.cleanup > 0 {
+		m.stop = make(chan struct{})
+		go m.janitor()
+	}
+	return m
+}
+
+func (m *memoryStore) janitor() {
+	t := time.NewTicker(m.cfg.cleanup)
+	defer t.Stop()
+	for {
+		select {
+		case <-m.stop:
+			return
+		case <-t.C:
+			m.sweep()
+		}
+	}
+}
+
+func (m *memoryStore) sweep() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := m.cfg.clk.Now()
+	for k, e := range m.items {
+		if !e.expires.IsZero() && now.After(e.expires) {
+			m.removeLocked(k, e)
+		}
+	}
+}
+
+func (m *memoryStore) removeLocked(k string, e *memEntry) {
+	delete(m.items, k)
+	m.lru.Remove(e.elem)
+}
+
+func (m *memoryStore) Get(_ context.Context, key string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil, ErrClosed
+	}
+	e, ok := m.items[key]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	if !e.expires.IsZero() && m.cfg.clk.Now().After(e.expires) {
+		m.removeLocked(key, e)
+		return nil, ErrNotFound
+	}
+	m.lru.MoveToFront(e.elem)
+	out := make([]byte, len(e.val))
+	copy(out, e.val)
+	return out, nil
+}
+
+func (m *memoryStore) Set(_ context.Context, key string, val []byte, ttl time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return ErrClosed
+	}
+	var expires time.Time
+	if ttl > 0 {
+		expires = m.cfg.clk.Now().Add(ttl)
+	}
+	stored := make([]byte, len(val))
+	copy(stored, val)
+	if e, ok := m.items[key]; ok {
+		e.val = stored
+		e.expires = expires
+		m.lru.MoveToFront(e.elem)
+		return nil
+	}
+	e := &memEntry{key: key, val: stored, expires: expires}
+	e.elem = m.lru.PushFront(e)
+	m.items[key] = e
+	if m.cfg.maxEntries > 0 && m.lru.Len() > m.cfg.maxEntries {
+		if back := m.lru.Back(); back != nil {
+			old := back.Value.(*memEntry)
+			m.removeLocked(old.key, old)
+		}
+	}
+	return nil
+}
+
+func (m *memoryStore) Delete(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return ErrClosed
+	}
+	if e, ok := m.items[key]; ok {
+		m.removeLocked(key, e)
+	}
+	return nil
+}
+
+func (m *memoryStore) Has(ctx context.Context, key string) (bool, error) {
+	_, err := m.Get(ctx, key)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, ErrNotFound):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func (m *memoryStore) DeletePrefix(_ context.Context, prefix string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return ErrClosed
+	}
+	for k, e := range m.items {
+		if strings.HasPrefix(k, prefix) {
+			m.removeLocked(k, e)
+		}
+	}
+	return nil
+}
+
+func (m *memoryStore) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil
+	}
+	m.closed = true
+	if m.stop != nil {
+		close(m.stop)
+	}
+	m.items = nil
+	m.lru.Init()
+	return nil
+}
+```
+
+- [ ] **Step 6: Run the test, verify it passes**
+
+Run: `just test ./cache/...`
+Expected: PASS (the janitor smoke test also runs clean under `-race`).
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+just fmt ./cache/...
+git add cache/errors.go cache/store.go cache/memory.go cache/memory_test.go
+git commit -m "feat(cache): Store interface, JSON marshaler, in-memory store"
+```
+
+---
+
+### Task 7: `cache` — typed `Cache[V]` facade + `GetOrSet`
+
+**Files:**
+- Create: `cache/cache.go`
+- Create: `cache/doc.go`
+- Test: `cache/cache_test.go`
+
+**Interfaces:**
+- Consumes: `Store`, `Marshaler[V]`, `jsonMarshaler[V]`, `NewMemoryStore`, sentinels (Task 6); `singleflight.Group[V]` (Task 3).
+- Produces: `type Cache[V any] struct{}`; `New[V any](store Store, opts ...Option) *Cache[V]`; methods `Get/Set/Delete/Has/Clear/GetOrSet`; `WithPrefix(p string) Option`; `WithDefaultTTL(d time.Duration) Option`; `WithMarshaler[V any](m Marshaler[V]) Option`.
+
+- [ ] **Step 1: Write the failing test** — `cache/cache_test.go`
+
+```go
+package cache_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/cache"
+)
+
+func TestCacheSetGetTyped(t *testing.T) {
+	store := cache.NewMemoryStore()
+	defer store.Close()
+	c := cache.New[string](store, cache.WithPrefix("greet:"))
+
+	require.NoError(t, c.Set(t.Context(), "en", "hello", 0))
+	v, err := c.Get(t.Context(), "en")
+	require.NoError(t, err)
+	assert.Equal(t, "hello", v)
+}
+
+func TestCacheMissIsErrNotFound(t *testing.T) {
+	store := cache.NewMemoryStore()
+	defer store.Close()
+	c := cache.New[int](store)
+	_, err := c.Get(t.Context(), "nope")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+}
+
+func TestCacheIsolationByPrefixOverSharedStore(t *testing.T) {
+	store := cache.NewMemoryStore()
+	defer store.Close()
+	a := cache.New[string](store, cache.WithPrefix("a:"))
+	b := cache.New[string](store, cache.WithPrefix("b:"))
+
+	require.NoError(t, a.Set(t.Context(), "k", "AAA", -1))
+	require.NoError(t, b.Set(t.Context(), "k", "BBB", -1))
+
+	av, _ := a.Get(t.Context(), "k")
+	bv, _ := b.Get(t.Context(), "k")
+	assert.Equal(t, "AAA", av)
+	assert.Equal(t, "BBB", bv)
+
+	require.NoError(t, a.Clear(t.Context()))
+	_, err := a.Get(t.Context(), "k")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+
+	still, err := b.Get(t.Context(), "k") // b untouched by a.Clear
+	require.NoError(t, err)
+	assert.Equal(t, "BBB", still)
+}
+
+func TestGetOrSetStampede(t *testing.T) {
+	store := cache.NewMemoryStore()
+	defer store.Close()
+	c := cache.New[int](store)
+
+	var calls atomic.Int32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			v, err := c.GetOrSet(t.Context(), "k", func(context.Context) (int, time.Duration, error) {
+				calls.Add(1)
+				time.Sleep(25 * time.Millisecond)
+				return 99, time.Minute, nil
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, 99, v)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	assert.Equal(t, int32(1), calls.Load())
+
+	// value is now cached; loader is not called again
+	v, err := c.GetOrSet(t.Context(), "k", func(context.Context) (int, time.Duration, error) {
+		t.Fatal("loader must not run on hit")
+		return 0, 0, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 99, v)
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `just test ./cache/...`
+Expected: FAIL — `undefined: cache.New`.
+
+- [ ] **Step 3: Write the facade** — `cache/cache.go`
+
+```go
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/dmitrymomot/forge/singleflight"
+)
+
+type config struct {
+	prefix     string
+	defaultTTL time.Duration
+	marshaler  any // Marshaler[V] set by WithMarshaler; resolved in New
+}
+
+// Option configures a Cache. Options are non-generic so call sites need no type
+// arguments; WithMarshaler infers V from its argument.
+type Option func(*config)
+
+// WithPrefix namespaces this cache's keys within its Store, isolating it from
+// other caches sharing the same Store.
+func WithPrefix(p string) Option { return func(c *config) { c.prefix = p } }
+
+// WithDefaultTTL is applied when Set receives ttl == 0 (default 5m).
+func WithDefaultTTL(d time.Duration) Option { return func(c *config) { c.defaultTTL = d } }
+
+// WithMarshaler overrides the default JSON serialization.
+func WithMarshaler[V any](m Marshaler[V]) Option {
+	return func(c *config) {
+		if m != nil {
+			c.marshaler = m
+		}
+	}
+}
+
+// Cache is a typed facade over a Store. It marshals values, applies the default
+// TTL, isolates keys by prefix, and provides GetOrSet. It does NOT own the
+// Store: construct and Close the Store yourself.
+type Cache[V any] struct {
+	store      Store
+	prefix     string
+	defaultTTL time.Duration
+	marshaler  Marshaler[V]
+	sf         singleflight.Group[V]
+}
+
+// New builds a typed cache over store. The Store's lifecycle stays with the
+// caller; Cache has no Close.
+func New[V any](store Store, opts ...Option) *Cache[V] {
+	c := config{defaultTTL: 5 * time.Minute}
+	for _, o := range opts {
+		o(&c)
+	}
+	var m Marshaler[V]
+	if c.marshaler != nil {
+		m = c.marshaler.(Marshaler[V]) // set by WithMarshaler[V]; V matches New[V]
+	} else {
+		m = jsonMarshaler[V]{}
+	}
+	return &Cache[V]{store: store, prefix: c.prefix, defaultTTL: c.defaultTTL, marshaler: m}
+}
+
+func (c *Cache[V]) key(k string) string { return c.prefix + k }
+
+// Get returns the value for key or ErrNotFound.
+func (c *Cache[V]) Get(ctx context.Context, key string) (V, error) {
+	var zero V
+	data, err := c.store.Get(ctx, c.key(key))
+	if err != nil {
+		return zero, err
+	}
+	return c.marshaler.Unmarshal(data)
+}
+
+// Set stores v under key. ttl == 0 uses the configured default; ttl < 0 never
+// expires.
+func (c *Cache[V]) Set(ctx context.Context, key string, v V, ttl time.Duration) error {
+	data, err := c.marshaler.Marshal(v)
+	if err != nil {
+		return err
+	}
+	if ttl == 0 {
+		ttl = c.defaultTTL
+	}
+	return c.store.Set(ctx, c.key(key), data, ttl)
+}
+
+// Delete removes key.
+func (c *Cache[V]) Delete(ctx context.Context, key string) error {
+	return c.store.Delete(ctx, c.key(key))
+}
+
+// Has reports whether key exists and is unexpired.
+func (c *Cache[V]) Has(ctx context.Context, key string) (bool, error) {
+	return c.store.Has(ctx, c.key(key))
+}
+
+// Clear removes every key under this cache's prefix. With an empty prefix it
+// clears the whole Store.
+func (c *Cache[V]) Clear(ctx context.Context) error {
+	return c.store.DeletePrefix(ctx, c.prefix)
+}
+
+// GetOrSet returns the cached value or computes it via fn on a miss,
+// deduplicating concurrent misses so fn runs once per key. The value is cached
+// best-effort with the TTL fn returns; load errors are not cached.
+func (c *Cache[V]) GetOrSet(ctx context.Context, key string, fn func(context.Context) (V, time.Duration, error)) (V, error) {
+	if v, err := c.Get(ctx, key); err == nil {
+		return v, nil
+	}
+	v, _, err := c.sf.Do(ctx, c.key(key), func(ctx context.Context) (V, error) {
+		val, ttl, ferr := fn(ctx)
+		if ferr != nil {
+			var zero V
+			return zero, ferr
+		}
+		_ = c.Set(ctx, key, val, ttl)
+		return val, nil
+	})
+	return v, err
+}
+```
+
+- [ ] **Step 4: Create `cache/doc.go`**
+
+```go
+// Package cache is a typed cache over a pluggable byte-level Store. Build a
+// Store (in-memory or, via cache/redis, Redis) and wrap it with a typed facade.
+// The facade never owns the Store's lifecycle.
+//
+//	store := cache.NewMemoryStore(cache.WithMaxEntries(10_000))
+//	defer store.Close()
+//
+//	users := cache.New[User](store, cache.WithPrefix("users:"), cache.WithDefaultTTL(30*time.Minute))
+//	u, err := users.GetOrSet(ctx, id, func(ctx context.Context) (User, time.Duration, error) {
+//	    u, err := repo.Load(ctx, id)
+//	    return u, 5 * time.Minute, err
+//	})
+package cache
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `just test ./cache/...`
+Expected: PASS.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+just fmt ./cache/...
+git add cache/cache.go cache/doc.go cache/cache_test.go
+git commit -m "feat(cache): typed Cache[V] facade with GetOrSet stampede protection"
+```
+
+---
+
+### Task 8: `cache/redis` — Redis `Store` adapter
+
+**Files:**
+- Create: `cache/redis/redis.go`
+- Create: `cache/redis/doc.go`
+- Test: `cache/redis/redis_test.go`
+
+**Interfaces:**
+- Consumes: `cache.Store`, `cache.ErrNotFound`, `cache.New`, `cache.WithPrefix` (Tasks 6–7); forge `redis.IsNil` and `goredis.UniversalClient`.
+- Produces: `NewStore(client goredis.UniversalClient) cache.Store`.
+
+- [ ] **Step 1: Write the failing test** — `cache/redis/redis_test.go`
+
+```go
+package redis_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/cache"
+	cacheredis "github.com/dmitrymomot/forge/cache/redis"
+)
+
+func testClient(t *testing.T) goredis.UniversalClient {
+	t.Helper()
+	url := os.Getenv("TEST_REDIS_URL")
+	if url == "" {
+		t.Skip("TEST_REDIS_URL not set")
+	}
+	opt, err := goredis.ParseURL(url)
+	require.NoError(t, err)
+	c := goredis.NewClient(opt)
+	require.NoError(t, c.Ping(context.Background()).Err())
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func TestRedisStoreRoundTripAndScopedClear(t *testing.T) {
+	client := testClient(t)
+	store := cacheredis.NewStore(client)
+
+	users := cache.New[string](store, cache.WithPrefix("test:cache:users:"))
+	other := cache.New[string](store, cache.WithPrefix("test:cache:other:"))
+
+	require.NoError(t, users.Set(t.Context(), "1", "alice", time.Minute))
+	require.NoError(t, other.Set(t.Context(), "1", "keep", time.Minute))
+
+	v, err := users.Get(t.Context(), "1")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", v)
+
+	require.NoError(t, users.Clear(t.Context()))
+	_, err = users.Get(t.Context(), "1")
+	assert.ErrorIs(t, err, cache.ErrNotFound)
+
+	kept, err := other.Get(t.Context(), "1") // scoped clear left other's prefix alone
+	require.NoError(t, err)
+	assert.Equal(t, "keep", kept)
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails (or skips without Redis)**
+
+Run: `just test ./cache/redis/...`
+Expected: FAIL to compile — `undefined: cacheredis.NewStore` (once implemented, SKIP when `TEST_REDIS_URL` is unset).
+
+- [ ] **Step 3: Write the adapter** — `cache/redis/redis.go`
+
+```go
+// Package redis provides a Redis-backed cache.Store. Construct a client (e.g.
+// via forge/redis.Open), pass it to NewStore, and wrap the result with a typed
+// cache.Cache. The client's lifecycle stays with the caller.
+package redis
+
+import (
+	"context"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/dmitrymomot/forge/cache"
+	forgeredis "github.com/dmitrymomot/forge/redis"
+)
+
+type store struct {
+	client goredis.UniversalClient
+}
+
+// NewStore returns a cache.Store backed by client. Store.Close is a no-op: the
+// caller owns the client and must close it.
+func NewStore(client goredis.UniversalClient) cache.Store {
+	return &store{client: client}
+}
+
+func (s *store) Get(ctx context.Context, key string) ([]byte, error) {
+	b, err := s.client.Get(ctx, key).Bytes()
+	if forgeredis.IsNil(err) {
+		return nil, cache.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (s *store) Set(ctx context.Context, key string, val []byte, ttl time.Duration) error {
+	var exp time.Duration // ttl <= 0 -> 0 -> no expiry in Redis
+	if ttl > 0 {
+		exp = ttl
+	}
+	return s.client.Set(ctx, key, val, exp).Err()
+}
+
+func (s *store) Delete(ctx context.Context, key string) error {
+	return s.client.Del(ctx, key).Err()
+}
+
+func (s *store) Has(ctx context.Context, key string) (bool, error) {
+	n, err := s.client.Exists(ctx, key).Result()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+func (s *store) DeletePrefix(ctx context.Context, prefix string) error {
+	var cursor uint64
+	for {
+		keys, next, err := s.client.Scan(ctx, cursor, prefix+"*", 100).Result()
+		if err != nil {
+			return err
+		}
+		if len(keys) > 0 {
+			if err := s.client.Del(ctx, keys...).Err(); err != nil {
+				return err
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			return nil
+		}
+	}
+}
+
+// Close is a no-op; the caller owns the client's lifecycle.
+func (s *store) Close() error { return nil }
+```
+
+- [ ] **Step 4: Create `cache/redis/doc.go`**
+
+```go
+// Package redis provides a Redis-backed cache.Store.
+//
+//	client := redis.Open(ctx, redis.WithConfig(cfg)) // forge/redis; caller closes it
+//	defer client.Close()
+//
+//	store := cacheredis.NewStore(client)
+//	sessions := cache.New[Session](store, cache.WithPrefix("sess:"))
+//
+// Store.Close is a no-op — close the underlying client yourself. Clear on a
+// typed cache issues SCAN + DEL over the cache's prefix (never FLUSHDB).
+package redis
+```
+
+- [ ] **Step 5: Run the test, verify it passes (or skips)**
+
+Run: `just test ./cache/redis/...`
+Expected: PASS (SKIP when `TEST_REDIS_URL` is unset; PASS against a real Redis when set).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+just fmt ./cache/redis/...
+git add cache/redis/
+git commit -m "feat(cache/redis): Redis-backed Store adapter (caller-owned client)"
+```
+
+---
+
+### Finalization
+
+- [ ] **Step 1: Run the full linter**
+
+Run: `just lint`
+Expected: clean. `modernize`, `nilaway`, `betteralign`, and `golangci-lint` must pass. Common fixes: run `just fmt ./...` to apply `betteralign` field reordering and `goimports`; add nil guards if `nilaway` flags a path.
+
+- [ ] **Step 2: Run the whole suite with the race detector**
+
+Run: `just test ./backoff/... ./retry/... ./singleflight/... ./parallel/... ./circuitbreaker/... ./cache/...`
+Expected: all PASS, no race warnings. (The `cache/redis` integration test SKIPs without `TEST_REDIS_URL`.)
+
+- [ ] **Step 3: Commit any lint/format fixups**
+
+```bash
+git add -A
+git commit -m "chore: fmt and lint fixups for resilience/caching bundle"
+```
+
+---
+
+## Notes for the implementer
+
+- **TDD rhythm:** every task is test-first — write the test, watch it fail, implement, watch it pass, commit. Don't batch.
+- **Black-box only:** tests live in `<pkg>_test` and touch only exported API. Don't reach into unexported state.
+- **`t.Context()`** (Go 1.24+) gives a per-test context cancelled at test end; use it instead of `context.Background()`.
+- **Determinism:** anything time-based (`circuitbreaker`, cache expiry) is tested with `clock.NewMock(time.Now())` + `Advance`. `retry` uses a 1ms `backoff.Constant` — never a real fake-clock sleep.
+- **Do not** add an env-loadable `Config`, a background service, `errors.Join` to `parallel`'s default mode, or typed eviction callbacks — all explicit non-goals in the spec.

--- a/docs/superpowers/specs/2026-07-02-resilience-caching-primitives-design.md
+++ b/docs/superpowers/specs/2026-07-02-resilience-caching-primitives-design.md
@@ -1,0 +1,289 @@
+# Resilience & Caching Primitives — Design
+
+**Date:** 2026-07-02
+**Status:** Approved (design), pending implementation plan
+**Bundle:** `backoff`, `retry`, `singleflight`, `parallel`, `ttlcache`, `circuitbreaker`
+
+## Context & motivation
+
+These six packages are the **dependency leaves** of the resilience/async layer: each
+depends only on the Go standard library and the already-shipped `clock` package —
+nothing unbuilt, and no additions to `go.mod`. They are the widest-fan-out building
+blocks in the recommended tier, forming the substrate under the not-yet-built
+`httpclient`, `jobqueue`, `lock`, `ratelimit`, `kv`, `otp`, `idempotency`, and
+`sessionstore` packages.
+
+Two of them (`backoff`, `retry`) are **core-tier** in the roadmap; they are folded
+into this bundle because they complete the resilience family and share the exact same
+zero-dependency profile.
+
+Selection criterion (agreed during brainstorming): *near-zero-dependency packages that
+are building blocks for more complex packages.* This bundle was chosen over
+"auth building-blocks" and the "cookie/pagination/objectstore trio" because it unblocks
+the most downstream work.
+
+## Conventions applied (existing forge DNA — not re-litigated)
+
+- `type Option func(*config)` with an **unexported** `config`; **no builders**.
+- **Options-only** configuration (agreed). These are code-configured library primitives
+  (like `sync.Mutex` / `errgroup`), *not* deploy-time services — so **no exported
+  `Config`, no `DefaultConfig`, no `Validate`, no `env` tags**.
+- `errors.go` with `errors.Is`-matchable single-line sentinels.
+- `doc.go` with a runnable example.
+- `clock.Clock` injection via `WithClock` on packages that read the current time
+  (`ttlcache`, `circuitbreaker`) → deterministic tests with `clock.NewMock`. The shipped
+  `clock.Clock` is `Now()`-only (no `Sleep`/`After`), so `retry` — which must *wait* —
+  sleeps via a real ctx-aware timer instead (see Deviation #4).
+- **Black-box tests only** (`package <name>_test`).
+- Flat top-level packages, ~120–300 LOC each. Go 1.26 idioms (`new(expr)`, run
+  `modernize` + `just fmt`/`just lint` before done).
+
+## Scope decisions (agreed)
+
+In scope for v1 (all four optional capabilities kept):
+
+- `ttlcache` **LRU eviction** (`WithMaxEntries`, `container/list`).
+- `ttlcache` **`GetOrLoad`** with singleflight stampede protection.
+- `parallel` **functional `Map`/`ForEach`** helpers (atop the bounded `Group`).
+- `circuitbreaker` **`OnStateChange`** callback hook.
+
+Explicitly out of scope for v1 (YAGNI, addable later):
+
+- `ttlcache` background janitor goroutine (lazy expiry only in v1).
+- `backoff` decorrelated-jitter / pluggable RNG seam (jitter uses `math/rand/v2`).
+- `parallel` error aggregation (`errors.Join`) — v1 is fail-fast.
+
+## Deviations from the roadmap sketch (deliberate)
+
+1. **`Backoff` is stateless.** The roadmap interface had both `Next(attempt int)` and
+   `Reset()`, which contradict — if the caller passes `attempt`, there is no internal
+   state to reset. The interface is `Next(attempt int) time.Duration` only, making it
+   goroutine-safe; `retry` owns the attempt counter.
+2. **`singleflight` is generic over the key type.** Roadmap keyed by `string`
+   (`Group[T any]`); this design is `Group[K comparable, V any]` so `ttlcache` can
+   coalesce on its own key type directly (`string` is just `K=string`).
+3. **`parallel` is fail-fast**, not aggregating. `Wait` returns the *first* error and the
+   derived context cancels the siblings (errgroup semantics), rather than
+   `errors.Join`-ing all failures.
+4. **`retry` does not take a clock.** The shipped `clock.Clock` interface is `Now()`-only
+   (no `Sleep`/`After`), so a mock clock cannot drive retry's waits. `retry` sleeps via a
+   context-aware real `time.Timer`; its tests use tiny backoff durations. Only the
+   `Now()`-based packages (`ttlcache`, `circuitbreaker`) take `WithClock`. This drops
+   `retry`'s roadmap dependency on `clock` — it depends only on `backoff`.
+
+---
+
+## Package specifications
+
+### `backoff`
+
+Pure, stateless delay strategies. Deps: `time`, `math`, `math/rand/v2`.
+
+```go
+type Backoff interface {
+    Next(attempt int) time.Duration // attempt ≥ 1
+}
+
+func Constant(d time.Duration) Backoff
+func Exponential(base, max time.Duration, opts ...Option) Backoff
+
+// Options (apply to Exponential):
+//   WithMultiplier(f float64)     // growth factor, default 2.0
+//   WithJitter(fraction float64)  // 0..1; randomizes the delay by ±fraction
+```
+
+- `Exponential` computes `base * multiplier^(attempt-1)`, capped at `max`.
+- Constructors are tolerant of degenerate input (clamp `base` to ≥ 1ns, `max` ≥ `base`);
+  they do **not** return errors — pure value constructors.
+- Jitter uses `math/rand/v2` top-level functions (auto-seeded, concurrency-safe).
+- **Tests:** exact values for `Constant`/un-jittered `Exponential`; jittered results
+  asserted within `[expected*(1-fraction), expected*(1+fraction)]` bounds.
+- **Errors:** none.
+
+### `retry`
+
+Execute a function with retries. Deps: `backoff`; `context`, `time`, `errors`.
+
+```go
+func Do(ctx context.Context, fn func(ctx context.Context) error, opts ...Option) error
+func Permanent(err error) error // wrap an error to stop retrying immediately
+
+// Options:
+//   WithMaxAttempts(n int)          // default 3
+//   WithBackoff(b backoff.Backoff)  // default Exponential(100ms, 10s, WithJitter(0.5))
+//   WithRetryIf(func(error) bool)   // default: retry all non-Permanent errors
+```
+
+- Loops up to `maxAttempts`. On error: if the error is `Permanent`-wrapped → return the
+  unwrapped error immediately; if `RetryIf` returns false → return the error; otherwise
+  sleep `backoff.Next(attempt)` and retry.
+- Sleeps use a context-aware real `time.Timer`
+  (`select { case <-ctx.Done(): …; case <-timer.C: }`); on cancellation returns
+  `ctx.Err()`.
+- On exhaustion returns the last error from `fn`.
+- `Permanent` is an unwrappable sentinel wrapper (detected via `errors.As` on an internal
+  `permanentError` type), not a package var.
+- **Tests:** use tiny backoff durations (e.g. `backoff.Constant(time.Millisecond)`) and
+  assert attempt counts, `Permanent` short-circuit, `RetryIf` gating, and ctx
+  cancellation. Exact delay math is covered by `backoff`'s own (pure) tests, so no fake
+  clock is needed here.
+
+### `singleflight`
+
+Generic request coalescing (cache-stampede protection). Deps: `context`, `sync`.
+
+```go
+type Group[K comparable, V any] struct { /* zero-value usable; no New() */ }
+
+func (g *Group[K, V]) Do(ctx context.Context, key K,
+    fn func(ctx context.Context) (V, error)) (v V, shared bool, err error)
+func (g *Group[K, V]) Forget(key K)
+```
+
+- Zero-value usable (lazy map init under mutex), like `sync.Once`.
+- The in-flight `fn` runs under a **cancellation-detached context**
+  (`context.WithoutCancel` of the leader's ctx) so one caller cancelling does not poison
+  the shared execution for the others. Each caller's own `ctx` still bounds *its* wait
+  and is what its `Do` returns on cancellation.
+- `shared` reports whether the result was shared with concurrent callers.
+- **Errors:** none.
+- **Tests:** launch N goroutines on the same key behind a sync barrier, assert `fn` ran
+  once and all callers got the same value with `shared==true`; `Forget` lets the next
+  call re-execute.
+
+### `parallel`
+
+Bounded concurrent execution with fail-fast error handling. Deps: `context`, `sync`.
+
+```go
+type Group struct { ... }
+
+func New(ctx context.Context, opts ...Option) (*Group, context.Context)
+func (g *Group) Go(fn func(ctx context.Context) error)
+func (g *Group) Wait() error
+
+// Option:
+//   WithLimit(n int) // max concurrent; n ≤ 0 = unbounded
+
+// Functional helpers (order-preserving results):
+func ForEach[T any](ctx context.Context, items []T, limit int,
+    fn func(ctx context.Context, item T) error) error
+func Map[T, U any](ctx context.Context, items []T, limit int,
+    fn func(ctx context.Context, item T) (U, error)) ([]U, error)
+```
+
+- `New` returns the group and a derived context that is **cancelled on the first error**
+  (or when all goroutines finish). `Wait` returns that first non-nil error.
+- `Map` preserves input order: `result[i]` corresponds to `items[i]`; on error returns
+  the first error and a nil slice.
+- `limit ≤ 0` means unbounded; otherwise a semaphore of size `limit` bounds concurrency.
+- **Errors:** none exported (returns caller `fn` errors verbatim).
+- **Tests:** assert bounded concurrency (peak in-flight ≤ limit via an atomic counter),
+  first-error propagation + sibling cancellation, order preservation in `Map`.
+
+### `ttlcache`
+
+Generic in-memory TTL cache with optional LRU cap and stampede-safe load.
+Deps: `clock`, `singleflight`; `sync`, `time`, `container/list`.
+
+```go
+type Cache[K comparable, V any] struct { ... }
+
+func New[K comparable, V any](opts ...Option) *Cache[K, V] // Option is NON-generic
+
+func (c *Cache[K, V]) Get(k K) (V, bool)
+func (c *Cache[K, V]) Set(k K, v V)
+func (c *Cache[K, V]) SetTTL(k K, v V, ttl time.Duration)
+func (c *Cache[K, V]) Delete(k K)
+func (c *Cache[K, V]) Len() int
+func (c *Cache[K, V]) GetOrLoad(ctx context.Context, k K,
+    fn func(ctx context.Context) (V, error)) (V, error)
+
+// Options:
+//   WithDefaultTTL(d time.Duration) // default 0 = no expiry
+//   WithMaxEntries(n int)           // default 0 = unbounded; >0 = LRU eviction
+//   WithClock(c clock.Clock)
+```
+
+- `Option` is **non-generic** (`func(*config)`): TTL, size, and clock do not reference
+  `K`/`V`, keeping call sites clean:
+  `ttlcache.New[string,int](ttlcache.WithMaxEntries(1000), ttlcache.WithDefaultTTL(time.Minute))`.
+- **Lazy expiry:** entries carry an expiry timestamp (from the clock); `Get` treats an
+  expired entry as absent and drops it. No background janitor in v1.
+- **LRU:** with `WithMaxEntries(n)`, storage is `map[K]*list.Element` over a
+  `container/list`; `Get`/`Set` move the entry to the front; exceeding `n` evicts the
+  back (least-recently-used). This bounds memory even without expiry.
+- **`GetOrLoad`** wraps an internal `singleflight.Group[K, V]`: on a cache miss, one
+  concurrent load runs, its result is stored with the default TTL, and all waiters
+  receive it. Load errors are not cached.
+- **Errors:** none (miss is `(zero, false)`); load errors from `fn` returned verbatim.
+- **Tests:** `clock.NewMock` + `Mock.Advance` drive expiry deterministically; assert LRU
+  eviction order, `GetOrLoad` single-flight under concurrent misses, and that a load
+  error is not stored.
+
+### `circuitbreaker`
+
+Closed/open/half-open breaker to fail fast against a failing dependency.
+Deps: `clock`; `sync`, `time`, `errors`.
+
+```go
+type State int // Closed, Open, HalfOpen; implements fmt.Stringer
+
+var ErrOpen = errors.New("circuitbreaker: circuit open")
+
+type Breaker struct { ... }
+
+func New(opts ...Option) *Breaker
+func (b *Breaker) Do(ctx context.Context, fn func(ctx context.Context) error) error
+func (b *Breaker) State() State
+
+// Options:
+//   WithFailureThreshold(n int)              // consecutive failures to open; default 5
+//   WithOpenTimeout(d time.Duration)         // time before half-open probe; default 30s
+//   WithHalfOpenMax(n int)                   // concurrent probes allowed; default 1
+//   WithOnStateChange(func(from, to State))  // transition hook (logging/metrics)
+//   WithClock(c clock.Clock)
+```
+
+- **Closed:** counts consecutive failures; at `≥ threshold` → **Open**.
+- **Open:** `Do` returns `ErrOpen` without calling `fn`; after `openTimeout` elapses →
+  **HalfOpen**.
+- **HalfOpen:** allows up to `halfOpenMax` probe calls; a success → **Closed** (counters
+  reset), a failure → **Open** (timeout restarts).
+- `OnStateChange` fires on every transition with `(from, to)`.
+- **Errors:** `ErrOpen`.
+- **Tests:** `clock.NewMock` + `Mock.Advance` drive the open→half-open timeout
+  deterministically; assert threshold tripping, `ErrOpen` fast-fail, half-open probe
+  gating, and `OnStateChange` callbacks.
+
+---
+
+## Cross-cutting
+
+- **Error surface (minimal):** only `circuitbreaker.ErrOpen` and `retry.Permanent()`.
+  The rest signal via `(V, bool)` or plain returns. Each package still gets an
+  `errors.go` per convention.
+- **Determinism:** `clock.NewMock` + `Mock.Advance` make ttlcache expiry and breaker
+  timeouts fully deterministic. `retry` is tested with tiny real backoff durations (its
+  delay math is covered by `backoff`'s exact tests). `singleflight`/`parallel` are tested
+  with sync barriers and atomic counters; `backoff` jitter is tested by bounds.
+- **Dependencies:** stdlib + shipped `clock` only. The single intra-bundle edge is
+  `ttlcache → singleflight`. Nothing changes `go.mod`.
+
+## Build order (DAG)
+
+Four parallelizable tracks:
+
+1. `backoff` → `retry`
+2. `singleflight` → `ttlcache`
+3. `parallel` (independent)
+4. `circuitbreaker` (independent)
+
+## Non-goals
+
+- No env-loadable configuration (these are code-configured primitives).
+- No background goroutines / lifecycle (`ttlcache` janitor deferred; supervised services
+  like `jobqueue`/`lock` build on these later).
+- No distributed/remote backends (Redis stores live in the consuming packages,
+  e.g. `ratelimit/redisstore`, not here).
+- No `errors.Join` aggregation in `parallel` v1.

--- a/docs/superpowers/specs/2026-07-02-resilience-caching-primitives-design.md
+++ b/docs/superpowers/specs/2026-07-02-resilience-caching-primitives-design.md
@@ -12,83 +12,84 @@ tier sits on — the substrate under the not-yet-built `httpclient`, `jobqueue`,
 
 Five of them (`backoff`, `retry`, `singleflight`, `parallel`, `circuitbreaker`) are
 near-zero-dependency leaves: stdlib, or stdlib + the shipped `clock`. The sixth, `cache`,
-is a **provider-backed package** — a generic `Cache[V]` interface with built-in **memory**
-and **Redis** adapters — whose core adds only `clock` + `singleflight`, and whose Redis
-adapter is isolated in a `cache/redis` subpackage. **No new `go.mod` dependencies:**
-go-redis is already present via the shipped `redis` package.
+is a **provider-backed package**: a pluggable byte-level `Store` (with built-in **memory**
+and **Redis** providers) and a typed `Cache[V]` facade over it. Its core adds only
+`singleflight` (plus `clock` for the built-in in-memory store); the Redis provider is
+isolated in a `cache/redis` subpackage. **No new `go.mod` dependencies:** go-redis is
+already present via the shipped `redis` package.
 
 Two of these (`backoff`, `retry`) are **core-tier** in the roadmap; they are folded into
 this bundle because they complete the resilience family.
 
 The `cache` design is informed by the prior forge `pkg/cache` implementation
-(commit `0b68f05`): the `Cache[V]` interface, memory + Redis adapters, standalone
-`GetOrSet` stampede protection, `Marshaler` seam, key-prefix isolation, and eviction
-callbacks all carry forward, re-expressed in v2 conventions.
+(commit `0b68f05`) — `Cache[V]`, memory + Redis providers, `GetOrSet` stampede protection,
+`Marshaler` seam, key-prefix isolation — re-expressed in v2 conventions and re-layered so
+the cache facade **does not own the backend lifecycle**.
 
 ## Design principles (all six packages)
 
-1. **Instances over globals.** Every constructor returns an isolated instance that owns
-   its own state. **Zero package-level mutable state, no singletons.**
-2. **Isolation.** Two instances never interfere. In-memory caches hold **separate maps**
-   (never shared buckets); Redis caches isolate via a **required key `Prefix`**. Two
-   `cache.NewMemory` calls in the same process are fully independent stores.
-3. **Usability first.** Sane defaults, one-line read-through (`GetOrSet`), JSON marshaling
-   by default for Redis, minimal construction boilerplate. Efficiency is necessary but not
-   sufficient — the API must be pleasant to use without a wrapper.
+1. **Instances over globals.** Every constructor returns an isolated instance that owns its
+   own state. **Zero package-level mutable state, no singletons.**
+2. **The cache facade owns no backend lifecycle.** A `Store` (in-memory or Redis) is a
+   standalone instance you construct and `Close` yourself — exactly like a `redis` client.
+   `Cache[V]` is a thin typed facade injected with a `Store`; it has **no `Close`** and
+   never starts or stops a backend. The in-memory engine (map, LRU, janitor goroutine) is a
+   first-class separate instance, not something hidden inside a cache constructor.
+3. **Isolation.** Two instances never interfere. Over a shared `Store`, each `Cache[V]`
+   isolates via a key `Prefix`; for physical isolation, construct separate `Store`s. Two
+   caches never share buckets.
+4. **Usability first.** Sane defaults, one-line read-through (`GetOrSet`), JSON marshaling
+   by default, minimal construction boilerplate. Efficiency is necessary but not sufficient
+   — the API must be pleasant without a wrapper.
 
 ## Conventions applied (existing forge DNA — not re-litigated)
 
 - `type Option func(*config)` with an **unexported** `config`; **no builders**.
-- **Options-only** configuration. These are code-configured library primitives, not
-  deploy-time services — no exported `Config`/env tags. (The `cache/redis` adapter may
-  grow an env-loadable `Config` later following the `redis` package pattern; not in v1.)
-- `errors.go` with `errors.Is`-matchable single-line sentinels.
-- `doc.go` with a runnable example.
+- **Options-only** configuration (no exported `Config`/env tags in v1). A `cache/redis` env
+  `Config` may follow the `redis` package pattern later.
+- `errors.go` with `errors.Is`-matchable single-line sentinels; `doc.go` runnable example.
 - `clock.Clock` injection via `WithClock` on packages that read the current time
-  (`circuitbreaker`, `cache` memory adapter) → deterministic tests with `clock.NewMock`.
-  The shipped `clock.Clock` is `Now()`-only (no `Sleep`/`After`), so `retry` — which must
-  *wait* — sleeps via a real ctx-aware timer instead (see Deviation #3).
-- **Black-box tests only** (`package <name>_test`). Flat top-level packages; Go 1.26
-  idioms (`new(expr)`; run `modernize` + `just fmt`/`just lint` before done).
+  (`circuitbreaker`, the memory `Store`) → deterministic tests with `clock.NewMock`. The
+  shipped `clock.Clock` is `Now()`-only (no `Sleep`/`After`), so `retry` sleeps via a real
+  ctx-aware timer instead (Deviation #3).
+- **Black-box tests only** (`package <name>_test`). Flat top-level packages; Go 1.26 idioms
+  (`new(expr)`; run `modernize` + `just fmt`/`just lint` before done).
 
 ## Scope decisions (agreed)
 
 In scope for v1:
 
-- `parallel` **functional `Map`/`ForEach`** helpers and an opt-in **`WithCollectAll()`**
-  aggregation mode.
-- `circuitbreaker` **`OnStateChange`** callback.
-- `cache` **memory + Redis adapters**, **`GetOrSet`** stampede protection, **LRU eviction**
-  (`WithMaxEntries`), **optional background janitor** (`WithCleanupInterval` + `Close`),
-  **eviction callback** (`WithOnEvict`), **`Marshaler`** seam (JSON default), **prefix
-  isolation** for Redis.
+- `parallel` functional `Map`/`ForEach` + opt-in `WithCollectAll()` aggregation.
+- `circuitbreaker` `OnStateChange` callback.
+- `cache`: pluggable `Store` with **memory + Redis** providers (each a standalone,
+  caller-closed instance), typed `Cache[V]` facade, `GetOrSet` stampede protection,
+  `Marshaler` seam (JSON default), LRU (`WithMaxEntries`), optional memory janitor
+  (`WithCleanupInterval` + the store's `Close`), key-prefix isolation.
 
 Out of scope for v1 (YAGNI, addable later):
 
-- `backoff` decorrelated-jitter / pluggable RNG seam (jitter uses `math/rand/v2`).
-- A byte-level `kv` Store seam for other stateful packages (`lock`/`otp`/…). Distinct from
-  `cache`; built when those packages are.
-- Env-loadable `Config` for the cache adapters.
+- `backoff` decorrelated-jitter / pluggable RNG seam.
+- Typed eviction callbacks (`WithOnEvict`) — the byte-level `Store` cannot surface a typed
+  `V` at eviction time; revisit if a concrete need appears.
+- A separate byte-level `kv` seam for `lock`/`otp`/`sessionstore`. (Those may reuse
+  `cache.Store` or get their own; decided when built.)
+- Env-loadable `Config` for the cache providers.
 
 ## Deviations from the roadmap sketch (deliberate)
 
-1. **`Backoff` is stateless.** The roadmap interface had both `Next(attempt int)` and
-   `Reset()`, which contradict. The interface is `Next(attempt int) time.Duration` only
-   (goroutine-safe); `retry` owns the attempt counter.
-2. **`parallel` is fail-fast by default, aggregation opt-in.** `Wait` returns the *first*
-   error and the derived context cancels the siblings (errgroup semantics);
-   `WithCollectAll()` switches to run-all-then-`errors.Join`.
-3. **`retry` takes no clock and is instance-based.** The shipped `clock.Clock` is
-   `Now()`-only, so a mock clock cannot drive retry's waits; it sleeps via a context-aware
-   real `time.Timer`. Shaped as `New(...Option) *Retrier` (configure once, reuse) plus a
-   convenience `retry.Do(...)`. Drops the roadmap's `clock` dependency — depends only on
-   `backoff`.
-4. **`cache` is a provider-backed package, not an in-memory-only `ttlcache`.** Renamed from
-   the roadmap's `ttlcache`; expanded to a generic `Cache[V]` interface with memory +
-   `cache/redis` adapters, **string keys** (Redis-native), and `GetOrSet` stampede
-   protection — per the prior `pkg/cache` implementation and the requirement to support
-   store providers. Consequently `singleflight` stays **string-keyed** (roadmap original);
-   the earlier "generalize to `Group[K,V]`" idea is dropped since `cache` keys by string.
+1. **`Backoff` is stateless.** Interface is `Next(attempt int) time.Duration` only
+   (goroutine-safe); `retry` owns the attempt counter. (Roadmap had a contradictory
+   `Reset()`.)
+2. **`parallel` is fail-fast by default, aggregation opt-in** (`WithCollectAll()` →
+   run-all-then-`errors.Join`).
+3. **`retry` takes no clock and is instance-based.** Shipped `clock` is `Now()`-only, so it
+   sleeps via a ctx-aware real `time.Timer`. Shaped as `New(...Option) *Retrier` + a
+   convenience `retry.Do(...)`. Depends only on `backoff`.
+4. **`cache` is a two-layer provider-backed package**, not the roadmap's in-memory-only
+   `ttlcache`. Byte-level `Store` (memory + `cache/redis` providers) + typed `Cache[V]`
+   facade; **string keys**; facade owns no backend lifecycle. `singleflight` stays
+   **string-keyed** (the earlier "generalize to `Group[K,V]`" idea is dropped — `cache`
+   keys by string).
 
 ---
 
@@ -99,225 +100,209 @@ Out of scope for v1 (YAGNI, addable later):
 Pure, stateless delay strategies. Deps: `time`, `math`, `math/rand/v2`.
 
 ```go
-type Backoff interface {
-    Next(attempt int) time.Duration // attempt ≥ 1
-}
+type Backoff interface { Next(attempt int) time.Duration } // attempt ≥ 1
 
 func Constant(d time.Duration) Backoff
 func Exponential(base, max time.Duration, opts ...Option) Backoff
-//   WithMultiplier(f float64)     // growth factor, default 2.0
-//   WithJitter(fraction float64)  // 0..1; randomizes the delay by ±fraction
+//   WithMultiplier(f float64)     // default 2.0
+//   WithJitter(fraction float64)  // 0..1; ±fraction randomization
 ```
 
-- `Exponential` computes `base * multiplier^(attempt-1)`, capped at `max`.
-- Constructors clamp degenerate input (`base` ≥ 1ns, `max` ≥ `base`); no error returns.
-- Jitter uses `math/rand/v2` (auto-seeded, concurrency-safe).
-- **Errors:** none. **Tests:** exact for `Constant`/un-jittered; jittered within bounds.
+- `base * multiplier^(attempt-1)`, capped at `max`. Constructors clamp degenerate input;
+  no error returns. Jitter uses `math/rand/v2`.
+- **Errors:** none. **Tests:** exact un-jittered; jittered within bounds.
 
 ### `retry`
 
-Execute a function with retries. Instance-based. Deps: `backoff`; `context`, `time`,
-`errors`.
+Instance-based retry. Deps: `backoff`; `context`, `time`, `errors`.
 
 ```go
 type Retrier struct { ... }
-
 func New(opts ...Option) *Retrier
 func (r *Retrier) Do(ctx context.Context, fn func(ctx context.Context) error) error
+func Do(ctx context.Context, fn func(ctx context.Context) error, opts ...Option) error // one-shot
+func Permanent(err error) error
 
-// Convenience one-shot (= New(opts...).Do(ctx, fn)); no global state:
-func Do(ctx context.Context, fn func(ctx context.Context) error, opts ...Option) error
-
-func Permanent(err error) error // wrap to stop retrying immediately
-
-// Options:
 //   WithMaxAttempts(n int)          // default 3
 //   WithBackoff(b backoff.Backoff)  // default Exponential(100ms, 10s, WithJitter(0.5))
-//   WithRetryIf(func(error) bool)   // default: retry all non-Permanent errors
+//   WithRetryIf(func(error) bool)   // default: retry all non-Permanent
 ```
 
-- Loops up to `maxAttempts`. `Permanent`-wrapped → return unwrapped immediately;
-  `RetryIf==false` → return; else sleep `backoff.Next(attempt)` and retry.
-- Sleeps use a context-aware real `time.Timer`; on cancellation returns `ctx.Err()`.
-- `Permanent` detected via `errors.As` on an internal `permanentError` (not a package var).
-- **Tests:** tiny backoff durations (`backoff.Constant(time.Millisecond)`); assert attempt
-  counts, `Permanent` short-circuit, `RetryIf` gating, ctx cancellation. Delay math is
-  covered by `backoff`'s exact tests, so no fake clock needed.
+- `Permanent`-wrapped → return unwrapped immediately; `RetryIf==false` → return; else sleep
+  `backoff.Next(attempt)` via a ctx-aware `time.Timer` and retry; cancellation → `ctx.Err()`.
+- `Permanent` detected via `errors.As` on an internal type. **Tests:** tiny backoff
+  durations; assert attempts, short-circuit, gating, cancellation.
 
 ### `singleflight`
 
-Generic request coalescing (cache-stampede protection). String-keyed. Deps: `context`,
-`sync`.
+String-keyed request coalescing. Deps: `context`, `sync`.
 
 ```go
-type Group[V any] struct { /* zero-value usable; no New() */ }
-
-func (g *Group[V]) Do(ctx context.Context, key string,
-    fn func(ctx context.Context) (V, error)) (v V, shared bool, err error)
+type Group[V any] struct { /* zero-value usable */ }
+func (g *Group[V]) Do(ctx context.Context, key string, fn func(ctx context.Context) (V, error)) (v V, shared bool, err error)
 func (g *Group[V]) Forget(key string)
 ```
 
-- Zero-value usable (lazy map init under mutex), like `sync.Once`. Each `Group` is
-  independent — no shared state across instances.
-- The in-flight `fn` runs under a **cancellation-detached context**
-  (`context.WithoutCancel` of the leader's ctx) so one caller cancelling does not poison
-  the shared execution; each caller's own `ctx` still bounds *its* wait.
-- `shared` reports whether the result was shared with concurrent callers.
-- Consumed internally by `cache.GetOrSet` (as `Group[any]`). **Errors:** none.
-- **Tests:** N goroutines on one key behind a sync barrier → `fn` ran once, all got the
-  same value with `shared==true`; `Forget` re-arms.
+- Zero-value usable; each `Group` independent. In-flight `fn` runs under
+  `context.WithoutCancel` of the leader ctx so one caller cancelling doesn't poison the
+  shared execution; each caller's ctx still bounds its wait. Used by `cache.GetOrSet`.
+- **Errors:** none. **Tests:** N goroutines/one key → `fn` runs once, `shared==true`.
 
 ### `parallel`
 
-Bounded concurrent execution. Fail-fast by default, opt-in aggregation. Deps: `context`,
-`sync`, `errors`.
+Bounded concurrency; fail-fast default, opt-in aggregation. Deps: `context`, `sync`, `errors`.
 
 ```go
 type Group struct { ... }
-
 func New(ctx context.Context, opts ...Option) (*Group, context.Context)
 func (g *Group) Go(fn func(ctx context.Context) error)
 func (g *Group) Wait() error
+//   WithLimit(n int)   // ≤0 = unbounded
+//   WithCollectAll()   // no cancel-on-error; Wait returns errors.Join(...)
 
-// Options:
-//   WithLimit(n int)    // max concurrent; n ≤ 0 = unbounded
-//   WithCollectAll()    // run all, no sibling cancellation; Wait returns errors.Join(...)
-
-// Functional helpers (fail-fast, order-preserving results):
-func ForEach[T any](ctx context.Context, items []T, limit int,
-    fn func(ctx context.Context, item T) error) error
-func Map[T, U any](ctx context.Context, items []T, limit int,
-    fn func(ctx context.Context, item T) (U, error)) ([]U, error)
+func ForEach[T any](ctx context.Context, items []T, limit int, fn func(ctx context.Context, T) error) error
+func Map[T, U any](ctx context.Context, items []T, limit int, fn func(ctx context.Context, T) (U, error)) ([]U, error)
 ```
 
-- Default: `New`'s derived context cancels on the **first** error; `Wait` returns it.
-- `WithCollectAll()`: no cancellation on error; every func runs to completion; `Wait`
-  returns `errors.Join` of all non-nil errors (nil if all succeed).
-- `Map` preserves order (`result[i]` ↔ `items[i]`); fail-fast; on error returns the first
-  error and a nil slice. `limit ≤ 0` = unbounded.
-- **Errors:** none exported. **Tests:** bounded concurrency (peak in-flight ≤ limit via
-  atomic counter), first-error cancellation, `WithCollectAll` joins all, `Map` ordering.
+- Default: derived ctx cancels on first error; `Wait` returns it. `WithCollectAll`: run all,
+  join errors. `Map` preserves order, fail-fast, nil slice on error.
+- **Tests:** bounded concurrency (atomic peak ≤ limit), first-error cancel, collect-all
+  join, `Map` ordering.
 
 ### `circuitbreaker`
 
-Closed/open/half-open breaker. Instance-based. Deps: `clock`; `sync`, `time`, `errors`.
+Closed/open/half-open breaker. Deps: `clock`; `sync`, `time`, `errors`.
 
 ```go
-type State int // Closed, Open, HalfOpen; fmt.Stringer
+type State int // Closed, Open, HalfOpen; Stringer
 var ErrOpen = errors.New("circuitbreaker: circuit open")
-
 type Breaker struct { ... }
 func New(opts ...Option) *Breaker
 func (b *Breaker) Do(ctx context.Context, fn func(ctx context.Context) error) error
 func (b *Breaker) State() State
-
-// Options:
-//   WithFailureThreshold(n int)              // consecutive failures to open; default 5
-//   WithOpenTimeout(d time.Duration)         // before half-open probe; default 30s
-//   WithHalfOpenMax(n int)                   // concurrent probes; default 1
-//   WithOnStateChange(func(from, to State))  // transition hook
+//   WithFailureThreshold(n)  // default 5    WithOpenTimeout(d)   // default 30s
+//   WithHalfOpenMax(n)       // default 1    WithOnStateChange(func(from, to State))
 //   WithClock(c clock.Clock)
 ```
 
-- Closed → counts consecutive failures, `≥ threshold` opens. Open → `Do` returns `ErrOpen`
-  without calling `fn`; after `openTimeout` → half-open. Half-open → up to `halfOpenMax`
-  probes; success closes (resets), failure re-opens.
-- **Errors:** `ErrOpen`. **Tests:** `clock.NewMock` + `Advance` drive the open→half-open
-  timeout; assert threshold tripping, fast-fail, probe gating, `OnStateChange`.
+- Closed→(≥threshold failures)→Open→(after timeout)→HalfOpen→(success)→Closed / (fail)→Open.
+- **Errors:** `ErrOpen`. **Tests:** `clock.NewMock` + `Advance` drive timeouts; assert
+  tripping, fast-fail, probe gating, `OnStateChange`.
 
 ### `cache` (+ `cache/redis`)
 
-Generic cache with pluggable providers. Core deps: `clock`, `singleflight`; `context`,
-`sync`, `time`, `container/list`, `encoding/json`. Subpackage `cache/redis` deps: forge
-`redis` + go-redis (isolated).
+Two layers: a byte-level **`Store`** provider (you construct and own it, like a redis
+client) and a typed **`Cache[V]`** facade over it (no lifecycle ownership).
 
 ```go
-// package cache
-type Cache[V any] interface {
-    Get(ctx context.Context, key string) (V, error)               // ErrNotFound on miss
-    Set(ctx context.Context, key string, value V, ttl time.Duration) error
+// package cache — abstraction + facade + memory store (deps: singleflight, clock; stdlib)
+
+type Store interface {                                    // the pluggable backend
+    Get(ctx context.Context, key string) ([]byte, error)             // ErrNotFound on miss
+    Set(ctx context.Context, key string, val []byte, ttl time.Duration) error
     Delete(ctx context.Context, key string) error
     Has(ctx context.Context, key string) (bool, error)
-    Clear(ctx context.Context) error                               // scoped to this instance
-    Close() error
+    DeletePrefix(ctx context.Context, prefix string) error           // scoped clear
+    Close() error                                                    // lifecycle: caller-owned
 }
 
-// TTL semantics for Set: positive = expire after d; zero = configured DefaultTTL;
-// negative = never expires.
-
-type Marshaler[V any] interface {          // storage backends needing bytes (Redis)
+type Marshaler[V any] interface {                         // JSON default; WithMarshaler overrides
     Marshal(v V) ([]byte, error)
     Unmarshal(data []byte) (V, error)
-}                                          // JSON default; override via WithMarshaler
+}
 
-// Memory adapter — zero-marshal, own map per instance (isolation)
-func NewMemory[V any](opts ...Option) Cache[V]
-//   WithDefaultTTL(d)         // default 5m
-//   WithMaxEntries(n)         // 0 = unbounded; >0 = LRU via container/list
-//   WithCleanupInterval(d)    // >0 starts a janitor goroutine; Close() stops it; 0 = lazy only
-//   WithOnEvict(func(key string, v V))  // fired on LRU evict / TTL cleanup / Delete / Clear
+// Built-in in-memory Store — a standalone instance (own map/LRU/janitor/Close):
+func NewMemoryStore(opts ...MemoryOption) Store
+//   WithMaxEntries(n)         // 0 = unbounded; >0 = LRU (container/list)
+//   WithCleanupInterval(d)    // >0 starts a janitor goroutine; Close() stops it; 0 = lazy
 //   WithClock(c clock.Clock)
 
-// Read-through with singleflight stampede protection (standalone: Go methods can't add
-// a type param; takes the instance, no globals):
-func GetOrSet[V any](ctx context.Context, c Cache[V], key string,
+// Typed facade over ANY Store — has NO Close():
+type Cache[V any] struct { ... }
+func New[V any](store Store, opts ...Option) *Cache[V]
+//   WithPrefix(p string)            // namespaces keys over a shared store (isolation)
+//   WithDefaultTTL(d)               // applied when Set ttl == 0; default 5m
+//   WithMarshaler(m Marshaler[V])   // default JSON
+
+func (c *Cache[V]) Get(ctx context.Context, key string) (V, error)   // ErrNotFound on miss
+func (c *Cache[V]) Set(ctx context.Context, key string, v V, ttl time.Duration) error
+func (c *Cache[V]) Delete(ctx context.Context, key string) error
+func (c *Cache[V]) Has(ctx context.Context, key string) (bool, error)
+func (c *Cache[V]) Clear(ctx context.Context) error                  // deletes only c's prefix
+func (c *Cache[V]) GetOrSet(ctx context.Context, key string,
     fn func(ctx context.Context) (V, time.Duration, error)) (V, error)
 ```
 
 ```go
-// package cache/redis — isolated adapter; not pulled in by memory-only users
-func New[V any](client goredis.UniversalClient, opts ...Option) cache.Cache[V]
-//   WithPrefix(p string)      // REQUIRED — namespaces keys; Clear() only deletes this prefix
-//   WithDefaultTTL(d)
-//   WithMarshaler(m cache.Marshaler[V])  // default JSON
+// package cache/redis — isolated Redis Store provider (deps: forge redis + go-redis)
+func NewStore(client goredis.UniversalClient, opts ...Option) cache.Store
 ```
 
-- **Isolation:** each `NewMemory` owns its map; each `cache/redis` instance requires a
-  `Prefix`. `Clear()` on Redis uses `SCAN`+`DEL` over the prefix — **never `FLUSHDB`**.
-- **`GetOrSet`:** fast-path `Get`; on miss, dedups concurrent loads via a per-instance
-  `singleflight.Group[any]` (through a small non-generic `deduper` interface the adapters
-  implement); best-effort `Set` with the returned TTL; load errors are **not** cached.
-- **Memory expiry:** lazy on `Get` (checks `clock.Now()`), plus the optional janitor
-  goroutine. Without `WithMaxEntries` or `WithCleanupInterval`, expired-but-unread entries
-  linger until the process exits — documented; set one of them for long-lived caches.
-- **Errors:** `ErrNotFound`, `ErrClosed`, `ErrMarshal`, `ErrUnmarshal`.
-- **Tests:** memory — `clock.NewMock` drives lazy expiry, LRU order, `GetOrSet`
-  single-flight, `WithOnEvict`, idempotent `Close`, and **cross-instance isolation** (two
-  caches don't see each other's keys). `cache/redis` — key-prefixing and marshaling logic
-  unit-tested without a server; integration tests hit a real Redis via `TEST_REDIS_URL`
-  and skip when unset (matching the shipped `redis` package; no miniredis dependency):
-  marshal round-trip, prefix isolation, `Clear` deletes only the prefix.
+TTL semantics: positive = expire; zero = facade `DefaultTTL`; negative = never.
+
+Usage — memory and Redis are **symmetric injected backends the caller owns**:
+
+```go
+// in-memory: engine is a separate instance with its own lifecycle
+store := cache.NewMemoryStore(cache.WithMaxEntries(10_000), cache.WithCleanupInterval(30*time.Second))
+defer store.Close()                                   // caller owns the backend
+users  := cache.New[User](store, cache.WithPrefix("users:"), cache.WithDefaultTTL(30*time.Minute))
+orders := cache.New[Order](store, cache.WithPrefix("orders:"))   // same engine, isolated buckets
+
+// Redis: identical shape — construct the client, own its Close
+client := redis.Open(ctx, redis.WithConfig(cfg)); defer client.Close()
+rstore := cacheredis.NewStore(client)
+sess   := cache.New[Session](rstore, cache.WithPrefix("sess:"))
+```
+
+- **Lifecycle:** `Store.Close()` is owned by the constructing code; `Cache[V]` has **no
+  `Close`** and never starts/stops a backend. This is the "backend is a separate instance,
+  like redis" requirement.
+- **Isolation:** `WithPrefix` namespaces a cache's keys over a shared store; construct
+  separate stores for physical isolation. `Clear()` deletes only the prefix (memory: prefix
+  match; redis: `SCAN`+`DEL`, **never `FLUSHDB`**). `Clear` with an empty prefix clears the
+  whole store — documented.
+- **GetOrSet:** method on the typed facade; dedups concurrent misses via a per-instance
+  `singleflight.Group[V]`; best-effort `Set`; load errors are not cached.
+- **Memory expiry:** lazy on access (`clock.Now()`) + optional janitor. Without
+  `WithMaxEntries`/`WithCleanupInterval`, expired-unread entries persist until the store is
+  closed/GC'd — documented; set one for long-lived stores.
+- **Errors:** `ErrNotFound/ErrClosed/ErrMarshal/ErrUnmarshal`.
+- **Tests:** memory store — `clock.NewMock` drives expiry, LRU order, `DeletePrefix`
+  isolation, idempotent `Close`. facade — marshal round-trip, prefix scoping, `GetOrSet`
+  single-flight (over a fake in-memory store). redis store — key/marshal logic unit-tested;
+  integration via `TEST_REDIS_URL`, skip when unset (matching the shipped `redis` package;
+  no miniredis dep): round-trip, prefix isolation, scoped `Clear`.
 
 ---
 
 ## Cross-cutting
 
 - **Error surface:** `cache.{ErrNotFound,ErrClosed,ErrMarshal,ErrUnmarshal}`,
-  `circuitbreaker.ErrOpen`, `retry.Permanent()`. Each package still gets an `errors.go`.
-- **Determinism:** `clock.NewMock` + `Mock.Advance` make circuitbreaker timeouts and cache
-  lazy-expiry deterministic. `retry` uses tiny real backoff durations. `singleflight` and
-  `parallel` use sync barriers + atomic counters; `backoff` jitter is tested by bounds.
-  The cache janitor goroutine is integration-tested (time-based).
-- **Dependencies:** `backoff`/`retry`/`singleflight`/`parallel` are pure stdlib;
-  `circuitbreaker` adds `clock`; `cache` core adds `clock` + `singleflight`; `cache/redis`
-  adds the shipped `redis` (go-redis) — isolated in the subpackage. **No new `go.mod`
-  entries** (go-redis already present).
+  `circuitbreaker.ErrOpen`, `retry.Permanent()`. Each package gets an `errors.go`.
+- **Determinism:** `clock.NewMock` + `Advance` for circuitbreaker timeouts and memory
+  expiry; `retry` uses tiny real backoff; `singleflight`/`parallel` use barriers + atomic
+  counters; `backoff` jitter by bounds; the memory janitor goroutine is integration-tested.
+- **Dependencies:** `backoff`/`retry`/`singleflight`/`parallel` pure stdlib;
+  `circuitbreaker` adds `clock`; `cache` core adds `singleflight` (+ `clock` for the memory
+  store); `cache/redis` adds the shipped `redis` (go-redis), isolated. **No new `go.mod`
+  entries.**
 
 ## Build order (DAG)
-
-Four parallelizable tracks:
 
 1. `backoff` → `retry`
 2. `singleflight` → `cache` → `cache/redis`
 3. `parallel` (independent)
 4. `circuitbreaker` (independent)
 
+(`clock` — already shipped — is a dep of `circuitbreaker` and the memory store.)
+
 ## Non-goals
 
-- No env-loadable configuration in v1 (code-configured primitives; a `cache/redis` env
-  `Config` can follow the `redis` pattern later).
-- No byte-level `kv` Store seam here (distinct from the typed `cache`; built with the
-  `lock`/`otp`/`sessionstore` packages that need it).
-- No supervised background services — the only goroutine is the opt-in cache janitor,
-  stopped by `Close()`; long-running services (`jobqueue`/`lock`) build on these later.
+- **The cache facade never owns backend lifecycle** — no implicit engine creation/teardown
+  inside `Cache[V]`; the `Store` is injected and caller-closed.
+- No env-loadable configuration in v1.
+- No supervised background services — the only goroutine is the opt-in memory janitor,
+  stopped by the store's `Close()`.
 - No `errors.Join` aggregation in `parallel`'s default mode (opt-in via `WithCollectAll`).
+- No typed eviction callbacks in v1 (byte-level `Store` can't surface `V` at eviction).

--- a/docs/superpowers/specs/2026-07-02-resilience-caching-primitives-design.md
+++ b/docs/superpowers/specs/2026-07-02-resilience-caching-primitives-design.md
@@ -2,74 +2,93 @@
 
 **Date:** 2026-07-02
 **Status:** Approved (design), pending implementation plan
-**Bundle:** `backoff`, `retry`, `singleflight`, `parallel`, `ttlcache`, `circuitbreaker`
+**Bundle:** `backoff`, `retry`, `singleflight`, `parallel`, `circuitbreaker`, `cache` (+ `cache/redis`)
 
 ## Context & motivation
 
-These six packages are the **dependency leaves** of the resilience/async layer: each
-depends only on the Go standard library and the already-shipped `clock` package —
-nothing unbuilt, and no additions to `go.mod`. They are the widest-fan-out building
-blocks in the recommended tier, forming the substrate under the not-yet-built
-`httpclient`, `jobqueue`, `lock`, `ratelimit`, `kv`, `otp`, `idempotency`, and
-`sessionstore` packages.
+These packages are the resilience/async building blocks that the rest of the recommended
+tier sits on — the substrate under the not-yet-built `httpclient`, `jobqueue`, `lock`,
+`ratelimit`, `otp`, `idempotency`, and `sessionstore` packages.
 
-Two of them (`backoff`, `retry`) are **core-tier** in the roadmap; they are folded
-into this bundle because they complete the resilience family and share the exact same
-zero-dependency profile.
+Five of them (`backoff`, `retry`, `singleflight`, `parallel`, `circuitbreaker`) are
+near-zero-dependency leaves: stdlib, or stdlib + the shipped `clock`. The sixth, `cache`,
+is a **provider-backed package** — a generic `Cache[V]` interface with built-in **memory**
+and **Redis** adapters — whose core adds only `clock` + `singleflight`, and whose Redis
+adapter is isolated in a `cache/redis` subpackage. **No new `go.mod` dependencies:**
+go-redis is already present via the shipped `redis` package.
 
-Selection criterion (agreed during brainstorming): *near-zero-dependency packages that
-are building blocks for more complex packages.* This bundle was chosen over
-"auth building-blocks" and the "cookie/pagination/objectstore trio" because it unblocks
-the most downstream work.
+Two of these (`backoff`, `retry`) are **core-tier** in the roadmap; they are folded into
+this bundle because they complete the resilience family.
+
+The `cache` design is informed by the prior forge `pkg/cache` implementation
+(commit `0b68f05`): the `Cache[V]` interface, memory + Redis adapters, standalone
+`GetOrSet` stampede protection, `Marshaler` seam, key-prefix isolation, and eviction
+callbacks all carry forward, re-expressed in v2 conventions.
+
+## Design principles (all six packages)
+
+1. **Instances over globals.** Every constructor returns an isolated instance that owns
+   its own state. **Zero package-level mutable state, no singletons.**
+2. **Isolation.** Two instances never interfere. In-memory caches hold **separate maps**
+   (never shared buckets); Redis caches isolate via a **required key `Prefix`**. Two
+   `cache.NewMemory` calls in the same process are fully independent stores.
+3. **Usability first.** Sane defaults, one-line read-through (`GetOrSet`), JSON marshaling
+   by default for Redis, minimal construction boilerplate. Efficiency is necessary but not
+   sufficient — the API must be pleasant to use without a wrapper.
 
 ## Conventions applied (existing forge DNA — not re-litigated)
 
 - `type Option func(*config)` with an **unexported** `config`; **no builders**.
-- **Options-only** configuration (agreed). These are code-configured library primitives
-  (like `sync.Mutex` / `errgroup`), *not* deploy-time services — so **no exported
-  `Config`, no `DefaultConfig`, no `Validate`, no `env` tags**.
+- **Options-only** configuration. These are code-configured library primitives, not
+  deploy-time services — no exported `Config`/env tags. (The `cache/redis` adapter may
+  grow an env-loadable `Config` later following the `redis` package pattern; not in v1.)
 - `errors.go` with `errors.Is`-matchable single-line sentinels.
 - `doc.go` with a runnable example.
 - `clock.Clock` injection via `WithClock` on packages that read the current time
-  (`ttlcache`, `circuitbreaker`) → deterministic tests with `clock.NewMock`. The shipped
-  `clock.Clock` is `Now()`-only (no `Sleep`/`After`), so `retry` — which must *wait* —
-  sleeps via a real ctx-aware timer instead (see Deviation #4).
-- **Black-box tests only** (`package <name>_test`).
-- Flat top-level packages, ~120–300 LOC each. Go 1.26 idioms (`new(expr)`, run
-  `modernize` + `just fmt`/`just lint` before done).
+  (`circuitbreaker`, `cache` memory adapter) → deterministic tests with `clock.NewMock`.
+  The shipped `clock.Clock` is `Now()`-only (no `Sleep`/`After`), so `retry` — which must
+  *wait* — sleeps via a real ctx-aware timer instead (see Deviation #3).
+- **Black-box tests only** (`package <name>_test`). Flat top-level packages; Go 1.26
+  idioms (`new(expr)`; run `modernize` + `just fmt`/`just lint` before done).
 
 ## Scope decisions (agreed)
 
-In scope for v1 (all four optional capabilities kept):
+In scope for v1:
 
-- `ttlcache` **LRU eviction** (`WithMaxEntries`, `container/list`).
-- `ttlcache` **`GetOrLoad`** with singleflight stampede protection.
-- `parallel` **functional `Map`/`ForEach`** helpers (atop the bounded `Group`).
-- `circuitbreaker` **`OnStateChange`** callback hook.
+- `parallel` **functional `Map`/`ForEach`** helpers and an opt-in **`WithCollectAll()`**
+  aggregation mode.
+- `circuitbreaker` **`OnStateChange`** callback.
+- `cache` **memory + Redis adapters**, **`GetOrSet`** stampede protection, **LRU eviction**
+  (`WithMaxEntries`), **optional background janitor** (`WithCleanupInterval` + `Close`),
+  **eviction callback** (`WithOnEvict`), **`Marshaler`** seam (JSON default), **prefix
+  isolation** for Redis.
 
-Explicitly out of scope for v1 (YAGNI, addable later):
+Out of scope for v1 (YAGNI, addable later):
 
-- `ttlcache` background janitor goroutine (lazy expiry only in v1).
 - `backoff` decorrelated-jitter / pluggable RNG seam (jitter uses `math/rand/v2`).
-- `parallel` error aggregation (`errors.Join`) — v1 is fail-fast.
+- A byte-level `kv` Store seam for other stateful packages (`lock`/`otp`/…). Distinct from
+  `cache`; built when those packages are.
+- Env-loadable `Config` for the cache adapters.
 
 ## Deviations from the roadmap sketch (deliberate)
 
 1. **`Backoff` is stateless.** The roadmap interface had both `Next(attempt int)` and
-   `Reset()`, which contradict — if the caller passes `attempt`, there is no internal
-   state to reset. The interface is `Next(attempt int) time.Duration` only, making it
-   goroutine-safe; `retry` owns the attempt counter.
-2. **`singleflight` is generic over the key type.** Roadmap keyed by `string`
-   (`Group[T any]`); this design is `Group[K comparable, V any]` so `ttlcache` can
-   coalesce on its own key type directly (`string` is just `K=string`).
-3. **`parallel` is fail-fast**, not aggregating. `Wait` returns the *first* error and the
-   derived context cancels the siblings (errgroup semantics), rather than
-   `errors.Join`-ing all failures.
-4. **`retry` does not take a clock.** The shipped `clock.Clock` interface is `Now()`-only
-   (no `Sleep`/`After`), so a mock clock cannot drive retry's waits. `retry` sleeps via a
-   context-aware real `time.Timer`; its tests use tiny backoff durations. Only the
-   `Now()`-based packages (`ttlcache`, `circuitbreaker`) take `WithClock`. This drops
-   `retry`'s roadmap dependency on `clock` — it depends only on `backoff`.
+   `Reset()`, which contradict. The interface is `Next(attempt int) time.Duration` only
+   (goroutine-safe); `retry` owns the attempt counter.
+2. **`parallel` is fail-fast by default, aggregation opt-in.** `Wait` returns the *first*
+   error and the derived context cancels the siblings (errgroup semantics);
+   `WithCollectAll()` switches to run-all-then-`errors.Join`.
+3. **`retry` takes no clock and is instance-based.** The shipped `clock.Clock` is
+   `Now()`-only, so a mock clock cannot drive retry's waits; it sleeps via a context-aware
+   real `time.Timer`. Shaped as `New(...Option) *Retrier` (configure once, reuse) plus a
+   convenience `retry.Do(...)`. Drops the roadmap's `clock` dependency — depends only on
+   `backoff`.
+4. **`cache` is a provider-backed package, not an in-memory-only `ttlcache`.** Renamed from
+   the roadmap's `ttlcache`; expanded to a generic `Cache[V]` interface with memory +
+   `cache/redis` adapters, **string keys** (Redis-native), and `GetOrSet` stampede
+   protection — per the prior `pkg/cache` implementation and the requirement to support
+   store providers. Consequently `singleflight` stays **string-keyed** (roadmap original);
+   the earlier "generalize to `Group[K,V]`" idea is dropped since `cache` keys by string.
 
 ---
 
@@ -86,27 +105,30 @@ type Backoff interface {
 
 func Constant(d time.Duration) Backoff
 func Exponential(base, max time.Duration, opts ...Option) Backoff
-
-// Options (apply to Exponential):
 //   WithMultiplier(f float64)     // growth factor, default 2.0
 //   WithJitter(fraction float64)  // 0..1; randomizes the delay by ±fraction
 ```
 
 - `Exponential` computes `base * multiplier^(attempt-1)`, capped at `max`.
-- Constructors are tolerant of degenerate input (clamp `base` to ≥ 1ns, `max` ≥ `base`);
-  they do **not** return errors — pure value constructors.
-- Jitter uses `math/rand/v2` top-level functions (auto-seeded, concurrency-safe).
-- **Tests:** exact values for `Constant`/un-jittered `Exponential`; jittered results
-  asserted within `[expected*(1-fraction), expected*(1+fraction)]` bounds.
-- **Errors:** none.
+- Constructors clamp degenerate input (`base` ≥ 1ns, `max` ≥ `base`); no error returns.
+- Jitter uses `math/rand/v2` (auto-seeded, concurrency-safe).
+- **Errors:** none. **Tests:** exact for `Constant`/un-jittered; jittered within bounds.
 
 ### `retry`
 
-Execute a function with retries. Deps: `backoff`; `context`, `time`, `errors`.
+Execute a function with retries. Instance-based. Deps: `backoff`; `context`, `time`,
+`errors`.
 
 ```go
+type Retrier struct { ... }
+
+func New(opts ...Option) *Retrier
+func (r *Retrier) Do(ctx context.Context, fn func(ctx context.Context) error) error
+
+// Convenience one-shot (= New(opts...).Do(ctx, fn)); no global state:
 func Do(ctx context.Context, fn func(ctx context.Context) error, opts ...Option) error
-func Permanent(err error) error // wrap an error to stop retrying immediately
+
+func Permanent(err error) error // wrap to stop retrying immediately
 
 // Options:
 //   WithMaxAttempts(n int)          // default 3
@@ -114,46 +136,41 @@ func Permanent(err error) error // wrap an error to stop retrying immediately
 //   WithRetryIf(func(error) bool)   // default: retry all non-Permanent errors
 ```
 
-- Loops up to `maxAttempts`. On error: if the error is `Permanent`-wrapped → return the
-  unwrapped error immediately; if `RetryIf` returns false → return the error; otherwise
-  sleep `backoff.Next(attempt)` and retry.
-- Sleeps use a context-aware real `time.Timer`
-  (`select { case <-ctx.Done(): …; case <-timer.C: }`); on cancellation returns
-  `ctx.Err()`.
-- On exhaustion returns the last error from `fn`.
-- `Permanent` is an unwrappable sentinel wrapper (detected via `errors.As` on an internal
-  `permanentError` type), not a package var.
-- **Tests:** use tiny backoff durations (e.g. `backoff.Constant(time.Millisecond)`) and
-  assert attempt counts, `Permanent` short-circuit, `RetryIf` gating, and ctx
-  cancellation. Exact delay math is covered by `backoff`'s own (pure) tests, so no fake
-  clock is needed here.
+- Loops up to `maxAttempts`. `Permanent`-wrapped → return unwrapped immediately;
+  `RetryIf==false` → return; else sleep `backoff.Next(attempt)` and retry.
+- Sleeps use a context-aware real `time.Timer`; on cancellation returns `ctx.Err()`.
+- `Permanent` detected via `errors.As` on an internal `permanentError` (not a package var).
+- **Tests:** tiny backoff durations (`backoff.Constant(time.Millisecond)`); assert attempt
+  counts, `Permanent` short-circuit, `RetryIf` gating, ctx cancellation. Delay math is
+  covered by `backoff`'s exact tests, so no fake clock needed.
 
 ### `singleflight`
 
-Generic request coalescing (cache-stampede protection). Deps: `context`, `sync`.
+Generic request coalescing (cache-stampede protection). String-keyed. Deps: `context`,
+`sync`.
 
 ```go
-type Group[K comparable, V any] struct { /* zero-value usable; no New() */ }
+type Group[V any] struct { /* zero-value usable; no New() */ }
 
-func (g *Group[K, V]) Do(ctx context.Context, key K,
+func (g *Group[V]) Do(ctx context.Context, key string,
     fn func(ctx context.Context) (V, error)) (v V, shared bool, err error)
-func (g *Group[K, V]) Forget(key K)
+func (g *Group[V]) Forget(key string)
 ```
 
-- Zero-value usable (lazy map init under mutex), like `sync.Once`.
+- Zero-value usable (lazy map init under mutex), like `sync.Once`. Each `Group` is
+  independent — no shared state across instances.
 - The in-flight `fn` runs under a **cancellation-detached context**
   (`context.WithoutCancel` of the leader's ctx) so one caller cancelling does not poison
-  the shared execution for the others. Each caller's own `ctx` still bounds *its* wait
-  and is what its `Do` returns on cancellation.
+  the shared execution; each caller's own `ctx` still bounds *its* wait.
 - `shared` reports whether the result was shared with concurrent callers.
-- **Errors:** none.
-- **Tests:** launch N goroutines on the same key behind a sync barrier, assert `fn` ran
-  once and all callers got the same value with `shared==true`; `Forget` lets the next
-  call re-execute.
+- Consumed internally by `cache.GetOrSet` (as `Group[any]`). **Errors:** none.
+- **Tests:** N goroutines on one key behind a sync barrier → `fn` ran once, all got the
+  same value with `shared==true`; `Forget` re-arms.
 
 ### `parallel`
 
-Bounded concurrent execution with fail-fast error handling. Deps: `context`, `sync`.
+Bounded concurrent execution. Fail-fast by default, opt-in aggregation. Deps: `context`,
+`sync`, `errors`.
 
 ```go
 type Group struct { ... }
@@ -162,128 +179,145 @@ func New(ctx context.Context, opts ...Option) (*Group, context.Context)
 func (g *Group) Go(fn func(ctx context.Context) error)
 func (g *Group) Wait() error
 
-// Option:
-//   WithLimit(n int) // max concurrent; n ≤ 0 = unbounded
+// Options:
+//   WithLimit(n int)    // max concurrent; n ≤ 0 = unbounded
+//   WithCollectAll()    // run all, no sibling cancellation; Wait returns errors.Join(...)
 
-// Functional helpers (order-preserving results):
+// Functional helpers (fail-fast, order-preserving results):
 func ForEach[T any](ctx context.Context, items []T, limit int,
     fn func(ctx context.Context, item T) error) error
 func Map[T, U any](ctx context.Context, items []T, limit int,
     fn func(ctx context.Context, item T) (U, error)) ([]U, error)
 ```
 
-- `New` returns the group and a derived context that is **cancelled on the first error**
-  (or when all goroutines finish). `Wait` returns that first non-nil error.
-- `Map` preserves input order: `result[i]` corresponds to `items[i]`; on error returns
-  the first error and a nil slice.
-- `limit ≤ 0` means unbounded; otherwise a semaphore of size `limit` bounds concurrency.
-- **Errors:** none exported (returns caller `fn` errors verbatim).
-- **Tests:** assert bounded concurrency (peak in-flight ≤ limit via an atomic counter),
-  first-error propagation + sibling cancellation, order preservation in `Map`.
-
-### `ttlcache`
-
-Generic in-memory TTL cache with optional LRU cap and stampede-safe load.
-Deps: `clock`, `singleflight`; `sync`, `time`, `container/list`.
-
-```go
-type Cache[K comparable, V any] struct { ... }
-
-func New[K comparable, V any](opts ...Option) *Cache[K, V] // Option is NON-generic
-
-func (c *Cache[K, V]) Get(k K) (V, bool)
-func (c *Cache[K, V]) Set(k K, v V)
-func (c *Cache[K, V]) SetTTL(k K, v V, ttl time.Duration)
-func (c *Cache[K, V]) Delete(k K)
-func (c *Cache[K, V]) Len() int
-func (c *Cache[K, V]) GetOrLoad(ctx context.Context, k K,
-    fn func(ctx context.Context) (V, error)) (V, error)
-
-// Options:
-//   WithDefaultTTL(d time.Duration) // default 0 = no expiry
-//   WithMaxEntries(n int)           // default 0 = unbounded; >0 = LRU eviction
-//   WithClock(c clock.Clock)
-```
-
-- `Option` is **non-generic** (`func(*config)`): TTL, size, and clock do not reference
-  `K`/`V`, keeping call sites clean:
-  `ttlcache.New[string,int](ttlcache.WithMaxEntries(1000), ttlcache.WithDefaultTTL(time.Minute))`.
-- **Lazy expiry:** entries carry an expiry timestamp (from the clock); `Get` treats an
-  expired entry as absent and drops it. No background janitor in v1.
-- **LRU:** with `WithMaxEntries(n)`, storage is `map[K]*list.Element` over a
-  `container/list`; `Get`/`Set` move the entry to the front; exceeding `n` evicts the
-  back (least-recently-used). This bounds memory even without expiry.
-- **`GetOrLoad`** wraps an internal `singleflight.Group[K, V]`: on a cache miss, one
-  concurrent load runs, its result is stored with the default TTL, and all waiters
-  receive it. Load errors are not cached.
-- **Errors:** none (miss is `(zero, false)`); load errors from `fn` returned verbatim.
-- **Tests:** `clock.NewMock` + `Mock.Advance` drive expiry deterministically; assert LRU
-  eviction order, `GetOrLoad` single-flight under concurrent misses, and that a load
-  error is not stored.
+- Default: `New`'s derived context cancels on the **first** error; `Wait` returns it.
+- `WithCollectAll()`: no cancellation on error; every func runs to completion; `Wait`
+  returns `errors.Join` of all non-nil errors (nil if all succeed).
+- `Map` preserves order (`result[i]` ↔ `items[i]`); fail-fast; on error returns the first
+  error and a nil slice. `limit ≤ 0` = unbounded.
+- **Errors:** none exported. **Tests:** bounded concurrency (peak in-flight ≤ limit via
+  atomic counter), first-error cancellation, `WithCollectAll` joins all, `Map` ordering.
 
 ### `circuitbreaker`
 
-Closed/open/half-open breaker to fail fast against a failing dependency.
-Deps: `clock`; `sync`, `time`, `errors`.
+Closed/open/half-open breaker. Instance-based. Deps: `clock`; `sync`, `time`, `errors`.
 
 ```go
-type State int // Closed, Open, HalfOpen; implements fmt.Stringer
-
+type State int // Closed, Open, HalfOpen; fmt.Stringer
 var ErrOpen = errors.New("circuitbreaker: circuit open")
 
 type Breaker struct { ... }
-
 func New(opts ...Option) *Breaker
 func (b *Breaker) Do(ctx context.Context, fn func(ctx context.Context) error) error
 func (b *Breaker) State() State
 
 // Options:
 //   WithFailureThreshold(n int)              // consecutive failures to open; default 5
-//   WithOpenTimeout(d time.Duration)         // time before half-open probe; default 30s
-//   WithHalfOpenMax(n int)                   // concurrent probes allowed; default 1
-//   WithOnStateChange(func(from, to State))  // transition hook (logging/metrics)
+//   WithOpenTimeout(d time.Duration)         // before half-open probe; default 30s
+//   WithHalfOpenMax(n int)                   // concurrent probes; default 1
+//   WithOnStateChange(func(from, to State))  // transition hook
 //   WithClock(c clock.Clock)
 ```
 
-- **Closed:** counts consecutive failures; at `≥ threshold` → **Open**.
-- **Open:** `Do` returns `ErrOpen` without calling `fn`; after `openTimeout` elapses →
-  **HalfOpen**.
-- **HalfOpen:** allows up to `halfOpenMax` probe calls; a success → **Closed** (counters
-  reset), a failure → **Open** (timeout restarts).
-- `OnStateChange` fires on every transition with `(from, to)`.
-- **Errors:** `ErrOpen`.
-- **Tests:** `clock.NewMock` + `Mock.Advance` drive the open→half-open timeout
-  deterministically; assert threshold tripping, `ErrOpen` fast-fail, half-open probe
-  gating, and `OnStateChange` callbacks.
+- Closed → counts consecutive failures, `≥ threshold` opens. Open → `Do` returns `ErrOpen`
+  without calling `fn`; after `openTimeout` → half-open. Half-open → up to `halfOpenMax`
+  probes; success closes (resets), failure re-opens.
+- **Errors:** `ErrOpen`. **Tests:** `clock.NewMock` + `Advance` drive the open→half-open
+  timeout; assert threshold tripping, fast-fail, probe gating, `OnStateChange`.
+
+### `cache` (+ `cache/redis`)
+
+Generic cache with pluggable providers. Core deps: `clock`, `singleflight`; `context`,
+`sync`, `time`, `container/list`, `encoding/json`. Subpackage `cache/redis` deps: forge
+`redis` + go-redis (isolated).
+
+```go
+// package cache
+type Cache[V any] interface {
+    Get(ctx context.Context, key string) (V, error)               // ErrNotFound on miss
+    Set(ctx context.Context, key string, value V, ttl time.Duration) error
+    Delete(ctx context.Context, key string) error
+    Has(ctx context.Context, key string) (bool, error)
+    Clear(ctx context.Context) error                               // scoped to this instance
+    Close() error
+}
+
+// TTL semantics for Set: positive = expire after d; zero = configured DefaultTTL;
+// negative = never expires.
+
+type Marshaler[V any] interface {          // storage backends needing bytes (Redis)
+    Marshal(v V) ([]byte, error)
+    Unmarshal(data []byte) (V, error)
+}                                          // JSON default; override via WithMarshaler
+
+// Memory adapter — zero-marshal, own map per instance (isolation)
+func NewMemory[V any](opts ...Option) Cache[V]
+//   WithDefaultTTL(d)         // default 5m
+//   WithMaxEntries(n)         // 0 = unbounded; >0 = LRU via container/list
+//   WithCleanupInterval(d)    // >0 starts a janitor goroutine; Close() stops it; 0 = lazy only
+//   WithOnEvict(func(key string, v V))  // fired on LRU evict / TTL cleanup / Delete / Clear
+//   WithClock(c clock.Clock)
+
+// Read-through with singleflight stampede protection (standalone: Go methods can't add
+// a type param; takes the instance, no globals):
+func GetOrSet[V any](ctx context.Context, c Cache[V], key string,
+    fn func(ctx context.Context) (V, time.Duration, error)) (V, error)
+```
+
+```go
+// package cache/redis — isolated adapter; not pulled in by memory-only users
+func New[V any](client goredis.UniversalClient, opts ...Option) cache.Cache[V]
+//   WithPrefix(p string)      // REQUIRED — namespaces keys; Clear() only deletes this prefix
+//   WithDefaultTTL(d)
+//   WithMarshaler(m cache.Marshaler[V])  // default JSON
+```
+
+- **Isolation:** each `NewMemory` owns its map; each `cache/redis` instance requires a
+  `Prefix`. `Clear()` on Redis uses `SCAN`+`DEL` over the prefix — **never `FLUSHDB`**.
+- **`GetOrSet`:** fast-path `Get`; on miss, dedups concurrent loads via a per-instance
+  `singleflight.Group[any]` (through a small non-generic `deduper` interface the adapters
+  implement); best-effort `Set` with the returned TTL; load errors are **not** cached.
+- **Memory expiry:** lazy on `Get` (checks `clock.Now()`), plus the optional janitor
+  goroutine. Without `WithMaxEntries` or `WithCleanupInterval`, expired-but-unread entries
+  linger until the process exits — documented; set one of them for long-lived caches.
+- **Errors:** `ErrNotFound`, `ErrClosed`, `ErrMarshal`, `ErrUnmarshal`.
+- **Tests:** memory — `clock.NewMock` drives lazy expiry, LRU order, `GetOrSet`
+  single-flight, `WithOnEvict`, idempotent `Close`, and **cross-instance isolation** (two
+  caches don't see each other's keys). `cache/redis` — key-prefixing and marshaling logic
+  unit-tested without a server; integration tests hit a real Redis via `TEST_REDIS_URL`
+  and skip when unset (matching the shipped `redis` package; no miniredis dependency):
+  marshal round-trip, prefix isolation, `Clear` deletes only the prefix.
 
 ---
 
 ## Cross-cutting
 
-- **Error surface (minimal):** only `circuitbreaker.ErrOpen` and `retry.Permanent()`.
-  The rest signal via `(V, bool)` or plain returns. Each package still gets an
-  `errors.go` per convention.
-- **Determinism:** `clock.NewMock` + `Mock.Advance` make ttlcache expiry and breaker
-  timeouts fully deterministic. `retry` is tested with tiny real backoff durations (its
-  delay math is covered by `backoff`'s exact tests). `singleflight`/`parallel` are tested
-  with sync barriers and atomic counters; `backoff` jitter is tested by bounds.
-- **Dependencies:** stdlib + shipped `clock` only. The single intra-bundle edge is
-  `ttlcache → singleflight`. Nothing changes `go.mod`.
+- **Error surface:** `cache.{ErrNotFound,ErrClosed,ErrMarshal,ErrUnmarshal}`,
+  `circuitbreaker.ErrOpen`, `retry.Permanent()`. Each package still gets an `errors.go`.
+- **Determinism:** `clock.NewMock` + `Mock.Advance` make circuitbreaker timeouts and cache
+  lazy-expiry deterministic. `retry` uses tiny real backoff durations. `singleflight` and
+  `parallel` use sync barriers + atomic counters; `backoff` jitter is tested by bounds.
+  The cache janitor goroutine is integration-tested (time-based).
+- **Dependencies:** `backoff`/`retry`/`singleflight`/`parallel` are pure stdlib;
+  `circuitbreaker` adds `clock`; `cache` core adds `clock` + `singleflight`; `cache/redis`
+  adds the shipped `redis` (go-redis) — isolated in the subpackage. **No new `go.mod`
+  entries** (go-redis already present).
 
 ## Build order (DAG)
 
 Four parallelizable tracks:
 
 1. `backoff` → `retry`
-2. `singleflight` → `ttlcache`
+2. `singleflight` → `cache` → `cache/redis`
 3. `parallel` (independent)
 4. `circuitbreaker` (independent)
 
 ## Non-goals
 
-- No env-loadable configuration (these are code-configured primitives).
-- No background goroutines / lifecycle (`ttlcache` janitor deferred; supervised services
-  like `jobqueue`/`lock` build on these later).
-- No distributed/remote backends (Redis stores live in the consuming packages,
-  e.g. `ratelimit/redisstore`, not here).
-- No `errors.Join` aggregation in `parallel` v1.
+- No env-loadable configuration in v1 (code-configured primitives; a `cache/redis` env
+  `Config` can follow the `redis` pattern later).
+- No byte-level `kv` Store seam here (distinct from the typed `cache`; built with the
+  `lock`/`otp`/`sessionstore` packages that need it).
+- No supervised background services — the only goroutine is the opt-in cache janitor,
+  stopped by `Close()`; long-running services (`jobqueue`/`lock`) build on these later.
+- No `errors.Join` aggregation in `parallel`'s default mode (opt-in via `WithCollectAll`).

--- a/parallel/doc.go
+++ b/parallel/doc.go
@@ -1,0 +1,14 @@
+// Package parallel runs work concurrently with a bounded worker count.
+//
+//	squares, err := parallel.Map(ctx, ids, 8, func(ctx context.Context, id int) (int, error) {
+//	    return id * id, nil
+//	})
+//
+// For imperative use, construct a Group:
+//
+//	g, ctx := parallel.New(ctx, parallel.WithLimit(4))
+//	for _, job := range jobs {
+//	    g.Go(func(ctx context.Context) error { return job.Run(ctx) })
+//	}
+//	err := g.Wait()
+package parallel

--- a/parallel/parallel.go
+++ b/parallel/parallel.go
@@ -1,0 +1,120 @@
+// Package parallel runs work concurrently with a bounded worker count. By
+// default it is fail-fast (first error cancels the rest); WithCollectAll runs
+// everything and joins all errors.
+package parallel
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+type config struct {
+	limit      int
+	collectAll bool
+}
+
+// Option configures a Group.
+type Option func(*config)
+
+// WithLimit bounds concurrent goroutines. n ≤ 0 means unbounded.
+func WithLimit(n int) Option { return func(c *config) { c.limit = n } }
+
+// WithCollectAll runs every task to completion and joins all errors instead of
+// cancelling siblings on the first failure.
+func WithCollectAll() Option { return func(c *config) { c.collectAll = true } }
+
+// Group runs a set of functions concurrently. Construct it with New.
+type Group struct {
+	ctx        context.Context
+	firstErr   error
+	cancel     context.CancelFunc
+	sem        chan struct{}
+	errs       []error
+	wg         sync.WaitGroup
+	once       sync.Once
+	mu         sync.Mutex
+	collectAll bool
+}
+
+// New returns a Group and a derived context. In fail-fast mode the context is
+// cancelled on the first error; it is always cancelled once Wait returns.
+func New(ctx context.Context, opts ...Option) (*Group, context.Context) {
+	c := config{}
+	for _, o := range opts {
+		o(&c)
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	g := &Group{ctx: ctx, cancel: cancel, collectAll: c.collectAll}
+	if c.limit > 0 {
+		g.sem = make(chan struct{}, c.limit)
+	}
+	return g, ctx
+}
+
+// Go runs fn in a new goroutine, blocking if the concurrency limit is reached.
+func (g *Group) Go(fn func(context.Context) error) {
+	g.wg.Add(1)
+	if g.sem != nil {
+		g.sem <- struct{}{}
+	}
+	go func() {
+		defer g.wg.Done()
+		if g.sem != nil {
+			defer func() { <-g.sem }()
+		}
+		if err := fn(g.ctx); err != nil {
+			if g.collectAll {
+				g.mu.Lock()
+				g.errs = append(g.errs, err)
+				g.mu.Unlock()
+				return
+			}
+			g.once.Do(func() {
+				g.firstErr = err
+				g.cancel()
+			})
+		}
+	}()
+}
+
+// Wait blocks until all Go'd functions return, then reports the error: the
+// first error in fail-fast mode, or errors.Join of all in collect-all mode.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	g.cancel()
+	if g.collectAll {
+		return errors.Join(g.errs...)
+	}
+	return g.firstErr
+}
+
+// ForEach runs fn for every item with bounded concurrency, fail-fast.
+func ForEach[T any](ctx context.Context, items []T, limit int, fn func(context.Context, T) error) error {
+	g, _ := New(ctx, WithLimit(limit))
+	for _, item := range items {
+		g.Go(func(ctx context.Context) error { return fn(ctx, item) })
+	}
+	return g.Wait()
+}
+
+// Map applies fn to every item with bounded concurrency, fail-fast, preserving
+// order. On any error it returns a nil slice and the first error.
+func Map[T, U any](ctx context.Context, items []T, limit int, fn func(context.Context, T) (U, error)) ([]U, error) {
+	results := make([]U, len(items))
+	g, _ := New(ctx, WithLimit(limit))
+	for i, item := range items {
+		g.Go(func(ctx context.Context) error {
+			u, err := fn(ctx, item)
+			if err != nil {
+				return err
+			}
+			results[i] = u
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/parallel/parallel.go
+++ b/parallel/parallel.go
@@ -1,6 +1,3 @@
-// Package parallel runs work concurrently with a bounded worker count. By
-// default it is fail-fast (first error cancels the rest); WithCollectAll runs
-// everything and joins all errors.
 package parallel
 
 import (

--- a/parallel/parallel_test.go
+++ b/parallel/parallel_test.go
@@ -65,3 +65,11 @@ func TestGroupCollectAll(t *testing.T) {
 	assert.Contains(t, err.Error(), "even 2")
 	assert.Contains(t, err.Error(), "even 4")
 }
+
+func TestContextCancelledAfterWait(t *testing.T) {
+	g, ctx := parallel.New(t.Context())
+	g.Go(func(context.Context) error { return nil })
+	require.NoError(t, g.Wait())
+	// The derived context is always cancelled once Wait returns, even on success.
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+}

--- a/parallel/parallel_test.go
+++ b/parallel/parallel_test.go
@@ -1,0 +1,67 @@
+package parallel_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/parallel"
+)
+
+func TestMapPreservesOrder(t *testing.T) {
+	out, err := parallel.Map(t.Context(), []int{1, 2, 3, 4, 5}, 2,
+		func(_ context.Context, n int) (int, error) { return n * n, nil })
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 4, 9, 16, 25}, out)
+}
+
+func TestForEachBoundsConcurrency(t *testing.T) {
+	var inflight, peak atomic.Int32
+	items := make([]int, 30)
+	err := parallel.ForEach(t.Context(), items, 3, func(context.Context, int) error {
+		n := inflight.Add(1)
+		for {
+			p := peak.Load()
+			if n <= p || peak.CompareAndSwap(p, n) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+		inflight.Add(-1)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.LessOrEqual(t, peak.Load(), int32(3))
+}
+
+func TestForEachFailFast(t *testing.T) {
+	err := parallel.ForEach(t.Context(), []int{1, 2, 3}, 2, func(_ context.Context, n int) error {
+		if n == 2 {
+			return errors.New("boom")
+		}
+		return nil
+	})
+	assert.Error(t, err)
+}
+
+func TestGroupCollectAll(t *testing.T) {
+	g, _ := parallel.New(t.Context(), parallel.WithCollectAll())
+	for _, n := range []int{1, 2, 3, 4} {
+		g.Go(func(context.Context) error {
+			if n%2 == 0 {
+				return fmt.Errorf("even %d", n)
+			}
+			return nil
+		})
+	}
+	err := g.Wait()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "even 2")
+	assert.Contains(t, err.Error(), "even 4")
+}

--- a/retry/doc.go
+++ b/retry/doc.go
@@ -1,0 +1,11 @@
+// Package retry runs an operation with a backoff strategy until it succeeds,
+// a permanent error is returned, or the context is cancelled.
+//
+//	err := retry.Do(ctx, func(ctx context.Context) error {
+//	    return callFlakyAPI(ctx)
+//	}, retry.WithMaxAttempts(5))
+//
+// Wrap an error with retry.Permanent to stop early:
+//
+//	return retry.Permanent(errBadRequest)
+package retry

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,112 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dmitrymomot/forge/backoff"
+)
+
+type config struct {
+	backoff     backoff.Backoff
+	retryIf     func(error) bool
+	maxAttempts int
+}
+
+// Option configures a Retrier.
+type Option func(*config)
+
+// WithMaxAttempts caps total attempts (default 3). Values ≤ 0 are ignored.
+func WithMaxAttempts(n int) Option {
+	return func(c *config) {
+		if n > 0 {
+			c.maxAttempts = n
+		}
+	}
+}
+
+// WithBackoff sets the delay strategy (default Exponential(100ms,10s,jitter 0.5)).
+func WithBackoff(b backoff.Backoff) Option {
+	return func(c *config) {
+		if b != nil {
+			c.backoff = b
+		}
+	}
+}
+
+// WithRetryIf decides, per error, whether to retry (default: retry all non-Permanent).
+func WithRetryIf(fn func(error) bool) Option {
+	return func(c *config) {
+		if fn != nil {
+			c.retryIf = fn
+		}
+	}
+}
+
+// Retrier executes functions with a fixed retry policy and is reusable and
+// safe for concurrent use.
+type Retrier struct{ cfg config }
+
+// New builds a Retrier from options.
+func New(opts ...Option) *Retrier {
+	c := config{
+		maxAttempts: 3,
+		backoff:     backoff.Exponential(100*time.Millisecond, 10*time.Second, backoff.WithJitter(0.5)),
+		retryIf:     func(error) bool { return true },
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	return &Retrier{cfg: c}
+}
+
+type permanentError struct{ err error }
+
+func (e *permanentError) Error() string { return e.err.Error() }
+func (e *permanentError) Unwrap() error { return e.err }
+
+// Permanent wraps err so retry stops immediately and returns the wrapped error.
+func Permanent(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &permanentError{err: err}
+}
+
+// Do runs fn, retrying per the policy. It returns nil on success, the wrapped
+// error for a Permanent, ctx.Err() on cancellation, or the last error on
+// exhaustion.
+func (r *Retrier) Do(ctx context.Context, fn func(context.Context) error) error {
+	var lastErr error
+	for attempt := 1; attempt <= r.cfg.maxAttempts; attempt++ {
+		err := fn(ctx)
+		if err == nil {
+			return nil
+		}
+		var perm *permanentError
+		if errors.As(err, &perm) {
+			return perm.err
+		}
+		lastErr = err
+		if !r.cfg.retryIf(err) {
+			return err
+		}
+		if attempt == r.cfg.maxAttempts {
+			break
+		}
+		timer := time.NewTimer(r.cfg.backoff.Next(attempt))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return lastErr
+}
+
+// Do is a one-shot convenience equivalent to New(opts...).Do(ctx, fn).
+func Do(ctx context.Context, fn func(context.Context) error, opts ...Option) error {
+	return New(opts...).Do(ctx, fn)
+}

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -84,8 +84,7 @@ func (r *Retrier) Do(ctx context.Context, fn func(context.Context) error) error 
 		if err == nil {
 			return nil
 		}
-		var perm *permanentError
-		if errors.As(err, &perm) {
+		if perm, ok := errors.AsType[*permanentError](err); ok {
 			return perm.err
 		}
 		lastErr = err

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -75,3 +75,26 @@ func TestRetrierReusable(t *testing.T) {
 	assert.Error(t, r.Do(t.Context(), func(context.Context) error { return errors.New("x") }))
 	assert.NoError(t, r.Do(t.Context(), func(context.Context) error { return nil }))
 }
+
+func TestWithMaxAttemptsZeroIgnored(t *testing.T) {
+	calls := 0
+	err := retry.Do(t.Context(), func(context.Context) error {
+		calls++
+		return errors.New("boom")
+	}, retry.WithMaxAttempts(0), fast) // 0 ignored -> default of 3 attempts
+	assert.Error(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestWithBackoffNilIgnored(t *testing.T) {
+	// A nil backoff must be ignored (the default is kept), not stored — otherwise
+	// Next would be invoked on a nil Backoff. Permanent stops after one call, so
+	// no real backoff wait is incurred.
+	calls := 0
+	err := retry.Do(t.Context(), func(context.Context) error {
+		calls++
+		return retry.Permanent(errors.New("stop"))
+	}, retry.WithBackoff(nil))
+	assert.Error(t, err)
+	assert.Equal(t, 1, calls)
+}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,0 +1,77 @@
+package retry_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/backoff"
+	"github.com/dmitrymomot/forge/retry"
+)
+
+var fast = retry.WithBackoff(backoff.Constant(time.Millisecond))
+
+func TestSucceedsAfterTransientFailures(t *testing.T) {
+	calls := 0
+	err := retry.Do(t.Context(), func(context.Context) error {
+		calls++
+		if calls < 3 {
+			return errors.New("boom")
+		}
+		return nil
+	}, retry.WithMaxAttempts(5), fast)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestExhaustsAndReturnsLastError(t *testing.T) {
+	calls := 0
+	err := retry.Do(t.Context(), func(context.Context) error {
+		calls++
+		return errors.New("boom")
+	}, retry.WithMaxAttempts(3), fast)
+	assert.Error(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestPermanentStopsImmediately(t *testing.T) {
+	sentinel := errors.New("nope")
+	calls := 0
+	err := retry.Do(t.Context(), func(context.Context) error {
+		calls++
+		return retry.Permanent(sentinel)
+	}, retry.WithMaxAttempts(5), fast)
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryIfGate(t *testing.T) {
+	stop := errors.New("do-not-retry")
+	calls := 0
+	err := retry.Do(t.Context(), func(context.Context) error {
+		calls++
+		return stop
+	}, retry.WithMaxAttempts(5), fast, retry.WithRetryIf(func(e error) bool {
+		return !errors.Is(e, stop)
+	}))
+	assert.ErrorIs(t, err, stop)
+	assert.Equal(t, 1, calls)
+}
+
+func TestContextCancellationDuringBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	err := retry.Do(ctx, func(context.Context) error {
+		return errors.New("boom")
+	}, retry.WithMaxAttempts(5), retry.WithBackoff(backoff.Constant(time.Hour)))
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestRetrierReusable(t *testing.T) {
+	r := retry.New(retry.WithMaxAttempts(2), fast)
+	assert.Error(t, r.Do(t.Context(), func(context.Context) error { return errors.New("x") }))
+	assert.NoError(t, r.Do(t.Context(), func(context.Context) error { return nil }))
+}

--- a/singleflight/doc.go
+++ b/singleflight/doc.go
@@ -5,4 +5,6 @@
 //	u, shared, err := g.Do(ctx, id, func(ctx context.Context) (User, error) {
 //	    return repo.Load(ctx, id)
 //	})
+//
+// If fn panics, waiters receive an error and the leader's caller re-panics.
 package singleflight

--- a/singleflight/doc.go
+++ b/singleflight/doc.go
@@ -1,0 +1,8 @@
+// Package singleflight coalesces concurrent calls for the same key into a
+// single execution whose result is shared among all callers.
+//
+//	var g singleflight.Group[User]
+//	u, shared, err := g.Do(ctx, id, func(ctx context.Context) (User, error) {
+//	    return repo.Load(ctx, id)
+//	})
+package singleflight

--- a/singleflight/singleflight.go
+++ b/singleflight/singleflight.go
@@ -2,13 +2,15 @@ package singleflight
 
 import (
 	"context"
+	"fmt"
 	"sync"
 )
 
 type call[V any] struct {
-	val V
-	err error
-	wg  sync.WaitGroup
+	val      V
+	err      error
+	panicVal any
+	wg       sync.WaitGroup
 }
 
 // Group deduplicates concurrent Do calls by key. The zero value is ready to
@@ -38,14 +40,24 @@ func (g *Group[V]) Do(ctx context.Context, key string, fn func(context.Context) 
 	g.m[key] = c
 	g.mu.Unlock()
 
-	c.val, c.err = fn(context.WithoutCancel(ctx))
-	c.wg.Done()
-
-	g.mu.Lock()
-	if g.m[key] == c {
-		delete(g.m, key)
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				c.panicVal = r
+				c.err = fmt.Errorf("singleflight: panic in fn: %v", r)
+			}
+			c.wg.Done()
+			g.mu.Lock()
+			if g.m[key] == c {
+				delete(g.m, key)
+			}
+			g.mu.Unlock()
+		}()
+		c.val, c.err = fn(context.WithoutCancel(ctx))
+	}()
+	if c.panicVal != nil {
+		panic(c.panicVal) // leader re-panics; waiters already observed c.err
 	}
-	g.mu.Unlock()
 	return c.val, false, c.err
 }
 

--- a/singleflight/singleflight.go
+++ b/singleflight/singleflight.go
@@ -1,0 +1,57 @@
+package singleflight
+
+import (
+	"context"
+	"sync"
+)
+
+type call[V any] struct {
+	val V
+	err error
+	wg  sync.WaitGroup
+}
+
+// Group deduplicates concurrent Do calls by key. The zero value is ready to
+// use; a Group must not be copied after first use.
+type Group[V any] struct {
+	m  map[string]*call[V]
+	mu sync.Mutex
+}
+
+// Do runs fn once for key while a call is in flight, sharing the result with
+// concurrent callers. shared reports whether the result came from another
+// caller's execution. fn runs under a cancellation-detached copy of ctx so one
+// caller cancelling does not abort the shared work; each caller's own ctx still
+// bounds its wait via fn's returned error, not the wait itself.
+func (g *Group[V]) Do(ctx context.Context, key string, fn func(context.Context) (V, error)) (V, bool, error) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call[V])
+	}
+	if c, ok := g.m[key]; ok {
+		g.mu.Unlock()
+		c.wg.Wait()
+		return c.val, true, c.err
+	}
+	c := new(call[V])
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	c.val, c.err = fn(context.WithoutCancel(ctx))
+	c.wg.Done()
+
+	g.mu.Lock()
+	if g.m[key] == c {
+		delete(g.m, key)
+	}
+	g.mu.Unlock()
+	return c.val, false, c.err
+}
+
+// Forget drops any in-flight/last record for key so the next Do re-executes.
+func (g *Group[V]) Forget(key string) {
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+}

--- a/singleflight/singleflight_test.go
+++ b/singleflight/singleflight_test.go
@@ -19,9 +19,7 @@ func TestCoalescesConcurrentCalls(t *testing.T) {
 	results := make([]int, 20)
 	var wg sync.WaitGroup
 	for i := range results {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			v, _, err := g.Do(t.Context(), "k", func(context.Context) (int, error) {
 				calls.Add(1)
@@ -30,7 +28,7 @@ func TestCoalescesConcurrentCalls(t *testing.T) {
 			})
 			assert.NoError(t, err)
 			results[i] = v
-		}()
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/singleflight/singleflight_test.go
+++ b/singleflight/singleflight_test.go
@@ -49,3 +49,19 @@ func TestForgetAllowsReexecution(t *testing.T) {
 	_, _, _ = g.Do(t.Context(), "k", load)
 	assert.Equal(t, int32(2), calls.Load())
 }
+
+func TestPanicInFnRePanicsAndDoesNotPoisonKey(t *testing.T) {
+	var g singleflight.Group[int]
+	assert.Panics(t, func() {
+		_, _, _ = g.Do(t.Context(), "k", func(context.Context) (int, error) {
+			panic("boom")
+		})
+	})
+	// Key must not be poisoned: a subsequent call re-executes and succeeds.
+	v, shared, err := g.Do(t.Context(), "k", func(context.Context) (int, error) {
+		return 7, nil
+	})
+	assert.NoError(t, err)
+	assert.False(t, shared)
+	assert.Equal(t, 7, v)
+}

--- a/singleflight/singleflight_test.go
+++ b/singleflight/singleflight_test.go
@@ -1,0 +1,51 @@
+package singleflight_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/singleflight"
+)
+
+func TestCoalescesConcurrentCalls(t *testing.T) {
+	var g singleflight.Group[int]
+	var calls atomic.Int32
+	start := make(chan struct{})
+	results := make([]int, 20)
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			v, _, err := g.Do(t.Context(), "k", func(context.Context) (int, error) {
+				calls.Add(1)
+				time.Sleep(25 * time.Millisecond)
+				return 42, nil
+			})
+			assert.NoError(t, err)
+			results[i] = v
+		}()
+	}
+	close(start)
+	wg.Wait()
+	assert.Equal(t, int32(1), calls.Load())
+	for _, r := range results {
+		assert.Equal(t, 42, r)
+	}
+}
+
+func TestForgetAllowsReexecution(t *testing.T) {
+	var g singleflight.Group[int]
+	var calls atomic.Int32
+	load := func(context.Context) (int, error) { calls.Add(1); return 1, nil }
+	_, _, _ = g.Do(t.Context(), "k", load)
+	g.Forget("k")
+	_, _, _ = g.Do(t.Context(), "k", load)
+	assert.Equal(t, int32(2), calls.Load())
+}


### PR DESCRIPTION
Ships the resilience & caching leaves of the recommended tier as six flat, near-zero-dependency packages. Implements `docs/superpowers/plans/2026-07-02-resilience-caching-primitives.md`.

## Packages

| Package | What it does |
|---|---|
| `backoff` | Stateless `Constant`/`Exponential` retry-delay strategies; jitter is clamped to the `max` ceiling. |
| `retry` | Instance-based retry over a `backoff.Backoff`; `Permanent(err)` early-stop; honors context cancellation during the wait. |
| `singleflight` | Generic per-key call coalescing (`Group[V]`, zero-value usable). Hardened: a panicking `fn` can't deadlock waiters or poison a key. |
| `parallel` | Bounded concurrency — fail-fast (single first error, cancels the derived ctx) or collect-all (`errors.Join`); `ForEach`/`Map` helpers. |
| `circuitbreaker` | Closed/open/half-open state machine with injectable `clock.Clock`; `WithOnStateChange` hook. |
| `cache` (+ `cache/redis`) | Byte-level `Store` (in-memory LRU/TTL + optional janitor) with a typed `Cache[V]` facade: prefix isolation, default TTL, and `GetOrSet` stampede protection via `singleflight`. `cache/redis` is an isolated adapter over a caller-owned `go-redis` client. |

## Design

- **Options only, no builders**; **instances over globals** (zero package-level mutable state).
- **Black-box tests only**; time is injected via `clock.Clock` and driven deterministically with `clock.NewMock`.
- The `go-redis` dependency is quarantined behind `cache/redis`; the `Cache[V]` facade never owns a Store's lifecycle.

## Notable review-driven hardening (beyond the plan's baseline)

- `backoff`: re-clamp jittered delays so `max` is a true ceiling.
- `singleflight`: deferred cleanup + panic recovery — waiters receive a wrapped error, the leader re-panics; a panicking loader can't wedge the group (also protects `cache.GetOrSet`).
- `cache`: `GetOrSet` surfaces real Store failures (`ErrClosed`, and unclassified errors wrapped with the new `ErrStore` sentinel) instead of masking them as a miss; only a genuine `ErrNotFound` invokes the loader.

## Verification

- `just lint` clean (golangci-lint, nilaway, betteralign, modernize).
- `go test -race -cover` green: backoff 93.3%, retry 91.9%, singleflight 100%, parallel 96.1%, circuitbreaker 95.6%, cache 85.9%. `cache/redis` integration test SKIPs without `TEST_REDIS_URL`.

