### PR TITLE
feat(web/subroute): chi.Mount-style prefix mounting for std ServeMux

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -121,7 +121,7 @@ forge/                              # single go.mod at the root
 │
 ├── web/           # HTTP in and out: transport, responses, boundary security, client
 │   # shipped: httpserver hostrouter middleware request clientip problem
-│   #          recoverer reqlog requestid render htmx
+│   #          recoverer reqlog requestid render htmx subroute
 │   # planned: httpclient cookie csrf secheaders cors timeout compress
 │   #          assets idempotency iplist captcha (captcha/turnstile ...)
 │   #          webhookverify autocert
@@ -258,7 +258,7 @@ Shipped: `backoff retry singleflight parallel circuitbreaker cache (cache/redis)
 ### web/
 
 Shipped: `httpserver hostrouter middleware request clientip problem recoverer
-reqlog requestid render htmx`.
+reqlog requestid render htmx subroute`.
 
 - **`httpclient`** — core, build early. Resilient outbound `*http.Client`
   via a RoundTripper stack: per-attempt timeout, jittered retry, circuit

--- a/docs/superpowers/plans/2026-07-04-subroute.md
+++ b/docs/superpowers/plans/2026-07-04-subroute.md
@@ -2,22 +2,23 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** A stdlib-only `web/subroute` package giving `chi.Mount` semantics for `*http.ServeMux`: mount handlers under (possibly wildcard) path prefixes with prefix stripping and cross-boundary path-value access.
+**Goal:** A `web/subroute` package giving `chi.Mount` semantics for `*http.ServeMux` — mount handlers under (possibly wildcard) path prefixes with prefix stripping — plus a path-value fallback seam in `web/request` so `request.Path` keeps working across mount boundaries.
 
-**Architecture:** One exported `Mount(mux, prefix, h)` that validates the prefix, registers exact + subtree patterns, and dispatches through an internal strip handler that clones the request, strips the prefix segments from the escaped path, and captures prefix path values into the request context. One exported `PathValue(r, name)` accessor reads current-mux values first, then mount-captured ones. Spec: `docs/superpowers/specs/2026-07-04-subroute-design.md`.
+**Architecture:** `subroute.Mount(mux, prefix, h)` validates the prefix, registers exact + subtree patterns, and dispatches through an internal strip handler that clones the request, strips the prefix segments from the escaped path, and captures prefix path values via `request.WithPathValues`. `web/request` owns the context seam: `Path`/`PathFunc`/`HasPath` read `r.PathValue` first, then the fallback map. `WithPathValues` merges later-over-earlier, so nested mounts need no merge logic in subroute. Spec: `docs/superpowers/specs/2026-07-04-subroute-design.md`.
 
-**Tech Stack:** Go 1.26 stdlib only (`net/http`, `net/url`, `strings`, `slices`, `fmt`, `context`). Tests use `testify` (already a repo dep).
+**Tech Stack:** Go 1.26 stdlib only (`net/http`, `net/url`, `strings`, `slices`, `fmt`, `context`). Tests use `testify` (already a repo dep). `subroute` imports `web/request`; `request` imports nothing forge-internal.
 
 ## Global Constraints
 
 - Work ONLY in the current branch (`claude/recursing-rubin-547f38`); never switch.
-- Module path: `github.com/dmitrymomot/forge`; package dir `web/subroute`, package name `subroute`.
-- Black-box tests ONLY: all test files use `package subroute_test`.
-- Run `just fmt <file.go>` after changing any Go file; run `just lint` when a task's code is done (lint includes vet, golangci-lint, nilaway, betteralign, modernize).
-- Test command: `go test -race -run <TestName> ./web/subroute` for single tests; `just test ./web/subroute` (race + cover, clean cache) for the full package.
-- No new dependencies. No builder pattern. Options pattern not needed here (two plain functions per spec).
-- Panics are setup-time only, message prefix `"subroute: "`. No runtime errors.
-- Go 1.26: use `strings.SplitSeq` for iteration (modernize enforces it), `for range n` for counted loops.
+- Module path: `github.com/dmitrymomot/forge`; package dirs `web/subroute` (new) and `web/request` (existing).
+- Black-box tests ONLY: test files use `package subroute_test` / `package request_test`.
+- Run `just fmt <path>` after changing any Go file; run `just lint` when a task's code is done (lint includes vet, golangci-lint, nilaway, betteralign, modernize).
+- Test command: `go test -race -run <TestName> ./web/<pkg>` for single tests; `just test ./web/...` (race + cover, clean cache) for full verification.
+- No new dependencies. No builder pattern.
+- Panics are setup-time only, message prefix `"subroute: "`. No runtime errors in subroute.
+- Go 1.26: use `strings.SplitSeq` for iteration (modernize enforces it), `for range n` for counted loops, `b.Loop()` in benchmarks.
+- Do not break any existing `web/request` behavior: its full test suite must stay green.
 - No Claude attribution in commits.
 
 ---
@@ -32,8 +33,8 @@
 - Consumes: nothing (first task).
 - Produces:
   - `func Mount(mux *http.ServeMux, prefix string, h http.Handler)` — exported, panics on invalid input.
-  - unexported `parsePrefix(prefix string) (segments int, names []string)` — validates, returns segment count and wildcard names (names are collected already in this task; they are *used* in Task 2).
-  - unexported `type stripHandler struct { h http.Handler; names []string; segments int }` with `ServeHTTP` — Task 2 extends `ServeHTTP` with param capture.
+  - unexported `parsePrefix(prefix string) (segments int, names []string)` — validates, returns segment count and wildcard names (names are collected already in this task; they are *used* in Task 3).
+  - unexported `type stripHandler struct { h http.Handler; names []string; segments int }` with `ServeHTTP` — Task 3 extends `ServeHTTP` with param capture.
   - unexported `stripSegments(path string, n int) string` — returns `""` when path has exactly n segments.
 
 - [ ] **Step 1: Write failing tests for Mount panics and static routing**
@@ -188,7 +189,7 @@ import (
 // subtree. prefix may contain single-segment {name} wildcards. Requests are
 // dispatched to h with the prefix segments stripped from the URL path; a
 // request for the bare prefix reaches h with path "/". Path values matched
-// by the prefix are captured and readable inside h via PathValue.
+// by the prefix are captured and readable inside h via request.Path.
 //
 // Mount panics on nil arguments or a malformed prefix; ServeMux.Handle
 // additionally panics on pattern conflicts and invalid wildcard names.
@@ -243,7 +244,8 @@ func parsePrefix(prefix string) (segments int, names []string) {
 }
 
 // stripHandler dispatches to h with the mount prefix removed from the URL of
-// a cloned request. names is non-nil only for wildcard prefixes (Task 2).
+// a cloned request. names is non-nil only for wildcard prefixes; capture is
+// added in a later task.
 type stripHandler struct {
 	h        http.Handler
 	names    []string
@@ -308,32 +310,242 @@ git commit -m "feat(web/subroute): static prefix mounting with segment stripping
 
 ---
 
-### Task 2: Wildcard prefixes — param capture and the PathValue accessor
+### Task 2: web/request — WithPathValues seam and Path fallback
 
 **Files:**
-- Create: `web/subroute/context.go`
+- Create: `web/request/pathvalues.go`
+- Modify: `web/request/path.go`
+- Test: `web/request/pathvalues_test.go`
+
+**Interfaces:**
+- Consumes: existing `request` internals: `resolve(src Source, key, raw string, p func(string) (T, error), def []T)` and `parse[T]` (both in `web/request/parse.go`), `SourcePath` constant (in `web/request/errors.go`).
+- Produces:
+  - `func WithPathValues(ctx context.Context, vals map[string]string) context.Context` — exported writer; merges later-over-earlier; copies the input map. Task 3's subroute code calls this.
+  - unexported `pathValue(r *http.Request, key string) string` — lookup used by `Path`, `PathFunc`, `HasPath`.
+
+- [ ] **Step 1: Write failing tests for the fallback seam**
+
+Create `web/request/pathvalues_test.go`:
+
+```go
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/web/request"
+)
+
+// withVals returns a request carrying vals as WithPathValues fallback.
+func withVals(vals map[string]string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	return r.WithContext(request.WithPathValues(r.Context(), vals))
+}
+
+func TestWithPathValues_Fallback(t *testing.T) {
+	r := withVals(map[string]string{"tenant": "acme", "n": "7"})
+
+	tenant, err := request.Path[string](r, "tenant")
+	require.NoError(t, err)
+	assert.Equal(t, "acme", tenant)
+
+	n, err := request.Path[int](r, "n") // typed parsing works on fallback values
+	require.NoError(t, err)
+	assert.Equal(t, 7, n)
+
+	assert.True(t, request.HasPath(r, "tenant"))
+	assert.False(t, request.HasPath(r, "absent"))
+
+	missing, err := request.Path[string](r, "absent", "def")
+	require.NoError(t, err)
+	assert.Equal(t, "def", missing)
+}
+
+func TestWithPathValues_CurrentMuxWins(t *testing.T) {
+	mux := http.NewServeMux()
+	var got string
+	mux.HandleFunc("GET /u/{id}", func(_ http.ResponseWriter, r *http.Request) {
+		got, _ = request.Path[string](r, "id")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/u/OWN", nil)
+	req = req.WithContext(request.WithPathValues(req.Context(), map[string]string{"id": "FALLBACK"}))
+	mux.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "OWN", got)
+}
+
+func TestWithPathValues_MergeLaterWins(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	ctx := request.WithPathValues(r.Context(), map[string]string{"a": "1", "b": "1"})
+	ctx = request.WithPathValues(ctx, map[string]string{"b": "2", "c": "2"})
+	r = r.WithContext(ctx)
+
+	a, _ := request.Path[string](r, "a")
+	b, _ := request.Path[string](r, "b")
+	c, _ := request.Path[string](r, "c")
+	assert.Equal(t, "1", a, "earlier keys retained")
+	assert.Equal(t, "2", b, "later call wins per key")
+	assert.Equal(t, "2", c)
+}
+
+func TestWithPathValues_EmptyMapIsNoop(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	assert.Equal(t, r.Context(), request.WithPathValues(r.Context(), nil))
+	assert.Equal(t, r.Context(), request.WithPathValues(r.Context(), map[string]string{}))
+}
+
+func TestWithPathValues_CopiesInput(t *testing.T) {
+	vals := map[string]string{"tenant": "acme"}
+	r := withVals(vals)
+	vals["tenant"] = "mutated"
+
+	tenant, err := request.Path[string](r, "tenant")
+	require.NoError(t, err)
+	assert.Equal(t, "acme", tenant)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -race -run TestWithPathValues ./web/request`
+Expected: FAIL — `undefined: request.WithPathValues`.
+
+- [ ] **Step 3: Implement the seam**
+
+Create `web/request/pathvalues.go`:
+
+```go
+package request
+
+import (
+	"context"
+	"maps"
+	"net/http"
+)
+
+type pathValuesKeyType struct{}
+
+var pathValuesKey = pathValuesKeyType{}
+
+// pathValuesCtx carries fallback path values in a single heap allocation
+// (plus the map), instead of the two context.WithValue would cost. Value
+// returns the same map every call, so reads never allocate.
+type pathValuesCtx struct {
+	context.Context
+	vals map[string]string
+}
+
+func (c *pathValuesCtx) Value(key any) any {
+	if key == pathValuesKey {
+		return c.vals
+	}
+	return c.Context.Value(key)
+}
+
+// WithPathValues returns a context carrying vals as fallback path values for
+// Path, PathFunc, and HasPath. Values merge over any previously stored ones
+// (later wins); the input map is copied, so later caller mutations have no
+// effect. Routers that dispatch across ServeMux boundaries (subroute) use
+// this to keep path params readable in nested handlers.
+func WithPathValues(ctx context.Context, vals map[string]string) context.Context {
+	if len(vals) == 0 {
+		return ctx
+	}
+	var outer map[string]string
+	if v, ok := ctx.Value(pathValuesKey).(map[string]string); ok {
+		outer = v
+	}
+	merged := make(map[string]string, len(outer)+len(vals))
+	maps.Copy(merged, outer)
+	maps.Copy(merged, vals)
+	return &pathValuesCtx{Context: ctx, vals: merged}
+}
+
+// pathValue resolves a path wildcard: the current mux's own match first,
+// then WithPathValues fallback, then "".
+func pathValue(r *http.Request, key string) string {
+	if v := r.PathValue(key); v != "" {
+		return v
+	}
+	if vals, ok := r.Context().Value(pathValuesKey).(map[string]string); ok {
+		return vals[key]
+	}
+	return ""
+}
+```
+
+Replace the full contents of `web/request/path.go` with:
+
+```go
+package request
+
+import "net/http"
+
+// Path reads path wildcard key and converts it to T. The value comes from
+// the current mux match (r.PathValue) or, when absent there, from values
+// stored with WithPathValues (e.g. by subroute mount prefixes).
+func Path[T any](r *http.Request, key string, def ...T) (T, error) {
+	return resolve(SourcePath, key, pathValue(r, key), parse[T], def)
+}
+
+// PathFunc is Path with a caller-supplied parser.
+func PathFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error) {
+	return resolve(SourcePath, key, pathValue(r, key), parse, def)
+}
+
+// HasPath reports whether the path wildcard key is set and non-empty,
+// checking the current mux match and then WithPathValues fallback.
+func HasPath(r *http.Request, key string) bool {
+	return pathValue(r, key) != ""
+}
+```
+
+- [ ] **Step 4: Format and run the FULL request suite (regression gate)**
+
+Run: `just fmt ./web/request/...`
+Run: `just test ./web/request`
+Expected: PASS — new tests green AND every pre-existing request test still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/request/pathvalues.go web/request/pathvalues_test.go web/request/path.go
+git commit -m "feat(web/request): WithPathValues fallback for path accessors"
+```
+
+---
+
+### Task 3: Wildcard prefixes — param capture through request.WithPathValues
+
+**Files:**
 - Modify: `web/subroute/subroute.go` (extend `stripHandler.ServeHTTP` with capture)
 - Test: `web/subroute/subroute_test.go` (append tests)
 
 **Interfaces:**
-- Consumes: `stripHandler{h, names, segments}` and `Mount` from Task 1 (`names` is already populated by `parsePrefix`).
-- Produces:
-  - `func PathValue(r *http.Request, name string) string` — exported accessor.
-  - unexported `paramsKey` (`ctxKey{}` value) and `type paramsCtx struct { context.Context; vals map[string]string }` — Task 3 reuses `paramsKey` for merge lookups.
+- Consumes: `stripHandler{h, names, segments}` and `Mount` from Task 1 (`names` populated by `parsePrefix`); `request.WithPathValues(ctx, vals) context.Context` and `request.Path[T]` from Task 2.
+- Produces: no new symbols — behavioral guarantee that wildcard and nested mounts capture params readable via `request.Path`, which Task 4's docs describe.
 
-- [ ] **Step 1: Write failing tests for wildcard mounts**
+- [ ] **Step 1: Write failing tests for wildcard and nested mounts**
 
-Append to `web/subroute/subroute_test.go`:
+Append to `web/subroute/subroute_test.go` (add `"github.com/dmitrymomot/forge/web/request"` to imports):
 
 ```go
 func TestMount_WildcardPrefix(t *testing.T) {
 	dashboardMux := http.NewServeMux()
 	dashboardMux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "home tenant=%s", subroute.PathValue(r, "tenant"))
+		tenant, _ := request.Path[string](r, "tenant")
+		fmt.Fprintf(w, "home tenant=%s", tenant)
 	})
 	dashboardMux.HandleFunc("GET /reports/{id}", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "report tenant=%s id=%s own=%s",
-			subroute.PathValue(r, "tenant"), subroute.PathValue(r, "id"), r.PathValue("id"))
+		tenant, _ := request.Path[string](r, "tenant")
+		id, _ := request.Path[int](r, "id")
+		fmt.Fprintf(w, "report tenant=%s id=%d own=%s", tenant, id, r.PathValue("id"))
 	})
 
 	mux := http.NewServeMux()
@@ -353,146 +565,12 @@ func TestMount_WildcardPrefix(t *testing.T) {
 	}
 }
 
-func TestPathValue_CurrentMuxWinsOverCapture(t *testing.T) {
-	inner := http.NewServeMux()
-	inner.HandleFunc("GET /sub/{id}", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "id=%s", subroute.PathValue(r, "id"))
-	})
-
-	mux := http.NewServeMux()
-	subroute.Mount(mux, "/m/{id}", inner)
-
-	rec := get(t, mux, "/m/OUTER/sub/INNER")
-	assert.Equal(t, "id=INNER", rec.Body.String())
-}
-
-func TestPathValue_StaticMountCapturesNothing(t *testing.T) {
-	mux := http.NewServeMux()
-	subroute.Mount(mux, "/admin", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "missing=%q", subroute.PathValue(r, "tenant"))
-	}))
-
-	rec := get(t, mux, "/admin/x")
-	assert.Equal(t, `missing=""`, rec.Body.String())
-}
-
-func TestPathValue_PlainRequest(t *testing.T) {
-	// Works on requests that never passed through a mount.
-	r := httptest.NewRequest(http.MethodGet, "/x", nil)
-	assert.Empty(t, subroute.PathValue(r, "anything"))
-}
-```
-
-- [ ] **Step 2: Run tests to verify they fail**
-
-Run: `go test -race -run 'TestMount_WildcardPrefix|TestPathValue' ./web/subroute`
-Expected: FAIL — `undefined: subroute.PathValue`.
-
-- [ ] **Step 3: Implement context capture and PathValue**
-
-Create `web/subroute/context.go`:
-
-```go
-package subroute
-
-import (
-	"context"
-	"net/http"
-)
-
-type ctxKey struct{}
-
-var paramsKey = ctxKey{}
-
-// paramsCtx carries mount-captured path values in a single heap allocation
-// (the map), instead of the two context.WithValue would cost. Value returns
-// the same map every call, so reads never allocate.
-type paramsCtx struct {
-	context.Context
-	vals map[string]string
-}
-
-func (c *paramsCtx) Value(key any) any {
-	if key == paramsKey {
-		return c.vals
-	}
-	return c.Context.Value(key)
-}
-
-// PathValue returns the named path value: r.PathValue first (the current
-// mux's own match), then values captured by enclosing Mount prefixes,
-// innermost mount first. It returns "" if the name is not present.
-//
-// Handlers use plain r.PathValue for their own mux's wildcards; PathValue is
-// needed only for params originating in mount prefixes, which the standard
-// library cannot propagate across a ServeMux boundary.
-func PathValue(r *http.Request, name string) string {
-	if v := r.PathValue(name); v != "" {
-		return v
-	}
-	if vals, ok := r.Context().Value(paramsKey).(map[string]string); ok {
-		return vals[name]
-	}
-	return ""
-}
-```
-
-In `web/subroute/subroute.go`, replace the first four lines of `stripHandler.ServeHTTP` (the `r2 := new(http.Request)` through `*r2.URL = *r.URL` block) with:
-
-```go
-func (s *stripHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	var r2 *http.Request
-	if len(s.names) > 0 {
-		vals := make(map[string]string, len(s.names))
-		for _, n := range s.names {
-			vals[n] = r.PathValue(n)
-		}
-		r2 = r.WithContext(&paramsCtx{Context: r.Context(), vals: vals})
-	} else {
-		// Static prefix: no capture, no context allocation.
-		r2 = new(http.Request)
-		*r2 = *r
-	}
-	r2.URL = new(url.URL)
-	*r2.URL = *r.URL
-	// ... rest of the method unchanged (tail := stripSegments... onward)
-```
-
-- [ ] **Step 4: Format and run the full package tests**
-
-Run: `just fmt ./web/subroute/...`
-Run: `go test -race ./web/subroute`
-Expected: PASS (Task 1 tests still green, new tests green).
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add web/subroute/context.go web/subroute/subroute.go web/subroute/subroute_test.go
-git commit -m "feat(web/subroute): wildcard prefixes with PathValue param propagation"
-```
-
----
-
-### Task 3: Nested mounts — capture merging with innermost-wins shadowing
-
-**Files:**
-- Modify: `web/subroute/subroute.go` (merge enclosing captures in `ServeHTTP`)
-- Test: `web/subroute/subroute_test.go` (append tests)
-
-**Interfaces:**
-- Consumes: `paramsKey`, `paramsCtx` from Task 2; `stripHandler.ServeHTTP` capture branch from Task 2.
-- Produces: no new symbols — behavioral guarantee that nested `Mount` calls merge captured params (innermost wins) which doc.go (Task 4) documents.
-
-- [ ] **Step 1: Write failing tests for nested mounts**
-
-Append to `web/subroute/subroute_test.go`:
-
-```go
 func TestMount_Nested(t *testing.T) {
 	projMux := http.NewServeMux()
 	projMux.HandleFunc("GET /info", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "path=%s tenant=%s proj=%s",
-			r.URL.Path, subroute.PathValue(r, "tenant"), subroute.PathValue(r, "proj"))
+		tenant, _ := request.Path[string](r, "tenant")
+		proj, _ := request.Path[string](r, "proj")
+		fmt.Fprintf(w, "path=%s tenant=%s proj=%s", r.URL.Path, tenant, proj)
 	})
 
 	appMux := http.NewServeMux()
@@ -508,7 +586,8 @@ func TestMount_Nested(t *testing.T) {
 
 func TestMount_NestedShadowing(t *testing.T) {
 	leaf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "id=%s", subroute.PathValue(r, "id"))
+		id, _ := request.Path[string](r, "id")
+		fmt.Fprintf(w, "id=%s", id)
 	})
 
 	innerMux := http.NewServeMux()
@@ -523,7 +602,8 @@ func TestMount_NestedShadowing(t *testing.T) {
 
 func TestMount_NestedStaticInsideWildcard(t *testing.T) {
 	leaf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "path=%s tenant=%s", r.URL.Path, subroute.PathValue(r, "tenant"))
+		tenant, _ := request.Path[string](r, "tenant")
+		fmt.Fprintf(w, "path=%s tenant=%s", r.URL.Path, tenant)
 	})
 
 	appMux := http.NewServeMux()
@@ -535,58 +615,99 @@ func TestMount_NestedStaticInsideWildcard(t *testing.T) {
 	rec := get(t, mux, "/app/acme/settings/profile")
 	assert.Equal(t, "path=/profile tenant=acme", rec.Body.String())
 }
+
+func TestMount_PrecedenceCurrentMuxWins(t *testing.T) {
+	inner := http.NewServeMux()
+	inner.HandleFunc("GET /sub/{id}", func(w http.ResponseWriter, r *http.Request) {
+		id, _ := request.Path[string](r, "id")
+		fmt.Fprintf(w, "id=%s", id)
+	})
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/m/{id}", inner)
+
+	rec := get(t, mux, "/m/OUTER/sub/INNER")
+	assert.Equal(t, "id=INNER", rec.Body.String())
+}
+
+func TestMount_StaticMountCapturesNothing(t *testing.T) {
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "has=%t ctxsame=%t", request.HasPath(r, "tenant"), r.Context() == context.Background())
+	}))
+
+	// httptest requests use context.Background; a static mount must not have
+	// wrapped it (no capture context for static prefixes).
+	rec := get(t, mux, "/admin/x")
+	assert.Equal(t, "has=false ctxsame=true", rec.Body.String())
+}
 ```
 
-- [ ] **Step 2: Run tests to verify the merge cases fail**
+Add `"context"` to the test file imports for `TestMount_StaticMountCapturesNothing`.
 
-Run: `go test -race -run TestMount_Nested ./web/subroute`
-Expected: `TestMount_Nested` FAILS (tenant is empty — the inner mount's fresh map hides the outer capture). `TestMount_NestedStaticInsideWildcard` PASSES already (static mounts don't replace the context; the outer `paramsCtx` is inherited through the cloned request). `TestMount_NestedShadowing` PASSES already (inner map is consulted first). Both still belong in this task: they pin the merge semantics against regressions.
+- [ ] **Step 2: Run tests to verify the capture cases fail**
 
-- [ ] **Step 3: Merge enclosing captures in the wildcard branch**
+Run: `go test -race -run 'TestMount_Wildcard|TestMount_Nested|TestMount_Precedence|TestMount_StaticMountCapturesNothing' ./web/subroute`
+Expected: `TestMount_WildcardPrefix`, `TestMount_Nested`, and `TestMount_NestedStaticInsideWildcard` FAIL (captured params come back empty — nothing stores them yet). Three PASS already and pin semantics against regressions: `TestMount_NestedShadowing` (the inner mux's own match state survives the request clone, so `r.PathValue` returns INNER even without capture), `TestMount_PrecedenceCurrentMuxWins` (same mechanism), and `TestMount_StaticMountCapturesNothing`.
 
-In `web/subroute/subroute.go`, inside the `len(s.names) > 0` branch, build the map by copying any enclosing capture first:
+- [ ] **Step 3: Add capture to the wildcard branch**
+
+In `web/subroute/subroute.go`, add `"github.com/dmitrymomot/forge/web/request"` to imports and replace the first four lines of `stripHandler.ServeHTTP` (the `r2 := new(http.Request)` through `*r2.URL = *r.URL` block) with:
 
 ```go
+func (s *stripHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var r2 *http.Request
 	if len(s.names) > 0 {
-		var outer map[string]string
-		if v, ok := r.Context().Value(paramsKey).(map[string]string); ok {
-			outer = v
-		}
-		vals := make(map[string]string, len(outer)+len(s.names))
-		for k, v := range outer {
-			vals[k] = v
-		}
+		vals := make(map[string]string, len(s.names))
 		for _, n := range s.names {
-			vals[n] = r.PathValue(n) // own names overwrite: innermost mount wins
+			vals[n] = r.PathValue(n)
 		}
-		r2 = r.WithContext(&paramsCtx{Context: r.Context(), vals: vals})
+		// WithPathValues merges over enclosing captures (later wins), so
+		// nested mounts accumulate params with the innermost mount winning.
+		r2 = r.WithContext(request.WithPathValues(r.Context(), vals))
 	} else {
+		// Static prefix: no capture, no context allocation.
+		r2 = new(http.Request)
+		*r2 = *r
+	}
+	r2.URL = new(url.URL)
+	*r2.URL = *r.URL
+	// ... rest of the method unchanged (tail := stripSegments... onward)
+```
+
+Also update the `stripHandler` doc comment to drop "capture is added in a later task":
+
+```go
+// stripHandler dispatches to h with the mount prefix removed from the URL of
+// a cloned request. For wildcard prefixes (names non-nil) it first captures
+// the prefix path values via request.WithPathValues.
 ```
 
 - [ ] **Step 4: Format and run the full package tests**
 
 Run: `just fmt ./web/subroute/...`
 Run: `go test -race ./web/subroute`
-Expected: PASS.
+Expected: PASS (Task 1 tests still green, new tests green).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add web/subroute/subroute.go web/subroute/subroute_test.go
-git commit -m "feat(web/subroute): merge captured params across nested mounts"
+git commit -m "feat(web/subroute): wildcard prefixes with request.WithPathValues capture"
 ```
 
 ---
 
-### Task 4: Middleware-boundary tests, doc.go, and examples
+### Task 4: Middleware-boundary test, doc.go, examples, request doc touch-up
 
 **Files:**
 - Create: `web/subroute/doc.go`
 - Create: `web/subroute/example_test.go`
+- Modify: `web/request/doc.go` (mention the fallback seam)
 - Test: `web/subroute/subroute_test.go` (append middleware test)
 
 **Interfaces:**
-- Consumes: `Mount`, `PathValue` (final signatures from Tasks 1–2); `middleware.Wrap` from `web/middleware` (`func Wrap(h http.Handler, mws ...Middleware) http.Handler`, `type Middleware func(http.Handler) http.Handler`).
+- Consumes: `Mount` (Task 1), `request.WithPathValues`/`request.Path` (Task 2); `middleware.Wrap` from `web/middleware` (`func Wrap(h http.Handler, mws ...Middleware) http.Handler`, `type Middleware func(http.Handler) http.Handler`).
 - Produces: package documentation; no new code symbols.
 
 - [ ] **Step 1: Write the middleware-boundary test**
@@ -651,19 +772,19 @@ Create `web/subroute/doc.go`:
 // # Wildcard prefixes
 //
 // Prefixes may contain single-segment {name} wildcards. Their matched values
-// are captured at the mount boundary and read with [PathValue], because the
-// standard library discards a parent mux's path values when a nested mux
-// matches:
+// are captured at the mount boundary (via request.WithPathValues), because
+// the standard library discards a parent mux's path values when a nested mux
+// matches. Read them with the request package's path accessors, which check
+// the current mux match first and then mount captures, innermost first:
 //
 //	subroute.Mount(mux, "/app/{tenant}/dashboard", dashboardMux)
 //
 //	// in a dashboardMux handler:
-//	tenant := subroute.PathValue(r, "tenant") // from the mount prefix
-//	id := r.PathValue("id")                   // own wildcards work as usual
+//	tenant, _ := request.Path[string](r, "tenant") // from the mount prefix
+//	id, _ := request.Path[int](r, "id")            // own wildcards, typed as usual
 //
-// [PathValue] prefers the current mux's own match, then walks enclosing
-// mounts innermost-first. Method, host, {$}, and {name...} elements are not
-// allowed in prefixes.
+// Plain r.PathValue only sees the current mux's own wildcards. Method, host,
+// {$}, and {name...} elements are not allowed in prefixes.
 //
 // # Middleware
 //
@@ -692,6 +813,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/dmitrymomot/forge/web/request"
 	"github.com/dmitrymomot/forge/web/subroute"
 )
 
@@ -710,10 +832,11 @@ func ExampleMount() {
 	// Output: user 42 at /users/42
 }
 
-func ExamplePathValue() {
+func ExampleMount_wildcardPrefix() {
 	dashboardMux := http.NewServeMux()
 	dashboardMux.HandleFunc("GET /reports/{id}", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "tenant %s, report %s", subroute.PathValue(r, "tenant"), r.PathValue("id"))
+		tenant, _ := request.Path[string](r, "tenant")
+		fmt.Fprintf(w, "tenant %s, report %s", tenant, r.PathValue("id"))
 	})
 
 	mux := http.NewServeMux()
@@ -726,22 +849,39 @@ func ExamplePathValue() {
 }
 ```
 
-- [ ] **Step 5: Format and run the full package tests (examples run as tests)**
+- [ ] **Step 5: Update web/request/doc.go**
 
-Run: `just fmt ./web/subroute/...`
-Run: `just test ./web/subroute`
-Expected: PASS including `ExampleMount` and `ExamplePathValue` output checks.
+In `web/request/doc.go`, the package comment currently ends with:
 
-- [ ] **Step 6: Commit**
+```
+// request reads; the render package writes; the htmx package handles HX-* headers.
+// None imports another. Stdlib only.
+```
+
+Insert this paragraph before those closing lines:
+
+```
+// Path accessors resolve the current mux match (r.PathValue) first, then
+// values stored with WithPathValues — the seam web/subroute uses so mount-
+// prefix params stay readable inside mounted handlers.
+```
+
+- [ ] **Step 6: Format and run both packages (examples run as tests)**
+
+Run: `just fmt ./web/...`
+Run: `just test ./web/subroute` and `just test ./web/request`
+Expected: PASS including both Example output checks.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add web/subroute/doc.go web/subroute/example_test.go web/subroute/subroute_test.go
+git add web/subroute/doc.go web/subroute/example_test.go web/subroute/subroute_test.go web/request/doc.go
 git commit -m "docs(web/subroute): package docs, examples, middleware-boundary test"
 ```
 
 ---
 
-### Task 5: Benchmarks, lint, and final verification
+### Task 5: Benchmarks, packages.md, lint, and final verification
 
 **Files:**
 - Create: `web/subroute/bench_test.go`
@@ -798,7 +938,7 @@ func BenchmarkMount_Wildcard(b *testing.B) {
 - [ ] **Step 2: Run benchmarks**
 
 Run: `just bench ./web/subroute`
-Expected: both benchmarks complete; static ~3–4 allocs/op (request + URL clones, mux internals), wildcard a few more (map + context). No pass/fail threshold — record the numbers in the commit message body if noteworthy.
+Expected: both benchmarks complete; static ~3–4 allocs/op (request + URL clones, mux internals), wildcard a few more (map + context wrapper). No pass/fail threshold — record the numbers in the commit message body if noteworthy.
 
 - [ ] **Step 3: Add subroute to docs/packages.md**
 
@@ -820,12 +960,12 @@ Also update the `Shipped:` line near line 260 the same way (append `subroute` to
 
 - [ ] **Step 4: Full quality gate**
 
-Run: `just fmt ./web/subroute/...`
+Run: `just fmt ./web/...`
 Run: `just lint`
 Expected: clean — no vet/golangci-lint/nilaway/betteralign/modernize findings. Fix anything reported (betteralign may reorder struct fields; accept its changes).
 
-Run: `just test ./web/subroute`
-Expected: PASS with race detector and coverage reported.
+Run: `just test ./web/...`
+Expected: PASS with race detector and coverage reported, including the untouched web packages.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-07-04-subroute.md
+++ b/docs/superpowers/plans/2026-07-04-subroute.md
@@ -1,0 +1,835 @@
+# web/subroute Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A stdlib-only `web/subroute` package giving `chi.Mount` semantics for `*http.ServeMux`: mount handlers under (possibly wildcard) path prefixes with prefix stripping and cross-boundary path-value access.
+
+**Architecture:** One exported `Mount(mux, prefix, h)` that validates the prefix, registers exact + subtree patterns, and dispatches through an internal strip handler that clones the request, strips the prefix segments from the escaped path, and captures prefix path values into the request context. One exported `PathValue(r, name)` accessor reads current-mux values first, then mount-captured ones. Spec: `docs/superpowers/specs/2026-07-04-subroute-design.md`.
+
+**Tech Stack:** Go 1.26 stdlib only (`net/http`, `net/url`, `strings`, `slices`, `fmt`, `context`). Tests use `testify` (already a repo dep).
+
+## Global Constraints
+
+- Work ONLY in the current branch (`claude/recursing-rubin-547f38`); never switch.
+- Module path: `github.com/dmitrymomot/forge`; package dir `web/subroute`, package name `subroute`.
+- Black-box tests ONLY: all test files use `package subroute_test`.
+- Run `just fmt <file.go>` after changing any Go file; run `just lint` when a task's code is done (lint includes vet, golangci-lint, nilaway, betteralign, modernize).
+- Test command: `go test -race -run <TestName> ./web/subroute` for single tests; `just test ./web/subroute` (race + cover, clean cache) for the full package.
+- No new dependencies. No builder pattern. Options pattern not needed here (two plain functions per spec).
+- Panics are setup-time only, message prefix `"subroute: "`. No runtime errors.
+- Go 1.26: use `strings.SplitSeq` for iteration (modernize enforces it), `for range n` for counted loops.
+- No Claude attribution in commits.
+
+---
+
+### Task 1: Static mounting — validation, registration, segment stripping
+
+**Files:**
+- Create: `web/subroute/subroute.go`
+- Test: `web/subroute/subroute_test.go`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces:
+  - `func Mount(mux *http.ServeMux, prefix string, h http.Handler)` — exported, panics on invalid input.
+  - unexported `parsePrefix(prefix string) (segments int, names []string)` — validates, returns segment count and wildcard names (names are collected already in this task; they are *used* in Task 2).
+  - unexported `type stripHandler struct { h http.Handler; names []string; segments int }` with `ServeHTTP` — Task 2 extends `ServeHTTP` with param capture.
+  - unexported `stripSegments(path string, n int) string` — returns `""` when path has exactly n segments.
+
+- [ ] **Step 1: Write failing tests for Mount panics and static routing**
+
+Create `web/subroute/subroute_test.go`:
+
+```go
+package subroute_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/web/subroute"
+)
+
+// echo returns a handler that writes the request's method, path, raw path,
+// and query so tests can assert exactly what the mounted handler observed.
+func echo() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "%s %s raw=%q q=%s", r.Method, r.URL.Path, r.URL.RawPath, r.URL.RawQuery)
+	})
+}
+
+func get(t *testing.T, mux *http.ServeMux, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, target, nil))
+	return rec
+}
+
+func TestMount_PanicsOnInvalidInput(t *testing.T) {
+	h := echo()
+	tests := []struct {
+		name string
+		fn   func()
+	}{
+		{"nil mux", func() { subroute.Mount(nil, "/a", h) }},
+		{"nil handler", func() { subroute.Mount(http.NewServeMux(), "/a", nil) }},
+		{"empty prefix", func() { subroute.Mount(http.NewServeMux(), "", h) }},
+		{"no leading slash", func() { subroute.Mount(http.NewServeMux(), "admin", h) }},
+		{"bare slash", func() { subroute.Mount(http.NewServeMux(), "/", h) }},
+		{"trailing slash", func() { subroute.Mount(http.NewServeMux(), "/admin/", h) }},
+		{"space smuggling method", func() { subroute.Mount(http.NewServeMux(), "GET /admin", h) }},
+		{"empty segment", func() { subroute.Mount(http.NewServeMux(), "/a//b", h) }},
+		{"dollar wildcard", func() { subroute.Mount(http.NewServeMux(), "/a/{$}", h) }},
+		{"multi-segment wildcard", func() { subroute.Mount(http.NewServeMux(), "/a/{rest...}", h) }},
+		{"empty wildcard name", func() { subroute.Mount(http.NewServeMux(), "/a/{}", h) }},
+		{"partial wildcard", func() { subroute.Mount(http.NewServeMux(), "/a/x{id}", h) }},
+		{"duplicate wildcard names", func() { subroute.Mount(http.NewServeMux(), "/{id}/x/{id}", h) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Panics(t, tt.fn)
+		})
+	}
+}
+
+func TestMount_DuplicateRegistrationPanics(t *testing.T) {
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", echo())
+	assert.Panics(t, func() { subroute.Mount(mux, "/admin", echo()) })
+}
+
+func TestMount_StaticStripping(t *testing.T) {
+	adminMux := http.NewServeMux()
+	adminMux.Handle("GET /{$}", echo())
+	adminMux.Handle("GET /users/{id}", echo())
+	adminMux.Handle("POST /submit", echo())
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "ok")
+	})
+	subroute.Mount(mux, "/admin", adminMux)
+	subroute.Mount(mux, "/api/v1", echo())
+
+	tests := []struct {
+		name, method, target, wantBody string
+		wantStatus                     int
+	}{
+		{"bare prefix serves as root", http.MethodGet, "/admin", `GET / raw="" q=`, http.StatusOK},
+		{"trailing slash serves as root", http.MethodGet, "/admin/", `GET / raw="" q=`, http.StatusOK},
+		{"subtree stripped", http.MethodGet, "/admin/users/42", `GET /users/42 raw="" q=`, http.StatusOK},
+		{"method pattern inside mount", http.MethodPost, "/admin/submit", `POST /submit raw="" q=`, http.StatusOK},
+		{"multi-segment static prefix", http.MethodGet, "/api/v1/orders/7", `GET /orders/7 raw="" q=`, http.StatusOK},
+		{"query preserved", http.MethodGet, "/admin/users/42?page=2", `GET /users/42 raw="" q=page=2`, http.StatusOK},
+		{"sibling route untouched", http.MethodGet, "/health", "ok", http.StatusOK},
+		{"unknown path 404s on outer mux", http.MethodGet, "/nope", "", http.StatusNotFound},
+		{"unknown path inside mount 404s", http.MethodGet, "/admin/nope", "", http.StatusNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(tt.method, tt.target, nil))
+			assert.Equal(t, tt.wantStatus, rec.Code)
+			if tt.wantBody != "" {
+				assert.Equal(t, tt.wantBody, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestMount_EncodedSegments(t *testing.T) {
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/files", echo())
+
+	// %2F must survive stripping: the mounted handler gets a consistent
+	// Path/RawPath pair, and the escaped form keeps the encoded slash.
+	rec := get(t, mux, "/files/a%2Fb/c")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, `GET /a/b/c raw="/a%2Fb/c" q=`, rec.Body.String())
+}
+
+func TestMount_CallerRequestNotMutated(t *testing.T) {
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", echo())
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/users/42", nil)
+	mux.ServeHTTP(httptest.NewRecorder(), req)
+	assert.Equal(t, "/admin/users/42", req.URL.Path)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -race ./web/subroute`
+Expected: FAIL — compile error `undefined: subroute` / package does not exist.
+
+- [ ] **Step 3: Implement Mount, parsePrefix, stripHandler, stripSegments**
+
+Create `web/subroute/subroute.go`:
+
+```go
+// Package subroute mounts http.Handlers under path prefixes on a standard
+// *http.ServeMux, chi.Mount-style. See doc.go for the full package comment.
+package subroute
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+// Mount registers h on mux at prefix, both as the exact path and as a
+// subtree. prefix may contain single-segment {name} wildcards. Requests are
+// dispatched to h with the prefix segments stripped from the URL path; a
+// request for the bare prefix reaches h with path "/". Path values matched
+// by the prefix are captured and readable inside h via PathValue.
+//
+// Mount panics on nil arguments or a malformed prefix; ServeMux.Handle
+// additionally panics on pattern conflicts and invalid wildcard names.
+func Mount(mux *http.ServeMux, prefix string, h http.Handler) {
+	if mux == nil {
+		panic("subroute: nil mux")
+	}
+	if h == nil {
+		panic(fmt.Sprintf("subroute: nil handler for prefix %q", prefix))
+	}
+	segments, names := parsePrefix(prefix)
+	sh := &stripHandler{h: h, names: names, segments: segments}
+	mux.Handle(prefix, sh)
+	mux.Handle(prefix+"/", sh)
+}
+
+// parsePrefix validates prefix and returns its segment count and wildcard
+// names. Wildcard name syntax beyond structure (valid identifiers) is left
+// to ServeMux.Handle, which panics with its own message.
+func parsePrefix(prefix string) (segments int, names []string) {
+	switch {
+	case prefix == "" || prefix[0] != '/':
+		panic(fmt.Sprintf("subroute: prefix %q must start with '/'", prefix))
+	case prefix == "/":
+		panic(`subroute: prefix "/" is not mountable; register the handler on the mux directly`)
+	case strings.HasSuffix(prefix, "/"):
+		panic(fmt.Sprintf("subroute: prefix %q must not end with '/'", prefix))
+	case strings.ContainsAny(prefix, " \t"):
+		panic(fmt.Sprintf("subroute: prefix %q must not contain whitespace", prefix))
+	}
+	for seg := range strings.SplitSeq(prefix[1:], "/") {
+		segments++
+		switch {
+		case seg == "":
+			panic(fmt.Sprintf("subroute: prefix %q contains an empty segment", prefix))
+		case seg[0] == '{' && seg[len(seg)-1] == '}':
+			name := seg[1 : len(seg)-1]
+			switch {
+			case name == "" || name == "$":
+				panic(fmt.Sprintf("subroute: prefix %q: %q is not a valid wildcard", prefix, seg))
+			case strings.HasSuffix(name, "..."):
+				panic(fmt.Sprintf("subroute: prefix %q: multi-segment wildcard %q is not allowed", prefix, seg))
+			case slices.Contains(names, name):
+				panic(fmt.Sprintf("subroute: prefix %q: duplicate wildcard name %q", prefix, name))
+			}
+			names = append(names, name)
+		case strings.ContainsAny(seg, "{}"):
+			panic(fmt.Sprintf("subroute: prefix %q: wildcard must occupy a whole segment, got %q", prefix, seg))
+		}
+	}
+	return segments, names
+}
+
+// stripHandler dispatches to h with the mount prefix removed from the URL of
+// a cloned request. names is non-nil only for wildcard prefixes (Task 2).
+type stripHandler struct {
+	h        http.Handler
+	names    []string
+	segments int
+}
+
+func (s *stripHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r2 := new(http.Request)
+	*r2 = *r
+	r2.URL = new(url.URL)
+	*r2.URL = *r.URL
+
+	// Strip on the escaped path so encoded separators (%2F) inside segments
+	// survive; then derive the decoded Path, keeping the URL invariant that
+	// RawPath is set only when it differs from Path.
+	tail := stripSegments(r.URL.EscapedPath(), s.segments)
+	if tail == "" {
+		tail = "/" // bare-prefix match: mounted handler sees the root
+	}
+	p, err := url.PathUnescape(tail)
+	if err != nil { // unreachable for paths ServeMux matched; keep escaped form
+		p = tail
+	}
+	r2.URL.Path = p
+	if p == tail {
+		r2.URL.RawPath = ""
+	} else {
+		r2.URL.RawPath = tail
+	}
+	s.h.ServeHTTP(w, r2)
+}
+
+// stripSegments returns path without its first n segments, starting at the
+// slash that follows them ("/a/b/c", 2 -> "/c"). It returns "" when path has
+// exactly n segments. path must begin with '/', which ServeMux guarantees
+// for matched requests.
+func stripSegments(path string, n int) string {
+	i := 0
+	for range n {
+		j := strings.IndexByte(path[i+1:], '/')
+		if j < 0 {
+			return ""
+		}
+		i += 1 + j
+	}
+	return path[i:]
+}
+```
+
+- [ ] **Step 4: Format and run tests to verify they pass**
+
+Run: `just fmt ./web/subroute/...`
+Run: `go test -race ./web/subroute`
+Expected: PASS (all tests in the two files above).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/subroute/subroute.go web/subroute/subroute_test.go
+git commit -m "feat(web/subroute): static prefix mounting with segment stripping"
+```
+
+---
+
+### Task 2: Wildcard prefixes — param capture and the PathValue accessor
+
+**Files:**
+- Create: `web/subroute/context.go`
+- Modify: `web/subroute/subroute.go` (extend `stripHandler.ServeHTTP` with capture)
+- Test: `web/subroute/subroute_test.go` (append tests)
+
+**Interfaces:**
+- Consumes: `stripHandler{h, names, segments}` and `Mount` from Task 1 (`names` is already populated by `parsePrefix`).
+- Produces:
+  - `func PathValue(r *http.Request, name string) string` — exported accessor.
+  - unexported `paramsKey` (`ctxKey{}` value) and `type paramsCtx struct { context.Context; vals map[string]string }` — Task 3 reuses `paramsKey` for merge lookups.
+
+- [ ] **Step 1: Write failing tests for wildcard mounts**
+
+Append to `web/subroute/subroute_test.go`:
+
+```go
+func TestMount_WildcardPrefix(t *testing.T) {
+	dashboardMux := http.NewServeMux()
+	dashboardMux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "home tenant=%s", subroute.PathValue(r, "tenant"))
+	})
+	dashboardMux.HandleFunc("GET /reports/{id}", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "report tenant=%s id=%s own=%s",
+			subroute.PathValue(r, "tenant"), subroute.PathValue(r, "id"), r.PathValue("id"))
+	})
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/app/{tenant}/dashboard", dashboardMux)
+
+	tests := []struct{ name, target, wantBody string }{
+		{"bare wildcard prefix", "/app/acme/dashboard", "home tenant=acme"},
+		{"subtree with own wildcard", "/app/acme/dashboard/reports/7", "report tenant=acme id=7 own=7"},
+		{"tenant varies per request", "/app/globex/dashboard", "home tenant=globex"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := get(t, mux, tt.target)
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, tt.wantBody, rec.Body.String())
+		})
+	}
+}
+
+func TestPathValue_CurrentMuxWinsOverCapture(t *testing.T) {
+	inner := http.NewServeMux()
+	inner.HandleFunc("GET /sub/{id}", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "id=%s", subroute.PathValue(r, "id"))
+	})
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/m/{id}", inner)
+
+	rec := get(t, mux, "/m/OUTER/sub/INNER")
+	assert.Equal(t, "id=INNER", rec.Body.String())
+}
+
+func TestPathValue_StaticMountCapturesNothing(t *testing.T) {
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "missing=%q", subroute.PathValue(r, "tenant"))
+	}))
+
+	rec := get(t, mux, "/admin/x")
+	assert.Equal(t, `missing=""`, rec.Body.String())
+}
+
+func TestPathValue_PlainRequest(t *testing.T) {
+	// Works on requests that never passed through a mount.
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	assert.Empty(t, subroute.PathValue(r, "anything"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -race -run 'TestMount_WildcardPrefix|TestPathValue' ./web/subroute`
+Expected: FAIL — `undefined: subroute.PathValue`.
+
+- [ ] **Step 3: Implement context capture and PathValue**
+
+Create `web/subroute/context.go`:
+
+```go
+package subroute
+
+import (
+	"context"
+	"net/http"
+)
+
+type ctxKey struct{}
+
+var paramsKey = ctxKey{}
+
+// paramsCtx carries mount-captured path values in a single heap allocation
+// (the map), instead of the two context.WithValue would cost. Value returns
+// the same map every call, so reads never allocate.
+type paramsCtx struct {
+	context.Context
+	vals map[string]string
+}
+
+func (c *paramsCtx) Value(key any) any {
+	if key == paramsKey {
+		return c.vals
+	}
+	return c.Context.Value(key)
+}
+
+// PathValue returns the named path value: r.PathValue first (the current
+// mux's own match), then values captured by enclosing Mount prefixes,
+// innermost mount first. It returns "" if the name is not present.
+//
+// Handlers use plain r.PathValue for their own mux's wildcards; PathValue is
+// needed only for params originating in mount prefixes, which the standard
+// library cannot propagate across a ServeMux boundary.
+func PathValue(r *http.Request, name string) string {
+	if v := r.PathValue(name); v != "" {
+		return v
+	}
+	if vals, ok := r.Context().Value(paramsKey).(map[string]string); ok {
+		return vals[name]
+	}
+	return ""
+}
+```
+
+In `web/subroute/subroute.go`, replace the first four lines of `stripHandler.ServeHTTP` (the `r2 := new(http.Request)` through `*r2.URL = *r.URL` block) with:
+
+```go
+func (s *stripHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var r2 *http.Request
+	if len(s.names) > 0 {
+		vals := make(map[string]string, len(s.names))
+		for _, n := range s.names {
+			vals[n] = r.PathValue(n)
+		}
+		r2 = r.WithContext(&paramsCtx{Context: r.Context(), vals: vals})
+	} else {
+		// Static prefix: no capture, no context allocation.
+		r2 = new(http.Request)
+		*r2 = *r
+	}
+	r2.URL = new(url.URL)
+	*r2.URL = *r.URL
+	// ... rest of the method unchanged (tail := stripSegments... onward)
+```
+
+- [ ] **Step 4: Format and run the full package tests**
+
+Run: `just fmt ./web/subroute/...`
+Run: `go test -race ./web/subroute`
+Expected: PASS (Task 1 tests still green, new tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/subroute/context.go web/subroute/subroute.go web/subroute/subroute_test.go
+git commit -m "feat(web/subroute): wildcard prefixes with PathValue param propagation"
+```
+
+---
+
+### Task 3: Nested mounts — capture merging with innermost-wins shadowing
+
+**Files:**
+- Modify: `web/subroute/subroute.go` (merge enclosing captures in `ServeHTTP`)
+- Test: `web/subroute/subroute_test.go` (append tests)
+
+**Interfaces:**
+- Consumes: `paramsKey`, `paramsCtx` from Task 2; `stripHandler.ServeHTTP` capture branch from Task 2.
+- Produces: no new symbols — behavioral guarantee that nested `Mount` calls merge captured params (innermost wins) which doc.go (Task 4) documents.
+
+- [ ] **Step 1: Write failing tests for nested mounts**
+
+Append to `web/subroute/subroute_test.go`:
+
+```go
+func TestMount_Nested(t *testing.T) {
+	projMux := http.NewServeMux()
+	projMux.HandleFunc("GET /info", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "path=%s tenant=%s proj=%s",
+			r.URL.Path, subroute.PathValue(r, "tenant"), subroute.PathValue(r, "proj"))
+	})
+
+	appMux := http.NewServeMux()
+	subroute.Mount(appMux, "/proj/{proj}", projMux)
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/app/{tenant}", appMux)
+
+	rec := get(t, mux, "/app/acme/proj/x/info")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "path=/info tenant=acme proj=x", rec.Body.String())
+}
+
+func TestMount_NestedShadowing(t *testing.T) {
+	leaf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "id=%s", subroute.PathValue(r, "id"))
+	})
+
+	innerMux := http.NewServeMux()
+	subroute.Mount(innerMux, "/dup/{id}", leaf) // same name as outer prefix
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/m/{id}", innerMux)
+
+	rec := get(t, mux, "/m/OUTER/dup/INNER/x")
+	assert.Equal(t, "id=INNER", rec.Body.String()) // innermost mount wins
+}
+
+func TestMount_NestedStaticInsideWildcard(t *testing.T) {
+	leaf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "path=%s tenant=%s", r.URL.Path, subroute.PathValue(r, "tenant"))
+	})
+
+	appMux := http.NewServeMux()
+	subroute.Mount(appMux, "/settings", leaf) // static mount below a wildcard mount
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/app/{tenant}", appMux)
+
+	rec := get(t, mux, "/app/acme/settings/profile")
+	assert.Equal(t, "path=/profile tenant=acme", rec.Body.String())
+}
+```
+
+- [ ] **Step 2: Run tests to verify the merge cases fail**
+
+Run: `go test -race -run TestMount_Nested ./web/subroute`
+Expected: `TestMount_Nested` FAILS (tenant is empty — the inner mount's fresh map hides the outer capture). `TestMount_NestedStaticInsideWildcard` PASSES already (static mounts don't replace the context; the outer `paramsCtx` is inherited through the cloned request). `TestMount_NestedShadowing` PASSES already (inner map is consulted first). Both still belong in this task: they pin the merge semantics against regressions.
+
+- [ ] **Step 3: Merge enclosing captures in the wildcard branch**
+
+In `web/subroute/subroute.go`, inside the `len(s.names) > 0` branch, build the map by copying any enclosing capture first:
+
+```go
+	if len(s.names) > 0 {
+		var outer map[string]string
+		if v, ok := r.Context().Value(paramsKey).(map[string]string); ok {
+			outer = v
+		}
+		vals := make(map[string]string, len(outer)+len(s.names))
+		for k, v := range outer {
+			vals[k] = v
+		}
+		for _, n := range s.names {
+			vals[n] = r.PathValue(n) // own names overwrite: innermost mount wins
+		}
+		r2 = r.WithContext(&paramsCtx{Context: r.Context(), vals: vals})
+	} else {
+```
+
+- [ ] **Step 4: Format and run the full package tests**
+
+Run: `just fmt ./web/subroute/...`
+Run: `go test -race ./web/subroute`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/subroute/subroute.go web/subroute/subroute_test.go
+git commit -m "feat(web/subroute): merge captured params across nested mounts"
+```
+
+---
+
+### Task 4: Middleware-boundary tests, doc.go, and examples
+
+**Files:**
+- Create: `web/subroute/doc.go`
+- Create: `web/subroute/example_test.go`
+- Test: `web/subroute/subroute_test.go` (append middleware test)
+
+**Interfaces:**
+- Consumes: `Mount`, `PathValue` (final signatures from Tasks 1–2); `middleware.Wrap` from `web/middleware` (`func Wrap(h http.Handler, mws ...Middleware) http.Handler`, `type Middleware func(http.Handler) http.Handler`).
+- Produces: package documentation; no new code symbols.
+
+- [ ] **Step 1: Write the middleware-boundary test**
+
+Append to `web/subroute/subroute_test.go` (add `"github.com/dmitrymomot/forge/web/middleware"` to imports):
+
+```go
+func TestMount_MiddlewareBoundary(t *testing.T) {
+	var outerSaw, innerSaw string
+	record := func(dst *string) middleware.Middleware {
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				*dst = r.URL.Path
+				next.ServeHTTP(w, r)
+			})
+		}
+	}
+
+	adminMux := http.NewServeMux()
+	adminMux.Handle("GET /users", echo())
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", middleware.Wrap(adminMux, record(&innerSaw)))
+	root := middleware.Wrap(mux, record(&outerSaw))
+
+	rec := httptest.NewRecorder()
+	root.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/users", nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "/admin/users", outerSaw, "outer middleware sees the full path")
+	assert.Equal(t, "/users", innerSaw, "mounted middleware sees the stripped path")
+}
+```
+
+- [ ] **Step 2: Run it to verify it passes**
+
+Run: `go test -race -run TestMount_MiddlewareBoundary ./web/subroute`
+Expected: PASS — this pins already-implemented behavior; no production change in this task. If it fails, stop and fix the implementation before writing docs.
+
+- [ ] **Step 3: Write doc.go**
+
+Create `web/subroute/doc.go`:
+
+```go
+// Package subroute mounts http.Handlers under path prefixes on a standard
+// *http.ServeMux, in the spirit of chi's Mount.
+//
+// Mount registers a prefix — exact and subtree — and dispatches to the
+// mounted handler with the prefix stripped, so sub-apps are written as if
+// they live at the root:
+//
+//	adminMux := http.NewServeMux()
+//	adminMux.HandleFunc("GET /users/{id}", showUser) // serves /admin/users/{id}
+//
+//	mux := http.NewServeMux()
+//	subroute.Mount(mux, "/admin", adminMux)
+//
+// A request for the bare prefix ("/admin") reaches the mounted handler with
+// path "/". The caller's request is never mutated; stripping happens on a
+// clone. Mounts nest: a mounted ServeMux can itself have Mount applied.
+//
+// # Wildcard prefixes
+//
+// Prefixes may contain single-segment {name} wildcards. Their matched values
+// are captured at the mount boundary and read with [PathValue], because the
+// standard library discards a parent mux's path values when a nested mux
+// matches:
+//
+//	subroute.Mount(mux, "/app/{tenant}/dashboard", dashboardMux)
+//
+//	// in a dashboardMux handler:
+//	tenant := subroute.PathValue(r, "tenant") // from the mount prefix
+//	id := r.PathValue("id")                   // own wildcards work as usual
+//
+// [PathValue] prefers the current mux's own match, then walks enclosing
+// mounts innermost-first. Method, host, {$}, and {name...} elements are not
+// allowed in prefixes.
+//
+// # Middleware
+//
+// Mount takes no middleware parameters; compose with web/middleware:
+//
+//	subroute.Mount(mux, "/admin", middleware.Wrap(adminMux, requireAuth))
+//	srv.Handler = middleware.Wrap(mux, reqlog, recoverer) // global
+//
+// Middleware wrapped inside the mount observes the stripped path ("/users"),
+// while middleware wrapping the outer mux observes the full original path
+// ("/admin/users"). This differs from chi, which routes through a shared
+// context and never rewrites the URL; with a plain ServeMux as the child
+// router the rewrite is unavoidable.
+package subroute
+```
+
+- [ ] **Step 4: Write example_test.go**
+
+Create `web/subroute/example_test.go`:
+
+```go
+package subroute_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/dmitrymomot/forge/web/subroute"
+)
+
+func ExampleMount() {
+	adminMux := http.NewServeMux()
+	adminMux.HandleFunc("GET /users/{id}", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "user %s at %s", r.PathValue("id"), r.URL.Path)
+	})
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", adminMux)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/users/42", nil))
+	fmt.Println(rec.Body.String())
+	// Output: user 42 at /users/42
+}
+
+func ExamplePathValue() {
+	dashboardMux := http.NewServeMux()
+	dashboardMux.HandleFunc("GET /reports/{id}", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "tenant %s, report %s", subroute.PathValue(r, "tenant"), r.PathValue("id"))
+	})
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/app/{tenant}/dashboard", dashboardMux)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/app/acme/dashboard/reports/7", nil))
+	fmt.Println(rec.Body.String())
+	// Output: tenant acme, report 7
+}
+```
+
+- [ ] **Step 5: Format and run the full package tests (examples run as tests)**
+
+Run: `just fmt ./web/subroute/...`
+Run: `just test ./web/subroute`
+Expected: PASS including `ExampleMount` and `ExamplePathValue` output checks.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/subroute/doc.go web/subroute/example_test.go web/subroute/subroute_test.go
+git commit -m "docs(web/subroute): package docs, examples, middleware-boundary test"
+```
+
+---
+
+### Task 5: Benchmarks, lint, and final verification
+
+**Files:**
+- Create: `web/subroute/bench_test.go`
+- Modify: `docs/packages.md` (add `subroute` to the web shipped list)
+
+**Interfaces:**
+- Consumes: `Mount` from Task 1.
+- Produces: nothing new — final quality gate.
+
+- [ ] **Step 1: Write benchmarks**
+
+Create `web/subroute/bench_test.go`:
+
+```go
+package subroute_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/subroute"
+)
+
+func BenchmarkMount_Static(b *testing.B) {
+	inner := http.NewServeMux()
+	inner.HandleFunc("GET /users/{id}", func(http.ResponseWriter, *http.Request) {})
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/users/42", nil)
+	rec := httptest.NewRecorder()
+	b.ReportAllocs()
+	for b.Loop() {
+		mux.ServeHTTP(rec, req)
+	}
+}
+
+func BenchmarkMount_Wildcard(b *testing.B) {
+	inner := http.NewServeMux()
+	inner.HandleFunc("GET /reports/{id}", func(http.ResponseWriter, *http.Request) {})
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/app/{tenant}/dashboard", inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/app/acme/dashboard/reports/7", nil)
+	rec := httptest.NewRecorder()
+	b.ReportAllocs()
+	for b.Loop() {
+		mux.ServeHTTP(rec, req)
+	}
+}
+```
+
+- [ ] **Step 2: Run benchmarks**
+
+Run: `just bench ./web/subroute`
+Expected: both benchmarks complete; static ~3–4 allocs/op (request + URL clones, mux internals), wildcard a few more (map + context). No pass/fail threshold — record the numbers in the commit message body if noteworthy.
+
+- [ ] **Step 3: Add subroute to docs/packages.md**
+
+In `docs/packages.md`, in the `web/` section of the target tree, move `subroute` into the shipped list — change:
+
+```
+│   # shipped: httpserver hostrouter middleware request clientip problem
+│   #          recoverer reqlog requestid render htmx
+```
+
+to:
+
+```
+│   # shipped: httpserver hostrouter middleware request clientip problem
+│   #          recoverer reqlog requestid render htmx subroute
+```
+
+Also update the `Shipped:` line near line 260 the same way (append `subroute` to its list). Search for other enumerations of shipped web packages (`grep -n "render htmx" docs/packages.md`) and keep them consistent.
+
+- [ ] **Step 4: Full quality gate**
+
+Run: `just fmt ./web/subroute/...`
+Run: `just lint`
+Expected: clean — no vet/golangci-lint/nilaway/betteralign/modernize findings. Fix anything reported (betteralign may reorder struct fields; accept its changes).
+
+Run: `just test ./web/subroute`
+Expected: PASS with race detector and coverage reported.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/subroute/bench_test.go docs/packages.md
+git commit -m "feat(web/subroute): benchmarks; mark package shipped in packages.md"
+```

--- a/docs/superpowers/plans/2026-07-04-subroute.md
+++ b/docs/superpowers/plans/2026-07-04-subroute.md
@@ -906,6 +906,20 @@ import (
 	"github.com/dmitrymomot/forge/web/subroute"
 )
 
+// BenchmarkMux_Direct is the no-mount baseline: the same route registered
+// directly on one mux. The Mount benchmarks read against this delta.
+func BenchmarkMux_Direct(b *testing.B) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /admin/users/{id}", func(http.ResponseWriter, *http.Request) {})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/users/42", nil)
+	rec := httptest.NewRecorder()
+	b.ReportAllocs()
+	for b.Loop() {
+		mux.ServeHTTP(rec, req)
+	}
+}
+
 func BenchmarkMount_Static(b *testing.B) {
 	inner := http.NewServeMux()
 	inner.HandleFunc("GET /users/{id}", func(http.ResponseWriter, *http.Request) {})
@@ -938,7 +952,7 @@ func BenchmarkMount_Wildcard(b *testing.B) {
 - [ ] **Step 2: Run benchmarks**
 
 Run: `just bench ./web/subroute`
-Expected: both benchmarks complete; static ~3–4 allocs/op (request + URL clones, mux internals), wildcard a few more (map + context wrapper). No pass/fail threshold — record the numbers in the commit message body if noteworthy.
+Expected: all three benchmarks complete. Read Mount numbers as deltas against `BenchmarkMux_Direct`: static should add ~2 allocs/op over the baseline (request + URL clones), wildcard ~2 more (params map + context wrapper). No pass/fail threshold — record the deltas in the commit message body.
 
 - [ ] **Step 3: Add subroute to docs/packages.md**
 

--- a/docs/superpowers/specs/2026-07-04-subroute-design.md
+++ b/docs/superpowers/specs/2026-07-04-subroute-design.md
@@ -1,7 +1,7 @@
 # web/subroute — design
 
 Date: 2026-07-04
-Status: approved for planning
+Status: approved for planning (rev 2: param accessor moved to web/request)
 
 ## Purpose
 
@@ -9,8 +9,13 @@ Status: approved for planning
 `http.Handler` (typically another `ServeMux`) under a path prefix — including
 prefixes with `{name}` wildcards — with the prefix stripped so the mounted
 handler sees root-relative paths, and prefix path values still readable from
-handlers inside the mount. Standalone package in the `web/` domain,
-stdlib-only, in the same spirit as `web/hostrouter`.
+handlers inside the mount. Standalone package in the `web/` domain, in the
+same spirit as `web/hostrouter`.
+
+Prefix path values are read through the existing `web/request` accessors
+(`request.Path`, `request.PathFunc`, `request.HasPath`), which gain a
+context-based fallback. `web/request` owns that seam; `subroute` writes
+through it.
 
 ## Background: why not exactly chi's mechanism
 
@@ -22,12 +27,13 @@ parent params remain readable in mounted subrouters.
 `http.ServeMux` has no such seam: it routes on `r.URL.Path` only, and its
 match state (what `r.PathValue` reads) is unexported and overwritten whenever
 a nested mux matches. Therefore a std-mux mount must (a) rewrite the path on
-a cloned request, and (b) carry prefix params through its own request-context
-value — the explicit-accessor equivalent of chi's `RouteContext`.
+a cloned request, and (b) carry prefix params through a request-context
+value — the equivalent of chi's `RouteContext`, owned here by `web/request`
+so that its typed accessors keep working across mount boundaries.
 
 ## API
 
-Two exported functions:
+### web/subroute — one exported function
 
 ```go
 package subroute
@@ -36,14 +42,25 @@ package subroute
 // subtree. prefix may contain single-segment {name} wildcards. Requests are
 // dispatched to h with the prefix segments stripped from the URL path; a
 // request for the bare prefix reaches h with path "/". Path values matched
-// by the prefix are captured and readable inside h via PathValue.
+// by the prefix are captured and readable inside h via request.Path.
 func Mount(mux *http.ServeMux, prefix string, h http.Handler)
-
-// PathValue returns the named path value: r.PathValue first (the current
-// mux's own match), then values captured by enclosing Mount prefixes,
-// innermost mount first. Returns "" if the name is not present.
-func PathValue(r *http.Request, name string) string
 ```
+
+### web/request — one new function, three extended
+
+```go
+package request
+
+// WithPathValues returns a context carrying vals as fallback path values for
+// Path, PathFunc, and HasPath. Values merge over any previously stored ones
+// (later wins). Routers that dispatch across ServeMux boundaries (subroute)
+// use this to keep path params readable in nested handlers.
+func WithPathValues(ctx context.Context, vals map[string]string) context.Context
+```
+
+`Path`, `PathFunc`, and `HasPath` change lookup from `r.PathValue(key)` to:
+`r.PathValue(key)` first (the current mux's own match wins), then the
+context-stored fallback, then absent.
 
 Usage:
 
@@ -57,8 +74,8 @@ dashboardMux.HandleFunc("GET /{$}", home)             // GET /app/acme/dashboard
 dashboardMux.HandleFunc("GET /reports/{id}", report)  // GET /app/acme/dashboard/reports/7
 
 func report(w http.ResponseWriter, r *http.Request) {
-    tenant := subroute.PathValue(r, "tenant") // "acme" — from the mount prefix
-    id := r.PathValue("id")                   // "7" — current mux match, stdlib as usual
+    tenant, _ := request.Path[string](r, "tenant") // "acme" — from the mount prefix
+    id, _ := request.Path[int](r, "id")            // 7 — current mux match, typed as usual
 }
 ```
 
@@ -69,7 +86,8 @@ func report(w http.ResponseWriter, r *http.Request) {
 `Mount` registers two patterns on the given mux — the exact `prefix` and the
 subtree `prefix + "/"` — both pointing at one internal strip handler.
 Duplicate-registration conflicts are caught by `ServeMux.Handle` itself,
-which already panics; `subroute` inherits that behavior.
+which already panics; `subroute` inherits that behavior. `Mount` panics on
+nil `mux`/`h` and malformed prefixes (see Validation).
 
 ### Strip handler (hot path)
 
@@ -77,10 +95,11 @@ which already panics; `subroute` inherits that behavior.
   mutated.
 - Captures prefix path values: for each `{name}` wildcard in the prefix
   (parsed once at Mount time), reads `r.PathValue(name)` — the outer mux has
-  just matched them — and stores the set in the request context. Nested
-  mounts merge with enclosing captures; on name collision the innermost mount
-  wins (matching chi's last-added-wins scan). Static prefixes skip capture
-  entirely (no context allocation).
+  just matched them — and stores the set via `request.WithPathValues`.
+  Because `WithPathValues` merges later-over-earlier, nested mounts
+  accumulate captures and the innermost mount wins on name collision
+  (matching chi's last-added-wins scan) with no extra logic in `subroute`.
+  Static prefixes skip capture entirely (no context allocation).
 - Strips as many leading path segments as the prefix has (segment-based, not
   literal trim, because wildcard segments vary per request). Operates on the
   escaped path; `URL.Path` and `URL.RawPath` are set consistently. An empty
@@ -91,18 +110,24 @@ which already panics; `subroute` inherits that behavior.
 - Composes under `web/hostrouter`, and nests: a mounted `ServeMux` can itself
   have `Mount` applied.
 
-### PathValue accessor
+### Path-value lookup (web/request)
 
-`subroute.PathValue(r, name)`:
+`request.Path` / `PathFunc` / `HasPath` resolve the raw value as:
 
-1. `r.PathValue(name)` — non-empty means the current mux's own pattern
-   matched it; return it.
-2. Otherwise walk mount-captured values from the innermost mount outward.
-3. `""` if absent.
+1. `r.PathValue(key)` — non-empty means the current mux's own pattern
+   matched it; use it.
+2. Otherwise the `WithPathValues` fallback map from the request context
+   (already merged, innermost mount first).
+3. Otherwise absent (zero value / default, per existing request semantics).
 
-Handlers keep using plain `r.PathValue` for their own mux's wildcards;
-`subroute.PathValue` is needed only for params originating in mount prefixes
-(stdlib physically cannot propagate those across a mux boundary).
+The context key and carrier type are unexported in `request`; the carrier is
+a custom context (hostrouter-style single allocation), and `WithPathValues`
+copies its input map, so callers cannot mutate stored values.
+
+### Dependencies
+
+`subroute` imports `web/request` (internal, for `WithPathValues` only).
+`request` remains stdlib-only and imports no forge packages.
 
 ### Validation (setup-time panics)
 
@@ -140,22 +165,34 @@ Caveats to document in `doc.go` and `example_test.go`:
   (`/admin/users`). This differs from chi, where mounted middleware sees the
   full path (chi never rewrites the URL); it is unavoidable with a std mux
   as the child router.
-- Mount-prefix params are read with `subroute.PathValue`, not `r.PathValue`.
+- Mount-prefix params are read with `request.Path` (or `r.PathValue` only
+  for the current mux's own wildcards).
 
 ## Testing
 
-Black-box only (`package subroute_test`):
+Black-box only.
+
+`web/request` (`package request_test`):
+
+- `Path`/`PathFunc`/`HasPath` fall back to `WithPathValues` values
+- `r.PathValue` (current mux match) takes precedence over fallback
+- `WithPathValues` merge: later call wins per key, earlier keys retained
+- `WithPathValues` with an empty/nil map returns the context unchanged
+- stored values are immune to caller mutating the input map afterward
+- typed parsing works on fallback values (e.g. `Path[int]`)
+
+`web/subroute` (`package subroute_test`):
 
 - bare prefix `GET /admin` → mounted handler sees `GET /`
 - subtree paths stripped (`/admin/users` → `/users`)
 - wildcard prefix: `GET /app/acme/dashboard/reports/7` → handler sees
-  `/reports/7`, `subroute.PathValue(r, "tenant") == "acme"`,
+  `/reports/7`, `request.Path[string](r, "tenant") == "acme"`,
   `r.PathValue("id") == "7"`
 - bare wildcard prefix (`GET /app/acme/dashboard` → path `/`, tenant
   captured)
-- nested mounts: param merging, innermost-wins shadowing, static-inside-
+- nested mounts: param accumulation, innermost-wins shadowing, static-inside-
   wildcard and wildcard-inside-wildcard
-- PathValue precedence: current-mux match beats captured mount values
+- precedence: current-mux match beats captured mount values
 - query string preserved; escaped/encoded segments handled consistently in
   `Path`/`RawPath`
 - non-matching paths fall through to the outer mux (404 or sibling routes)
@@ -166,14 +203,17 @@ Black-box only (`package subroute_test`):
 - static-prefix mounts allocate no capture context
 - all panic cases
 
-Package layout mirrors `web/hostrouter`: `subroute.go`, `context.go`,
-`doc.go`, `example_test.go`, tests, and a small benchmark.
+Package layout mirrors `web/hostrouter`: `subroute.go`, `doc.go`,
+`example_test.go`, tests, and a small benchmark. In `web/request`, the seam
+lives in a new `pathvalues.go` with `path.go` gaining the fallback.
 
 ## Non-goals
 
-- No router type, no options, no `Use()` — two functions.
+- No router type, no options, no `Use()` — subroute exports `Mount` only.
 - No middleware parameters on `Mount` (compose via `middleware.Wrap`).
 - No method, host, `{$}`, or `{name...}` elements in the prefix.
 - No handler-returning variant (`subroute.At`) unless a real need appears.
+- No exported reader for the raw fallback map in `request` — `Path`/
+  `PathFunc`/`HasPath` are the read API.
 - No propagation of the parent mux's 404/405 handlers into the child
   (chi does this for chi-to-chi mounts; std `ServeMux` has no seam for it).

--- a/docs/superpowers/specs/2026-07-04-subroute-design.md
+++ b/docs/superpowers/specs/2026-07-04-subroute-design.md
@@ -5,23 +5,44 @@ Status: approved for planning
 
 ## Purpose
 
-`chi.Mount` ergonomics for the standard library `*http.ServeMux`: mount any
-`http.Handler` (typically another `ServeMux`) under a path prefix, with the
-prefix stripped so the mounted handler sees root-relative paths. Standalone
-package in the `web/` domain, stdlib-only, in the same spirit as
-`web/hostrouter`.
+`chi.Mount` semantics for the standard library `*http.ServeMux`: mount any
+`http.Handler` (typically another `ServeMux`) under a path prefix — including
+prefixes with `{name}` wildcards — with the prefix stripped so the mounted
+handler sees root-relative paths, and prefix path values still readable from
+handlers inside the mount. Standalone package in the `web/` domain,
+stdlib-only, in the same spirit as `web/hostrouter`.
+
+## Background: why not exactly chi's mechanism
+
+chi's `Mount` never rewrites `r.URL.Path`. Parent and child chi routers share
+one `RouteContext`: the mount handler shifts `rctx.RoutePath` and the child
+routes on that, while `rctx.URLParams` accumulates across the chain — so
+parent params remain readable in mounted subrouters.
+
+`http.ServeMux` has no such seam: it routes on `r.URL.Path` only, and its
+match state (what `r.PathValue` reads) is unexported and overwritten whenever
+a nested mux matches. Therefore a std-mux mount must (a) rewrite the path on
+a cloned request, and (b) carry prefix params through its own request-context
+value — the explicit-accessor equivalent of chi's `RouteContext`.
 
 ## API
 
-One exported function, nothing else:
+Two exported functions:
 
 ```go
 package subroute
 
 // Mount registers h on mux at prefix, both as the exact path and as a
-// subtree. Requests are dispatched to h with prefix stripped from the URL
-// path; a request for the bare prefix reaches h with path "/".
+// subtree. prefix may contain single-segment {name} wildcards. Requests are
+// dispatched to h with the prefix segments stripped from the URL path; a
+// request for the bare prefix reaches h with path "/". Path values matched
+// by the prefix are captured and readable inside h via PathValue.
 func Mount(mux *http.ServeMux, prefix string, h http.Handler)
+
+// PathValue returns the named path value: r.PathValue first (the current
+// mux's own match), then values captured by enclosing Mount prefixes,
+// innermost mount first. Returns "" if the name is not present.
+func PathValue(r *http.Request, name string) string
 ```
 
 Usage:
@@ -29,7 +50,16 @@ Usage:
 ```go
 mux := http.NewServeMux()
 subroute.Mount(mux, "/admin", middleware.Wrap(adminMux, requireAuth))
-subroute.Mount(mux, "/api/v1", apiMux)
+subroute.Mount(mux, "/app/{tenant}/dashboard", middleware.Wrap(dashboardMux, mws...))
+
+// dashboardMux routes are root-relative:
+dashboardMux.HandleFunc("GET /{$}", home)             // GET /app/acme/dashboard
+dashboardMux.HandleFunc("GET /reports/{id}", report)  // GET /app/acme/dashboard/reports/7
+
+func report(w http.ResponseWriter, r *http.Request) {
+    tenant := subroute.PathValue(r, "tenant") // "acme" — from the mount prefix
+    id := r.PathValue("id")                   // "7" — current mux match, stdlib as usual
+}
 ```
 
 ## Behavior
@@ -45,15 +75,34 @@ which already panics; `subroute` inherits that behavior.
 
 - Shallow-clones the request and its URL; the caller's request is never
   mutated.
-- Trims `prefix` from `URL.Path`; an empty result is normalized to `"/"`, so
-  `GET /admin` reaches the mounted handler as `GET /`. (Plain
-  `http.StripPrefix` cannot do this: it leaves the path empty, and a nested
-  `ServeMux` then 301-redirects to `/`.)
-- `URL.RawPath`: trim the prefix if present; otherwise clear `RawPath` so
-  `EscapedPath()` recomputes consistently.
+- Captures prefix path values: for each `{name}` wildcard in the prefix
+  (parsed once at Mount time), reads `r.PathValue(name)` — the outer mux has
+  just matched them — and stores the set in the request context. Nested
+  mounts merge with enclosing captures; on name collision the innermost mount
+  wins (matching chi's last-added-wins scan). Static prefixes skip capture
+  entirely (no context allocation).
+- Strips as many leading path segments as the prefix has (segment-based, not
+  literal trim, because wildcard segments vary per request). Operates on the
+  escaped path; `URL.Path` and `URL.RawPath` are set consistently. An empty
+  result is normalized to `"/"`, so a bare-prefix request reaches h as
+  `GET /`. (Plain `http.StripPrefix` cannot do this: it leaves the path
+  empty, and a nested `ServeMux` then 301-redirects to `/`.)
 - Query string, method, host, headers, and body are untouched.
 - Composes under `web/hostrouter`, and nests: a mounted `ServeMux` can itself
   have `Mount` applied.
+
+### PathValue accessor
+
+`subroute.PathValue(r, name)`:
+
+1. `r.PathValue(name)` — non-empty means the current mux's own pattern
+   matched it; return it.
+2. Otherwise walk mount-captured values from the innermost mount outward.
+3. `""` if absent.
+
+Handlers keep using plain `r.PathValue` for their own mux's wildcards;
+`subroute.PathValue` is needed only for params originating in mount prefixes
+(stdlib physically cannot propagate those across a mux boundary).
 
 ### Validation (setup-time panics)
 
@@ -64,12 +113,15 @@ panics with a descriptive message on:
 - prefix not starting with `/`
 - prefix `"/"` (use `mux.Handle("/", h)` directly)
 - trailing slash in prefix
-- ServeMux pattern metacharacters in prefix: `{`, `}`, or any space
-  (prevents smuggling method/host patterns such as `"GET /admin"` or
-  wildcards)
+- malformed wildcards: `{` or `}` not forming a full-segment `{name}`,
+  empty name, `{$}`, or multi-segment `{name...}`
+- duplicate wildcard names within one prefix
+- spaces in prefix (prevents smuggling method/host patterns such as
+  `"GET /admin"`)
 
-Multi-segment prefixes such as `/api/v1` are valid. There are no runtime
-errors: after setup it is pure routing.
+Static and wildcard segments may mix freely: `/api/v1`,
+`/app/{tenant}/dashboard`, `/{org}/{repo}/settings` are all valid. There are
+no runtime errors: after setup it is pure routing.
 
 ## Middleware composition (documentation concern)
 
@@ -81,10 +133,14 @@ way, via `web/middleware`:
 - Global: `srv.Handler = middleware.Wrap(mux, reqlog, recoverer)` — wraps the
   outer mux, so it runs for every request including mounted subtrees.
 
-Caveat to document: middleware wrapped inside the mount sees the **stripped**
-path (`/users`), while middleware wrapping the outer mux sees the full
-original path (`/admin/users`). `doc.go` and `example_test.go` must show both
-patterns and the caveat.
+Caveats to document in `doc.go` and `example_test.go`:
+
+- Middleware wrapped inside the mount sees the **stripped** path (`/users`),
+  while middleware wrapping the outer mux sees the full original path
+  (`/admin/users`). This differs from chi, where mounted middleware sees the
+  full path (chi never rewrites the URL); it is unavoidable with a std mux
+  as the child router.
+- Mount-prefix params are read with `subroute.PathValue`, not `r.PathValue`.
 
 ## Testing
 
@@ -92,21 +148,32 @@ Black-box only (`package subroute_test`):
 
 - bare prefix `GET /admin` → mounted handler sees `GET /`
 - subtree paths stripped (`/admin/users` → `/users`)
-- nested mounts (mount inside a mounted mux)
-- query string preserved; `RawPath`/encoded segments handled
+- wildcard prefix: `GET /app/acme/dashboard/reports/7` → handler sees
+  `/reports/7`, `subroute.PathValue(r, "tenant") == "acme"`,
+  `r.PathValue("id") == "7"`
+- bare wildcard prefix (`GET /app/acme/dashboard` → path `/`, tenant
+  captured)
+- nested mounts: param merging, innermost-wins shadowing, static-inside-
+  wildcard and wildcard-inside-wildcard
+- PathValue precedence: current-mux match beats captured mount values
+- query string preserved; escaped/encoded segments handled consistently in
+  `Path`/`RawPath`
 - non-matching paths fall through to the outer mux (404 or sibling routes)
 - Go 1.22+ method patterns work inside the mounted mux
 - middleware ordering across the mount boundary (outer sees full path, inner
   sees stripped path)
 - caller's request not mutated
+- static-prefix mounts allocate no capture context
 - all panic cases
 
-Package layout mirrors `web/hostrouter`: `subroute.go`, `doc.go`,
-`example_test.go`, tests, and a small benchmark.
+Package layout mirrors `web/hostrouter`: `subroute.go`, `context.go`,
+`doc.go`, `example_test.go`, tests, and a small benchmark.
 
 ## Non-goals
 
-- No router type, no options, no `Use()` — one function.
+- No router type, no options, no `Use()` — two functions.
 - No middleware parameters on `Mount` (compose via `middleware.Wrap`).
-- No pattern features in the prefix (methods, hosts, wildcards).
+- No method, host, `{$}`, or `{name...}` elements in the prefix.
 - No handler-returning variant (`subroute.At`) unless a real need appears.
+- No propagation of the parent mux's 404/405 handlers into the child
+  (chi does this for chi-to-chi mounts; std `ServeMux` has no seam for it).

--- a/docs/superpowers/specs/2026-07-04-subroute-design.md
+++ b/docs/superpowers/specs/2026-07-04-subroute-design.md
@@ -1,0 +1,112 @@
+# web/subroute — design
+
+Date: 2026-07-04
+Status: approved for planning
+
+## Purpose
+
+`chi.Mount` ergonomics for the standard library `*http.ServeMux`: mount any
+`http.Handler` (typically another `ServeMux`) under a path prefix, with the
+prefix stripped so the mounted handler sees root-relative paths. Standalone
+package in the `web/` domain, stdlib-only, in the same spirit as
+`web/hostrouter`.
+
+## API
+
+One exported function, nothing else:
+
+```go
+package subroute
+
+// Mount registers h on mux at prefix, both as the exact path and as a
+// subtree. Requests are dispatched to h with prefix stripped from the URL
+// path; a request for the bare prefix reaches h with path "/".
+func Mount(mux *http.ServeMux, prefix string, h http.Handler)
+```
+
+Usage:
+
+```go
+mux := http.NewServeMux()
+subroute.Mount(mux, "/admin", middleware.Wrap(adminMux, requireAuth))
+subroute.Mount(mux, "/api/v1", apiMux)
+```
+
+## Behavior
+
+### Registration
+
+`Mount` registers two patterns on the given mux — the exact `prefix` and the
+subtree `prefix + "/"` — both pointing at one internal strip handler.
+Duplicate-registration conflicts are caught by `ServeMux.Handle` itself,
+which already panics; `subroute` inherits that behavior.
+
+### Strip handler (hot path)
+
+- Shallow-clones the request and its URL; the caller's request is never
+  mutated.
+- Trims `prefix` from `URL.Path`; an empty result is normalized to `"/"`, so
+  `GET /admin` reaches the mounted handler as `GET /`. (Plain
+  `http.StripPrefix` cannot do this: it leaves the path empty, and a nested
+  `ServeMux` then 301-redirects to `/`.)
+- `URL.RawPath`: trim the prefix if present; otherwise clear `RawPath` so
+  `EscapedPath()` recomputes consistently.
+- Query string, method, host, headers, and body are untouched.
+- Composes under `web/hostrouter`, and nests: a mounted `ServeMux` can itself
+  have `Mount` applied.
+
+### Validation (setup-time panics)
+
+Matching `hostrouter`'s panic-on-invalid-registration convention, `Mount`
+panics with a descriptive message on:
+
+- nil `mux` or nil `h`
+- prefix not starting with `/`
+- prefix `"/"` (use `mux.Handle("/", h)` directly)
+- trailing slash in prefix
+- ServeMux pattern metacharacters in prefix: `{`, `}`, or any space
+  (prevents smuggling method/host patterns such as `"GET /admin"` or
+  wildcards)
+
+Multi-segment prefixes such as `/api/v1` are valid. There are no runtime
+errors: after setup it is pure routing.
+
+## Middleware composition (documentation concern)
+
+`Mount` deliberately takes no middleware parameters; there is one canonical
+way, via `web/middleware`:
+
+- Per-mount: `subroute.Mount(mux, "/admin", middleware.Wrap(adminMux, mws...))`
+  — runs only for requests under `/admin`.
+- Global: `srv.Handler = middleware.Wrap(mux, reqlog, recoverer)` — wraps the
+  outer mux, so it runs for every request including mounted subtrees.
+
+Caveat to document: middleware wrapped inside the mount sees the **stripped**
+path (`/users`), while middleware wrapping the outer mux sees the full
+original path (`/admin/users`). `doc.go` and `example_test.go` must show both
+patterns and the caveat.
+
+## Testing
+
+Black-box only (`package subroute_test`):
+
+- bare prefix `GET /admin` → mounted handler sees `GET /`
+- subtree paths stripped (`/admin/users` → `/users`)
+- nested mounts (mount inside a mounted mux)
+- query string preserved; `RawPath`/encoded segments handled
+- non-matching paths fall through to the outer mux (404 or sibling routes)
+- Go 1.22+ method patterns work inside the mounted mux
+- middleware ordering across the mount boundary (outer sees full path, inner
+  sees stripped path)
+- caller's request not mutated
+- all panic cases
+
+Package layout mirrors `web/hostrouter`: `subroute.go`, `doc.go`,
+`example_test.go`, tests, and a small benchmark.
+
+## Non-goals
+
+- No router type, no options, no `Use()` — one function.
+- No middleware parameters on `Mount` (compose via `middleware.Wrap`).
+- No pattern features in the prefix (methods, hosts, wildcards).
+- No handler-returning variant (`subroute.At`) unless a real need appears.

--- a/web/request/doc.go
+++ b/web/request/doc.go
@@ -20,6 +20,10 @@
 // encoding.TextUnmarshaler (uuid.UUID, netip.Addr, time.Time, custom enums) works
 // through the generic engine; anything else can use the Func variants.
 //
+// Path accessors resolve the current mux match (r.PathValue) first, then
+// values stored with WithPathValues — the seam web/subroute uses so mount-
+// prefix params stay readable inside mounted handlers.
+//
 // request reads; the render package writes; the htmx package handles HX-* headers.
 // None imports another. Stdlib only.
 package request

--- a/web/request/path.go
+++ b/web/request/path.go
@@ -2,18 +2,20 @@ package request
 
 import "net/http"
 
-// Path reads path wildcard key (r.PathValue) and converts it to T. Requires a
-// Go 1.22+ ServeMux pattern that defines key.
+// Path reads path wildcard key and converts it to T. The value comes from
+// the current mux match (r.PathValue) or, when absent there, from values
+// stored with WithPathValues (e.g. by subroute mount prefixes).
 func Path[T any](r *http.Request, key string, def ...T) (T, error) {
-	return resolve(SourcePath, key, r.PathValue(key), parse[T], def)
+	return resolve(SourcePath, key, pathValue(r, key), parse[T], def)
 }
 
 // PathFunc is Path with a caller-supplied parser.
 func PathFunc[T any](r *http.Request, key string, parse func(string) (T, error), def ...T) (T, error) {
-	return resolve(SourcePath, key, r.PathValue(key), parse, def)
+	return resolve(SourcePath, key, pathValue(r, key), parse, def)
 }
 
-// HasPath reports whether the path wildcard key is set and non-empty.
+// HasPath reports whether the path wildcard key is set and non-empty,
+// checking the current mux match and then WithPathValues fallback.
 func HasPath(r *http.Request, key string) bool {
-	return r.PathValue(key) != ""
+	return pathValue(r, key) != ""
 }

--- a/web/request/pathvalues.go
+++ b/web/request/pathvalues.go
@@ -45,7 +45,9 @@ func WithPathValues(ctx context.Context, vals map[string]string) context.Context
 }
 
 // pathValue resolves a path wildcard: the current mux's own match first,
-// then WithPathValues fallback, then "".
+// then WithPathValues fallback, then "". Treating an empty r.PathValue
+// result as absent is safe: a ServeMux single-segment wildcard never
+// matches an empty segment, so "" can only mean the key was not matched.
 func pathValue(r *http.Request, key string) string {
 	if v := r.PathValue(key); v != "" {
 		return v

--- a/web/request/pathvalues.go
+++ b/web/request/pathvalues.go
@@ -1,0 +1,57 @@
+package request
+
+import (
+	"context"
+	"maps"
+	"net/http"
+)
+
+type pathValuesKeyType struct{}
+
+var pathValuesKey = pathValuesKeyType{}
+
+// pathValuesCtx carries fallback path values in a single heap allocation
+// (plus the map), instead of the two context.WithValue would cost. Value
+// returns the same map every call, so reads never allocate.
+type pathValuesCtx struct {
+	context.Context
+	vals map[string]string
+}
+
+func (c *pathValuesCtx) Value(key any) any {
+	if key == pathValuesKey {
+		return c.vals
+	}
+	return c.Context.Value(key)
+}
+
+// WithPathValues returns a context carrying vals as fallback path values for
+// Path, PathFunc, and HasPath. Values merge over any previously stored ones
+// (later wins); the input map is copied, so later caller mutations have no
+// effect. Routers that dispatch across ServeMux boundaries (subroute) use
+// this to keep path params readable in nested handlers.
+func WithPathValues(ctx context.Context, vals map[string]string) context.Context {
+	if len(vals) == 0 {
+		return ctx
+	}
+	var outer map[string]string
+	if v, ok := ctx.Value(pathValuesKey).(map[string]string); ok {
+		outer = v
+	}
+	merged := make(map[string]string, len(outer)+len(vals))
+	maps.Copy(merged, outer)
+	maps.Copy(merged, vals)
+	return &pathValuesCtx{Context: ctx, vals: merged}
+}
+
+// pathValue resolves a path wildcard: the current mux's own match first,
+// then WithPathValues fallback, then "".
+func pathValue(r *http.Request, key string) string {
+	if v := r.PathValue(key); v != "" {
+		return v
+	}
+	if vals, ok := r.Context().Value(pathValuesKey).(map[string]string); ok {
+		return vals[key]
+	}
+	return ""
+}

--- a/web/request/pathvalues_test.go
+++ b/web/request/pathvalues_test.go
@@ -1,0 +1,81 @@
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/web/request"
+)
+
+// withVals returns a request carrying vals as WithPathValues fallback.
+func withVals(vals map[string]string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	return r.WithContext(request.WithPathValues(r.Context(), vals))
+}
+
+func TestWithPathValues_Fallback(t *testing.T) {
+	r := withVals(map[string]string{"tenant": "acme", "n": "7"})
+
+	tenant, err := request.Path[string](r, "tenant")
+	require.NoError(t, err)
+	assert.Equal(t, "acme", tenant)
+
+	n, err := request.Path[int](r, "n") // typed parsing works on fallback values
+	require.NoError(t, err)
+	assert.Equal(t, 7, n)
+
+	assert.True(t, request.HasPath(r, "tenant"))
+	assert.False(t, request.HasPath(r, "absent"))
+
+	missing, err := request.Path[string](r, "absent", "def")
+	require.NoError(t, err)
+	assert.Equal(t, "def", missing)
+}
+
+func TestWithPathValues_CurrentMuxWins(t *testing.T) {
+	mux := http.NewServeMux()
+	var got string
+	mux.HandleFunc("GET /u/{id}", func(_ http.ResponseWriter, r *http.Request) {
+		got, _ = request.Path[string](r, "id")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/u/OWN", nil)
+	req = req.WithContext(request.WithPathValues(req.Context(), map[string]string{"id": "FALLBACK"}))
+	mux.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "OWN", got)
+}
+
+func TestWithPathValues_MergeLaterWins(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	ctx := request.WithPathValues(r.Context(), map[string]string{"a": "1", "b": "1"})
+	ctx = request.WithPathValues(ctx, map[string]string{"b": "2", "c": "2"})
+	r = r.WithContext(ctx)
+
+	a, _ := request.Path[string](r, "a")
+	b, _ := request.Path[string](r, "b")
+	c, _ := request.Path[string](r, "c")
+	assert.Equal(t, "1", a, "earlier keys retained")
+	assert.Equal(t, "2", b, "later call wins per key")
+	assert.Equal(t, "2", c)
+}
+
+func TestWithPathValues_EmptyMapIsNoop(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	assert.Equal(t, r.Context(), request.WithPathValues(r.Context(), nil))
+	assert.Equal(t, r.Context(), request.WithPathValues(r.Context(), map[string]string{}))
+}
+
+func TestWithPathValues_CopiesInput(t *testing.T) {
+	vals := map[string]string{"tenant": "acme"}
+	r := withVals(vals)
+	vals["tenant"] = "mutated"
+
+	tenant, err := request.Path[string](r, "tenant")
+	require.NoError(t, err)
+	assert.Equal(t, "acme", tenant)
+}

--- a/web/subroute/bench_test.go
+++ b/web/subroute/bench_test.go
@@ -1,0 +1,51 @@
+package subroute_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/subroute"
+)
+
+// BenchmarkMux_Direct is the no-mount baseline: the same route registered
+// directly on one mux. The Mount benchmarks read against this delta.
+func BenchmarkMux_Direct(b *testing.B) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /admin/users/{id}", func(http.ResponseWriter, *http.Request) {})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/users/42", nil)
+	rec := httptest.NewRecorder()
+	b.ReportAllocs()
+	for b.Loop() {
+		mux.ServeHTTP(rec, req)
+	}
+}
+
+func BenchmarkMount_Static(b *testing.B) {
+	inner := http.NewServeMux()
+	inner.HandleFunc("GET /users/{id}", func(http.ResponseWriter, *http.Request) {})
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/users/42", nil)
+	rec := httptest.NewRecorder()
+	b.ReportAllocs()
+	for b.Loop() {
+		mux.ServeHTTP(rec, req)
+	}
+}
+
+func BenchmarkMount_Wildcard(b *testing.B) {
+	inner := http.NewServeMux()
+	inner.HandleFunc("GET /reports/{id}", func(http.ResponseWriter, *http.Request) {})
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/app/{tenant}/dashboard", inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/app/acme/dashboard/reports/7", nil)
+	rec := httptest.NewRecorder()
+	b.ReportAllocs()
+	for b.Loop() {
+		mux.ServeHTTP(rec, req)
+	}
+}

--- a/web/subroute/doc.go
+++ b/web/subroute/doc.go
@@ -1,0 +1,47 @@
+// Package subroute mounts http.Handlers under path prefixes on a standard
+// *http.ServeMux, in the spirit of chi's Mount.
+//
+// Mount registers a prefix — exact and subtree — and dispatches to the
+// mounted handler with the prefix stripped, so sub-apps are written as if
+// they live at the root:
+//
+//	adminMux := http.NewServeMux()
+//	adminMux.HandleFunc("GET /users/{id}", showUser) // serves /admin/users/{id}
+//
+//	mux := http.NewServeMux()
+//	subroute.Mount(mux, "/admin", adminMux)
+//
+// A request for the bare prefix ("/admin") reaches the mounted handler with
+// path "/". The caller's request is never mutated; stripping happens on a
+// clone. Mounts nest: a mounted ServeMux can itself have Mount applied.
+//
+// # Wildcard prefixes
+//
+// Prefixes may contain single-segment {name} wildcards. Their matched values
+// are captured at the mount boundary (via request.WithPathValues), because
+// the standard library discards a parent mux's path values when a nested mux
+// matches. Read them with the request package's path accessors, which check
+// the current mux match first and then mount captures, innermost first:
+//
+//	subroute.Mount(mux, "/app/{tenant}/dashboard", dashboardMux)
+//
+//	// in a dashboardMux handler:
+//	tenant, _ := request.Path[string](r, "tenant") // from the mount prefix
+//	id, _ := request.Path[int](r, "id")            // own wildcards, typed as usual
+//
+// Plain r.PathValue only sees the current mux's own wildcards. Method, host,
+// {$}, and {name...} elements are not allowed in prefixes.
+//
+// # Middleware
+//
+// Mount takes no middleware parameters; compose with web/middleware:
+//
+//	subroute.Mount(mux, "/admin", middleware.Wrap(adminMux, requireAuth))
+//	srv.Handler = middleware.Wrap(mux, reqlog, recoverer) // global
+//
+// Middleware wrapped inside the mount observes the stripped path ("/users"),
+// while middleware wrapping the outer mux observes the full original path
+// ("/admin/users"). This differs from chi, which routes through a shared
+// context and never rewrites the URL; with a plain ServeMux as the child
+// router the rewrite is unavoidable.
+package subroute

--- a/web/subroute/example_test.go
+++ b/web/subroute/example_test.go
@@ -1,0 +1,41 @@
+package subroute_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/dmitrymomot/forge/web/request"
+	"github.com/dmitrymomot/forge/web/subroute"
+)
+
+func ExampleMount() {
+	adminMux := http.NewServeMux()
+	adminMux.HandleFunc("GET /users/{id}", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "user %s at %s", r.PathValue("id"), r.URL.Path)
+	})
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", adminMux)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/users/42", nil))
+	fmt.Println(rec.Body.String())
+	// Output: user 42 at /users/42
+}
+
+func ExampleMount_wildcardPrefix() {
+	dashboardMux := http.NewServeMux()
+	dashboardMux.HandleFunc("GET /reports/{id}", func(w http.ResponseWriter, r *http.Request) {
+		tenant, _ := request.Path[string](r, "tenant")
+		_, _ = fmt.Fprintf(w, "tenant %s, report %s", tenant, r.PathValue("id"))
+	})
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/app/{tenant}/dashboard", dashboardMux)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/app/acme/dashboard/reports/7", nil))
+	fmt.Println(rec.Body.String())
+	// Output: tenant acme, report 7
+}

--- a/web/subroute/subroute.go
+++ b/web/subroute/subroute.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+
+	"github.com/dmitrymomot/forge/web/request"
 )
 
 // Mount registers h on mux at prefix, both as the exact path and as a
@@ -69,8 +71,8 @@ func parsePrefix(prefix string) (segments int, names []string) {
 }
 
 // stripHandler dispatches to h with the mount prefix removed from the URL of
-// a cloned request. names is non-nil only for wildcard prefixes; capture is
-// added in a later task.
+// a cloned request. For wildcard prefixes (names non-nil) it first captures
+// the prefix path values via request.WithPathValues.
 type stripHandler struct {
 	h        http.Handler
 	names    []string
@@ -78,8 +80,20 @@ type stripHandler struct {
 }
 
 func (s *stripHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	r2 := new(http.Request)
-	*r2 = *r
+	var r2 *http.Request
+	if len(s.names) > 0 {
+		vals := make(map[string]string, len(s.names))
+		for _, n := range s.names {
+			vals[n] = r.PathValue(n)
+		}
+		// WithPathValues merges over enclosing captures (later wins), so
+		// nested mounts accumulate params with the innermost mount winning.
+		r2 = r.WithContext(request.WithPathValues(r.Context(), vals))
+	} else {
+		// Static prefix: no capture, no context allocation.
+		r2 = new(http.Request)
+		*r2 = *r
+	}
 	r2.URL = new(url.URL)
 	*r2.URL = *r.URL
 

--- a/web/subroute/subroute.go
+++ b/web/subroute/subroute.go
@@ -1,0 +1,120 @@
+// Package subroute mounts http.Handlers under path prefixes on a standard
+// *http.ServeMux, chi.Mount-style. See doc.go for the full package comment.
+package subroute
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+// Mount registers h on mux at prefix, both as the exact path and as a
+// subtree. prefix may contain single-segment {name} wildcards. Requests are
+// dispatched to h with the prefix segments stripped from the URL path; a
+// request for the bare prefix reaches h with path "/". Path values matched
+// by the prefix are captured and readable inside h via request.Path.
+//
+// Mount panics on nil arguments or a malformed prefix; ServeMux.Handle
+// additionally panics on pattern conflicts and invalid wildcard names.
+func Mount(mux *http.ServeMux, prefix string, h http.Handler) {
+	if mux == nil {
+		panic("subroute: nil mux")
+	}
+	if h == nil {
+		panic(fmt.Sprintf("subroute: nil handler for prefix %q", prefix))
+	}
+	segments, names := parsePrefix(prefix)
+	sh := &stripHandler{h: h, names: names, segments: segments}
+	mux.Handle(prefix, sh)
+	mux.Handle(prefix+"/", sh)
+}
+
+// parsePrefix validates prefix and returns its segment count and wildcard
+// names. Wildcard name syntax beyond structure (valid identifiers) is left
+// to ServeMux.Handle, which panics with its own message.
+func parsePrefix(prefix string) (segments int, names []string) {
+	switch {
+	case prefix == "" || prefix[0] != '/':
+		panic(fmt.Sprintf("subroute: prefix %q must start with '/'", prefix))
+	case prefix == "/":
+		panic(`subroute: prefix "/" is not mountable; register the handler on the mux directly`)
+	case strings.HasSuffix(prefix, "/"):
+		panic(fmt.Sprintf("subroute: prefix %q must not end with '/'", prefix))
+	case strings.ContainsAny(prefix, " \t"):
+		panic(fmt.Sprintf("subroute: prefix %q must not contain whitespace", prefix))
+	}
+	for seg := range strings.SplitSeq(prefix[1:], "/") {
+		segments++
+		switch {
+		case seg == "":
+			panic(fmt.Sprintf("subroute: prefix %q contains an empty segment", prefix))
+		case seg[0] == '{' && seg[len(seg)-1] == '}':
+			name := seg[1 : len(seg)-1]
+			switch {
+			case name == "" || name == "$":
+				panic(fmt.Sprintf("subroute: prefix %q: %q is not a valid wildcard", prefix, seg))
+			case strings.HasSuffix(name, "..."):
+				panic(fmt.Sprintf("subroute: prefix %q: multi-segment wildcard %q is not allowed", prefix, seg))
+			case slices.Contains(names, name):
+				panic(fmt.Sprintf("subroute: prefix %q: duplicate wildcard name %q", prefix, name))
+			}
+			names = append(names, name)
+		case strings.ContainsAny(seg, "{}"):
+			panic(fmt.Sprintf("subroute: prefix %q: wildcard must occupy a whole segment, got %q", prefix, seg))
+		}
+	}
+	return segments, names
+}
+
+// stripHandler dispatches to h with the mount prefix removed from the URL of
+// a cloned request. names is non-nil only for wildcard prefixes; capture is
+// added in a later task.
+type stripHandler struct {
+	h        http.Handler
+	names    []string
+	segments int
+}
+
+func (s *stripHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r2 := new(http.Request)
+	*r2 = *r
+	r2.URL = new(url.URL)
+	*r2.URL = *r.URL
+
+	// Strip on the escaped path so encoded separators (%2F) inside segments
+	// survive; then derive the decoded Path, keeping the URL invariant that
+	// RawPath is set only when it differs from Path.
+	tail := stripSegments(r.URL.EscapedPath(), s.segments)
+	if tail == "" {
+		tail = "/" // bare-prefix match: mounted handler sees the root
+	}
+	p, err := url.PathUnescape(tail)
+	if err != nil { // unreachable for paths ServeMux matched; keep escaped form
+		p = tail
+	}
+	r2.URL.Path = p
+	if p == tail {
+		r2.URL.RawPath = ""
+	} else {
+		r2.URL.RawPath = tail
+	}
+	s.h.ServeHTTP(w, r2)
+}
+
+// stripSegments returns path without its first n segments, starting at the
+// slash that follows them ("/a/b/c", 2 -> "/c"). It returns "" when path has
+// exactly n segments. path must begin with '/', which ServeMux guarantees
+// for matched requests.
+func stripSegments(path string, n int) string {
+	i := 0
+	for range n {
+		j := strings.IndexByte(path[i+1:], '/')
+		if j < 0 {
+			return ""
+		}
+		i += 1 + j
+	}
+	return path[i:]
+}

--- a/web/subroute/subroute.go
+++ b/web/subroute/subroute.go
@@ -1,5 +1,3 @@
-// Package subroute mounts http.Handlers under path prefixes on a standard
-// *http.ServeMux, chi.Mount-style. See doc.go for the full package comment.
 package subroute
 
 import (

--- a/web/subroute/subroute_test.go
+++ b/web/subroute/subroute_test.go
@@ -1,6 +1,7 @@
 package subroute_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/dmitrymomot/forge/web/request"
 	"github.com/dmitrymomot/forge/web/subroute"
 )
 
@@ -116,4 +118,110 @@ func TestMount_CallerRequestNotMutated(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/admin/users/42", nil)
 	mux.ServeHTTP(httptest.NewRecorder(), req)
 	assert.Equal(t, "/admin/users/42", req.URL.Path)
+}
+
+func TestMount_WildcardPrefix(t *testing.T) {
+	dashboardMux := http.NewServeMux()
+	dashboardMux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
+		tenant, _ := request.Path[string](r, "tenant")
+		_, _ = fmt.Fprintf(w, "home tenant=%s", tenant)
+	})
+	dashboardMux.HandleFunc("GET /reports/{id}", func(w http.ResponseWriter, r *http.Request) {
+		tenant, _ := request.Path[string](r, "tenant")
+		id, _ := request.Path[int](r, "id")
+		_, _ = fmt.Fprintf(w, "report tenant=%s id=%d own=%s", tenant, id, r.PathValue("id"))
+	})
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/app/{tenant}/dashboard", dashboardMux)
+
+	tests := []struct{ name, target, wantBody string }{
+		{"bare wildcard prefix", "/app/acme/dashboard", "home tenant=acme"},
+		{"subtree with own wildcard", "/app/acme/dashboard/reports/7", "report tenant=acme id=7 own=7"},
+		{"tenant varies per request", "/app/globex/dashboard", "home tenant=globex"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := get(t, mux, tt.target)
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, tt.wantBody, rec.Body.String())
+		})
+	}
+}
+
+func TestMount_Nested(t *testing.T) {
+	projMux := http.NewServeMux()
+	projMux.HandleFunc("GET /info", func(w http.ResponseWriter, r *http.Request) {
+		tenant, _ := request.Path[string](r, "tenant")
+		proj, _ := request.Path[string](r, "proj")
+		_, _ = fmt.Fprintf(w, "path=%s tenant=%s proj=%s", r.URL.Path, tenant, proj)
+	})
+
+	appMux := http.NewServeMux()
+	subroute.Mount(appMux, "/proj/{proj}", projMux)
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/app/{tenant}", appMux)
+
+	rec := get(t, mux, "/app/acme/proj/x/info")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "path=/info tenant=acme proj=x", rec.Body.String())
+}
+
+func TestMount_NestedShadowing(t *testing.T) {
+	leaf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, _ := request.Path[string](r, "id")
+		_, _ = fmt.Fprintf(w, "id=%s", id)
+	})
+
+	innerMux := http.NewServeMux()
+	subroute.Mount(innerMux, "/dup/{id}", leaf) // same name as outer prefix
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/m/{id}", innerMux)
+
+	rec := get(t, mux, "/m/OUTER/dup/INNER/x")
+	assert.Equal(t, "id=INNER", rec.Body.String()) // innermost mount wins
+}
+
+func TestMount_NestedStaticInsideWildcard(t *testing.T) {
+	leaf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tenant, _ := request.Path[string](r, "tenant")
+		_, _ = fmt.Fprintf(w, "path=%s tenant=%s", r.URL.Path, tenant)
+	})
+
+	appMux := http.NewServeMux()
+	subroute.Mount(appMux, "/settings", leaf) // static mount below a wildcard mount
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/app/{tenant}", appMux)
+
+	rec := get(t, mux, "/app/acme/settings/profile")
+	assert.Equal(t, "path=/profile tenant=acme", rec.Body.String())
+}
+
+func TestMount_PrecedenceCurrentMuxWins(t *testing.T) {
+	inner := http.NewServeMux()
+	inner.HandleFunc("GET /sub/{id}", func(w http.ResponseWriter, r *http.Request) {
+		id, _ := request.Path[string](r, "id")
+		_, _ = fmt.Fprintf(w, "id=%s", id)
+	})
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/m/{id}", inner)
+
+	rec := get(t, mux, "/m/OUTER/sub/INNER")
+	assert.Equal(t, "id=INNER", rec.Body.String())
+}
+
+func TestMount_StaticMountCapturesNothing(t *testing.T) {
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "has=%t ctxsame=%t", request.HasPath(r, "tenant"), r.Context() == context.Background())
+	}))
+
+	// httptest requests use context.Background; a static mount must not have
+	// wrapped it (no capture context for static prefixes).
+	rec := get(t, mux, "/admin/x")
+	assert.Equal(t, "has=false ctxsame=true", rec.Body.String())
 }

--- a/web/subroute/subroute_test.go
+++ b/web/subroute/subroute_test.go
@@ -1,0 +1,119 @@
+package subroute_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/web/subroute"
+)
+
+// echo returns a handler that writes the request's method, path, raw path,
+// and query so tests can assert exactly what the mounted handler observed.
+func echo() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "%s %s raw=%q q=%s", r.Method, r.URL.Path, r.URL.RawPath, r.URL.RawQuery)
+	})
+}
+
+func get(t *testing.T, mux *http.ServeMux, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, target, nil))
+	return rec
+}
+
+func TestMount_PanicsOnInvalidInput(t *testing.T) {
+	h := echo()
+	tests := []struct {
+		name string
+		fn   func()
+	}{
+		{"nil mux", func() { subroute.Mount(nil, "/a", h) }},
+		{"nil handler", func() { subroute.Mount(http.NewServeMux(), "/a", nil) }},
+		{"empty prefix", func() { subroute.Mount(http.NewServeMux(), "", h) }},
+		{"no leading slash", func() { subroute.Mount(http.NewServeMux(), "admin", h) }},
+		{"bare slash", func() { subroute.Mount(http.NewServeMux(), "/", h) }},
+		{"trailing slash", func() { subroute.Mount(http.NewServeMux(), "/admin/", h) }},
+		{"space smuggling method", func() { subroute.Mount(http.NewServeMux(), "GET /admin", h) }},
+		{"empty segment", func() { subroute.Mount(http.NewServeMux(), "/a//b", h) }},
+		{"dollar wildcard", func() { subroute.Mount(http.NewServeMux(), "/a/{$}", h) }},
+		{"multi-segment wildcard", func() { subroute.Mount(http.NewServeMux(), "/a/{rest...}", h) }},
+		{"empty wildcard name", func() { subroute.Mount(http.NewServeMux(), "/a/{}", h) }},
+		{"partial wildcard", func() { subroute.Mount(http.NewServeMux(), "/a/x{id}", h) }},
+		{"duplicate wildcard names", func() { subroute.Mount(http.NewServeMux(), "/{id}/x/{id}", h) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Panics(t, tt.fn)
+		})
+	}
+}
+
+func TestMount_DuplicateRegistrationPanics(t *testing.T) {
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", echo())
+	assert.Panics(t, func() { subroute.Mount(mux, "/admin", echo()) })
+}
+
+func TestMount_StaticStripping(t *testing.T) {
+	adminMux := http.NewServeMux()
+	adminMux.Handle("GET /{$}", echo())
+	adminMux.Handle("GET /users/{id}", echo())
+	adminMux.Handle("POST /submit", echo())
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, "ok")
+	})
+	subroute.Mount(mux, "/admin", adminMux)
+	subroute.Mount(mux, "/api/v1", echo())
+
+	tests := []struct {
+		name, method, target, wantBody string
+		wantStatus                     int
+	}{
+		{"bare prefix serves as root", http.MethodGet, "/admin", `GET / raw="" q=`, http.StatusOK},
+		{"trailing slash serves as root", http.MethodGet, "/admin/", `GET / raw="" q=`, http.StatusOK},
+		{"subtree stripped", http.MethodGet, "/admin/users/42", `GET /users/42 raw="" q=`, http.StatusOK},
+		{"method pattern inside mount", http.MethodPost, "/admin/submit", `POST /submit raw="" q=`, http.StatusOK},
+		{"multi-segment static prefix", http.MethodGet, "/api/v1/orders/7", `GET /orders/7 raw="" q=`, http.StatusOK},
+		{"query preserved", http.MethodGet, "/admin/users/42?page=2", `GET /users/42 raw="" q=page=2`, http.StatusOK},
+		{"sibling route untouched", http.MethodGet, "/health", "ok", http.StatusOK},
+		{"unknown path 404s on outer mux", http.MethodGet, "/nope", "", http.StatusNotFound},
+		{"unknown path inside mount 404s", http.MethodGet, "/admin/nope", "", http.StatusNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(tt.method, tt.target, nil))
+			assert.Equal(t, tt.wantStatus, rec.Code)
+			if tt.wantBody != "" {
+				assert.Equal(t, tt.wantBody, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestMount_EncodedSegments(t *testing.T) {
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/files", echo())
+
+	// %2F must survive stripping: the mounted handler gets a consistent
+	// Path/RawPath pair, and the escaped form keeps the encoded slash.
+	rec := get(t, mux, "/files/a%2Fb/c")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, `GET /a/b/c raw="/a%2Fb/c" q=`, rec.Body.String())
+}
+
+func TestMount_CallerRequestNotMutated(t *testing.T) {
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", echo())
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/users/42", nil)
+	mux.ServeHTTP(httptest.NewRecorder(), req)
+	assert.Equal(t, "/admin/users/42", req.URL.Path)
+}

--- a/web/subroute/subroute_test.go
+++ b/web/subroute/subroute_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/dmitrymomot/forge/web/middleware"
 	"github.com/dmitrymomot/forge/web/request"
 	"github.com/dmitrymomot/forge/web/subroute"
 )
@@ -224,4 +225,30 @@ func TestMount_StaticMountCapturesNothing(t *testing.T) {
 	// wrapped it (no capture context for static prefixes).
 	rec := get(t, mux, "/admin/x")
 	assert.Equal(t, "has=false ctxsame=true", rec.Body.String())
+}
+
+func TestMount_MiddlewareBoundary(t *testing.T) {
+	var outerSaw, innerSaw string
+	record := func(dst *string) middleware.Middleware {
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				*dst = r.URL.Path
+				next.ServeHTTP(w, r)
+			})
+		}
+	}
+
+	adminMux := http.NewServeMux()
+	adminMux.Handle("GET /users", echo())
+
+	mux := http.NewServeMux()
+	subroute.Mount(mux, "/admin", middleware.Wrap(adminMux, record(&innerSaw)))
+	root := middleware.Wrap(mux, record(&outerSaw))
+
+	rec := httptest.NewRecorder()
+	root.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/users", nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "/admin/users", outerSaw, "outer middleware sees the full path")
+	assert.Equal(t, "/users", innerSaw, "mounted middleware sees the stripped path")
 }


### PR DESCRIPTION
## Summary

New `web/subroute` package: mount any `http.Handler` under a path prefix on a standard `*http.ServeMux`, chi.Mount-style — plus a path-value fallback seam in `web/request` so `request.Path` keeps working across mount boundaries.

- **`subroute.Mount(mux, prefix, h)`** registers the prefix (exact + subtree) and dispatches with the prefix stripped, so sub-apps are written root-relative. A bare-prefix request reaches the handler as `GET /` (plain `http.StripPrefix` can't do this — it leaves an empty path that a nested ServeMux 301-redirects).
- **Wildcard prefixes** (`/app/{tenant}/dashboard`): prefix params are captured at the mount boundary because the std router discards a parent mux's path values when a nested mux matches. Stripping is segment-based on the escaped path (`%2F`-safe), with the `Path`/`RawPath` invariant preserved.
- **`request.WithPathValues(ctx, vals)`** is the new seam: `Path`/`PathFunc`/`HasPath` now read `r.PathValue` first, then the fallback — so `request.Path[string](r, "tenant")` works (typed) inside mounted handlers, and nested mounts merge later-wins with no logic in subroute. `web/request` stays stdlib-only.
- Static-prefix mounts skip capture entirely (no context allocation, asserted by test). The caller's request is never mutated. Setup-time panics only; no runtime errors.
- Docs: full godoc with the middleware-composition patterns and the honest chi difference (mounted middleware sees the stripped path); runnable examples; benchmarks with a no-mount baseline (+5 allocs/op static, +10 wildcard, dominated by the inner mux re-dispatch).

Design spec and implementation plan are included under `docs/superpowers/`.

## Test plan

- Full `just test` green (race + cover): `web/subroute` 96.2%, `web/request` 85.9%
- Black-box tests cover: bare/subtree/wildcard/nested stripping, innermost-wins shadowing, current-mux precedence over captures, encoded `%2F` segments, query preservation, sibling-route fall-through, Go 1.22 method patterns inside mounts, middleware path visibility on both sides of the boundary, caller-request immutability, static no-capture, 13 panic cases
- `ExampleMount` / `ExampleMount_wildcardPrefix` run as tests with exact output
- Scoped lint clean (`golangci-lint`, `nilaway`, `betteralign`, `modernize`)