### PR TITLE
feat(resilience): seam bundle — cache NX claim, circuitbreaker Group + HTTP middleware, retry delay floor

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -6,7 +6,7 @@
 > against kratos, go-kit, go-micro, fiber v3, fiber-contrib, and forge v1).
 >
 > **State: 57 shipped packages** across `core/ crypto/ resilience/ web/ data/ ops/`
-> · **65 roadmap** (committed) · **27 icebox** (demand-driven, no commitment).
+> · **64 roadmap** (committed) · **27 icebox** (demand-driven, no commitment).
 
 ## Design DNA every package follows
 
@@ -73,10 +73,10 @@ messaging engine, and the driver leaves stays stdlib.
 
 - **TTL-KV seam** — `resilience/cache.Store` (byte-level Get/Set-TTL/Delete
   + atomic SetNX claim) is THE key-value seam. Backends: memory (shipped),
-  `cache/redis` (shipped), `cache/postgres` (planned — durable; the memory
-  store is LRU-evicting and unsuitable for sessions/idempotency). Consumers:
-  `session`, `idempotency`, `otp`, `lockout`, server-side `flash`. No package
-  defines a private byte-KV store.
+  `cache/redis` (shipped). The memory store is LRU-evicting and unsuitable
+  for sessions/idempotency, so those consumers need `cache/redis` (or bring a
+  durable Store of their own). Consumers: `session`, `idempotency`, `otp`,
+  `lockout`, server-side `flash`. No package defines a private byte-KV store.
 - **Counter seam** — windowed atomic counters (Incr-within-window) can't ride
   Get/Set KV without races. `ratelimit` owns the counter `Store` contract;
   `quota` and `lockout` share it. Two store seams total — byte-KV + counter.
@@ -117,7 +117,7 @@ forge/                              # single go.mod at the root
 │   # shipped: backoff retry singleflight parallel circuitbreaker
 │   #          cache (cache/redis)
 │   # planned: ratelimit (ratelimit/redisstore) quota (quota/pgstore)
-│   #          loadshed lock (lock/pglock) cache/postgres
+│   #          loadshed lock (lock/pglock)
 │
 ├── web/           # HTTP in and out: transport, responses, boundary security, client
 │   # shipped: httpserver hostrouter middleware request clientip problem
@@ -252,8 +252,6 @@ Shipped: `backoff retry singleflight parallel circuitbreaker cache (cache/redis)
   fencing tokens, auto-refresh; `RunAsLeader` as `supervisor.Service`.
   In-process store in core; Postgres advisory locks are the only shipped
   distributed backend (a Redis consumer implements the 3-method Store).
-- **`cache/postgres`** — recommended. Durable Postgres backend for the
-  shipped `cache.Store` seam (single table, upsert + expiry sweep).
 
 ### web/
 
@@ -609,7 +607,7 @@ Queued API additions to shipped packages (each unblocks roadmap work):
 Each wave depends only on earlier ones. Icebox packages slot in wherever
 demand appears.
 
-1. **Unblockers** — the shipped-package work items above; `cache/postgres`;
+1. **Unblockers** — the shipped-package work items above;
    `httpclient` (transport under half the roadmap); `ratelimit` (counter
    seam); `envconfig`; `health`.
 2. **Web boundary + ops glue** — `cookie` → `csrf`, `secheaders`, `cors`,

--- a/docs/superpowers/plans/2026-07-04-resilience-seam-bundle.md
+++ b/docs/superpowers/plans/2026-07-04-resilience-seam-bundle.md
@@ -1,0 +1,1296 @@
+# Resilience Seam Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three seam features across the shipped `resilience/` packages — an options-based `cache.Store.Set` with an atomic NX claim, a keyed `circuitbreaker.Group` plus HTTP middleware, and a `retry` delay floor — shipped as one PR that unblocks `web/httpclient`.
+
+**Architecture:** Each feature is an additive/edit change to an existing package. `cache.Set` moves TTL+NX into `...SetOption`, resolved via an exported `SetOptions` so the `cache/redis` sibling can read them. `circuitbreaker` gains a keyed `Group` (opportunistic idle-TTL eviction, no goroutine) and a `net/http`-only middleware; its open error carries a dynamic `RetryAfter()`. `retry` honors any error implementing `RetryAfterError` as a per-attempt delay floor — satisfied structurally by the breaker error, with no import between the two.
+
+**Tech Stack:** Go 1.26, `github.com/redis/go-redis/v9` (v9.21.0), `core/clock`, `resilience/backoff`, `resilience/singleflight`. Full design + reference code: [2026-07-04-resilience-seam-bundle-design.md](../specs/2026-07-04-resilience-seam-bundle-design.md).
+
+## Global Constraints
+
+- **Go 1.26.** `errors.AsType[E error]` is available and works with interface `E`.
+- **Black-box tests only.** Test files use package `<pkg>_test` and exercise only exported API. White-box only to assert unexported state (not needed here).
+- **Options pattern, never builders.** `type XOption func(*config)`; no fluent/builder chains.
+- **No global or shared mutable state.** No `init()`, no singletons, no registries, no default global instances. Only immutable error sentinels and stateless funcs may be package-level.
+- **`resilience/` imports no `web/` package.** The breaker middleware uses `net/http` only.
+- **Run `just fmt <file>.go` after editing each Go file; run `just lint` after the final task.**
+- **Redis backend behavior:** use `goredis.SetArgs{Mode:"NX"}` (SET…NX), not the legacy `SetNX`; map `forgeredis.IsNil` → `cache.ErrExists`.
+- **Commit style:** `type(scope): summary`. No Claude attribution/co-author trailers anywhere.
+
+---
+
+### Task 1: cache — options-based `Set` with atomic NX claim
+
+Flips `Store.Set(…, ttl)` to `Set(…, ...SetOption)` and folds NX in. The interface change breaks `memory`, the `Cache[V]` facade, **and** the `cache/redis` sibling at once, so all land together for a compiling, green commit.
+
+**Files:**
+- Modify: `resilience/cache/errors.go` (+`ErrExists`)
+- Modify: `resilience/cache/store.go` (interface signature; +`SetOptions`/`SetOption`/`WithTTL`/`WithSetNonExist`/`ApplySetOptions`)
+- Modify: `resilience/cache/memory.go` (`Set` body)
+- Modify: `resilience/cache/cache.go` (`Cache[V].Set`, `GetOrSet` internal write)
+- Modify: `resilience/cache/redis/redis.go` (`Set` body)
+- Test: `resilience/cache/cache_test.go`, `resilience/cache/memory_test.go`, `resilience/cache/redis/redis_test.go` — **migrate every existing `Set(…, ttl)` call site** to the options form and the `errStore` stub's signature, then **add** NX/TTL cases. These files use testify (`require`/`assert`) and `t.Context()`; match that style.
+
+**Interfaces:**
+- Produces:
+  - `cache.SetOptions struct { TTL time.Duration; OnlyIfNew bool }`
+  - `cache.SetOption func(*SetOptions)`
+  - `cache.WithTTL(d time.Duration) SetOption`
+  - `cache.WithSetNonExist() SetOption`
+  - `cache.ApplySetOptions(opts ...SetOption) SetOptions`
+  - `cache.ErrExists error`
+  - `cache.Store.Set(ctx context.Context, key string, val []byte, opts ...SetOption) error`
+  - `(*cache.Cache[V]).Set(ctx context.Context, key string, v V, opts ...SetOption) error`
+- Consumes: nothing from other tasks.
+
+- [ ] **Step 1a: Migrate existing `Set(…, ttl)` call sites to options**
+
+These stale 4-arg calls will not compile against the new signature, so rewrite them. Mapping (applies to both `Store` and `Cache[V]` calls): `, 0)` → `)` (drop the arg); `, -1)` → `, cache.WithTTL(-1))`; `, D)` with `D>0` → `, cache.WithTTL(D))`.
+
+In `resilience/cache/cache_test.go`:
+- L22 `c.Set(t.Context(), "en", "hello", 0)` → `c.Set(t.Context(), "en", "hello")`
+- L42 `a.Set(t.Context(), "k", "AAA", -1)` → `a.Set(t.Context(), "k", "AAA", cache.WithTTL(-1))`
+- L43 `b.Set(t.Context(), "k", "BBB", -1)` → `b.Set(t.Context(), "k", "BBB", cache.WithTTL(-1))`
+- L136 `c.Set(t.Context(), "k", "hi", -1)` → `c.Set(t.Context(), "k", "hi", cache.WithTTL(-1))`
+- L107 the `errStore` stub — change its `Set` method signature so it still satisfies `Store`:
+
+```go
+func (errStore) Set(context.Context, string, []byte, ...cache.SetOption) error { return nil }
+```
+
+In `resilience/cache/memory_test.go` (all `s.Set(...)`): `, 0)` → `)` at L18 and L86; `, 30*time.Second)` → `, cache.WithTTL(30*time.Second))` at L33; `, time.Millisecond)` → `, cache.WithTTL(time.Millisecond))` at L94; `, -1)` → `, cache.WithTTL(-1))` at L44, L55, L56, L58, L70, L71, L72.
+
+In `resilience/cache/redis/redis_test.go` (all facade `.Set(...)`): `, time.Minute)` → `, cache.WithTTL(time.Minute))` at L38, L39, L64, L65.
+
+- [ ] **Step 1b: Add failing black-box tests (testify style, matching the files)**
+
+Append to `resilience/cache/memory_test.go` (add `"sync"` and `"sync/atomic"` to its imports):
+
+```go
+func TestMemoryStoreSetNonExistClaimsOnce(t *testing.T) {
+	s := cache.NewMemoryStore()
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, s.Set(t.Context(), "k", []byte("first"), cache.WithSetNonExist()))
+	assert.ErrorIs(t, s.Set(t.Context(), "k", []byte("second"), cache.WithSetNonExist()), cache.ErrExists)
+
+	got, _ := s.Get(t.Context(), "k")
+	assert.Equal(t, []byte("first"), got) // original not overwritten
+}
+
+func TestMemoryStoreSetNonExistReclaimsExpired(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	s := cache.NewMemoryStore(cache.WithClock(clk))
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, s.Set(t.Context(), "k", []byte("old"), cache.WithSetNonExist(), cache.WithTTL(time.Second)))
+	clk.Advance(2 * time.Second) // entry now expired
+	require.NoError(t, s.Set(t.Context(), "k", []byte("new"), cache.WithSetNonExist()))
+	got, _ := s.Get(t.Context(), "k")
+	assert.Equal(t, []byte("new"), got)
+}
+
+func TestMemoryStoreSetNonExistConcurrent(t *testing.T) {
+	s := cache.NewMemoryStore()
+	defer func() { _ = s.Close() }()
+
+	var wins atomic.Int32
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			if err := s.Set(t.Context(), "k", []byte("v"), cache.WithSetNonExist()); err == nil {
+				wins.Add(1)
+			}
+		})
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), wins.Load()) // exactly one claim wins
+}
+```
+
+Append to `resilience/cache/cache_test.go` (its imports already include `time` and testify):
+
+```go
+func TestFacadeSetNonExistReturnsErrExists(t *testing.T) {
+	store := cache.NewMemoryStore()
+	defer func() { _ = store.Close() }()
+	c := cache.New[string](store)
+
+	require.NoError(t, c.Set(t.Context(), "k", "first", cache.WithSetNonExist()))
+	assert.ErrorIs(t, c.Set(t.Context(), "k", "second", cache.WithSetNonExist()), cache.ErrExists)
+}
+
+func TestApplySetOptions(t *testing.T) {
+	o := cache.ApplySetOptions(cache.WithTTL(5*time.Second), cache.WithSetNonExist())
+	assert.Equal(t, 5*time.Second, o.TTL)
+	assert.True(t, o.OnlyIfNew)
+
+	z := cache.ApplySetOptions()
+	assert.Zero(t, z.TTL)
+	assert.False(t, z.OnlyIfNew)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./resilience/cache/... 2>&1 | head`
+Expected: FAIL to build — the migrated call sites and new tests reference `cache.WithTTL`/`cache.WithSetNonExist`/`cache.ErrExists`/`cache.ApplySetOptions`, none defined yet.
+
+- [ ] **Step 3: Add `ErrExists` to `errors.go`**
+
+Inside the existing `var ( … )` block in `resilience/cache/errors.go`, add:
+
+```go
+	// ErrExists is returned by Set with WithSetNonExist when the key is present.
+	ErrExists = errors.New("cache: entry already exists")
+```
+
+- [ ] **Step 4: Add option types + flip the interface in `store.go`**
+
+Replace the `Store` interface doc comment and `Set` line, and append the option types. The `Store` block becomes:
+
+```go
+// Store is a byte-level key/value backend with optional per-entry TTL.
+// Implementations are standalone instances whose lifecycle (background
+// goroutines, connections) is owned by the caller via Close.
+//
+// Set is configured with SetOption values: WithTTL sets an expiry (no option
+// means no expiry), WithSetNonExist makes the write conditional and returns
+// ErrExists when the key already exists. Implementations resolve options with
+// ApplySetOptions so every backend behaves identically.
+type Store interface {
+	Get(ctx context.Context, key string) ([]byte, error)
+	Set(ctx context.Context, key string, val []byte, opts ...SetOption) error
+	Delete(ctx context.Context, key string) error
+	Has(ctx context.Context, key string) (bool, error)
+	DeletePrefix(ctx context.Context, prefix string) error
+	Close() error
+}
+
+// SetOptions holds the resolved settings for one Set call. It is exported
+// because Store implementations in sibling packages (e.g. cache/redis) apply
+// SetOption values and read the result. The zero value means: never expire,
+// overwrite an existing key.
+type SetOptions struct {
+	// TTL expires the entry after the duration. A value <= 0 means no expiry.
+	TTL time.Duration
+	// OnlyIfNew stores the value only when the key is absent or expired; on a
+	// live key Set writes nothing and returns ErrExists.
+	OnlyIfNew bool
+}
+
+// SetOption configures a single Set call.
+type SetOption func(*SetOptions)
+
+// WithTTL expires the written entry after d. Without it the entry never
+// expires; a non-positive d is equivalent to omitting the option.
+func WithTTL(d time.Duration) SetOption { return func(o *SetOptions) { o.TTL = d } }
+
+// WithSetNonExist stores the value only if the key is absent or expired. On a
+// live key Set writes nothing and returns ErrExists. Combined with WithTTL it
+// is an atomic claim-with-lease (set-if-absent + expiry).
+func WithSetNonExist() SetOption { return func(o *SetOptions) { o.OnlyIfNew = true } }
+
+// ApplySetOptions resolves opts into a SetOptions so every backend applies the
+// options identically.
+func ApplySetOptions(opts ...SetOption) SetOptions {
+	var o SetOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+```
+
+- [ ] **Step 5: Update `memory.go` `Set`**
+
+Replace the whole `func (m *memoryStore) Set(...)` with:
+
+```go
+func (m *memoryStore) Set(_ context.Context, key string, val []byte, opts ...SetOption) error {
+	o := ApplySetOptions(opts...)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return ErrClosed
+	}
+	now := m.cfg.clk.Now()
+	if o.OnlyIfNew {
+		if e, ok := m.items[key]; ok && (e.expires.IsZero() || now.Before(e.expires)) {
+			return ErrExists
+		}
+	}
+	var expires time.Time
+	if o.TTL > 0 {
+		expires = now.Add(o.TTL)
+	}
+	stored := make([]byte, len(val))
+	copy(stored, val)
+	if e, ok := m.items[key]; ok {
+		e.val = stored
+		e.expires = expires
+		m.lru.MoveToFront(e.elem)
+		return nil
+	}
+	e := &memEntry{key: key, val: stored, expires: expires}
+	e.elem = m.lru.PushFront(e)
+	m.items[key] = e
+	if m.cfg.maxEntries > 0 && m.lru.Len() > m.cfg.maxEntries {
+		if back := m.lru.Back(); back != nil {
+			old := back.Value.(*memEntry)
+			m.removeLocked(old.key, old)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 6: Update `cache.go` facade `Set` and `GetOrSet`**
+
+Replace `func (c *Cache[V]) Set(...)` with:
+
+```go
+// Set stores v under key. Without a WithTTL option the cache's default TTL
+// applies; WithTTL overrides it (a non-positive duration means no expiry).
+// WithSetNonExist makes the write conditional, returning ErrExists when the key
+// is already present.
+func (c *Cache[V]) Set(ctx context.Context, key string, v V, opts ...SetOption) error {
+	data, err := c.marshaler.Marshal(v)
+	if err != nil {
+		return err
+	}
+	// Prepend the default TTL so any caller WithTTL (including a non-positive
+	// "never expire") overrides it; a fresh slice leaves the caller's untouched.
+	opts = append([]SetOption{WithTTL(c.defaultTTL)}, opts...)
+	return c.store.Set(ctx, c.key(key), data, opts...)
+}
+```
+
+In `GetOrSet`, replace the inner `_ = c.Set(ctx, key, val, ttl)` write with:
+
+```go
+		var opts []SetOption
+		if ttl != 0 {
+			opts = append(opts, WithTTL(ttl))
+		}
+		_ = c.Set(ctx, key, val, opts...)
+```
+
+- [ ] **Step 7: Update `redis/redis.go` `Set`**
+
+Replace `func (s *store) Set(...)` with:
+
+```go
+func (s *store) Set(ctx context.Context, key string, val []byte, opts ...cache.SetOption) error {
+	o := cache.ApplySetOptions(opts...)
+	var ttl time.Duration
+	if o.TTL > 0 {
+		ttl = o.TTL // SetArgs treats TTL <= 0 as "no expiry"
+	}
+	if o.OnlyIfNew {
+		// SET key val NX [PX ttl] — the modern replacement for SETNX. On a
+		// present key the server returns a null reply, surfaced as redis.Nil.
+		err := s.client.SetArgs(ctx, key, val, goredis.SetArgs{Mode: "NX", TTL: ttl}).Err()
+		if forgeredis.IsNil(err) {
+			return cache.ErrExists
+		}
+		return err
+	}
+	return s.client.Set(ctx, key, val, ttl).Err()
+}
+```
+
+- [ ] **Step 8: Format, build, test**
+
+Run: `just fmt resilience/cache/store.go resilience/cache/memory.go resilience/cache/cache.go resilience/cache/errors.go resilience/cache/redis/redis.go resilience/cache/cache_test.go`
+Run: `go build ./... && go test ./resilience/cache/... -race`
+Expected: build OK; all cache tests PASS (redis integration tests skip without a live server; the redis package compiles).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add resilience/cache/
+git commit -m "feat(resilience/cache): options-based Set with atomic WithSetNonExist claim"
+```
+
+---
+
+### Task 2: retry — honor `RetryAfterError` as a delay floor
+
+**Files:**
+- Create: `resilience/retry/errors.go`
+- Modify: `resilience/retry/retry.go` (delay computation in `Do`)
+- Test: `resilience/retry/retry_test.go` (black-box; add cases)
+
+**Interfaces:**
+- Produces: `retry.RetryAfterError interface { error; RetryAfter() time.Duration }`
+- Consumes: nothing. (Satisfied structurally later by `circuitbreaker`'s open error — no import.)
+
+- [ ] **Step 1: Write failing black-box tests**
+
+Append to `resilience/retry/retry_test.go`:
+
+```go
+type retryAfterErr struct{ d time.Duration }
+
+func (e retryAfterErr) Error() string              { return "slow down" }
+func (e retryAfterErr) RetryAfter() time.Duration  { return e.d }
+
+func TestRetryAfterRaisesDelayToFloor(t *testing.T) {
+	var attempts int
+	start := time.Now()
+	err := retry.Do(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts < 2 {
+			return retryAfterErr{d: 120 * time.Millisecond}
+		}
+		return nil
+	},
+		retry.WithMaxAttempts(2),
+		retry.WithBackoff(backoff.Constant(1*time.Millisecond)), // far below the hint
+	)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("waited %v, want >= ~120ms (the RetryAfter floor)", elapsed)
+	}
+}
+
+func TestRetryAfterHonoredThroughWrappedError(t *testing.T) {
+	var attempts int
+	start := time.Now()
+	_ = retry.Do(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts < 2 {
+			return fmt.Errorf("wrapped: %w", retryAfterErr{d: 120 * time.Millisecond})
+		}
+		return nil
+	}, retry.WithMaxAttempts(2), retry.WithBackoff(backoff.Constant(1*time.Millisecond)))
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("waited %v, want >= ~120ms via wrapped hint", elapsed)
+	}
+}
+
+func TestRetryAfterBelowBackoffKeepsBackoff(t *testing.T) {
+	var attempts int
+	start := time.Now()
+	_ = retry.Do(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts < 2 {
+			return retryAfterErr{d: 1 * time.Millisecond} // below backoff
+		}
+		return nil
+	}, retry.WithMaxAttempts(2), retry.WithBackoff(backoff.Constant(80*time.Millisecond)))
+	if elapsed := time.Since(start); elapsed < 60*time.Millisecond {
+		t.Fatalf("waited %v, want >= ~80ms (backoff wins)", elapsed)
+	}
+}
+```
+
+Ensure imports include `context`, `fmt`, `time`, `github.com/dmitrymomot/forge/resilience/backoff`, `github.com/dmitrymomot/forge/resilience/retry`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./resilience/retry/ -run TestRetryAfter 2>&1 | head`
+Expected: FAIL — the floor is not applied yet, so `TestRetryAfterRaisesDelayToFloor` waits ~1ms and the assertion fails.
+
+- [ ] **Step 3: Create `resilience/retry/errors.go`**
+
+```go
+package retry
+
+import "time"
+
+// RetryAfterError is implemented by errors that carry a minimum delay before
+// the next attempt — e.g. an HTTP 429/503 with a Retry-After header, or a
+// circuitbreaker open error. Retrier.Do treats the reported duration as a
+// floor: it waits at least this long before the next attempt, even beyond the
+// backoff ceiling. The context deadline still bounds the total.
+type RetryAfterError interface {
+	error
+	RetryAfter() time.Duration
+}
+```
+
+- [ ] **Step 4: Apply the floor in `retry.go` `Do`**
+
+Replace the line `timer := time.NewTimer(r.cfg.backoff.Next(attempt))` with:
+
+```go
+		// Wait per the backoff, raised to any server/breaker-stated floor.
+		wait := r.cfg.backoff.Next(attempt)
+		if ra, ok := errors.AsType[RetryAfterError](err); ok {
+			if hint := ra.RetryAfter(); hint > wait {
+				wait = hint
+			}
+		}
+		timer := time.NewTimer(wait)
+```
+
+(`errors` and `time` are already imported in `retry.go`.)
+
+- [ ] **Step 5: Format, test**
+
+Run: `just fmt resilience/retry/errors.go resilience/retry/retry.go resilience/retry/retry_test.go`
+Run: `go test ./resilience/retry/ -race`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add resilience/retry/
+git commit -m "feat(resilience/retry): honor RetryAfterError as a per-attempt delay floor"
+```
+
+---
+
+### Task 3: circuitbreaker — dynamic open error + `RetryAfter()`
+
+Introduces `openError` (unwraps to `ErrOpen`, carries a delay) and exposes `Breaker.RetryAfter()`. Refactors config building into `newConfig` for reuse by `Group` (Task 4).
+
+**Files:**
+- Modify: `resilience/circuitbreaker/errors.go` (+`openError`)
+- Modify: `resilience/circuitbreaker/circuitbreaker.go` (`newConfig`, `New`, `before`, +`RetryAfter`)
+- Test: `resilience/circuitbreaker/circuitbreaker_test.go` (black-box; append cases, reusing the package's existing `fail`/`ok`/`errBoom` helpers and testify `assert`; existing `ErrOpen` checks already use `assert.ErrorIs`, so nothing to migrate)
+
+**Interfaces:**
+- Produces:
+  - `circuitbreaker.ErrOpen` (unchanged sentinel; now matched via `errors.Is`)
+  - unexported `openError` implementing `Error()`, `Unwrap() error`, `RetryAfter() time.Duration`
+  - `(*circuitbreaker.Breaker).RetryAfter() time.Duration`
+  - unexported `newConfig(opts ...Option) config` (used by Task 4)
+- Consumes: nothing.
+
+- [ ] **Step 1: Write failing black-box tests**
+
+Append to `resilience/circuitbreaker/circuitbreaker_test.go`:
+
+```go
+func TestOpenErrorIsMatchableAndCarriesRetryAfter(t *testing.T) {
+	b := circuitbreaker.New(
+		circuitbreaker.WithFailureThreshold(1),
+		circuitbreaker.WithOpenTimeout(30*time.Second),
+	)
+	_ = b.Do(t.Context(), fail) // trips open after one failure
+	err := b.Do(t.Context(), ok) // rejected; ok is not run
+
+	assert.ErrorIs(t, err, circuitbreaker.ErrOpen)
+	var ra interface{ RetryAfter() time.Duration }
+	assert.ErrorAs(t, err, &ra)
+	d := ra.RetryAfter()
+	assert.Greater(t, d, time.Duration(0))
+	assert.LessOrEqual(t, d, 30*time.Second)
+}
+
+func TestRetryAfterShrinksAndZeroesOut(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	b := circuitbreaker.New(
+		circuitbreaker.WithFailureThreshold(1),
+		circuitbreaker.WithOpenTimeout(30*time.Second),
+		circuitbreaker.WithClock(clk),
+	)
+	_ = b.Do(t.Context(), fail)
+
+	assert.Equal(t, 30*time.Second, b.RetryAfter())
+	clk.Advance(10 * time.Second)
+	assert.Equal(t, 20*time.Second, b.RetryAfter())
+	clk.Advance(30 * time.Second) // past the open window
+	assert.Equal(t, time.Duration(0), b.RetryAfter())
+}
+```
+
+These reuse the existing package-level `fail`/`ok`/testify `assert` from `circuitbreaker_test.go` — do not redeclare them.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./resilience/circuitbreaker/ -run 'TestOpenError|TestRetryAfter' 2>&1 | head`
+Expected: FAIL — `b.RetryAfter` undefined.
+
+- [ ] **Step 3: Replace `errors.go`**
+
+```go
+package circuitbreaker
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrOpen is the sentinel a rejected call matches with errors.Is. The concrete
+// error returned by Do also reports a suggested retry delay via RetryAfter.
+var ErrOpen = errors.New("circuitbreaker: circuit open")
+
+// openError is returned when the breaker rejects a call. It unwraps to ErrOpen
+// (so errors.Is(err, ErrOpen) holds) and reports the delay until the next
+// probe, satisfying retry.RetryAfterError and feeding the HTTP middleware's
+// Retry-After header.
+type openError struct{ retryAfter time.Duration }
+
+func (e *openError) Error() string             { return ErrOpen.Error() }
+func (e *openError) Unwrap() error             { return ErrOpen }
+func (e *openError) RetryAfter() time.Duration { return e.retryAfter }
+```
+
+- [ ] **Step 4: Refactor `circuitbreaker.go` — `newConfig`, `New`, `before`, `RetryAfter`**
+
+Replace the existing `func New(...)` with:
+
+```go
+// newConfig applies opts over the defaults. Shared by New and Group.
+func newConfig(opts ...Option) config {
+	c := config{threshold: 5, openTimeout: 30 * time.Second, halfOpenMax: 1, clk: clock.System()}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// New builds a Breaker from options.
+func New(opts ...Option) *Breaker {
+	return &Breaker{cfg: newConfig(opts...), state: StateClosed}
+}
+```
+
+Replace the existing `func (b *Breaker) before()` with:
+
+```go
+func (b *Breaker) before() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch b.state {
+	case StateOpen:
+		elapsed := b.cfg.clk.Now().Sub(b.openedAt)
+		if elapsed < b.cfg.openTimeout {
+			return &openError{retryAfter: b.cfg.openTimeout - elapsed}
+		}
+		b.transition(StateHalfOpen)
+		b.halfOpenIn = 1
+		return nil
+	case StateHalfOpen:
+		if b.halfOpenIn >= b.cfg.halfOpenMax {
+			return &openError{retryAfter: 0} // a probe is in flight; retry shortly
+		}
+		b.halfOpenIn++
+		return nil
+	default:
+		return nil
+	}
+}
+```
+
+Add this method (next to `State()`):
+
+```go
+// RetryAfter reports how long until the breaker would admit a probe call, or 0
+// when it is not open.
+func (b *Breaker) RetryAfter() time.Duration {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.state != StateOpen {
+		return 0
+	}
+	if remaining := b.cfg.openTimeout - b.cfg.clk.Now().Sub(b.openedAt); remaining > 0 {
+		return remaining
+	}
+	return 0
+}
+```
+
+- [ ] **Step 5: Verify no `== ErrOpen` equality checks remain**
+
+Run: `grep -rn "== circuitbreaker.ErrOpen\|== ErrOpen" resilience/circuitbreaker/`
+Expected: no matches — the existing tests already use `assert.ErrorIs(..., circuitbreaker.ErrOpen)` (which keeps working since `openError` unwraps to `ErrOpen`). If a hit does appear, change `err == ErrOpen` to `errors.Is(err, ErrOpen)`.
+
+- [ ] **Step 6: Format, test**
+
+Run: `just fmt resilience/circuitbreaker/errors.go resilience/circuitbreaker/circuitbreaker.go resilience/circuitbreaker/circuitbreaker_test.go`
+Run: `go test ./resilience/circuitbreaker/ -race`
+Expected: PASS (existing + new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add resilience/circuitbreaker/errors.go resilience/circuitbreaker/circuitbreaker.go resilience/circuitbreaker/circuitbreaker_test.go
+git commit -m "feat(resilience/circuitbreaker): open error carries RetryAfter; add Breaker.RetryAfter"
+```
+
+---
+
+### Task 4: circuitbreaker — keyed `Group` with idle-TTL eviction
+
+**Files:**
+- Create: `resilience/circuitbreaker/group.go`
+- Test: `resilience/circuitbreaker/group_test.go` (black-box)
+
+**Interfaces:**
+- Consumes (from Task 3): `newConfig`, `New`, `*Breaker`, `Breaker.State`, `Breaker.RetryAfter`, `State`, `StateClosed`, `Option`, `WithClock`.
+- Produces:
+  - `circuitbreaker.Group` (struct)
+  - `circuitbreaker.GroupOption func(*groupConfig)`
+  - `WithBreakerOptions(opts ...Option) GroupOption`
+  - `WithIdleTTL(d time.Duration) GroupOption`
+  - `WithSweepInterval(d time.Duration) GroupOption`
+  - `NewGroup(opts ...GroupOption) *Group`
+  - `(*Group).Do(ctx, key string, fn func(context.Context) error) error`
+  - `(*Group).State(key string) State`
+  - `(*Group).Len() int`
+  - unexported `(*Group).breaker(key string) *Breaker` (used by Task 5)
+
+- [ ] **Step 1: Write failing black-box tests**
+
+Create `resilience/circuitbreaker/group_test.go`. It is package `circuitbreaker_test`, so it reuses the package-level `fail`/`ok` helpers and testify `assert` already declared in `circuitbreaker_test.go` — do not redeclare them:
+
+```go
+package circuitbreaker_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/resilience/circuitbreaker"
+)
+
+func TestGroupLazyCreateAndIndependence(t *testing.T) {
+	g := circuitbreaker.NewGroup(circuitbreaker.WithBreakerOptions(
+		circuitbreaker.WithFailureThreshold(1),
+	))
+	assert.Equal(t, 0, g.Len())
+
+	_ = g.Do(t.Context(), "a", fail) // trips "a"
+	_ = g.Do(t.Context(), "b", ok)   // healthy "b"
+
+	assert.Equal(t, 2, g.Len())
+	assert.Equal(t, circuitbreaker.StateOpen, g.State("a"))
+	assert.Equal(t, circuitbreaker.StateClosed, g.State("b"))
+	assert.Equal(t, circuitbreaker.StateClosed, g.State("never-seen"))
+}
+
+func TestGroupEvictsIdleBreakers(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	g := circuitbreaker.NewGroup(
+		circuitbreaker.WithBreakerOptions(circuitbreaker.WithClock(clk)),
+		circuitbreaker.WithIdleTTL(time.Minute),
+		circuitbreaker.WithSweepInterval(time.Second),
+	)
+	_ = g.Do(t.Context(), "a", ok) // create "a" at t0
+	clk.Advance(2 * time.Minute)
+	_ = g.Do(t.Context(), "b", ok) // sweep interval elapsed -> "a" idle > 1m -> evicted
+
+	assert.Equal(t, 1, g.Len())
+	assert.Equal(t, circuitbreaker.StateClosed, g.State("a")) // evicted -> reads Closed
+}
+
+func TestGroupActiveKeySurvivesSweep(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	g := circuitbreaker.NewGroup(
+		circuitbreaker.WithBreakerOptions(
+			circuitbreaker.WithClock(clk),
+			circuitbreaker.WithFailureThreshold(2),
+		),
+		circuitbreaker.WithIdleTTL(time.Minute),
+		circuitbreaker.WithSweepInterval(time.Second),
+	)
+	_ = g.Do(t.Context(), "a", fail) // a: 1 failure of 2 -> still Closed
+	clk.Advance(90 * time.Second)
+	// breaker() refreshes a's last-access BEFORE the sweep, so the ORIGINAL a
+	// survives and its SECOND failure trips it. A recreated breaker would be
+	// back to one failure and stay Closed — so StateOpen proves preservation.
+	_ = g.Do(t.Context(), "a", fail)
+	assert.Equal(t, circuitbreaker.StateOpen, g.State("a"),
+		"active key's breaker must be preserved across the sweep")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./resilience/circuitbreaker/ -run TestGroup 2>&1 | head`
+Expected: FAIL to build — `circuitbreaker.NewGroup` undefined.
+
+- [ ] **Step 3: Create `group.go`**
+
+```go
+package circuitbreaker
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type groupConfig struct {
+	breakerOpts   []Option
+	idleTTL       time.Duration
+	sweepInterval time.Duration
+}
+
+// GroupOption configures a Group.
+type GroupOption func(*groupConfig)
+
+// WithBreakerOptions sets the options applied to every per-key breaker the
+// Group creates (including WithClock, which the Group reuses for eviction).
+func WithBreakerOptions(opts ...Option) GroupOption {
+	return func(c *groupConfig) { c.breakerOpts = opts }
+}
+
+// WithIdleTTL evicts a breaker after it has gone this long with no Do call,
+// regardless of state (default 10m). Active traffic refreshes a breaker's
+// last-access time, so a breaker in use is never evicted. Non-positive ignored.
+func WithIdleTTL(d time.Duration) GroupOption {
+	return func(c *groupConfig) {
+		if d > 0 {
+			c.idleTTL = d
+		}
+	}
+}
+
+// WithSweepInterval sets the minimum clock gap between eviction scans
+// (default 1m). Scans run during Do, at most once per interval, so an idle
+// Group does no work and holds no goroutine. Non-positive ignored.
+func WithSweepInterval(d time.Duration) GroupOption {
+	return func(c *groupConfig) {
+		if d > 0 {
+			c.sweepInterval = d
+		}
+	}
+}
+
+type groupEntry struct {
+	breaker    *Breaker
+	lastAccess time.Time
+}
+
+// Group manages breakers keyed by string, creating each on first use and
+// sharing one option set. Breakers with no Do call for longer than the idle TTL
+// are evicted opportunistically during Do, so an unbounded key space cannot
+// leak memory and no background goroutine is needed. Safe for concurrent use.
+type Group struct {
+	entries   map[string]*groupEntry
+	clk       clock.Clock
+	lastSweep time.Time
+	cfg       groupConfig
+	mu        sync.Mutex
+}
+
+// NewGroup builds a Group. Configure per-key breakers with WithBreakerOptions
+// and eviction with WithIdleTTL / WithSweepInterval.
+func NewGroup(opts ...GroupOption) *Group {
+	gc := groupConfig{idleTTL: 10 * time.Minute, sweepInterval: time.Minute}
+	for _, o := range opts {
+		o(&gc)
+	}
+	clk := newConfig(gc.breakerOpts...).clk // reuse the breaker clock
+	return &Group{
+		entries:   make(map[string]*groupEntry),
+		clk:       clk,
+		lastSweep: clk.Now(),
+		cfg:       gc,
+	}
+}
+
+// Do runs fn under key's breaker, creating it on first use. It returns an error
+// matching ErrOpen when that breaker is open.
+func (g *Group) Do(ctx context.Context, key string, fn func(context.Context) error) error {
+	return g.breaker(key).Do(ctx, fn)
+}
+
+// State reports the state of key's breaker, or StateClosed if key has no
+// breaker (never called, or evicted). Querying state is not traffic: it neither
+// refreshes last-access nor triggers a sweep.
+func (g *Group) State(key string) State {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if e, ok := g.entries[key]; ok {
+		return e.breaker.State()
+	}
+	return StateClosed
+}
+
+// Len reports the number of live breakers (for tests and metrics).
+func (g *Group) Len() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.entries)
+}
+
+// breaker returns key's breaker, creating it on first use. It refreshes the
+// requested key's last-access time BEFORE running the eviction scan, so a key
+// touched this call is never evicted this call (an in-use key always survives).
+// The scan runs at most once per sweep interval. Shared by Do and the HTTP
+// middleware.
+func (g *Group) breaker(key string) *Breaker {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	now := g.clk.Now()
+	e, ok := g.entries[key]
+	if ok {
+		e.lastAccess = now // refresh before the sweep so an active key survives
+	}
+	if now.Sub(g.lastSweep) >= g.cfg.sweepInterval {
+		g.sweepLocked(now)
+		g.lastSweep = now
+	}
+	if ok {
+		return e.breaker
+	}
+	b := New(g.cfg.breakerOpts...)
+	g.entries[key] = &groupEntry{breaker: b, lastAccess: now}
+	return b
+}
+
+// sweepLocked drops entries idle beyond idleTTL. Caller holds g.mu.
+func (g *Group) sweepLocked(now time.Time) {
+	cutoff := now.Add(-g.cfg.idleTTL)
+	for k, e := range g.entries {
+		if e.lastAccess.Before(cutoff) {
+			delete(g.entries, k)
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Format, test**
+
+Run: `just fmt resilience/circuitbreaker/group.go resilience/circuitbreaker/group_test.go`
+Run: `go test ./resilience/circuitbreaker/ -race`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resilience/circuitbreaker/group.go resilience/circuitbreaker/group_test.go
+git commit -m "feat(resilience/circuitbreaker): keyed Group with opportunistic idle-TTL eviction"
+```
+
+---
+
+### Task 5: circuitbreaker — HTTP middleware (`net/http` only)
+
+**Files:**
+- Create: `resilience/circuitbreaker/http.go`
+- Test: `resilience/circuitbreaker/http_test.go` (black-box)
+
+**Interfaces:**
+- Consumes: `*Breaker`, `*Group`, `Breaker.Do`, `(*Group).breaker`, `openError`.
+- Produces:
+  - `KeyFunc func(*http.Request) string`
+  - `KeyByHost(*http.Request) string`
+  - `OpenResponder func(http.ResponseWriter, *http.Request, time.Duration)`
+  - `MiddlewareOption func(*middlewareConfig)`
+  - `WithFailurePredicate(func(status int) bool) MiddlewareOption`
+  - `WithOpenResponder(OpenResponder) MiddlewareOption`
+  - `Middleware(b *Breaker, opts ...MiddlewareOption) func(http.Handler) http.Handler`
+  - `GroupMiddleware(g *Group, key KeyFunc, opts ...MiddlewareOption) func(http.Handler) http.Handler`
+  - `GroupKey(g *Group, key string, opts ...MiddlewareOption) func(http.Handler) http.Handler`
+
+- [ ] **Step 1: Write failing black-box tests**
+
+Create `resilience/circuitbreaker/http_test.go`:
+
+```go
+package circuitbreaker_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/resilience/circuitbreaker"
+)
+
+// runMW serves one request through mw(h) and returns the recorder.
+func runMW(mw func(http.Handler) http.Handler, h http.Handler, method, target string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	mw(h).ServeHTTP(rec, httptest.NewRequest(method, target, nil))
+	return rec
+}
+
+// status returns a handler that writes the given status code.
+func status(code int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(code) })
+}
+
+func TestMiddlewarePassesThroughWhenClosed(t *testing.T) {
+	rec := runMW(circuitbreaker.Middleware(circuitbreaker.New()), status(200), "GET", "/")
+	assert.Equal(t, 200, rec.Code)
+}
+
+func TestMiddlewareTripsAndReturns503WithRetryAfter(t *testing.T) {
+	b := circuitbreaker.New(circuitbreaker.WithFailureThreshold(1), circuitbreaker.WithOpenTimeout(30*time.Second))
+	mw := circuitbreaker.Middleware(b)
+
+	assert.Equal(t, 500, runMW(mw, status(500), "GET", "/").Code) // downstream 500 reaches client
+	rec := runMW(mw, status(500), "GET", "/")                     // breaker now open
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.NotEmpty(t, rec.Header().Get("Retry-After"))
+}
+
+func TestMiddlewareCustomFailurePredicate(t *testing.T) {
+	b := circuitbreaker.New(circuitbreaker.WithFailureThreshold(1))
+	mw := circuitbreaker.Middleware(b, circuitbreaker.WithFailurePredicate(func(s int) bool { return s == 429 }))
+
+	_ = runMW(mw, status(429), "GET", "/") // 429 counts as failure -> opens
+	assert.Equal(t, http.StatusServiceUnavailable, runMW(mw, status(429), "GET", "/").Code)
+}
+
+func TestMiddlewareCustomOpenResponder(t *testing.T) {
+	b := circuitbreaker.New(circuitbreaker.WithFailureThreshold(1))
+	mw := circuitbreaker.Middleware(b, circuitbreaker.WithOpenResponder(
+		func(w http.ResponseWriter, _ *http.Request, _ time.Duration) { w.WriteHeader(http.StatusTooManyRequests) }))
+
+	_ = runMW(mw, status(500), "GET", "/")
+	assert.Equal(t, http.StatusTooManyRequests, runMW(mw, status(500), "GET", "/").Code)
+}
+
+func TestGroupKeyStaticKey(t *testing.T) {
+	g := circuitbreaker.NewGroup(circuitbreaker.WithBreakerOptions(circuitbreaker.WithFailureThreshold(1)))
+	mw := circuitbreaker.GroupKey(g, "checkout")
+
+	_ = runMW(mw, status(500), "GET", "/")
+	assert.Equal(t, http.StatusServiceUnavailable, runMW(mw, status(500), "GET", "/").Code)
+	assert.Equal(t, circuitbreaker.StateOpen, g.State("checkout"))
+}
+
+func TestGroupKeyEmptyBypasses(t *testing.T) {
+	g := circuitbreaker.NewGroup()
+	assert.Equal(t, 204, runMW(circuitbreaker.GroupKey(g, ""), status(204), "GET", "/").Code)
+	assert.Equal(t, 0, g.Len())
+}
+
+func TestGroupMiddlewareKeyByHostIndependent(t *testing.T) {
+	g := circuitbreaker.NewGroup(circuitbreaker.WithBreakerOptions(circuitbreaker.WithFailureThreshold(1)))
+	mw := circuitbreaker.GroupMiddleware(g, circuitbreaker.KeyByHost)
+
+	trip := func(host string) int {
+		rec := httptest.NewRecorder()
+		mw(status(500)).ServeHTTP(rec, httptest.NewRequest("GET", "http://"+host+"/", nil))
+		return rec.Code
+	}
+	_ = trip("a.example")
+	_ = trip("a.example")                   // a.example now open
+	assert.Equal(t, 500, trip("b.example")) // b.example independent -> its 500 reaches client
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./resilience/circuitbreaker/ -run 'TestMiddleware|TestGroupKey|TestGroupMiddleware' 2>&1 | head`
+Expected: FAIL to build — `circuitbreaker.Middleware` undefined.
+
+- [ ] **Step 3: Create `http.go`**
+
+```go
+package circuitbreaker
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// KeyFunc selects the breaker key for a request in GroupMiddleware. Returning
+// an empty string skips the breaker for that request.
+type KeyFunc func(*http.Request) string
+
+// KeyByHost keys a Group breaker by request Host — the common reverse-proxy
+// case, so GroupMiddleware needs no custom key code. Any func(*http.Request)
+// string works for other strategies.
+func KeyByHost(r *http.Request) string { return r.Host }
+
+// OpenResponder writes the response when the circuit is open. retryAfter is the
+// suggested delay before retrying (0 if unknown).
+type OpenResponder func(w http.ResponseWriter, r *http.Request, retryAfter time.Duration)
+
+type middlewareConfig struct {
+	isFailure func(status int) bool
+	onOpen    OpenResponder
+}
+
+// MiddlewareOption configures Middleware, GroupMiddleware, and GroupKey.
+type MiddlewareOption func(*middlewareConfig)
+
+// WithFailurePredicate classifies a downstream response status as a breaker
+// failure. Default: status >= 500. A nil predicate is ignored.
+func WithFailurePredicate(fn func(status int) bool) MiddlewareOption {
+	return func(c *middlewareConfig) {
+		if fn != nil {
+			c.isFailure = fn
+		}
+	}
+}
+
+// WithOpenResponder overrides the response written when the circuit is open.
+// The default writes 503 with a Retry-After header and a plain-text body. A nil
+// responder is ignored.
+func WithOpenResponder(fn OpenResponder) MiddlewareOption {
+	return func(c *middlewareConfig) {
+		if fn != nil {
+			c.onOpen = fn
+		}
+	}
+}
+
+func newMiddlewareConfig(opts ...MiddlewareOption) middlewareConfig {
+	c := middlewareConfig{
+		isFailure: func(status int) bool { return status >= 500 },
+		onOpen:    defaultOpenResponder,
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// Middleware guards next with b. When the circuit is open it responds via the
+// open responder (503 + Retry-After by default) without calling next. When the
+// circuit is closed it calls next; a response whose status the failure
+// predicate matches is recorded as a breaker failure, while the response itself
+// still reaches the client unchanged. The returned value is assignable to
+// web/middleware.Middleware.
+func Middleware(b *Breaker, opts ...MiddlewareOption) func(http.Handler) http.Handler {
+	cfg := newMiddlewareConfig(opts...)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			serve(b, cfg, next, w, r)
+		})
+	}
+}
+
+// GroupMiddleware guards next with a per-request breaker chosen by key from g.
+// A request whose key is empty bypasses the breaker. Otherwise identical to
+// Middleware.
+func GroupMiddleware(g *Group, key KeyFunc, opts ...MiddlewareOption) func(http.Handler) http.Handler {
+	cfg := newMiddlewareConfig(opts...)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			k := key(r)
+			if k == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			serve(g.breaker(k), cfg, next, w, r)
+		})
+	}
+}
+
+// GroupKey guards next with the breaker named key from g — a fixed key chosen
+// at wrap time, so a specific route handler gets its own breaker within one
+// managed Group (shared options, unified eviction and introspection). An empty
+// key bypasses the breaker.
+func GroupKey(g *Group, key string, opts ...MiddlewareOption) func(http.Handler) http.Handler {
+	cfg := newMiddlewareConfig(opts...)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if key == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			serve(g.breaker(key), cfg, next, w, r)
+		})
+	}
+}
+
+// errDownstreamFailure signals to the breaker that the guarded handler produced
+// a failure status. It never leaves the middleware.
+var errDownstreamFailure = errors.New("circuitbreaker: downstream failure")
+
+func serve(b *Breaker, cfg middlewareConfig, next http.Handler, w http.ResponseWriter, r *http.Request) {
+	rec := &statusRecorder{ResponseWriter: w}
+	err := b.Do(r.Context(), func(ctx context.Context) error {
+		next.ServeHTTP(rec, r.WithContext(ctx))
+		if cfg.isFailure(rec.status()) {
+			return errDownstreamFailure
+		}
+		return nil
+	})
+	if err == nil || errors.Is(err, errDownstreamFailure) {
+		return // downstream already wrote its response (success or a matched failure)
+	}
+	var oe *openError
+	if errors.As(err, &oe) {
+		cfg.onOpen(w, r, oe.retryAfter)
+	}
+}
+
+func defaultOpenResponder(w http.ResponseWriter, _ *http.Request, retryAfter time.Duration) {
+	if secs := retryAfterSeconds(retryAfter); secs > 0 {
+		w.Header().Set("Retry-After", strconv.Itoa(secs))
+	}
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_, _ = w.Write([]byte("service unavailable: circuit open\n"))
+}
+
+// retryAfterSeconds rounds a positive delay up to whole seconds (Retry-After is
+// second-granular). Returns 0 for a non-positive delay so the header is omitted.
+func retryAfterSeconds(d time.Duration) int {
+	if d <= 0 {
+		return 0
+	}
+	secs := int(d / time.Second)
+	if d%time.Second != 0 {
+		secs++
+	}
+	return secs
+}
+
+// statusRecorder captures the response status for failure classification while
+// passing writes through unchanged. It exposes the underlying writer via Unwrap
+// so http.ResponseController reaches optional interfaces (Flusher for
+// SSE/streaming, Hijacker, SetWriteDeadline, …) without falsely advertising
+// them when the underlying writer lacks them.
+type statusRecorder struct {
+	http.ResponseWriter
+	code  int
+	wrote bool
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	if r.wrote {
+		return
+	}
+	r.code = code
+	r.wrote = true
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if !r.wrote {
+		r.WriteHeader(http.StatusOK)
+	}
+	return r.ResponseWriter.Write(b)
+}
+
+// status returns the committed status, or 200 when the handler wrote a body or
+// nothing without an explicit WriteHeader (net/http's implicit 200).
+func (r *statusRecorder) status() int {
+	if !r.wrote {
+		return http.StatusOK
+	}
+	return r.code
+}
+
+func (r *statusRecorder) Unwrap() http.ResponseWriter { return r.ResponseWriter }
+```
+
+- [ ] **Step 4: Format, build (assert no web import), test**
+
+Run: `just fmt resilience/circuitbreaker/http.go resilience/circuitbreaker/http_test.go`
+Run: `go test ./resilience/circuitbreaker/ -race`
+Run: `go list -deps ./resilience/circuitbreaker/ | grep -c 'forge/web' || true`
+Expected: tests PASS; the `grep -c` prints `0` (no `web/` dependency).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resilience/circuitbreaker/http.go resilience/circuitbreaker/http_test.go
+git commit -m "feat(resilience/circuitbreaker): HTTP middleware (single, group, static key)"
+```
+
+---
+
+### Task 6: docs, package-set sync, and final verification
+
+**Files:**
+- Modify: `resilience/cache/doc.go` (NX/claim example)
+- Modify: `resilience/circuitbreaker/doc.go` (Group + Middleware example)
+- Modify: `resilience/retry/doc.go` (RetryAfter note)
+- (`docs/packages.md` is deliberately NOT edited here — see Step 4.)
+
+**Interfaces:** none produced/consumed; documentation + verification only.
+
+- [ ] **Step 1: Add the cache claim example to `resilience/cache/doc.go`**
+
+Append inside the package doc comment (above `package cache`):
+
+```go
+// Claim a one-shot key (idempotency / session start):
+//
+//	err := store.Set(ctx, "idem:"+key, marker, cache.WithSetNonExist(), cache.WithTTL(24*time.Hour))
+//	switch {
+//	case errors.Is(err, cache.ErrExists):
+//		// lost the claim — replay or reject
+//	case err != nil:
+//		// real failure
+//	default:
+//		// won the claim — do the work exactly once
+//	}
+```
+
+- [ ] **Step 2: Add a runnable `Example` to circuitbreaker docs**
+
+Append to `resilience/circuitbreaker/doc.go` (or create `example_test.go` in package `circuitbreaker_test` if `doc.go` holds only the package comment — prefer a runnable `Example` in a test file so it is compiled):
+
+Create `resilience/circuitbreaker/example_test.go`:
+
+```go
+package circuitbreaker_test
+
+import (
+	"net/http"
+
+	"github.com/dmitrymomot/forge/resilience/circuitbreaker"
+)
+
+func ExampleGroupKey() {
+	g := circuitbreaker.NewGroup()
+	mux := http.NewServeMux()
+	checkout := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {})
+	mux.Handle("/checkout", circuitbreaker.GroupKey(g, "checkout")(checkout))
+	// Output:
+}
+```
+
+- [ ] **Step 3: Add the retry note to `resilience/retry/doc.go`**
+
+Append inside the package doc comment:
+
+```go
+// An error implementing RetryAfterError (RetryAfter() time.Duration) raises the
+// wait before the next attempt to at least the reported duration — e.g. an HTTP
+// 429/503 Retry-After or a circuitbreaker open error is honored automatically.
+```
+
+- [ ] **Step 4: (Post-merge, NOT in this PR) note the shipped work items**
+
+Do **not** edit `docs/packages.md` in this PR. Per the spec's "Post-merge doc sync", once this merges, remove these three now-completed rows from the "Shipped-package work items" table (they are no longer pending):
+- the `resilience/circuitbreaker` "Keyed `Group` + HTTP middleware adapter" row
+- the `resilience/retry` "Honor `RetryAfter()` errors as the delay floor" row
+- the `resilience/cache` "Atomic SetNX in the Store contract" row
+
+Keeping `packages.md` out of this PR also avoids sweeping the earlier, already-committed cache/postgres change. No action in this step.
+
+- [ ] **Step 5: Format, full race suite, lint**
+
+Run: `just fmt resilience/cache/doc.go resilience/circuitbreaker/doc.go resilience/circuitbreaker/example_test.go resilience/retry/doc.go`
+Run: `go test ./resilience/... -race`
+Run: `just lint`
+Expected: all tests PASS; lint clean (fix any findings before committing — e.g. `modernize` may rewrite `new(...)`/loop forms; re-run until clean).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add resilience/cache/doc.go resilience/circuitbreaker/doc.go resilience/circuitbreaker/example_test.go resilience/retry/doc.go
+git commit -m "docs(resilience): claim/Group/RetryAfter examples"
+```
+
+---
+
+## Notes for the implementer
+
+- **`clock.WithClock` reuse:** `WithClock` is a `circuitbreaker.Option`. Pass it to a `Group` via `WithBreakerOptions(WithClock(mock))`; `NewGroup` derives the group's own clock from those breaker options, so one mock drives both breakers and eviction.
+- **Why the interface flip is one task:** changing `Store.Set` breaks `memory`, `Cache[V]`, and `cache/redis` at once; splitting them would leave `go build ./...` broken between commits.
+- **`errDownstreamFailure` never escapes:** it is the sentinel `fn` returns so the breaker counts a 5xx; `serve` swallows it (the real downstream response is already written).
+- **Eviction determinism:** the sweep reads the injected clock, and the janitor is opportunistic (runs inside `Do`), so `clock.Mock` + `Advance` + one `Do` deterministically triggers eviction — no `time.Sleep` in tests.
+- **`docs/packages.md` is intentionally untouched by this plan.** The cache/postgres removal was already committed separately (`da9be85`); the shipped-work-item tick is a post-merge follow-up (Task 6, Step 4). This keeps the working tree clean so no plan commit sweeps unrelated hunks.

--- a/docs/superpowers/specs/2026-07-04-resilience-seam-bundle-design.md
+++ b/docs/superpowers/specs/2026-07-04-resilience-seam-bundle-design.md
@@ -1,0 +1,830 @@
+# Resilience Seam Bundle — Design Spec
+
+> Date: 2026-07-04 · Status: awaiting approval · Ships as one PR.
+> Unblocks: `web/httpclient`, and the `session`/`idempotency`/`otp`/`lockout` line.
+
+Three additions across three shipped `resilience/` packages. This spec contains
+complete, compilable reference implementations for every changed or new symbol —
+no sketches. Black-box tests only; options pattern (never builders); `errors.Is`
+sentinels; minimal deps.
+
+## Locked decisions (from brainstorming)
+
+1. **cache**: no new `Store` method. `Set` gains variadic `...SetOption`; TTL and
+   NX are options. NX-conflict is the `ErrExists` sentinel (consistent with
+   `ErrNotFound`-on-miss). `SetOptions` is **exported** because `cache/redis`
+   applies options across the package boundary. `Cache[V]` mirrors the seam.
+2. **redis**: use `SetArgs{Mode:"NX"}` (`SET … NX`), not the (now-internally-fixed
+   but still legacy) `SetNX` helper. `redis.Nil` → `ErrExists`.
+3. **circuitbreaker**: `Group` = lazy per-key breakers with **idle-TTL eviction,
+   any state**, done **opportunistically on `Do`** (no goroutine, no `Close`) —
+   see rationale below. Ships **both** `Middleware(*Breaker,…)` and
+   `GroupMiddleware(*Group, KeyFunc,…)`. Open error carries a dynamic
+   `RetryAfter()`.
+4. **retry**: honor a `RetryAfterError` interface as a delay **floor**
+   (`max(backoff, hint)`), uncapped by the backoff ceiling; `ctx` still bounds.
+5. **Layering**: `resilience/` stays free of `web/` imports. The breaker
+   middleware uses a small `net/http`-only status recorder rather than importing
+   `web/middleware.WrapWriter`. (Tradeoff: ~30 duplicated lines vs. preserving the
+   resilience-is-foundational dependency direction, since `web/httpclient` imports
+   `resilience`. Flagged for override.)
+
+### Why `Group` evicts opportunistically, not via a janitor
+
+`clock.Clock` exposes only `Now()` — no ticker. A background sweeper would run on
+real wall-time, so a `Mock` clock couldn't drive it and eviction wouldn't be
+black-box testable deterministically; it would also add a goroutine + `Close()`
+lifecycle to a primitive.
+
+Instead, `Group.breaker(key)` (the get-or-create path shared by `Do` and the
+middleware) runs an eviction scan at most once per `sweepInterval` of the injected
+clock, gated by a `lastSweep` timestamp. Properties:
+
+- **Bounds memory under the only condition that grows the map** — a steady stream
+  of new keys. Each such call passes through the gated scan. No traffic ⇒ no
+  growth ⇒ nothing to reclaim.
+- **Zero idle cost, no goroutine, no `Close()`.**
+- **No thundering herd**: eviction is by *idle time*, and any active key refreshes
+  `lastAccess` on every call, so a key under load is never idle and never evicted.
+  Only zero-traffic keys are dropped — forgetting one is harmless.
+- **Deterministic tests**: inject a `Mock` clock via `WithBreakerOptions(WithClock(m))`;
+  `m.Advance(...)` + one `Do` triggers the scan; assert via `Group.Len()`.
+
+## Design invariants — no global state, no boilerplate
+
+Guaranteed for every symbol in this bundle; enforced in review and by the tests
+below.
+
+**No global or shared mutable state.**
+- No `init()`, no package-level singletons, no default global instances, no
+  registries. Every stateful object (`Cache`, `Store`, `Breaker`, `Group`,
+  `Retrier`) is explicitly constructed and injected; two instances never share
+  hidden state.
+- The only package-level vars are immutable error sentinels (`ErrExists`,
+  `ErrOpen`, unexported `errDownstreamFailure`) and stateless funcs
+  (`defaultOpenResponder`, `KeyByHost`) — matching the existing `ErrNotFound`
+  idiom.
+- Nothing is smuggled through `context`; the open-circuit delay reaches a custom
+  responder as an explicit `OpenResponder` parameter.
+
+**Every feature works on zero-config defaults — no wiring boilerplate.**
+- `store.Set(ctx, k, v, cache.WithSetNonExist())` — atomic claim, nothing to set up.
+- `circuitbreaker.New().Do(...)`, `NewGroup().Do(...)`, `Middleware(b)(h)`,
+  `GroupMiddleware(g, KeyByHost)(h)`, `GroupKey(g, "checkout")(h)` — all usable
+  with no options; defaults are sensible (503 + Retry-After, status ≥ 500 =
+  failure, 10m idle TTL, 5m cache TTL).
+- The **retry ↔ breaker link is structural**: `openError` satisfies
+  `retry.RetryAfterError` by shape, so `retry` honors the delay with **no import,
+  no registration, no adapter** — `circuitbreaker` never imports `retry`. The
+  same holds for a future `httpclient` 429/503 error.
+
+**The only two "you must supply this" points are essential inputs, not boilerplate.**
+1. A custom `Store` implementer writes one line — `cache.ApplySetOptions(opts...)`
+   — to read the options. Unavoidable for functional options crossing a package
+   boundary; both shipped backends already do it.
+2. `GroupMiddleware` takes a `KeyFunc` because a per-request keying strategy is
+   required information; `KeyByHost` ships for the common case. When you know the
+   route at mount time, `GroupKey(g, "checkout")` sets the key explicitly at the
+   wrap site — no request-derived key at all.
+
+---
+
+## Component 1 — `resilience/cache`
+
+### 1a. `errors.go` — add one sentinel
+
+```go
+	// ErrExists is returned by Set with WithSetNonExist when the key is present.
+	ErrExists = errors.New("cache: entry already exists")
+```
+
+### 1b. `store.go` — options replace the `ttl` parameter
+
+```go
+// Store is a byte-level key/value backend with optional per-entry TTL.
+// Implementations are standalone instances whose lifecycle (background
+// goroutines, connections) is owned by the caller via Close.
+//
+// Set is configured with SetOption values: WithTTL sets an expiry (no option
+// means no expiry), WithSetNonExist makes the write conditional and returns
+// ErrExists when the key already exists. Implementations resolve options with
+// ApplySetOptions so every backend behaves identically.
+type Store interface {
+	Get(ctx context.Context, key string) ([]byte, error)
+	Set(ctx context.Context, key string, val []byte, opts ...SetOption) error
+	Delete(ctx context.Context, key string) error
+	Has(ctx context.Context, key string) (bool, error)
+	DeletePrefix(ctx context.Context, prefix string) error
+	Close() error
+}
+
+// SetOptions holds the resolved settings for one Set call. It is exported
+// because Store implementations in sibling packages (e.g. cache/redis) apply
+// SetOption values and read the result. The zero value means: never expire,
+// overwrite an existing key.
+type SetOptions struct {
+	// TTL expires the entry after the duration. A value <= 0 means no expiry.
+	TTL time.Duration
+	// OnlyIfNew stores the value only when the key is absent or expired; on a
+	// live key Set writes nothing and returns ErrExists.
+	OnlyIfNew bool
+}
+
+// SetOption configures a single Set call.
+type SetOption func(*SetOptions)
+
+// WithTTL expires the written entry after d. Without it the entry never
+// expires; a non-positive d is equivalent to omitting the option.
+func WithTTL(d time.Duration) SetOption { return func(o *SetOptions) { o.TTL = d } }
+
+// WithSetNonExist stores the value only if the key is absent or expired. On a
+// live key Set writes nothing and returns ErrExists. Combined with WithTTL it
+// is an atomic claim-with-lease (set-if-absent + expiry).
+func WithSetNonExist() SetOption { return func(o *SetOptions) { o.OnlyIfNew = true } }
+
+// ApplySetOptions resolves opts into a SetOptions so every backend applies the
+// options identically.
+func ApplySetOptions(opts ...SetOption) SetOptions {
+	var o SetOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+```
+
+### 1c. `memory.go` — `Set` becomes options-aware (atomic under the existing mutex)
+
+```go
+func (m *memoryStore) Set(_ context.Context, key string, val []byte, opts ...SetOption) error {
+	o := ApplySetOptions(opts...)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return ErrClosed
+	}
+	now := m.cfg.clk.Now()
+	if o.OnlyIfNew {
+		if e, ok := m.items[key]; ok && (e.expires.IsZero() || now.Before(e.expires)) {
+			return ErrExists
+		}
+	}
+	var expires time.Time
+	if o.TTL > 0 {
+		expires = now.Add(o.TTL)
+	}
+	stored := make([]byte, len(val))
+	copy(stored, val)
+	if e, ok := m.items[key]; ok {
+		e.val = stored
+		e.expires = expires
+		m.lru.MoveToFront(e.elem)
+		return nil
+	}
+	e := &memEntry{key: key, val: stored, expires: expires}
+	e.elem = m.lru.PushFront(e)
+	m.items[key] = e
+	if m.cfg.maxEntries > 0 && m.lru.Len() > m.cfg.maxEntries {
+		if back := m.lru.Back(); back != nil {
+			old := back.Value.(*memEntry)
+			m.removeLocked(old.key, old)
+		}
+	}
+	return nil
+}
+```
+
+### 1d. `redis/redis.go` — `SET … NX` via `SetArgs`, no legacy `SETNX`
+
+```go
+func (s *store) Set(ctx context.Context, key string, val []byte, opts ...cache.SetOption) error {
+	o := cache.ApplySetOptions(opts...)
+	var ttl time.Duration
+	if o.TTL > 0 {
+		ttl = o.TTL // SetArgs treats TTL <= 0 as "no expiry"
+	}
+	if o.OnlyIfNew {
+		// SET key val NX [PX ttl] — the modern replacement for SETNX. On a
+		// present key the server returns a null reply, surfaced as redis.Nil.
+		err := s.client.SetArgs(ctx, key, val, goredis.SetArgs{Mode: "NX", TTL: ttl}).Err()
+		if forgeredis.IsNil(err) {
+			return cache.ErrExists
+		}
+		return err
+	}
+	return s.client.Set(ctx, key, val, ttl).Err()
+}
+```
+
+### 1e. `cache.go` — facade mirrors the seam
+
+```go
+// Set stores v under key. Without a WithTTL option the cache's default TTL
+// applies; WithTTL overrides it (a non-positive duration means no expiry).
+// WithSetNonExist makes the write conditional, returning ErrExists when the key
+// is already present.
+func (c *Cache[V]) Set(ctx context.Context, key string, v V, opts ...SetOption) error {
+	data, err := c.marshaler.Marshal(v)
+	if err != nil {
+		return err
+	}
+	// Prepend the default TTL so any caller WithTTL (including a non-positive
+	// "never expire") overrides it; a fresh slice leaves the caller's untouched.
+	opts = append([]SetOption{WithTTL(c.defaultTTL)}, opts...)
+	return c.store.Set(ctx, c.key(key), data, opts...)
+}
+```
+
+`GetOrSet`'s internal write preserves its "fn returns 0 ⇒ default TTL" semantics
+by only emitting `WithTTL` for a non-zero duration:
+
+```go
+	v, _, err = c.sf.Do(ctx, c.key(key), func(ctx context.Context) (V, error) {
+		val, ttl, ferr := fn(ctx)
+		if ferr != nil {
+			var zero V
+			return zero, ferr
+		}
+		var opts []SetOption
+		if ttl != 0 {
+			opts = append(opts, WithTTL(ttl))
+		}
+		_ = c.Set(ctx, key, val, opts...)
+		return val, nil
+	})
+```
+
+### 1f. Facade TTL semantics (unchanged behavior, new spelling)
+
+| Caller writes | Store receives | Effect |
+|---|---|---|
+| `c.Set(ctx,k,v)` | `WithTTL(defaultTTL)` | default (5m) |
+| `c.Set(ctx,k,v, WithTTL(d>0))` | `WithTTL(d)` | expires after `d` |
+| `c.Set(ctx,k,v, WithTTL(0))` / `WithTTL(<0)` | `WithTTL(<=0)` | never expires |
+| `c.Set(ctx,k,v, WithSetNonExist())` | `WithTTL(default)+NX` | claim w/ default TTL |
+
+### 1g. `doc.go` — runnable example addition
+
+```go
+// Claim a one-shot key (idempotency / session start):
+//
+//	err := store.Set(ctx, "idem:"+key, marker, cache.WithSetNonExist(), cache.WithTTL(24*time.Hour))
+//	switch {
+//	case errors.Is(err, cache.ErrExists):
+//		// lost the claim — replay or reject
+//	case err != nil:
+//		// real failure
+//	default:
+//		// won the claim — do the work exactly once
+//	}
+```
+
+---
+
+## Component 2 — `resilience/circuitbreaker`
+
+### 2a. `errors.go` — dynamic open error carrying `RetryAfter`
+
+```go
+package circuitbreaker
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrOpen is the sentinel a rejected call matches with errors.Is. The concrete
+// error returned by Do also reports a suggested retry delay via RetryAfter.
+var ErrOpen = errors.New("circuitbreaker: circuit open")
+
+// openError is returned when the breaker rejects a call. It unwraps to ErrOpen
+// (so errors.Is(err, ErrOpen) holds) and reports the delay until the next
+// probe, satisfying retry.RetryAfterError and feeding the HTTP middleware's
+// Retry-After header.
+type openError struct{ retryAfter time.Duration }
+
+func (e *openError) Error() string             { return ErrOpen.Error() }
+func (e *openError) Unwrap() error             { return ErrOpen }
+func (e *openError) RetryAfter() time.Duration { return e.retryAfter }
+```
+
+> **Behavior change:** `Do` now returns `*openError` instead of the bare `ErrOpen`
+> value. `errors.Is(err, ErrOpen)` still holds. Any consumer/test using `err ==
+> ErrOpen` must switch to `errors.Is` (the sanctioned check). `doc.go` updated to
+> say "an error matching ErrOpen".
+
+### 2b. `circuitbreaker.go` — shared config builder, remaining-time in `before`, public `RetryAfter`
+
+```go
+// newConfig applies opts over the defaults. Shared by New and Group.
+func newConfig(opts ...Option) config {
+	c := config{threshold: 5, openTimeout: 30 * time.Second, halfOpenMax: 1, clk: clock.System()}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// New builds a Breaker from options.
+func New(opts ...Option) *Breaker {
+	return &Breaker{cfg: newConfig(opts...), state: StateClosed}
+}
+```
+
+```go
+func (b *Breaker) before() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch b.state {
+	case StateOpen:
+		elapsed := b.cfg.clk.Now().Sub(b.openedAt)
+		if elapsed < b.cfg.openTimeout {
+			return &openError{retryAfter: b.cfg.openTimeout - elapsed}
+		}
+		b.transition(StateHalfOpen)
+		b.halfOpenIn = 1
+		return nil
+	case StateHalfOpen:
+		if b.halfOpenIn >= b.cfg.halfOpenMax {
+			return &openError{retryAfter: 0} // a probe is in flight; retry shortly
+		}
+		b.halfOpenIn++
+		return nil
+	default:
+		return nil
+	}
+}
+
+// RetryAfter reports how long until the breaker would admit a probe call, or 0
+// when it is not open.
+func (b *Breaker) RetryAfter() time.Duration {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.state != StateOpen {
+		return 0
+	}
+	if remaining := b.cfg.openTimeout - b.cfg.clk.Now().Sub(b.openedAt); remaining > 0 {
+		return remaining
+	}
+	return 0
+}
+```
+
+### 2c. `group.go` — new file, complete
+
+```go
+package circuitbreaker
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type groupConfig struct {
+	breakerOpts   []Option
+	idleTTL       time.Duration
+	sweepInterval time.Duration
+}
+
+// GroupOption configures a Group.
+type GroupOption func(*groupConfig)
+
+// WithBreakerOptions sets the options applied to every per-key breaker the
+// Group creates (including WithClock, which the Group reuses for eviction).
+func WithBreakerOptions(opts ...Option) GroupOption {
+	return func(c *groupConfig) { c.breakerOpts = opts }
+}
+
+// WithIdleTTL evicts a breaker after it has gone this long with no Do call,
+// regardless of state (default 10m). Active traffic refreshes a breaker's
+// last-access time, so a breaker in use is never evicted. Non-positive ignored.
+func WithIdleTTL(d time.Duration) GroupOption {
+	return func(c *groupConfig) {
+		if d > 0 {
+			c.idleTTL = d
+		}
+	}
+}
+
+// WithSweepInterval sets the minimum clock gap between eviction scans
+// (default 1m). Scans run during Do, at most once per interval, so an idle
+// Group does no work and holds no goroutine. Non-positive ignored.
+func WithSweepInterval(d time.Duration) GroupOption {
+	return func(c *groupConfig) {
+		if d > 0 {
+			c.sweepInterval = d
+		}
+	}
+}
+
+type groupEntry struct {
+	breaker    *Breaker
+	lastAccess time.Time
+}
+
+// Group manages breakers keyed by string, creating each on first use and
+// sharing one option set. Breakers with no Do call for longer than the idle TTL
+// are evicted opportunistically during Do, so an unbounded key space cannot
+// leak memory and no background goroutine is needed. Safe for concurrent use.
+type Group struct {
+	entries   map[string]*groupEntry
+	clk       clock.Clock
+	lastSweep time.Time
+	cfg       groupConfig
+	mu        sync.Mutex
+}
+
+// NewGroup builds a Group. Configure per-key breakers with WithBreakerOptions
+// and eviction with WithIdleTTL / WithSweepInterval.
+func NewGroup(opts ...GroupOption) *Group {
+	gc := groupConfig{idleTTL: 10 * time.Minute, sweepInterval: time.Minute}
+	for _, o := range opts {
+		o(&gc)
+	}
+	clk := newConfig(gc.breakerOpts...).clk // reuse the breaker clock
+	return &Group{
+		entries:   make(map[string]*groupEntry),
+		clk:       clk,
+		lastSweep: clk.Now(),
+		cfg:       gc,
+	}
+}
+
+// Do runs fn under key's breaker, creating it on first use. It returns an error
+// matching ErrOpen when that breaker is open.
+func (g *Group) Do(ctx context.Context, key string, fn func(context.Context) error) error {
+	return g.breaker(key).Do(ctx, fn)
+}
+
+// State reports the state of key's breaker, or StateClosed if key has no
+// breaker (never called, or evicted). Querying state is not traffic: it neither
+// refreshes last-access nor triggers a sweep.
+func (g *Group) State(key string) State {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if e, ok := g.entries[key]; ok {
+		return e.breaker.State()
+	}
+	return StateClosed
+}
+
+// Len reports the number of live breakers (for tests and metrics).
+func (g *Group) Len() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.entries)
+}
+
+// breaker returns key's breaker, creating it on first use and refreshing its
+// last-access time. It first runs an eviction scan if the sweep interval has
+// elapsed. Shared by Do and the HTTP middleware.
+func (g *Group) breaker(key string) *Breaker {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	now := g.clk.Now()
+	if now.Sub(g.lastSweep) >= g.cfg.sweepInterval {
+		g.sweepLocked(now)
+		g.lastSweep = now
+	}
+	if e, ok := g.entries[key]; ok {
+		e.lastAccess = now
+		return e.breaker
+	}
+	b := New(g.cfg.breakerOpts...)
+	g.entries[key] = &groupEntry{breaker: b, lastAccess: now}
+	return b
+}
+
+// sweepLocked drops entries idle beyond idleTTL. Caller holds g.mu.
+func (g *Group) sweepLocked(now time.Time) {
+	cutoff := now.Add(-g.cfg.idleTTL)
+	for k, e := range g.entries {
+		if e.lastAccess.Before(cutoff) {
+			delete(g.entries, k)
+		}
+	}
+}
+```
+
+### 2d. `http.go` — new file, complete (both middlewares, `net/http` only)
+
+```go
+package circuitbreaker
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// KeyFunc selects the breaker key for a request in GroupMiddleware. Returning
+// an empty string skips the breaker for that request.
+type KeyFunc func(*http.Request) string
+
+// KeyByHost keys a Group breaker by request Host — the common reverse-proxy
+// case, so GroupMiddleware needs no custom key code. Any func(*http.Request)
+// string works for other strategies.
+func KeyByHost(r *http.Request) string { return r.Host }
+
+// OpenResponder writes the response when the circuit is open. retryAfter is the
+// suggested delay before retrying (0 if unknown).
+type OpenResponder func(w http.ResponseWriter, r *http.Request, retryAfter time.Duration)
+
+type middlewareConfig struct {
+	isFailure func(status int) bool
+	onOpen    OpenResponder
+}
+
+// MiddlewareOption configures Middleware and GroupMiddleware.
+type MiddlewareOption func(*middlewareConfig)
+
+// WithFailurePredicate classifies a downstream response status as a breaker
+// failure. Default: status >= 500. A nil predicate is ignored.
+func WithFailurePredicate(fn func(status int) bool) MiddlewareOption {
+	return func(c *middlewareConfig) {
+		if fn != nil {
+			c.isFailure = fn
+		}
+	}
+}
+
+// WithOpenResponder overrides the response written when the circuit is open.
+// The default writes 503 with a Retry-After header and a plain-text body. A nil
+// responder is ignored.
+func WithOpenResponder(fn OpenResponder) MiddlewareOption {
+	return func(c *middlewareConfig) {
+		if fn != nil {
+			c.onOpen = fn
+		}
+	}
+}
+
+func newMiddlewareConfig(opts ...MiddlewareOption) middlewareConfig {
+	c := middlewareConfig{
+		isFailure: func(status int) bool { return status >= 500 },
+		onOpen:    defaultOpenResponder,
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// Middleware guards next with b. When the circuit is open it responds via the
+// open responder (503 + Retry-After by default) without calling next. When the
+// circuit is closed it calls next; a response whose status the failure
+// predicate matches is recorded as a breaker failure, while the response itself
+// still reaches the client unchanged. The returned value is assignable to
+// web/middleware.Middleware.
+func Middleware(b *Breaker, opts ...MiddlewareOption) func(http.Handler) http.Handler {
+	cfg := newMiddlewareConfig(opts...)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			serve(b, cfg, next, w, r)
+		})
+	}
+}
+
+// GroupMiddleware guards next with a per-request breaker chosen by key from g.
+// A request whose key is empty bypasses the breaker. Otherwise identical to
+// Middleware.
+func GroupMiddleware(g *Group, key KeyFunc, opts ...MiddlewareOption) func(http.Handler) http.Handler {
+	cfg := newMiddlewareConfig(opts...)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			k := key(r)
+			if k == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			serve(g.breaker(k), cfg, next, w, r)
+		})
+	}
+}
+
+// GroupKey guards next with the breaker named key from g — a fixed key chosen
+// at wrap time, so a specific route handler gets its own breaker within one
+// managed Group (shared options, unified eviction and introspection). An empty
+// key bypasses the breaker. Use this when you know the route at mount time:
+//
+//	mux.Handle("/checkout", circuitbreaker.GroupKey(g, "checkout")(checkoutHandler))
+//	mux.Handle("/search",   circuitbreaker.GroupKey(g, "search")(searchHandler))
+func GroupKey(g *Group, key string, opts ...MiddlewareOption) func(http.Handler) http.Handler {
+	cfg := newMiddlewareConfig(opts...)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if key == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			serve(g.breaker(key), cfg, next, w, r)
+		})
+	}
+}
+
+// errDownstreamFailure signals to the breaker that the guarded handler produced
+// a failure status. It never leaves the middleware.
+var errDownstreamFailure = errors.New("circuitbreaker: downstream failure")
+
+func serve(b *Breaker, cfg middlewareConfig, next http.Handler, w http.ResponseWriter, r *http.Request) {
+	rec := &statusRecorder{ResponseWriter: w}
+	err := b.Do(r.Context(), func(ctx context.Context) error {
+		next.ServeHTTP(rec, r.WithContext(ctx))
+		if cfg.isFailure(rec.status()) {
+			return errDownstreamFailure
+		}
+		return nil
+	})
+	if err == nil || errors.Is(err, errDownstreamFailure) {
+		return // downstream already wrote its response (success or a matched failure)
+	}
+	var oe *openError
+	if errors.As(err, &oe) {
+		cfg.onOpen(w, r, oe.retryAfter)
+	}
+}
+
+func defaultOpenResponder(w http.ResponseWriter, _ *http.Request, retryAfter time.Duration) {
+	if secs := retryAfterSeconds(retryAfter); secs > 0 {
+		w.Header().Set("Retry-After", strconv.Itoa(secs))
+	}
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_, _ = w.Write([]byte("service unavailable: circuit open\n"))
+}
+
+// retryAfterSeconds rounds a positive delay up to whole seconds (Retry-After is
+// second-granular). Returns 0 for a non-positive delay so the header is omitted.
+func retryAfterSeconds(d time.Duration) int {
+	if d <= 0 {
+		return 0
+	}
+	secs := int(d / time.Second)
+	if d%time.Second != 0 {
+		secs++
+	}
+	return secs
+}
+
+// statusRecorder captures the response status for failure classification while
+// passing writes through unchanged. It exposes the underlying writer via Unwrap
+// so http.ResponseController reaches optional interfaces (Flusher for
+// SSE/streaming, Hijacker, SetWriteDeadline, …) without falsely advertising
+// them when the underlying writer lacks them. This mirrors web/middleware's
+// recorder convention.
+type statusRecorder struct {
+	http.ResponseWriter
+	code  int
+	wrote bool
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	if r.wrote {
+		return
+	}
+	r.code = code
+	r.wrote = true
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if !r.wrote {
+		r.WriteHeader(http.StatusOK)
+	}
+	return r.ResponseWriter.Write(b)
+}
+
+// status returns the committed status, or 200 when the handler wrote a body or
+// nothing without an explicit WriteHeader (net/http's implicit 200).
+func (r *statusRecorder) status() int {
+	if !r.wrote {
+		return http.StatusOK
+	}
+	return r.code
+}
+
+func (r *statusRecorder) Unwrap() http.ResponseWriter { return r.ResponseWriter }
+```
+
+### 2e. `doc.go` — add a runnable `Example` mounting `Middleware` and showing `Group`.
+
+---
+
+## Component 3 — `resilience/retry`
+
+### 3a. `errors.go` — new file with the contract interface
+
+```go
+package retry
+
+import "time"
+
+// RetryAfterError is implemented by errors that carry a minimum delay before
+// the next attempt — e.g. an HTTP 429/503 with a Retry-After header, or a
+// circuitbreaker open error. Retrier.Do treats the reported duration as a
+// floor: it waits at least this long before the next attempt, even beyond the
+// backoff ceiling. The context deadline still bounds the total.
+type RetryAfterError interface {
+	error
+	RetryAfter() time.Duration
+}
+```
+
+### 3b. `retry.go` — apply the floor in the `Do` loop
+
+Only the delay computation changes (replacing the single `time.NewTimer` line):
+
+```go
+		// Wait per the backoff, raised to any server/breaker-stated floor.
+		wait := r.cfg.backoff.Next(attempt)
+		if ra, ok := errors.AsType[RetryAfterError](err); ok {
+			if hint := ra.RetryAfter(); hint > wait {
+				wait = hint
+			}
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+```
+
+`errors.AsType[RetryAfterError]` walks the unwrap chain and returns the first
+error whose dynamic type implements `RetryAfter()` (Go 1.26 `asType` does a
+type-assert to the interface `E`). `retryIf` and `maxAttempts` are untouched —
+the hint changes only *how long* a retry waits, never *whether* it happens.
+
+---
+
+## Testing plan (black-box, `_test` packages)
+
+**cache** (`cache_test`, `redis_test`):
+- `WithSetNonExist` on absent key → stored, `ok`; on present live key → `ErrExists`,
+  original value intact; on **expired** key → overwrites (mock clock advance).
+- `WithTTL` expiry vs. no-option no-expiry vs. negative → never; via memory mock clock.
+- Facade: default TTL applied when no `WithTTL`; explicit `WithTTL` overrides;
+  `GetOrSet` still uses default when `fn` returns `0`.
+- Concurrency: N goroutines `WithSetNonExist` same key → exactly one `ok`
+  (race detector).
+- redis path gated behind the existing redis test build tag/skip.
+
+**circuitbreaker** (`circuitbreaker_test`):
+- `openError`: `errors.Is(err, ErrOpen)` true; `RetryAfter()` > 0 while open and
+  shrinks as the mock clock advances; 0 once half-open/closed.
+- `Group`: lazy create (`Len` grows); shared options honored; idle eviction —
+  advance mock clock past `idleTTL`, one `Do` on another key triggers the scan,
+  assert `Len` drops and the idle key’s `State` is `StateClosed`; an *active* key
+  survives; `State`/`Len` do not themselves cause eviction.
+- `Middleware`: closed→passes through, 5xx trips after threshold; open→503 +
+  `Retry-After` header without calling next; custom `WithFailurePredicate` and
+  `WithOpenResponder`; a handler flushing via `http.ResponseController` still
+  works through the recorder's `Unwrap`.
+- `GroupMiddleware`: distinct keys → independent breakers; empty key → bypass;
+  `KeyByHost` routes by `r.Host`.
+- `GroupKey`: the fixed key selects one breaker from the group across requests;
+  two mounts with different keys are independent; empty key → bypass; the wrapped
+  breaker trips/opens like `Middleware`.
+- Invariants: no `init`/singleton/registry in any file; a feature exercised with
+  zero options behaves per its documented defaults.
+
+**retry** (`retry_test`):
+- Error implementing `RetryAfterError` with hint > backoff → waits ≥ hint
+  (mock/tolerance); hint < backoff → backoff wins; wrapped hint found through
+  `fmt.Errorf("%w")`; `ctx` cancel still returns promptly during a long hint.
+
+## File inventory
+
+```
+resilience/cache/errors.go        + ErrExists
+resilience/cache/store.go         Store.Set signature; +SetOptions/SetOption/WithTTL/WithSetNonExist/ApplySetOptions
+resilience/cache/memory.go        Set(...SetOption)
+resilience/cache/cache.go         Cache[V].Set(...SetOption); GetOrSet internal write
+resilience/cache/redis/redis.go   Set(...SetOption) via SetArgs NX
+resilience/cache/doc.go           NX/claim example
+resilience/circuitbreaker/errors.go        +openError
+resilience/circuitbreaker/circuitbreaker.go newConfig; before() remaining; +RetryAfter()
+resilience/circuitbreaker/group.go          NEW
+resilience/circuitbreaker/http.go           NEW
+resilience/circuitbreaker/doc.go            Group + Middleware example
+resilience/retry/errors.go        NEW (RetryAfterError)
+resilience/retry/retry.go         delay floor in Do loop
+```
+
+## Non-goals (this PR)
+
+- No metrics/observability hooks beyond existing `WithOnStateChange`.
+- No per-key eviction knobs beyond `WithIdleTTL` + `WithSweepInterval`.
+- No `RetryAfter` cap option (ctx/deadline bounds the wait).
+- No `httpclient` (this only unblocks it).
+- No `web/middleware` import from `resilience/` (see decision 5).
+
+## Post-merge doc sync
+
+Tick the four work items in `docs/packages.md` "Shipped-package work items"
+(cache SetNX, circuitbreaker Group + middleware, retry RetryAfter) once merged.

--- a/docs/superpowers/specs/2026-07-04-resilience-seam-bundle-design.md
+++ b/docs/superpowers/specs/2026-07-04-resilience-seam-bundle-design.md
@@ -478,19 +478,24 @@ func (g *Group) Len() int {
 	return len(g.entries)
 }
 
-// breaker returns key's breaker, creating it on first use and refreshing its
-// last-access time. It first runs an eviction scan if the sweep interval has
-// elapsed. Shared by Do and the HTTP middleware.
+// breaker returns key's breaker, creating it on first use. It refreshes the
+// requested key's last-access time BEFORE running the eviction scan, so a key
+// touched this call is never evicted this call (an active key always survives).
+// The scan runs at most once per sweep interval. Shared by Do and the HTTP
+// middleware.
 func (g *Group) breaker(key string) *Breaker {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	now := g.clk.Now()
+	e, ok := g.entries[key]
+	if ok {
+		e.lastAccess = now // refresh before the sweep so an active key survives
+	}
 	if now.Sub(g.lastSweep) >= g.cfg.sweepInterval {
 		g.sweepLocked(now)
 		g.lastSweep = now
 	}
-	if e, ok := g.entries[key]; ok {
-		e.lastAccess = now
+	if ok {
 		return e.breaker
 	}
 	b := New(g.cfg.breakerOpts...)
@@ -540,7 +545,7 @@ type middlewareConfig struct {
 	onOpen    OpenResponder
 }
 
-// MiddlewareOption configures Middleware and GroupMiddleware.
+// MiddlewareOption configures Middleware, GroupMiddleware, and GroupKey.
 type MiddlewareOption func(*middlewareConfig)
 
 // WithFailurePredicate classifies a downstream response status as a breaker

--- a/resilience/cache/cache.go
+++ b/resilience/cache/cache.go
@@ -23,7 +23,8 @@ type Option func(*config)
 // other caches sharing the same Store.
 func WithPrefix(p string) Option { return func(c *config) { c.prefix = p } }
 
-// WithDefaultTTL is applied when Set receives ttl == 0 (default 5m).
+// WithDefaultTTL sets the TTL applied when Set is called without a WithTTL
+// option (default 5m).
 func WithDefaultTTL(d time.Duration) Option { return func(c *config) { c.defaultTTL = d } }
 
 // WithMarshaler overrides the default JSON serialization. Its type parameter

--- a/resilience/cache/cache.go
+++ b/resilience/cache/cache.go
@@ -81,17 +81,19 @@ func (c *Cache[V]) Get(ctx context.Context, key string) (V, error) {
 	return c.marshaler.Unmarshal(data)
 }
 
-// Set stores v under key. ttl == 0 uses the configured default; ttl < 0 never
-// expires.
-func (c *Cache[V]) Set(ctx context.Context, key string, v V, ttl time.Duration) error {
+// Set stores v under key. Without a WithTTL option the cache's default TTL
+// applies; WithTTL overrides it (a non-positive duration means no expiry).
+// WithSetNonExist makes the write conditional, returning ErrExists when the key
+// is already present.
+func (c *Cache[V]) Set(ctx context.Context, key string, v V, opts ...SetOption) error {
 	data, err := c.marshaler.Marshal(v)
 	if err != nil {
 		return err
 	}
-	if ttl == 0 {
-		ttl = c.defaultTTL
-	}
-	return c.store.Set(ctx, c.key(key), data, ttl)
+	// Prepend the default TTL so any caller WithTTL (including a non-positive
+	// "never expire") overrides it; a fresh slice leaves the caller's untouched.
+	opts = append([]SetOption{WithTTL(c.defaultTTL)}, opts...)
+	return c.store.Set(ctx, c.key(key), data, opts...)
 }
 
 // Delete removes key. Deleting a key that does not exist is not an error.
@@ -136,7 +138,11 @@ func (c *Cache[V]) GetOrSet(ctx context.Context, key string, fn func(context.Con
 			var zero V
 			return zero, ferr
 		}
-		_ = c.Set(ctx, key, val, ttl)
+		var opts []SetOption
+		if ttl != 0 {
+			opts = append(opts, WithTTL(ttl))
+		}
+		_ = c.Set(ctx, key, val, opts...)
 		return val, nil
 	})
 	return v, err

--- a/resilience/cache/cache_test.go
+++ b/resilience/cache/cache_test.go
@@ -19,7 +19,7 @@ func TestCacheSetGetTyped(t *testing.T) {
 	defer func() { _ = store.Close() }()
 	c := cache.New[string](store, cache.WithPrefix("greet:"))
 
-	require.NoError(t, c.Set(t.Context(), "en", "hello", 0))
+	require.NoError(t, c.Set(t.Context(), "en", "hello"))
 	v, err := c.Get(t.Context(), "en")
 	require.NoError(t, err)
 	assert.Equal(t, "hello", v)
@@ -39,8 +39,8 @@ func TestCacheIsolationByPrefixOverSharedStore(t *testing.T) {
 	a := cache.New[string](store, cache.WithPrefix("a:"))
 	b := cache.New[string](store, cache.WithPrefix("b:"))
 
-	require.NoError(t, a.Set(t.Context(), "k", "AAA", -1))
-	require.NoError(t, b.Set(t.Context(), "k", "BBB", -1))
+	require.NoError(t, a.Set(t.Context(), "k", "AAA", cache.WithTTL(-1)))
+	require.NoError(t, b.Set(t.Context(), "k", "BBB", cache.WithTTL(-1)))
 
 	av, _ := a.Get(t.Context(), "k")
 	bv, _ := b.Get(t.Context(), "k")
@@ -103,12 +103,12 @@ func TestGetOrSetSurfacesClosedStore(t *testing.T) {
 // errStore is a Store stub whose Get fails with a non-sentinel error.
 type errStore struct{ getErr error }
 
-func (e errStore) Get(context.Context, string) ([]byte, error)            { return nil, e.getErr }
-func (errStore) Set(context.Context, string, []byte, time.Duration) error { return nil }
-func (errStore) Delete(context.Context, string) error                     { return nil }
-func (errStore) Has(context.Context, string) (bool, error)                { return false, nil }
-func (errStore) DeletePrefix(context.Context, string) error               { return nil }
-func (errStore) Close() error                                             { return nil }
+func (e errStore) Get(context.Context, string) ([]byte, error)                 { return nil, e.getErr }
+func (errStore) Set(context.Context, string, []byte, ...cache.SetOption) error { return nil }
+func (errStore) Delete(context.Context, string) error                          { return nil }
+func (errStore) Has(context.Context, string) (bool, error)                     { return false, nil }
+func (errStore) DeletePrefix(context.Context, string) error                    { return nil }
+func (errStore) Close() error                                                  { return nil }
 
 func TestGetOrSetWrapsUnclassifiedStoreError(t *testing.T) {
 	boom := errors.New("connection reset")
@@ -133,7 +133,7 @@ func TestWithMarshalerUsesCustomMarshaler(t *testing.T) {
 	defer func() { _ = store.Close() }()
 	c := cache.New[string](store, cache.WithMarshaler(rawStringMarshaler{}))
 
-	require.NoError(t, c.Set(t.Context(), "k", "hi", -1))
+	require.NoError(t, c.Set(t.Context(), "k", "hi", cache.WithTTL(-1)))
 
 	// Stored bytes are raw, not JSON-quoted (`"hi"`), so the custom marshaler ran.
 	raw, err := store.Get(t.Context(), "k")
@@ -153,4 +153,23 @@ func TestWithMarshalerTypeMismatchPanics(t *testing.T) {
 	assert.Panics(t, func() {
 		_ = cache.New[int](store, cache.WithMarshaler(rawStringMarshaler{}))
 	})
+}
+
+func TestFacadeSetNonExistReturnsErrExists(t *testing.T) {
+	store := cache.NewMemoryStore()
+	defer func() { _ = store.Close() }()
+	c := cache.New[string](store)
+
+	require.NoError(t, c.Set(t.Context(), "k", "first", cache.WithSetNonExist()))
+	assert.ErrorIs(t, c.Set(t.Context(), "k", "second", cache.WithSetNonExist()), cache.ErrExists)
+}
+
+func TestApplySetOptions(t *testing.T) {
+	o := cache.ApplySetOptions(cache.WithTTL(5*time.Second), cache.WithSetNonExist())
+	assert.Equal(t, 5*time.Second, o.TTL)
+	assert.True(t, o.OnlyIfNew)
+
+	z := cache.ApplySetOptions()
+	assert.Zero(t, z.TTL)
+	assert.False(t, z.OnlyIfNew)
 }

--- a/resilience/cache/doc.go
+++ b/resilience/cache/doc.go
@@ -12,4 +12,16 @@
 //	    u, err := repo.Load(ctx, id)
 //	    return u, 5 * time.Minute, err
 //	})
+//
+// Claim a one-shot key (idempotency / session start):
+//
+//	err := store.Set(ctx, "idem:"+key, marker, cache.WithSetNonExist(), cache.WithTTL(24*time.Hour))
+//	switch {
+//	case errors.Is(err, cache.ErrExists):
+//	    // lost the claim — replay or reject
+//	case err != nil:
+//	    // real failure
+//	default:
+//	    // won the claim — do the work exactly once
+//	}
 package cache

--- a/resilience/cache/errors.go
+++ b/resilience/cache/errors.go
@@ -14,4 +14,6 @@ var (
 	ErrUnmarshal = errors.New("cache: failed to unmarshal value")
 	// ErrStore wraps an unclassified error returned by the underlying Store.
 	ErrStore = errors.New("cache: store operation failed")
+	// ErrExists is returned by Set with WithSetNonExist when the key is present.
+	ErrExists = errors.New("cache: entry already exists")
 )

--- a/resilience/cache/memory.go
+++ b/resilience/cache/memory.go
@@ -119,15 +119,22 @@ func (m *memoryStore) Get(_ context.Context, key string) ([]byte, error) {
 	return out, nil
 }
 
-func (m *memoryStore) Set(_ context.Context, key string, val []byte, ttl time.Duration) error {
+func (m *memoryStore) Set(_ context.Context, key string, val []byte, opts ...SetOption) error {
+	o := ApplySetOptions(opts...)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.closed {
 		return ErrClosed
 	}
+	now := m.cfg.clk.Now()
+	if o.OnlyIfNew {
+		if e, ok := m.items[key]; ok && (e.expires.IsZero() || now.Before(e.expires)) {
+			return ErrExists
+		}
+	}
 	var expires time.Time
-	if ttl > 0 {
-		expires = m.cfg.clk.Now().Add(ttl)
+	if o.TTL > 0 {
+		expires = now.Add(o.TTL)
 	}
 	stored := make([]byte, len(val))
 	copy(stored, val)

--- a/resilience/cache/memory_test.go
+++ b/resilience/cache/memory_test.go
@@ -1,6 +1,8 @@
 package cache_test
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +17,7 @@ func TestMemoryStoreSetGetDelete(t *testing.T) {
 	s := cache.NewMemoryStore()
 	defer func() { _ = s.Close() }()
 
-	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), 0))
+	require.NoError(t, s.Set(t.Context(), "k", []byte("v")))
 	got, err := s.Get(t.Context(), "k")
 	require.NoError(t, err)
 	assert.Equal(t, []byte("v"), got)
@@ -30,7 +32,7 @@ func TestMemoryStoreExpiry(t *testing.T) {
 	s := cache.NewMemoryStore(cache.WithClock(clk))
 	defer func() { _ = s.Close() }()
 
-	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), 30*time.Second))
+	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), cache.WithTTL(30*time.Second)))
 	clk.Advance(31 * time.Second)
 	_, err := s.Get(t.Context(), "k")
 	assert.ErrorIs(t, err, cache.ErrNotFound)
@@ -41,7 +43,7 @@ func TestMemoryStoreNegativeTTLNeverExpires(t *testing.T) {
 	s := cache.NewMemoryStore(cache.WithClock(clk))
 	defer func() { _ = s.Close() }()
 
-	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), -1))
+	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), cache.WithTTL(-1)))
 	clk.Advance(1000 * time.Hour)
 	got, err := s.Get(t.Context(), "k")
 	require.NoError(t, err)
@@ -52,10 +54,10 @@ func TestMemoryStoreLRUEviction(t *testing.T) {
 	s := cache.NewMemoryStore(cache.WithMaxEntries(2))
 	defer func() { _ = s.Close() }()
 
-	require.NoError(t, s.Set(t.Context(), "a", []byte("1"), -1))
-	require.NoError(t, s.Set(t.Context(), "b", []byte("2"), -1))
+	require.NoError(t, s.Set(t.Context(), "a", []byte("1"), cache.WithTTL(-1)))
+	require.NoError(t, s.Set(t.Context(), "b", []byte("2"), cache.WithTTL(-1)))
 	_, _ = s.Get(t.Context(), "a") // touch a -> b is least-recently-used
-	require.NoError(t, s.Set(t.Context(), "c", []byte("3"), -1))
+	require.NoError(t, s.Set(t.Context(), "c", []byte("3"), cache.WithTTL(-1)))
 
 	_, err := s.Get(t.Context(), "b")
 	assert.ErrorIs(t, err, cache.ErrNotFound)
@@ -67,9 +69,9 @@ func TestMemoryStoreDeletePrefix(t *testing.T) {
 	s := cache.NewMemoryStore()
 	defer func() { _ = s.Close() }()
 
-	require.NoError(t, s.Set(t.Context(), "a:1", []byte("x"), -1))
-	require.NoError(t, s.Set(t.Context(), "a:2", []byte("x"), -1))
-	require.NoError(t, s.Set(t.Context(), "b:1", []byte("x"), -1))
+	require.NoError(t, s.Set(t.Context(), "a:1", []byte("x"), cache.WithTTL(-1)))
+	require.NoError(t, s.Set(t.Context(), "a:2", []byte("x"), cache.WithTTL(-1)))
+	require.NoError(t, s.Set(t.Context(), "b:1", []byte("x"), cache.WithTTL(-1)))
 
 	require.NoError(t, s.DeletePrefix(t.Context(), "a:"))
 	_, err := s.Get(t.Context(), "a:1")
@@ -83,7 +85,7 @@ func TestMemoryStoreClosedRejects(t *testing.T) {
 	s := cache.NewMemoryStore()
 	require.NoError(t, s.Close())
 	require.NoError(t, s.Close()) // idempotent
-	err := s.Set(t.Context(), "k", []byte("v"), 0)
+	err := s.Set(t.Context(), "k", []byte("v"))
 	assert.ErrorIs(t, err, cache.ErrClosed)
 }
 
@@ -91,7 +93,47 @@ func TestMemoryStoreClosedRejects(t *testing.T) {
 // The janitor uses a real ticker, so this asserts no panic/leak, not timing.
 func TestMemoryStoreJanitorStartsAndStops(t *testing.T) {
 	s := cache.NewMemoryStore(cache.WithCleanupInterval(5 * time.Millisecond))
-	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), time.Millisecond))
+	require.NoError(t, s.Set(t.Context(), "k", []byte("v"), cache.WithTTL(time.Millisecond)))
 	time.Sleep(20 * time.Millisecond) // let the ticker fire at least once
 	require.NoError(t, s.Close())     // must stop the goroutine cleanly
+}
+
+func TestMemoryStoreSetNonExistClaimsOnce(t *testing.T) {
+	s := cache.NewMemoryStore()
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, s.Set(t.Context(), "k", []byte("first"), cache.WithSetNonExist()))
+	assert.ErrorIs(t, s.Set(t.Context(), "k", []byte("second"), cache.WithSetNonExist()), cache.ErrExists)
+
+	got, _ := s.Get(t.Context(), "k")
+	assert.Equal(t, []byte("first"), got) // original not overwritten
+}
+
+func TestMemoryStoreSetNonExistReclaimsExpired(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	s := cache.NewMemoryStore(cache.WithClock(clk))
+	defer func() { _ = s.Close() }()
+
+	require.NoError(t, s.Set(t.Context(), "k", []byte("old"), cache.WithSetNonExist(), cache.WithTTL(time.Second)))
+	clk.Advance(2 * time.Second) // entry now expired
+	require.NoError(t, s.Set(t.Context(), "k", []byte("new"), cache.WithSetNonExist()))
+	got, _ := s.Get(t.Context(), "k")
+	assert.Equal(t, []byte("new"), got)
+}
+
+func TestMemoryStoreSetNonExistConcurrent(t *testing.T) {
+	s := cache.NewMemoryStore()
+	defer func() { _ = s.Close() }()
+
+	var wins atomic.Int32
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			if err := s.Set(t.Context(), "k", []byte("v"), cache.WithSetNonExist()); err == nil {
+				wins.Add(1)
+			}
+		})
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), wins.Load()) // exactly one claim wins
 }

--- a/resilience/cache/redis/redis.go
+++ b/resilience/cache/redis/redis.go
@@ -32,12 +32,22 @@ func (s *store) Get(ctx context.Context, key string) ([]byte, error) {
 	return b, nil
 }
 
-func (s *store) Set(ctx context.Context, key string, val []byte, ttl time.Duration) error {
-	var exp time.Duration // ttl <= 0 -> 0 -> no expiry in Redis
-	if ttl > 0 {
-		exp = ttl
+func (s *store) Set(ctx context.Context, key string, val []byte, opts ...cache.SetOption) error {
+	o := cache.ApplySetOptions(opts...)
+	var ttl time.Duration
+	if o.TTL > 0 {
+		ttl = o.TTL // SetArgs treats TTL <= 0 as "no expiry"
 	}
-	return s.client.Set(ctx, key, val, exp).Err()
+	if o.OnlyIfNew {
+		// SET key val NX [PX ttl] — the modern replacement for SETNX. On a
+		// present key the server returns a null reply, surfaced as redis.Nil.
+		err := s.client.SetArgs(ctx, key, val, goredis.SetArgs{Mode: "NX", TTL: ttl}).Err()
+		if forgeredis.IsNil(err) {
+			return cache.ErrExists
+		}
+		return err
+	}
+	return s.client.Set(ctx, key, val, ttl).Err()
 }
 
 func (s *store) Delete(ctx context.Context, key string) error {

--- a/resilience/cache/redis/redis_test.go
+++ b/resilience/cache/redis/redis_test.go
@@ -92,3 +92,18 @@ func TestRedisStoreSetNonExistClaimsOnce(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte("first"), got) // NX did not overwrite the original
 }
+
+func TestRedisStoreSetNonExistWithoutTTLPersists(t *testing.T) {
+	client := testClient(t) // SKIPs without TEST_REDIS_URL
+	store := cacheredis.NewStore(client)
+
+	key := "test:cache:nx:nottl"
+	t.Cleanup(func() { _ = store.Delete(context.Background(), key) })
+
+	// NX claim with no WithTTL: SET key val NX with no PX. The claim still wins,
+	// a live-key reclaim is still rejected, and — since no PX is sent — the key
+	// has no expiry (redis reports TTL -1 for a persistent key).
+	require.NoError(t, store.Set(t.Context(), key, []byte("v"), cache.WithSetNonExist()))
+	assert.ErrorIs(t, store.Set(t.Context(), key, []byte("w"), cache.WithSetNonExist()), cache.ErrExists)
+	assert.Equal(t, time.Duration(-1), client.TTL(t.Context(), key).Val())
+}

--- a/resilience/cache/redis/redis_test.go
+++ b/resilience/cache/redis/redis_test.go
@@ -73,3 +73,22 @@ func TestRedisStoreDeletePrefixMatchesLiterally(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "keep", kept)
 }
+
+func TestRedisStoreSetNonExistClaimsOnce(t *testing.T) {
+	store := cacheredis.NewStore(testClient(t)) // SKIPs without TEST_REDIS_URL
+
+	key := "test:cache:nx:claim"
+	t.Cleanup(func() { _ = store.Delete(context.Background(), key) })
+
+	// First NX claim wins and takes a lease (SET key val NX PX ttl).
+	require.NoError(t, store.Set(t.Context(), key, []byte("first"), cache.WithSetNonExist(), cache.WithTTL(time.Minute)))
+
+	// A second NX claim on the live key is rejected: the server returns a null
+	// reply (redis.Nil), which the backend maps to cache.ErrExists.
+	err := store.Set(t.Context(), key, []byte("second"), cache.WithSetNonExist(), cache.WithTTL(time.Minute))
+	assert.ErrorIs(t, err, cache.ErrExists)
+
+	got, err := store.Get(t.Context(), key)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("first"), got) // NX did not overwrite the original
+}

--- a/resilience/cache/redis/redis_test.go
+++ b/resilience/cache/redis/redis_test.go
@@ -35,8 +35,8 @@ func TestRedisStoreRoundTripAndScopedClear(t *testing.T) {
 	users := cache.New[string](store, cache.WithPrefix("test:cache:users:"))
 	other := cache.New[string](store, cache.WithPrefix("test:cache:other:"))
 
-	require.NoError(t, users.Set(t.Context(), "1", "alice", time.Minute))
-	require.NoError(t, other.Set(t.Context(), "1", "keep", time.Minute))
+	require.NoError(t, users.Set(t.Context(), "1", "alice", cache.WithTTL(time.Minute)))
+	require.NoError(t, other.Set(t.Context(), "1", "keep", cache.WithTTL(time.Minute)))
 
 	v, err := users.Get(t.Context(), "1")
 	require.NoError(t, err)
@@ -61,8 +61,8 @@ func TestRedisStoreDeletePrefixMatchesLiterally(t *testing.T) {
 	target := cache.New[string](store, cache.WithPrefix("test:cache:g[x]:"))
 	sibling := cache.New[string](store, cache.WithPrefix("test:cache:gx:"))
 
-	require.NoError(t, target.Set(t.Context(), "1", "gone", time.Minute))
-	require.NoError(t, sibling.Set(t.Context(), "1", "keep", time.Minute))
+	require.NoError(t, target.Set(t.Context(), "1", "gone", cache.WithTTL(time.Minute)))
+	require.NoError(t, sibling.Set(t.Context(), "1", "keep", cache.WithTTL(time.Minute)))
 
 	require.NoError(t, target.Clear(t.Context()))
 

--- a/resilience/cache/store.go
+++ b/resilience/cache/store.go
@@ -7,17 +7,55 @@ import (
 	"time"
 )
 
-// Store is a byte-level key/value backend with TTL. Implementations are
-// standalone instances whose lifecycle (background goroutines, connections) is
-// owned by the caller via Close. TTL semantics: >0 expires after the duration,
-// 0 means the store's own default (none for the memory store), <0 never expires.
+// Store is a byte-level key/value backend with optional per-entry TTL.
+// Implementations are standalone instances whose lifecycle (background
+// goroutines, connections) is owned by the caller via Close.
+//
+// Set is configured with SetOption values: WithTTL sets an expiry (no option
+// means no expiry), WithSetNonExist makes the write conditional and returns
+// ErrExists when the key already exists. Implementations resolve options with
+// ApplySetOptions so every backend behaves identically.
 type Store interface {
 	Get(ctx context.Context, key string) ([]byte, error)
-	Set(ctx context.Context, key string, val []byte, ttl time.Duration) error
+	Set(ctx context.Context, key string, val []byte, opts ...SetOption) error
 	Delete(ctx context.Context, key string) error
 	Has(ctx context.Context, key string) (bool, error)
 	DeletePrefix(ctx context.Context, prefix string) error
 	Close() error
+}
+
+// SetOptions holds the resolved settings for one Set call. It is exported
+// because Store implementations in sibling packages (e.g. cache/redis) apply
+// SetOption values and read the result. The zero value means: never expire,
+// overwrite an existing key.
+type SetOptions struct {
+	// TTL expires the entry after the duration. A value <= 0 means no expiry.
+	TTL time.Duration
+	// OnlyIfNew stores the value only when the key is absent or expired; on a
+	// live key Set writes nothing and returns ErrExists.
+	OnlyIfNew bool
+}
+
+// SetOption configures a single Set call.
+type SetOption func(*SetOptions)
+
+// WithTTL expires the written entry after d. Without it the entry never
+// expires; a non-positive d is equivalent to omitting the option.
+func WithTTL(d time.Duration) SetOption { return func(o *SetOptions) { o.TTL = d } }
+
+// WithSetNonExist stores the value only if the key is absent or expired. On a
+// live key Set writes nothing and returns ErrExists. Combined with WithTTL it
+// is an atomic claim-with-lease (set-if-absent + expiry).
+func WithSetNonExist() SetOption { return func(o *SetOptions) { o.OnlyIfNew = true } }
+
+// ApplySetOptions resolves opts into a SetOptions so every backend applies the
+// options identically.
+func ApplySetOptions(opts ...SetOption) SetOptions {
+	var o SetOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
 }
 
 // Marshaler serializes cache values to and from bytes.

--- a/resilience/circuitbreaker/circuitbreaker.go
+++ b/resilience/circuitbreaker/circuitbreaker.go
@@ -132,12 +132,21 @@ func (b *Breaker) RetryAfter() time.Duration {
 }
 
 // Do runs fn unless the circuit rejects it, recording the outcome. It returns
-// ErrOpen without calling fn when the circuit is open.
+// ErrOpen without calling fn when the circuit is open. If fn panics, Do records
+// the panic as a failure — so a half-open probe releases its slot and the
+// breaker reopens instead of wedging — and then lets the panic propagate.
 func (b *Breaker) Do(ctx context.Context, fn func(context.Context) error) error {
 	if err := b.before(); err != nil {
 		return err
 	}
+	completed := false
+	defer func() {
+		if !completed {
+			b.after(errPanic) // fn panicked: record a failure, then the panic unwinds
+		}
+	}()
 	err := fn(ctx)
+	completed = true
 	b.after(err)
 	return err
 }

--- a/resilience/circuitbreaker/circuitbreaker.go
+++ b/resilience/circuitbreaker/circuitbreaker.go
@@ -96,13 +96,18 @@ type Breaker struct {
 	mu         sync.Mutex
 }
 
-// New builds a Breaker from options.
-func New(opts ...Option) *Breaker {
+// newConfig applies opts over the defaults. Shared by New and Group.
+func newConfig(opts ...Option) config {
 	c := config{threshold: 5, openTimeout: 30 * time.Second, halfOpenMax: 1, clk: clock.System()}
 	for _, o := range opts {
 		o(&c)
 	}
-	return &Breaker{cfg: c, state: StateClosed}
+	return c
+}
+
+// New builds a Breaker from options.
+func New(opts ...Option) *Breaker {
+	return &Breaker{cfg: newConfig(opts...), state: StateClosed}
 }
 
 // State reports the current state.
@@ -110,6 +115,20 @@ func (b *Breaker) State() State {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.state
+}
+
+// RetryAfter reports how long until the breaker would admit a probe call, or 0
+// when it is not open.
+func (b *Breaker) RetryAfter() time.Duration {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.state != StateOpen {
+		return 0
+	}
+	if remaining := b.cfg.openTimeout - b.cfg.clk.Now().Sub(b.openedAt); remaining > 0 {
+		return remaining
+	}
+	return 0
 }
 
 // Do runs fn unless the circuit rejects it, recording the outcome. It returns
@@ -128,15 +147,16 @@ func (b *Breaker) before() error {
 	defer b.mu.Unlock()
 	switch b.state {
 	case StateOpen:
-		if b.cfg.clk.Now().Sub(b.openedAt) < b.cfg.openTimeout {
-			return ErrOpen
+		elapsed := b.cfg.clk.Now().Sub(b.openedAt)
+		if elapsed < b.cfg.openTimeout {
+			return &openError{retryAfter: b.cfg.openTimeout - elapsed}
 		}
 		b.transition(StateHalfOpen)
 		b.halfOpenIn = 1
 		return nil
 	case StateHalfOpen:
 		if b.halfOpenIn >= b.cfg.halfOpenMax {
-			return ErrOpen
+			return &openError{retryAfter: 0} // a probe is in flight; retry shortly
 		}
 		b.halfOpenIn++
 		return nil

--- a/resilience/circuitbreaker/circuitbreaker_test.go
+++ b/resilience/circuitbreaker/circuitbreaker_test.go
@@ -133,3 +133,32 @@ func TestRetryAfterShrinksAndZeroesOut(t *testing.T) {
 	clk.Advance(30 * time.Second) // past the open window
 	assert.Equal(t, time.Duration(0), b.RetryAfter())
 }
+
+func TestBreakerDoPanicRepanicsAndDoesNotWedge(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	b := circuitbreaker.New(
+		circuitbreaker.WithFailureThreshold(1),
+		circuitbreaker.WithOpenTimeout(30*time.Second),
+		circuitbreaker.WithClock(clk),
+	)
+	_ = b.Do(t.Context(), fail) // trip to open
+	require.Equal(t, circuitbreaker.StateOpen, b.State())
+
+	clk.Advance(30 * time.Second) // window elapsed -> next call is admitted as a half-open probe
+
+	// The half-open probe panics. Do must let the panic propagate AND record the
+	// failure so the half-open slot is released; otherwise the breaker wedges in
+	// StateHalfOpen with halfOpenIn >= halfOpenMax forever, rejecting every call.
+	assert.Panics(t, func() {
+		_ = b.Do(t.Context(), func(context.Context) error { panic("boom") })
+	})
+
+	// Not wedged: the recorded panic reopened the breaker rather than leaving it
+	// stuck half-open.
+	require.Equal(t, circuitbreaker.StateOpen, b.State())
+
+	// And it still recovers: after the window a successful probe closes it.
+	clk.Advance(30 * time.Second)
+	require.NoError(t, b.Do(t.Context(), ok))
+	assert.Equal(t, circuitbreaker.StateClosed, b.State())
+}

--- a/resilience/circuitbreaker/circuitbreaker_test.go
+++ b/resilience/circuitbreaker/circuitbreaker_test.go
@@ -100,3 +100,35 @@ func TestHalfOpenMaxAdmitsConcurrentProbesThenRejects(t *testing.T) {
 	// Both probes succeeded → breaker closed.
 	assert.Equal(t, circuitbreaker.StateClosed, b.State())
 }
+
+func TestOpenErrorIsMatchableAndCarriesRetryAfter(t *testing.T) {
+	b := circuitbreaker.New(
+		circuitbreaker.WithFailureThreshold(1),
+		circuitbreaker.WithOpenTimeout(30*time.Second),
+	)
+	_ = b.Do(t.Context(), fail)  // trips open after one failure
+	err := b.Do(t.Context(), ok) // rejected; ok is not run
+
+	assert.ErrorIs(t, err, circuitbreaker.ErrOpen)
+	var ra interface{ RetryAfter() time.Duration }
+	assert.ErrorAs(t, err, &ra)
+	d := ra.RetryAfter()
+	assert.Greater(t, d, time.Duration(0))
+	assert.LessOrEqual(t, d, 30*time.Second)
+}
+
+func TestRetryAfterShrinksAndZeroesOut(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	b := circuitbreaker.New(
+		circuitbreaker.WithFailureThreshold(1),
+		circuitbreaker.WithOpenTimeout(30*time.Second),
+		circuitbreaker.WithClock(clk),
+	)
+	_ = b.Do(t.Context(), fail)
+
+	assert.Equal(t, 30*time.Second, b.RetryAfter())
+	clk.Advance(10 * time.Second)
+	assert.Equal(t, 20*time.Second, b.RetryAfter())
+	clk.Advance(30 * time.Second) // past the open window
+	assert.Equal(t, time.Duration(0), b.RetryAfter())
+}

--- a/resilience/circuitbreaker/circuitbreaker_test.go
+++ b/resilience/circuitbreaker/circuitbreaker_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/resilience/circuitbreaker"
@@ -111,8 +112,8 @@ func TestOpenErrorIsMatchableAndCarriesRetryAfter(t *testing.T) {
 
 	assert.ErrorIs(t, err, circuitbreaker.ErrOpen)
 	var ra interface{ RetryAfter() time.Duration }
-	assert.ErrorAs(t, err, &ra)
-	d := ra.RetryAfter()
+	require.ErrorAs(t, err, &ra)
+	d := ra.RetryAfter() //nolint:nilaway // ra is guaranteed non-nil by require.ErrorAs above
 	assert.Greater(t, d, time.Duration(0))
 	assert.LessOrEqual(t, d, 30*time.Second)
 }

--- a/resilience/circuitbreaker/errors.go
+++ b/resilience/circuitbreaker/errors.go
@@ -18,3 +18,8 @@ type openError struct{ retryAfter time.Duration }
 func (e *openError) Error() string             { return ErrOpen.Error() }
 func (e *openError) Unwrap() error             { return ErrOpen }
 func (e *openError) RetryAfter() time.Duration { return e.retryAfter }
+
+// errPanic is handed to after when the guarded call panics, so the panic counts
+// as a failure and a half-open probe releases its slot instead of wedging the
+// breaker. It never escapes Do — the original panic re-propagates unchanged.
+var errPanic = errors.New("circuitbreaker: panic in guarded call")

--- a/resilience/circuitbreaker/errors.go
+++ b/resilience/circuitbreaker/errors.go
@@ -1,6 +1,20 @@
 package circuitbreaker
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
 
-// ErrOpen is returned by Do when the circuit is open and the call is rejected.
+// ErrOpen is the sentinel a rejected call matches with errors.Is. The concrete
+// error returned by Do also reports a suggested retry delay via RetryAfter.
 var ErrOpen = errors.New("circuitbreaker: circuit open")
+
+// openError is returned when the breaker rejects a call. It unwraps to ErrOpen
+// (so errors.Is(err, ErrOpen) holds) and reports the delay until the next
+// probe, satisfying retry.RetryAfterError and feeding the HTTP middleware's
+// Retry-After header.
+type openError struct{ retryAfter time.Duration }
+
+func (e *openError) Error() string             { return ErrOpen.Error() }
+func (e *openError) Unwrap() error             { return ErrOpen }
+func (e *openError) RetryAfter() time.Duration { return e.retryAfter }

--- a/resilience/circuitbreaker/example_test.go
+++ b/resilience/circuitbreaker/example_test.go
@@ -1,0 +1,15 @@
+package circuitbreaker_test
+
+import (
+	"net/http"
+
+	"github.com/dmitrymomot/forge/resilience/circuitbreaker"
+)
+
+func ExampleGroupKey() {
+	g := circuitbreaker.NewGroup()
+	mux := http.NewServeMux()
+	checkout := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {})
+	mux.Handle("/checkout", circuitbreaker.GroupKey(g, "checkout")(checkout))
+	// Output:
+}

--- a/resilience/circuitbreaker/group.go
+++ b/resilience/circuitbreaker/group.go
@@ -1,0 +1,139 @@
+package circuitbreaker
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type groupConfig struct {
+	breakerOpts   []Option
+	idleTTL       time.Duration
+	sweepInterval time.Duration
+}
+
+// GroupOption configures a Group.
+type GroupOption func(*groupConfig)
+
+// WithBreakerOptions sets the options applied to every per-key breaker the
+// Group creates (including WithClock, which the Group reuses for eviction).
+func WithBreakerOptions(opts ...Option) GroupOption {
+	return func(c *groupConfig) { c.breakerOpts = opts }
+}
+
+// WithIdleTTL evicts a breaker after it has gone this long with no Do call,
+// regardless of state (default 10m). Active traffic refreshes a breaker's
+// last-access time, so a breaker in use is never evicted. Non-positive ignored.
+func WithIdleTTL(d time.Duration) GroupOption {
+	return func(c *groupConfig) {
+		if d > 0 {
+			c.idleTTL = d
+		}
+	}
+}
+
+// WithSweepInterval sets the minimum clock gap between eviction scans
+// (default 1m). Scans run during Do, at most once per interval, so an idle
+// Group does no work and holds no goroutine. Non-positive ignored.
+func WithSweepInterval(d time.Duration) GroupOption {
+	return func(c *groupConfig) {
+		if d > 0 {
+			c.sweepInterval = d
+		}
+	}
+}
+
+type groupEntry struct {
+	breaker    *Breaker
+	lastAccess time.Time
+}
+
+// Group manages breakers keyed by string, creating each on first use and
+// sharing one option set. Breakers with no Do call for longer than the idle TTL
+// are evicted opportunistically during Do, so an unbounded key space cannot
+// leak memory and no background goroutine is needed. Safe for concurrent use.
+type Group struct {
+	entries   map[string]*groupEntry
+	clk       clock.Clock
+	lastSweep time.Time
+	cfg       groupConfig
+	mu        sync.Mutex
+}
+
+// NewGroup builds a Group. Configure per-key breakers with WithBreakerOptions
+// and eviction with WithIdleTTL / WithSweepInterval.
+func NewGroup(opts ...GroupOption) *Group {
+	gc := groupConfig{idleTTL: 10 * time.Minute, sweepInterval: time.Minute}
+	for _, o := range opts {
+		o(&gc)
+	}
+	clk := newConfig(gc.breakerOpts...).clk // reuse the breaker clock
+	return &Group{
+		entries:   make(map[string]*groupEntry),
+		clk:       clk,
+		lastSweep: clk.Now(),
+		cfg:       gc,
+	}
+}
+
+// Do runs fn under key's breaker, creating it on first use. It returns an error
+// matching ErrOpen when that breaker is open.
+func (g *Group) Do(ctx context.Context, key string, fn func(context.Context) error) error {
+	return g.breaker(key).Do(ctx, fn)
+}
+
+// State reports the state of key's breaker, or StateClosed if key has no
+// breaker (never called, or evicted). Querying state is not traffic: it neither
+// refreshes last-access nor triggers a sweep.
+func (g *Group) State(key string) State {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if e, ok := g.entries[key]; ok {
+		return e.breaker.State()
+	}
+	return StateClosed
+}
+
+// Len reports the number of live breakers (for tests and metrics).
+func (g *Group) Len() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.entries)
+}
+
+// breaker returns key's breaker, creating it on first use. It refreshes the
+// requested key's last-access time BEFORE running the eviction scan, so a key
+// touched this call is never evicted this call (an in-use key always survives).
+// The scan runs at most once per sweep interval. Shared by Do and the HTTP
+// middleware.
+func (g *Group) breaker(key string) *Breaker {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	now := g.clk.Now()
+	e, ok := g.entries[key]
+	if ok {
+		e.lastAccess = now // refresh before the sweep so an active key survives
+	}
+	if now.Sub(g.lastSweep) >= g.cfg.sweepInterval {
+		g.sweepLocked(now)
+		g.lastSweep = now
+	}
+	if ok {
+		return e.breaker
+	}
+	b := New(g.cfg.breakerOpts...)
+	g.entries[key] = &groupEntry{breaker: b, lastAccess: now}
+	return b
+}
+
+// sweepLocked drops entries idle beyond idleTTL. Caller holds g.mu.
+func (g *Group) sweepLocked(now time.Time) {
+	cutoff := now.Add(-g.cfg.idleTTL)
+	for k, e := range g.entries {
+		if e.lastAccess.Before(cutoff) {
+			delete(g.entries, k)
+		}
+	}
+}

--- a/resilience/circuitbreaker/group_test.go
+++ b/resilience/circuitbreaker/group_test.go
@@ -1,6 +1,7 @@
 package circuitbreaker_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -58,4 +59,31 @@ func TestGroupActiveKeySurvivesSweep(t *testing.T) {
 	_ = g.Do(t.Context(), "a", fail)
 	assert.Equal(t, circuitbreaker.StateOpen, g.State("a"),
 		"active key's breaker must be preserved across the sweep")
+}
+
+func TestGroupConcurrentAccessIsRaceFree(t *testing.T) {
+	// Exercises Group's write path (lazy create + opportunistic sweep in
+	// breaker()) against its read paths (State/Len) across many goroutines
+	// sharing the same keys, so -race validates the mutex/sweep interaction.
+	g := circuitbreaker.NewGroup(
+		circuitbreaker.WithBreakerOptions(circuitbreaker.WithFailureThreshold(3)),
+		circuitbreaker.WithSweepInterval(time.Millisecond), // sweeps interleave with Do
+		circuitbreaker.WithIdleTTL(time.Hour),              // nothing idles out mid-test
+	)
+	keys := []string{"a", "b", "c", "d"}
+
+	var wg sync.WaitGroup
+	for i := range 64 {
+		key := keys[i%len(keys)]
+		wg.Go(func() {
+			for range 25 {
+				_ = g.Do(t.Context(), key, ok) // write path: breaker() + sweep
+				_ = g.State(key)               // read path
+				_ = g.Len()                    // read path
+			}
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, len(keys), g.Len()) // every shared key created exactly once, none lost
 }

--- a/resilience/circuitbreaker/group_test.go
+++ b/resilience/circuitbreaker/group_test.go
@@ -1,0 +1,61 @@
+package circuitbreaker_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/resilience/circuitbreaker"
+)
+
+func TestGroupLazyCreateAndIndependence(t *testing.T) {
+	g := circuitbreaker.NewGroup(circuitbreaker.WithBreakerOptions(
+		circuitbreaker.WithFailureThreshold(1),
+	))
+	assert.Equal(t, 0, g.Len())
+
+	_ = g.Do(t.Context(), "a", fail) // trips "a"
+	_ = g.Do(t.Context(), "b", ok)   // healthy "b"
+
+	assert.Equal(t, 2, g.Len())
+	assert.Equal(t, circuitbreaker.StateOpen, g.State("a"))
+	assert.Equal(t, circuitbreaker.StateClosed, g.State("b"))
+	assert.Equal(t, circuitbreaker.StateClosed, g.State("never-seen"))
+}
+
+func TestGroupEvictsIdleBreakers(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	g := circuitbreaker.NewGroup(
+		circuitbreaker.WithBreakerOptions(circuitbreaker.WithClock(clk)),
+		circuitbreaker.WithIdleTTL(time.Minute),
+		circuitbreaker.WithSweepInterval(time.Second),
+	)
+	_ = g.Do(t.Context(), "a", ok) // create "a" at t0
+	clk.Advance(2 * time.Minute)
+	_ = g.Do(t.Context(), "b", ok) // sweep interval elapsed -> "a" idle > 1m -> evicted
+
+	assert.Equal(t, 1, g.Len())
+	assert.Equal(t, circuitbreaker.StateClosed, g.State("a")) // evicted -> reads Closed
+}
+
+func TestGroupActiveKeySurvivesSweep(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	g := circuitbreaker.NewGroup(
+		circuitbreaker.WithBreakerOptions(
+			circuitbreaker.WithClock(clk),
+			circuitbreaker.WithFailureThreshold(2),
+		),
+		circuitbreaker.WithIdleTTL(time.Minute),
+		circuitbreaker.WithSweepInterval(time.Second),
+	)
+	_ = g.Do(t.Context(), "a", fail) // a: 1 failure of 2 -> still Closed
+	clk.Advance(90 * time.Second)
+	// breaker() refreshes a's last-access BEFORE the sweep, so the ORIGINAL a
+	// survives and its SECOND failure trips it. A recreated breaker would be
+	// back to one failure and stay Closed — so StateOpen proves preservation.
+	_ = g.Do(t.Context(), "a", fail)
+	assert.Equal(t, circuitbreaker.StateOpen, g.State("a"),
+		"active key's breaker must be preserved across the sweep")
+}

--- a/resilience/circuitbreaker/http.go
+++ b/resilience/circuitbreaker/http.go
@@ -1,0 +1,192 @@
+package circuitbreaker
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// KeyFunc selects the breaker key for a request in GroupMiddleware. Returning
+// an empty string skips the breaker for that request.
+type KeyFunc func(*http.Request) string
+
+// KeyByHost keys a Group breaker by request Host — the common reverse-proxy
+// case, so GroupMiddleware needs no custom key code. Any func(*http.Request)
+// string works for other strategies.
+func KeyByHost(r *http.Request) string { return r.Host }
+
+// OpenResponder writes the response when the circuit is open. retryAfter is the
+// suggested delay before retrying (0 if unknown).
+type OpenResponder func(w http.ResponseWriter, r *http.Request, retryAfter time.Duration)
+
+type middlewareConfig struct {
+	isFailure func(status int) bool
+	onOpen    OpenResponder
+}
+
+// MiddlewareOption configures Middleware, GroupMiddleware, and GroupKey.
+type MiddlewareOption func(*middlewareConfig)
+
+// WithFailurePredicate classifies a downstream response status as a breaker
+// failure. Default: status >= 500. A nil predicate is ignored.
+func WithFailurePredicate(fn func(status int) bool) MiddlewareOption {
+	return func(c *middlewareConfig) {
+		if fn != nil {
+			c.isFailure = fn
+		}
+	}
+}
+
+// WithOpenResponder overrides the response written when the circuit is open.
+// The default writes 503 with a Retry-After header and a plain-text body. A nil
+// responder is ignored.
+func WithOpenResponder(fn OpenResponder) MiddlewareOption {
+	return func(c *middlewareConfig) {
+		if fn != nil {
+			c.onOpen = fn
+		}
+	}
+}
+
+func newMiddlewareConfig(opts ...MiddlewareOption) middlewareConfig {
+	c := middlewareConfig{
+		isFailure: func(status int) bool { return status >= 500 },
+		onOpen:    defaultOpenResponder,
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// Middleware guards next with b. When the circuit is open it responds via the
+// open responder (503 + Retry-After by default) without calling next. When the
+// circuit is closed it calls next; a response whose status the failure
+// predicate matches is recorded as a breaker failure, while the response itself
+// still reaches the client unchanged. The returned value is assignable to
+// web/middleware.Middleware.
+func Middleware(b *Breaker, opts ...MiddlewareOption) func(http.Handler) http.Handler {
+	cfg := newMiddlewareConfig(opts...)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			serve(b, cfg, next, w, r)
+		})
+	}
+}
+
+// GroupMiddleware guards next with a per-request breaker chosen by key from g.
+// A request whose key is empty bypasses the breaker. Otherwise identical to
+// Middleware.
+func GroupMiddleware(g *Group, key KeyFunc, opts ...MiddlewareOption) func(http.Handler) http.Handler {
+	cfg := newMiddlewareConfig(opts...)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			k := key(r)
+			if k == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			serve(g.breaker(k), cfg, next, w, r)
+		})
+	}
+}
+
+// GroupKey guards next with the breaker named key from g — a fixed key chosen
+// at wrap time, so a specific route handler gets its own breaker within one
+// managed Group (shared options, unified eviction and introspection). An empty
+// key bypasses the breaker.
+func GroupKey(g *Group, key string, opts ...MiddlewareOption) func(http.Handler) http.Handler {
+	cfg := newMiddlewareConfig(opts...)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if key == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			serve(g.breaker(key), cfg, next, w, r)
+		})
+	}
+}
+
+// errDownstreamFailure signals to the breaker that the guarded handler produced
+// a failure status. It never leaves the middleware.
+var errDownstreamFailure = errors.New("circuitbreaker: downstream failure")
+
+func serve(b *Breaker, cfg middlewareConfig, next http.Handler, w http.ResponseWriter, r *http.Request) {
+	rec := &statusRecorder{ResponseWriter: w}
+	err := b.Do(r.Context(), func(ctx context.Context) error {
+		next.ServeHTTP(rec, r.WithContext(ctx))
+		if cfg.isFailure(rec.status()) {
+			return errDownstreamFailure
+		}
+		return nil
+	})
+	if err == nil || errors.Is(err, errDownstreamFailure) {
+		return // downstream already wrote its response (success or a matched failure)
+	}
+	var oe *openError
+	if errors.As(err, &oe) {
+		cfg.onOpen(w, r, oe.retryAfter)
+	}
+}
+
+func defaultOpenResponder(w http.ResponseWriter, _ *http.Request, retryAfter time.Duration) {
+	if secs := retryAfterSeconds(retryAfter); secs > 0 {
+		w.Header().Set("Retry-After", strconv.Itoa(secs))
+	}
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_, _ = w.Write([]byte("service unavailable: circuit open\n"))
+}
+
+// retryAfterSeconds rounds a positive delay up to whole seconds (Retry-After is
+// second-granular). Returns 0 for a non-positive delay so the header is omitted.
+func retryAfterSeconds(d time.Duration) int {
+	if d <= 0 {
+		return 0
+	}
+	secs := int(d / time.Second)
+	if d%time.Second != 0 {
+		secs++
+	}
+	return secs
+}
+
+// statusRecorder captures the response status for failure classification while
+// passing writes through unchanged. It exposes the underlying writer via Unwrap
+// so http.ResponseController reaches optional interfaces (Flusher for
+// SSE/streaming, Hijacker, SetWriteDeadline, …) without falsely advertising
+// them when the underlying writer lacks them.
+type statusRecorder struct {
+	http.ResponseWriter
+	code  int
+	wrote bool
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	if r.wrote {
+		return
+	}
+	r.code = code
+	r.wrote = true
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if !r.wrote {
+		r.WriteHeader(http.StatusOK)
+	}
+	return r.ResponseWriter.Write(b)
+}
+
+// status returns the committed status, or 200 when the handler wrote a body or
+// nothing without an explicit WriteHeader (net/http's implicit 200).
+func (r *statusRecorder) status() int {
+	if !r.wrote {
+		return http.StatusOK
+	}
+	return r.code
+}
+
+func (r *statusRecorder) Unwrap() http.ResponseWriter { return r.ResponseWriter }

--- a/resilience/circuitbreaker/http.go
+++ b/resilience/circuitbreaker/http.go
@@ -126,8 +126,7 @@ func serve(b *Breaker, cfg middlewareConfig, next http.Handler, w http.ResponseW
 	if err == nil || errors.Is(err, errDownstreamFailure) {
 		return // downstream already wrote its response (success or a matched failure)
 	}
-	var oe *openError
-	if errors.As(err, &oe) {
+	if oe, ok := errors.AsType[*openError](err); ok {
 		cfg.onOpen(w, r, oe.retryAfter)
 	}
 }

--- a/resilience/circuitbreaker/http.go
+++ b/resilience/circuitbreaker/http.go
@@ -15,6 +15,12 @@ type KeyFunc func(*http.Request) string
 // KeyByHost keys a Group breaker by request Host — the common reverse-proxy
 // case, so GroupMiddleware needs no custom key code. Any func(*http.Request)
 // string works for other strategies.
+//
+// Each distinct Host creates a breaker in the Group, reclaimed only after the
+// Group's idle TTL. Behind a trusted proxy that normalizes Host to a bounded
+// set this is fine; on an untrusted edge, arbitrary Host headers grow the key
+// space until they idle out, so front it with an allowlist or a bounded key
+// func there.
 func KeyByHost(r *http.Request) string { return r.Host }
 
 // OpenResponder writes the response when the circuit is open. retryAfter is the

--- a/resilience/circuitbreaker/http_test.go
+++ b/resilience/circuitbreaker/http_test.go
@@ -1,0 +1,87 @@
+package circuitbreaker_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/resilience/circuitbreaker"
+)
+
+// runMW serves one request through mw(h) and returns the recorder.
+func runMW(mw func(http.Handler) http.Handler, h http.Handler, method, target string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	mw(h).ServeHTTP(rec, httptest.NewRequest(method, target, nil))
+	return rec
+}
+
+// status returns a handler that writes the given status code.
+func status(code int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(code) })
+}
+
+func TestMiddlewarePassesThroughWhenClosed(t *testing.T) {
+	rec := runMW(circuitbreaker.Middleware(circuitbreaker.New()), status(200), "GET", "/")
+	assert.Equal(t, 200, rec.Code)
+}
+
+func TestMiddlewareTripsAndReturns503WithRetryAfter(t *testing.T) {
+	b := circuitbreaker.New(circuitbreaker.WithFailureThreshold(1), circuitbreaker.WithOpenTimeout(30*time.Second))
+	mw := circuitbreaker.Middleware(b)
+
+	assert.Equal(t, 500, runMW(mw, status(500), "GET", "/").Code) // downstream 500 reaches client
+	rec := runMW(mw, status(500), "GET", "/")                     // breaker now open
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.NotEmpty(t, rec.Header().Get("Retry-After"))
+}
+
+func TestMiddlewareCustomFailurePredicate(t *testing.T) {
+	b := circuitbreaker.New(circuitbreaker.WithFailureThreshold(1))
+	mw := circuitbreaker.Middleware(b, circuitbreaker.WithFailurePredicate(func(s int) bool { return s == 429 }))
+
+	_ = runMW(mw, status(429), "GET", "/") // 429 counts as failure -> opens
+	assert.Equal(t, http.StatusServiceUnavailable, runMW(mw, status(429), "GET", "/").Code)
+}
+
+func TestMiddlewareCustomOpenResponder(t *testing.T) {
+	b := circuitbreaker.New(circuitbreaker.WithFailureThreshold(1))
+	mw := circuitbreaker.Middleware(b, circuitbreaker.WithOpenResponder(
+		func(w http.ResponseWriter, _ *http.Request, _ time.Duration) {
+			w.WriteHeader(http.StatusTooManyRequests)
+		}))
+
+	_ = runMW(mw, status(500), "GET", "/")
+	assert.Equal(t, http.StatusTooManyRequests, runMW(mw, status(500), "GET", "/").Code)
+}
+
+func TestGroupKeyStaticKey(t *testing.T) {
+	g := circuitbreaker.NewGroup(circuitbreaker.WithBreakerOptions(circuitbreaker.WithFailureThreshold(1)))
+	mw := circuitbreaker.GroupKey(g, "checkout")
+
+	_ = runMW(mw, status(500), "GET", "/")
+	assert.Equal(t, http.StatusServiceUnavailable, runMW(mw, status(500), "GET", "/").Code)
+	assert.Equal(t, circuitbreaker.StateOpen, g.State("checkout"))
+}
+
+func TestGroupKeyEmptyBypasses(t *testing.T) {
+	g := circuitbreaker.NewGroup()
+	assert.Equal(t, 204, runMW(circuitbreaker.GroupKey(g, ""), status(204), "GET", "/").Code)
+	assert.Equal(t, 0, g.Len())
+}
+
+func TestGroupMiddlewareKeyByHostIndependent(t *testing.T) {
+	g := circuitbreaker.NewGroup(circuitbreaker.WithBreakerOptions(circuitbreaker.WithFailureThreshold(1)))
+	mw := circuitbreaker.GroupMiddleware(g, circuitbreaker.KeyByHost)
+
+	trip := func(host string) int {
+		rec := httptest.NewRecorder()
+		mw(status(500)).ServeHTTP(rec, httptest.NewRequest("GET", "http://"+host+"/", nil))
+		return rec.Code
+	}
+	_ = trip("a.example")
+	_ = trip("a.example")                   // a.example now open
+	assert.Equal(t, 500, trip("b.example")) // b.example independent -> its 500 reaches client
+}

--- a/resilience/retry/doc.go
+++ b/resilience/retry/doc.go
@@ -10,4 +10,8 @@
 // Wrap an error with retry.Permanent to stop early:
 //
 //	return retry.Permanent(errBadRequest)
+//
+// An error implementing RetryAfterError (RetryAfter() time.Duration) raises the
+// wait before the next attempt to at least the reported duration — e.g. an HTTP
+// 429/503 Retry-After or a circuitbreaker open error is honored automatically.
 package retry

--- a/resilience/retry/errors.go
+++ b/resilience/retry/errors.go
@@ -1,0 +1,13 @@
+package retry
+
+import "time"
+
+// RetryAfterError is implemented by errors that carry a minimum delay before
+// the next attempt — e.g. an HTTP 429/503 with a Retry-After header, or a
+// circuitbreaker open error. Retrier.Do treats the reported duration as a
+// floor: it waits at least this long before the next attempt, even beyond the
+// backoff ceiling. The context deadline still bounds the total.
+type RetryAfterError interface {
+	error
+	RetryAfter() time.Duration
+}

--- a/resilience/retry/retry.go
+++ b/resilience/retry/retry.go
@@ -95,7 +95,14 @@ func (r *Retrier) Do(ctx context.Context, fn func(context.Context) error) error 
 		if attempt == r.cfg.maxAttempts {
 			break
 		}
-		timer := time.NewTimer(r.cfg.backoff.Next(attempt))
+		// Wait per the backoff, raised to any server/breaker-stated floor.
+		wait := r.cfg.backoff.Next(attempt)
+		if ra, ok := errors.AsType[RetryAfterError](err); ok {
+			if hint := ra.RetryAfter(); hint > wait {
+				wait = hint
+			}
+		}
+		timer := time.NewTimer(wait)
 		select {
 		case <-ctx.Done():
 			timer.Stop()

--- a/resilience/retry/retry_test.go
+++ b/resilience/retry/retry_test.go
@@ -3,6 +3,7 @@ package retry_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -97,4 +98,60 @@ func TestWithBackoffNilIgnored(t *testing.T) {
 	}, retry.WithBackoff(nil))
 	assert.Error(t, err)
 	assert.Equal(t, 1, calls)
+}
+
+type retryAfterErr struct{ d time.Duration }
+
+func (e retryAfterErr) Error() string             { return "slow down" }
+func (e retryAfterErr) RetryAfter() time.Duration { return e.d }
+
+func TestRetryAfterRaisesDelayToFloor(t *testing.T) {
+	var attempts int
+	start := time.Now()
+	err := retry.Do(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts < 2 {
+			return retryAfterErr{d: 120 * time.Millisecond}
+		}
+		return nil
+	},
+		retry.WithMaxAttempts(2),
+		retry.WithBackoff(backoff.Constant(1*time.Millisecond)), // far below the hint
+	)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("waited %v, want >= ~120ms (the RetryAfter floor)", elapsed)
+	}
+}
+
+func TestRetryAfterHonoredThroughWrappedError(t *testing.T) {
+	var attempts int
+	start := time.Now()
+	_ = retry.Do(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts < 2 {
+			return fmt.Errorf("wrapped: %w", retryAfterErr{d: 120 * time.Millisecond})
+		}
+		return nil
+	}, retry.WithMaxAttempts(2), retry.WithBackoff(backoff.Constant(1*time.Millisecond)))
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("waited %v, want >= ~120ms via wrapped hint", elapsed)
+	}
+}
+
+func TestRetryAfterBelowBackoffKeepsBackoff(t *testing.T) {
+	var attempts int
+	start := time.Now()
+	_ = retry.Do(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts < 2 {
+			return retryAfterErr{d: 1 * time.Millisecond} // below backoff
+		}
+		return nil
+	}, retry.WithMaxAttempts(2), retry.WithBackoff(backoff.Constant(80*time.Millisecond)))
+	if elapsed := time.Since(start); elapsed < 60*time.Millisecond {
+		t.Fatalf("waited %v, want >= ~80ms (backoff wins)", elapsed)
+	}
 }


### PR DESCRIPTION
## Summary

Adds three seam features across the shipped `resilience/` packages so a future `web/httpclient` can build on them. Each is an additive/edit change to an existing package; no new packages.

- **`resilience/cache` — options-based `Set` + atomic NX claim.** `Store.Set(…, ttl)` becomes `Set(…, ...SetOption)` (`WithTTL`, `WithSetNonExist`), resolved via an exported `ApplySetOptions` so the `cache/redis` sibling applies options identically. `WithSetNonExist` is an atomic set-if-absent that returns the new `ErrExists` sentinel on a live key — an idempotency/once primitive. Memory backend claims under one lock (no TOCTOU); redis backend uses `SET … NX [PX ttl]` via `goredis.SetArgs`, mapping `redis.Nil` → `ErrExists`.
- **`resilience/circuitbreaker` — keyed `Group`, HTTP middleware, dynamic open error.** A rejected call now returns an error that unwraps to `ErrOpen` and reports `RetryAfter()`. New `Breaker.RetryAfter()`. New keyed `Group` lazily creates one breaker per string key with opportunistic idle-TTL eviction (no background goroutine); an in-use key always survives its own sweep. New `net/http`-only middleware (`Middleware`, `GroupMiddleware`, `GroupKey`, `KeyByHost`) responds 503 + `Retry-After` when open, records ≥500 downstream responses as failures while passing the response through unchanged.
- **`resilience/retry` — honor `RetryAfterError` as a delay floor.** `Do` raises the per-attempt wait to at least any `RetryAfter()` reported by the returned error (directly or `%w`-wrapped), bounded by the context deadline. The circuitbreaker open error satisfies this **structurally, with no import between the two packages**.

## Constraints honored

- Go 1.26; black-box tests only; options pattern (no builders).
- No global/shared mutable state (only immutable error sentinels + stateless funcs/types at package level).
- `resilience/` imports no `web/` package — the middleware is `net/http` only (verified: `go list -deps` shows zero `forge/web` deps).

## Testing / verification

- `go test ./... -race` — all packages pass (redis integration tests skip without `TEST_REDIS_URL`).
- `just lint` — 0 issues (vet, build, golangci-lint, nilaway, betteralign, modernize).
- Each feature landed test-first (RED→GREEN); the interface flip lands memory + facade + redis together in one green commit.
- A multi-lens adversarial final review (cross-package composition, correctness/concurrency, API design, test integrity) surfaced 2 candidate findings, both refuted on tracing; the one legitimate coverage gap (redis NX path) was closed with an added integration test.

## Follow-up (post-merge, not in this PR)

`docs/packages.md` is intentionally untouched here. After merge, drop the three now-completed "Shipped-package work items" rows (cache atomic SetNX, circuitbreaker keyed Group + HTTP middleware, retry `RetryAfter` floor).
