### PR TITLE
feat: Wave 1 unblocker bundle (random/id/problem/request/middleware/supervisor/logger)

### DIFF
--- a/core/id/errors.go
+++ b/core/id/errors.go
@@ -5,3 +5,7 @@ import "errors"
 // ErrMalformed is returned by the Parse functions and by Scan when the input is
 // not a valid encoding of the target ID type. Match it with errors.Is.
 var ErrMalformed = errors.New("id: malformed")
+
+// ErrWrongPrefix is returned by Prefix.Parse (and ParsePrefixed) when the input
+// does not carry the expected "<prefix>_" head. Match it with errors.Is.
+var ErrWrongPrefix = errors.New("id: wrong prefix")

--- a/core/id/prefix.go
+++ b/core/id/prefix.go
@@ -1,0 +1,100 @@
+package id
+
+import "strings"
+
+// Prefix is an immutable, concurrency-safe Stripe-style ID codec: a human prefix
+// joined to a generated body by "_". The zero value is unusable; construct with
+// NewPrefix. Options are optional; the default body generator is Short.
+type Prefix struct {
+	gen    func() string
+	prefix string
+	joined string // prefix + "_"
+}
+
+// PrefixOption configures NewPrefix.
+type PrefixOption func(*Prefix)
+
+// WithGenerator sets the body generator — the part after "<prefix>_". The default
+// is Short (NewShort().String()); pass any func to mint ULID/UUID/random bodies,
+// e.g. WithGenerator(func() string { return NewULID().String() }). A nil gen
+// panics via NewPrefix.
+func WithGenerator(gen func() string) PrefixOption {
+	return func(p *Prefix) { p.gen = gen }
+}
+
+// NewPrefix returns a codec emitting IDs of the form "<prefix>_<body>". prefix
+// must be non-empty and match [a-z0-9]+ (Stripe convention; "_" is the separator).
+// Options are optional. It panics on an invalid prefix or a nil generator — both
+// are boot-time programming errors.
+func NewPrefix(prefix string, opts ...PrefixOption) Prefix {
+	if !validPrefix(prefix) {
+		panic("id: NewPrefix prefix must match [a-z0-9]+")
+	}
+	p := Prefix{
+		prefix: prefix,
+		joined: prefix + "_",
+		gen:    func() string { return NewShort().String() },
+	}
+	for _, o := range opts {
+		o(&p)
+	}
+	if p.gen == nil {
+		panic("id: NewPrefix generator must not be nil")
+	}
+	return p
+}
+
+// New returns a fresh ID: "<prefix>_" + gen().
+func (p Prefix) New() string { return p.joined + p.gen() }
+
+// Parse validates that s carries p's prefix and a non-empty body, returning the
+// body (the part after "<prefix>_"). Because the body generator is pluggable, the
+// body is returned opaque — for the default Short generator, decode it with
+// ParseShort. A wrong/absent prefix returns ErrWrongPrefix; an empty body returns
+// ErrMalformed.
+func (p Prefix) Parse(s string) (string, error) {
+	body, ok := strings.CutPrefix(s, p.joined)
+	if !ok {
+		return "", ErrWrongPrefix
+	}
+	if body == "" {
+		return "", ErrMalformed
+	}
+	return body, nil
+}
+
+// Is reports whether s carries p's prefix and a non-empty body. It validates the
+// prefix and body presence only, not the body's internal format.
+func (p Prefix) Is(s string) bool {
+	_, err := p.Parse(s)
+	return err == nil
+}
+
+// Prefix returns the bound prefix (for logging / diagnostics).
+func (p Prefix) Prefix() string { return p.prefix }
+
+// NewPrefixed returns a fresh "<prefix>_<short>" ID using the default Short
+// generator. Equivalent to NewPrefix(prefix).New(); it panics on an invalid prefix.
+func NewPrefixed(prefix string) string { return NewPrefix(prefix).New() }
+
+// ParsePrefixed validates prefix on s and returns the body. Equivalent to
+// NewPrefix(prefix).Parse(s).
+func ParsePrefixed(prefix, s string) (string, error) { return NewPrefix(prefix).Parse(s) }
+
+// IsPrefixed reports whether s carries prefix with a non-empty body. Equivalent to
+// NewPrefix(prefix).Is(s).
+func IsPrefixed(prefix, s string) bool { return NewPrefix(prefix).Is(s) }
+
+// validPrefix reports whether s is a non-empty [a-z0-9]+ string.
+func validPrefix(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := range len(s) {
+		c := s[i]
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}

--- a/core/id/prefix_test.go
+++ b/core/id/prefix_test.go
@@ -1,0 +1,70 @@
+package id_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+func TestPrefix_RoundTripDefault(t *testing.T) {
+	p := id.NewPrefix("user")
+	s := p.New()
+	assert.True(t, strings.HasPrefix(s, "user_"))
+	body, err := p.Parse(s)
+	require.NoError(t, err)
+	_, err = id.ParseShort(body)
+	require.NoError(t, err, "default body must decode as Short")
+	assert.True(t, p.Is(s))
+	assert.Equal(t, "user", p.Prefix())
+}
+
+func TestPrefix_CustomGenerator(t *testing.T) {
+	p := id.NewPrefix("tok", id.WithGenerator(func() string { return id.NewULID().String() }))
+	s := p.New()
+	assert.True(t, strings.HasPrefix(s, "tok_"))
+	body, err := p.Parse(s)
+	require.NoError(t, err)
+	_, err = id.ParseULID(body)
+	require.NoError(t, err)
+}
+
+func TestPrefix_WrongPrefix(t *testing.T) {
+	p := id.NewPrefix("user")
+	_, err := p.Parse("org_" + id.NewShort().String())
+	assert.ErrorIs(t, err, id.ErrWrongPrefix)
+	assert.False(t, p.Is("org_abc"))
+}
+
+func TestPrefix_EmptyBody(t *testing.T) {
+	p := id.NewPrefix("user")
+	_, err := p.Parse("user_")
+	assert.ErrorIs(t, err, id.ErrMalformed)
+}
+
+func TestPrefix_NoSeparator(t *testing.T) {
+	p := id.NewPrefix("user")
+	_, err := p.Parse("userabc")
+	assert.ErrorIs(t, err, id.ErrWrongPrefix)
+}
+
+func TestPrefixed_StaticAliases(t *testing.T) {
+	s := id.NewPrefixed("acct")
+	assert.True(t, strings.HasPrefix(s, "acct_"))
+	body, err := id.ParsePrefixed("acct", s)
+	require.NoError(t, err)
+	assert.NotEmpty(t, body)
+	assert.True(t, id.IsPrefixed("acct", s))
+	assert.False(t, id.IsPrefixed("other", s))
+}
+
+func TestPrefix_PanicsOnInvalid(t *testing.T) {
+	assert.Panics(t, func() { id.NewPrefix("") })
+	assert.Panics(t, func() { id.NewPrefix("User") })
+	assert.Panics(t, func() { id.NewPrefix("a_b") })
+	assert.Panics(t, func() { id.NewPrefix("x", id.WithGenerator(nil)) })
+	assert.Panics(t, func() { id.NewPrefixed("") })
+}

--- a/core/random/doc.go
+++ b/core/random/doc.go
@@ -5,8 +5,17 @@
 // is broken and the program cannot safely continue. Use Read for an error-returning
 // variant. Int is unbiased (rejection sampling via crypto/rand.Int).
 //
+// String draws n characters from one or more charsets (Lowercase, Uppercase, Digits,
+// Alphabetic, Alphanumeric, Symbols), defaulting to Alphanumeric when none are given.
+// Overlapping charsets are de-duplicated so the result stays uniform over distinct
+// characters. Like Bytes, it is crypto-secure and panics only on a crypto/rand
+// failure; use Read if you need the error-returning escape hatch instead. DigitCode
+// is a thin wrapper over String(n, Digits) for OTP and verification codes, preserving
+// leading zeros.
+//
 // # Usage
 //
 //	salt := random.Bytes(16)
 //	id := random.URLSafe(24)
+//	code := random.DigitCode(6)
 package random

--- a/core/random/random.go
+++ b/core/random/random.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strings"
 )
 
 // Read fills p with cryptographically secure random bytes. It is the error-returning
@@ -43,4 +44,84 @@ func Int(max int) int {
 		panic(fmt.Errorf("random: crypto/rand failed: %w", err))
 	}
 	return int(v.Int64())
+}
+
+// Charset constants for String. Each is an ASCII byte string.
+const (
+	Lowercase    = "abcdefghijklmnopqrstuvwxyz"
+	Uppercase    = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	Digits       = "0123456789"
+	Alphabetic   = Lowercase + Uppercase
+	Alphanumeric = Alphabetic + Digits
+	Symbols      = "~!@#$%^&*()-_+={}[]|\\;:\"<>,./?`"
+)
+
+// String returns a cryptographically secure random string of n characters drawn
+// uniformly (bias-free, via crypto/rand rejection sampling) from the concatenation
+// of charsets. With no charsets it defaults to Alphanumeric. Overlapping charsets
+// are de-duplicated (first occurrence wins) so the distribution stays uniform over
+// the distinct characters. The charset is treated as bytes; multi-byte UTF-8
+// alphabets are not supported. It panics if n < 0 or the combined charset is empty.
+func String(n int, charsets ...string) string {
+	if n < 0 {
+		panic("random: String n must be >= 0")
+	}
+	set := dedupeCharset(charsets)
+	k := len(set)
+	if k == 0 {
+		panic("random: String charset is empty")
+	}
+	if n == 0 {
+		return ""
+	}
+	out := make([]byte, n)
+	// limit is the largest multiple of k within a byte; bytes at or above it are
+	// rejected to remove modulo bias. De-duping over bytes guarantees k <= 256.
+	limit := 256 - (256 % k)
+	buf := make([]byte, n)
+	bi := len(buf) // force an initial fill
+	for i := 0; i < n; {
+		if bi >= len(buf) {
+			if _, err := rand.Read(buf); err != nil {
+				panic(fmt.Errorf("random: crypto/rand failed: %w", err))
+			}
+			bi = 0
+		}
+		b := int(buf[bi])
+		bi++
+		if b < limit {
+			out[i] = set[b%k]
+			i++
+		}
+	}
+	return string(out)
+}
+
+// DigitCode returns an n-digit decimal string with leading zeros preserved,
+// suitable for OTP and email verification codes. It panics if n <= 0.
+func DigitCode(n int) string {
+	if n <= 0 {
+		panic("random: DigitCode n must be > 0")
+	}
+	return String(n, Digits)
+}
+
+// dedupeCharset joins charsets (defaulting to Alphanumeric) and removes duplicate
+// bytes, preserving first-occurrence order, so String stays uniform over distinct
+// characters.
+func dedupeCharset(charsets []string) []byte {
+	joined := Alphanumeric
+	if len(charsets) > 0 {
+		joined = strings.Join(charsets, "")
+	}
+	var seen [256]bool
+	out := make([]byte, 0, len(joined))
+	for i := range len(joined) {
+		c := joined[i]
+		if !seen[c] {
+			seen[c] = true
+			out = append(out, c)
+		}
+	}
+	return out
 }

--- a/core/random/random_test.go
+++ b/core/random/random_test.go
@@ -3,6 +3,7 @@ package random_test
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,4 +53,72 @@ func TestInt_InRange(t *testing.T) {
 func TestInt_PanicsOnNonPositive(t *testing.T) {
 	assert.Panics(t, func() { random.Int(0) })
 	assert.Panics(t, func() { random.Int(-5) })
+}
+
+func TestString_LengthAndAlphabet(t *testing.T) {
+	for range 100 {
+		s := random.String(16, random.Uppercase, random.Digits)
+		assert.Len(t, s, 16)
+		for _, c := range s {
+			assert.True(t, strings.ContainsRune(random.Uppercase+random.Digits, c), "unexpected char %q", c)
+		}
+	}
+}
+
+func TestString_DefaultIsAlphanumeric(t *testing.T) {
+	s := random.String(32)
+	assert.Len(t, s, 32)
+	for _, c := range s {
+		assert.True(t, strings.ContainsRune(random.Alphanumeric, c))
+	}
+}
+
+func TestString_Zero(t *testing.T) {
+	assert.Equal(t, "", random.String(0))
+}
+
+func TestString_DedupesOverlap(t *testing.T) {
+	// Alphanumeric already contains Digits; passing both must not bias digits.
+	const n = 20000
+	s := random.String(n, random.Alphanumeric, random.Digits)
+	digits := 0
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			digits++
+		}
+	}
+	frac := float64(digits) / float64(n)
+	// 10 of 62 distinct chars are digits => ~0.161. Un-deduped (2x) would be ~0.278.
+	assert.InDelta(t, 10.0/62.0, frac, 0.03, "digit fraction suggests charset not de-duplicated")
+}
+
+func TestString_PanicsOnEmptyCharsetOrNegative(t *testing.T) {
+	assert.Panics(t, func() { random.String(-1) })
+	assert.Panics(t, func() { random.String(4, "") })
+}
+
+func TestDigitCode(t *testing.T) {
+	for range 100 {
+		c := random.DigitCode(6)
+		assert.Len(t, c, 6)
+		for _, r := range c {
+			assert.True(t, r >= '0' && r <= '9', "non-digit %q", r)
+		}
+	}
+}
+
+func TestDigitCode_LeadingZerosPossible(t *testing.T) {
+	seen := false
+	for range 3000 {
+		if random.DigitCode(4)[0] == '0' {
+			seen = true
+			break
+		}
+	}
+	assert.True(t, seen, "leading zero should be possible")
+}
+
+func TestDigitCode_PanicsOnNonPositive(t *testing.T) {
+	assert.Panics(t, func() { random.DigitCode(0) })
+	assert.Panics(t, func() { random.DigitCode(-1) })
 }

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -589,18 +589,7 @@ Queued API additions to shipped packages (each unblocks roadmap work):
 
 | Package | Addition |
 |---|---|
-| `core/random` | `String(n, alphabet)`, `DigitCode(n)` (bias-free; `otp` needs it) |
-| `core/id` | Stripe-style `Prefixed` IDs with prefix-validating Parse |
-| `web/request` | `ValidateFile` (MIME allowlist + `filetype` sniff over File/Files); `Accept`/`AcceptsJSON` helpers |
-| `web/middleware` | `Skip`/`When(predicate)` combinator |
-| `web/problem` | Machine-readable `Code` field; `Decode(*http.Response)`; `errors.Is` on (Status, Code) |
-| `web/htmx` | SSE `SendComponent` bridge (moved out of sse's scope) |
-| `resilience/circuitbreaker` | Keyed `Group` (lazy per-key breakers); server-side HTTP middleware adapter (503 + Retry-After) |
-| `resilience/retry` | Honor `interface{ RetryAfter() time.Duration }` errors as the delay floor |
-| `resilience/cache` | Atomic SetNX in the Store contract |
-| `ops/supervisor` | `WithForceQuit` second-signal option on `NewContext` |
-| `ops/logger` | Recording slog test handler |
-| `web/hostrouter` | Doc note: unknown hosts default-deny = DNS-rebinding protection |
+| `web/htmx` | SSE `SendComponent` bridge — deferred to the realtime/sse wave |
 
 ## Build order
 

--- a/docs/superpowers/plans/2026-07-05-wave1-unblockers.md
+++ b/docs/superpowers/plans/2026-07-05-wave1-unblockers.md
@@ -1,0 +1,1584 @@
+# Wave 1 Unblocker Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add eight small, independent API additions across seven shipped forge packages (plus a hostrouter doc note and a packages.md table edit) that unblock the core-tier roadmap.
+
+**Architecture:** Each task extends one already-shipped package with a focused addition following that package's existing conventions. Tasks are fully independent (distinct packages, no shared symbols), so they can be implemented in any order or in parallel. Every addition is crypto-secure / stdlib-only where relevant, uses the options pattern (never builders), and ships `errors.Is`-matchable sentinels.
+
+**Tech Stack:** Go 1.26, stdlib (`crypto/rand`, `log/slog`, `net/http`, `mime/multipart`, `os/signal`), `github.com/stretchr/testify` (assert/require). Reference spec: `docs/superpowers/specs/2026-07-05-wave1-unblockers-design.md`.
+
+## Global Constraints
+
+- **Work only in the current branch** (`claude/optimistic-sutherland-ac07eb`) — never switch branches.
+- **Black-box tests only**: test files use `package <pkg>_test` and import the package by its full path. White-box (`package <pkg>`) is allowed *only* to assert unexported state — none is needed here.
+- **Options, never builders**: configuration is `func(*config)` variadics.
+- **`errors.Is`-matchable single-line sentinels**: `var Err… = errors.New("pkg: …")`.
+- **Public methods never return unexported types.**
+- **Go 1.26 idioms**: `for i := range n` integer ranges; `new(expr)` (never a `ptr.To` helper); `errors.AsType`. `just lint` runs `modernize` and will flag violations.
+- **Assertions**: `github.com/stretchr/testify/assert` and `.../require` (require for setup that must not continue on failure). No dot-imports.
+- **Imports**: goimports local-prefix is `github.com/dmitrymomot/forge` (handled by `just fmt`).
+- **Per-package formatting**: run `just fmt ./<domain>/<pkg>/...` (package-path form). The single-file form (`just fmt path/file.go`) trips a spurious betteralign "undefined" — always use the `./…/...` form.
+- **Per-task close-out**: `just fmt ./<domain>/<pkg>/...` → `just lint` → `just test ./<domain>/<pkg>/...` must all pass before committing.
+- **No Claude attribution** in commit messages (no "Generated with", no `Co-Authored-By: Claude`).
+
+---
+
+## Task 1: `core/random` — bias-free `String` + `DigitCode`
+
+**Files:**
+- Modify: `core/random/random.go` (add constants + `String` + `DigitCode` + `dedupeCharset`)
+- Test: `core/random/random_test.go` (`package random_test`, already exists — append)
+
+**Interfaces:**
+- Consumes: existing `random.Bytes`, `crypto/rand` (imported as `rand`), `fmt`.
+- Produces:
+  - `const Lowercase, Uppercase, Digits, Alphabetic, Alphanumeric, Symbols string`
+  - `func String(n int, charsets ...string) string`
+  - `func DigitCode(n int) string`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `core/random/random_test.go` (ensure `strings` is imported in the test file):
+
+```go
+func TestString_LengthAndAlphabet(t *testing.T) {
+	for range 100 {
+		s := random.String(16, random.Uppercase, random.Digits)
+		assert.Len(t, s, 16)
+		for _, c := range s {
+			assert.True(t, strings.ContainsRune(random.Uppercase+random.Digits, c), "unexpected char %q", c)
+		}
+	}
+}
+
+func TestString_DefaultIsAlphanumeric(t *testing.T) {
+	s := random.String(32)
+	assert.Len(t, s, 32)
+	for _, c := range s {
+		assert.True(t, strings.ContainsRune(random.Alphanumeric, c))
+	}
+}
+
+func TestString_Zero(t *testing.T) {
+	assert.Equal(t, "", random.String(0))
+}
+
+func TestString_DedupesOverlap(t *testing.T) {
+	// Alphanumeric already contains Digits; passing both must not bias digits.
+	const n = 20000
+	s := random.String(n, random.Alphanumeric, random.Digits)
+	digits := 0
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			digits++
+		}
+	}
+	frac := float64(digits) / float64(n)
+	// 10 of 62 distinct chars are digits => ~0.161. Un-deduped (2x) would be ~0.278.
+	assert.InDelta(t, 10.0/62.0, frac, 0.03, "digit fraction suggests charset not de-duplicated")
+}
+
+func TestString_PanicsOnEmptyCharsetOrNegative(t *testing.T) {
+	assert.Panics(t, func() { random.String(-1) })
+	assert.Panics(t, func() { random.String(4, "") })
+}
+
+func TestDigitCode(t *testing.T) {
+	for range 100 {
+		c := random.DigitCode(6)
+		assert.Len(t, c, 6)
+		for _, r := range c {
+			assert.True(t, r >= '0' && r <= '9', "non-digit %q", r)
+		}
+	}
+}
+
+func TestDigitCode_LeadingZerosPossible(t *testing.T) {
+	seen := false
+	for range 3000 {
+		if random.DigitCode(4)[0] == '0' {
+			seen = true
+			break
+		}
+	}
+	assert.True(t, seen, "leading zero should be possible")
+}
+
+func TestDigitCode_PanicsOnNonPositive(t *testing.T) {
+	assert.Panics(t, func() { random.DigitCode(0) })
+	assert.Panics(t, func() { random.DigitCode(-1) })
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./core/random -run 'TestString|TestDigitCode' -v`
+Expected: FAIL — `undefined: random.String` / `random.Digits` etc.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `core/random/random.go` (add `"strings"` to the import block; `crypto/rand` is already imported as `rand`, `fmt` is already imported):
+
+```go
+// Charset constants for String. Each is an ASCII byte string.
+const (
+	Lowercase    = "abcdefghijklmnopqrstuvwxyz"
+	Uppercase    = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	Digits       = "0123456789"
+	Alphabetic   = Lowercase + Uppercase
+	Alphanumeric = Alphabetic + Digits
+	Symbols      = "~!@#$%^&*()-_+={}[]|\\;:\"<>,./?`"
+)
+
+// String returns a cryptographically secure random string of n characters drawn
+// uniformly (bias-free, via crypto/rand rejection sampling) from the concatenation
+// of charsets. With no charsets it defaults to Alphanumeric. Overlapping charsets
+// are de-duplicated (first occurrence wins) so the distribution stays uniform over
+// the distinct characters. The charset is treated as bytes; multi-byte UTF-8
+// alphabets are not supported. It panics if n < 0 or the combined charset is empty.
+func String(n int, charsets ...string) string {
+	if n < 0 {
+		panic("random: String n must be >= 0")
+	}
+	set := dedupeCharset(charsets)
+	k := len(set)
+	if k == 0 {
+		panic("random: String charset is empty")
+	}
+	if n == 0 {
+		return ""
+	}
+	out := make([]byte, n)
+	// max is the largest multiple of k within a byte; bytes at or above it are
+	// rejected to remove modulo bias. De-duping over bytes guarantees k <= 256.
+	max := 256 - (256 % k)
+	buf := make([]byte, n)
+	bi := len(buf) // force an initial fill
+	for i := 0; i < n; {
+		if bi >= len(buf) {
+			if _, err := rand.Read(buf); err != nil {
+				panic(fmt.Errorf("random: crypto/rand failed: %w", err))
+			}
+			bi = 0
+		}
+		b := int(buf[bi])
+		bi++
+		if b < max {
+			out[i] = set[b%k]
+			i++
+		}
+	}
+	return string(out)
+}
+
+// DigitCode returns an n-digit decimal string with leading zeros preserved,
+// suitable for OTP and email verification codes. It panics if n <= 0.
+func DigitCode(n int) string {
+	if n <= 0 {
+		panic("random: DigitCode n must be > 0")
+	}
+	return String(n, Digits)
+}
+
+// dedupeCharset joins charsets (defaulting to Alphanumeric) and removes duplicate
+// bytes, preserving first-occurrence order, so String stays uniform over distinct
+// characters.
+func dedupeCharset(charsets []string) []byte {
+	joined := Alphanumeric
+	if len(charsets) > 0 {
+		joined = strings.Join(charsets, "")
+	}
+	var seen [256]bool
+	out := make([]byte, 0, len(joined))
+	for i := range len(joined) {
+		c := joined[i]
+		if !seen[c] {
+			seen[c] = true
+			out = append(out, c)
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./core/random -run 'TestString|TestDigitCode' -v`
+Expected: PASS (all sub-tests).
+
+- [ ] **Step 5: Update the package doc**
+
+Add a short paragraph to `core/random/doc.go` documenting `String`/`DigitCode` and the charset constants, and noting `String` is crypto-secure (bias-free) while callers who need the error escape hatch use `Read`.
+
+- [ ] **Step 6: Format, lint, test, commit**
+
+```bash
+just fmt ./core/random/...
+just lint
+just test ./core/random/...
+git add core/random/random.go core/random/random_test.go core/random/doc.go
+git commit -m "feat(core/random): bias-free String and DigitCode with charset constants"
+```
+
+---
+
+## Task 2: `core/id` — bound `Prefix` codec + static aliases
+
+**Files:**
+- Create: `core/id/prefix.go` (type, options, methods, static aliases)
+- Modify: `core/id/errors.go` (add `ErrWrongPrefix`)
+- Test: `core/id/prefix_test.go` (`package id_test`)
+
+**Interfaces:**
+- Consumes: `id.NewShort() Short`, `Short.String() string`, `id.ParseShort(string) (Short, error)`, `id.NewULID()`, `id.ParseULID`, existing `id.ErrMalformed`.
+- Produces:
+  - `type Prefix struct{…}` · `type PrefixOption func(*Prefix)`
+  - `func WithGenerator(gen func() string) PrefixOption`
+  - `func NewPrefix(prefix string, opts ...PrefixOption) Prefix`
+  - `func (Prefix) New() string` · `func (Prefix) Parse(string) (string, error)` · `func (Prefix) Is(string) bool` · `func (Prefix) Prefix() string`
+  - `func NewPrefixed(prefix string) string` · `func ParsePrefixed(prefix, s string) (string, error)` · `func IsPrefixed(prefix, s string) bool`
+  - `var ErrWrongPrefix error`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `core/id/prefix_test.go`:
+
+```go
+package id_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefix_RoundTripDefault(t *testing.T) {
+	p := id.NewPrefix("user")
+	s := p.New()
+	assert.True(t, strings.HasPrefix(s, "user_"))
+	body, err := p.Parse(s)
+	require.NoError(t, err)
+	_, err = id.ParseShort(body)
+	require.NoError(t, err, "default body must decode as Short")
+	assert.True(t, p.Is(s))
+	assert.Equal(t, "user", p.Prefix())
+}
+
+func TestPrefix_CustomGenerator(t *testing.T) {
+	p := id.NewPrefix("tok", id.WithGenerator(func() string { return id.NewULID().String() }))
+	s := p.New()
+	assert.True(t, strings.HasPrefix(s, "tok_"))
+	body, err := p.Parse(s)
+	require.NoError(t, err)
+	_, err = id.ParseULID(body)
+	require.NoError(t, err)
+}
+
+func TestPrefix_WrongPrefix(t *testing.T) {
+	p := id.NewPrefix("user")
+	_, err := p.Parse("org_" + id.NewShort().String())
+	assert.ErrorIs(t, err, id.ErrWrongPrefix)
+	assert.False(t, p.Is("org_abc"))
+}
+
+func TestPrefix_EmptyBody(t *testing.T) {
+	p := id.NewPrefix("user")
+	_, err := p.Parse("user_")
+	assert.ErrorIs(t, err, id.ErrMalformed)
+}
+
+func TestPrefix_NoSeparator(t *testing.T) {
+	p := id.NewPrefix("user")
+	_, err := p.Parse("userabc")
+	assert.ErrorIs(t, err, id.ErrWrongPrefix)
+}
+
+func TestPrefixed_StaticAliases(t *testing.T) {
+	s := id.NewPrefixed("acct")
+	assert.True(t, strings.HasPrefix(s, "acct_"))
+	body, err := id.ParsePrefixed("acct", s)
+	require.NoError(t, err)
+	assert.NotEmpty(t, body)
+	assert.True(t, id.IsPrefixed("acct", s))
+	assert.False(t, id.IsPrefixed("other", s))
+}
+
+func TestPrefix_PanicsOnInvalid(t *testing.T) {
+	assert.Panics(t, func() { id.NewPrefix("") })
+	assert.Panics(t, func() { id.NewPrefix("User") })
+	assert.Panics(t, func() { id.NewPrefix("a_b") })
+	assert.Panics(t, func() { id.NewPrefix("x", id.WithGenerator(nil)) })
+	assert.Panics(t, func() { id.NewPrefixed("") })
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./core/id -run TestPrefix -v`
+Expected: FAIL — `undefined: id.NewPrefix` etc.
+
+- [ ] **Step 3: Add the sentinel**
+
+Append to `core/id/errors.go` (already `package id`, already imports `errors`):
+
+```go
+// ErrWrongPrefix is returned by Prefix.Parse (and ParsePrefixed) when the input
+// does not carry the expected "<prefix>_" head. Match it with errors.Is.
+var ErrWrongPrefix = errors.New("id: wrong prefix")
+```
+
+- [ ] **Step 4: Write the implementation**
+
+Create `core/id/prefix.go`:
+
+```go
+package id
+
+import "strings"
+
+// Prefix is an immutable, concurrency-safe Stripe-style ID codec: a human prefix
+// joined to a generated body by "_". The zero value is unusable; construct with
+// NewPrefix. Options are optional; the default body generator is Short.
+type Prefix struct {
+	gen    func() string
+	prefix string
+	joined string // prefix + "_"
+}
+
+// PrefixOption configures NewPrefix.
+type PrefixOption func(*Prefix)
+
+// WithGenerator sets the body generator — the part after "<prefix>_". The default
+// is Short (NewShort().String()); pass any func to mint ULID/UUID/random bodies,
+// e.g. WithGenerator(func() string { return NewULID().String() }). A nil gen
+// panics via NewPrefix.
+func WithGenerator(gen func() string) PrefixOption {
+	return func(p *Prefix) { p.gen = gen }
+}
+
+// NewPrefix returns a codec emitting IDs of the form "<prefix>_<body>". prefix
+// must be non-empty and match [a-z0-9]+ (Stripe convention; "_" is the separator).
+// Options are optional. It panics on an invalid prefix or a nil generator — both
+// are boot-time programming errors.
+func NewPrefix(prefix string, opts ...PrefixOption) Prefix {
+	if !validPrefix(prefix) {
+		panic("id: NewPrefix prefix must match [a-z0-9]+")
+	}
+	p := Prefix{
+		prefix: prefix,
+		joined: prefix + "_",
+		gen:    func() string { return NewShort().String() },
+	}
+	for _, o := range opts {
+		o(&p)
+	}
+	if p.gen == nil {
+		panic("id: NewPrefix generator must not be nil")
+	}
+	return p
+}
+
+// New returns a fresh ID: "<prefix>_" + gen().
+func (p Prefix) New() string { return p.joined + p.gen() }
+
+// Parse validates that s carries p's prefix and a non-empty body, returning the
+// body (the part after "<prefix>_"). Because the body generator is pluggable, the
+// body is returned opaque — for the default Short generator, decode it with
+// ParseShort. A wrong/absent prefix returns ErrWrongPrefix; an empty body returns
+// ErrMalformed.
+func (p Prefix) Parse(s string) (string, error) {
+	body, ok := strings.CutPrefix(s, p.joined)
+	if !ok {
+		return "", ErrWrongPrefix
+	}
+	if body == "" {
+		return "", ErrMalformed
+	}
+	return body, nil
+}
+
+// Is reports whether s carries p's prefix and a non-empty body. It validates the
+// prefix and body presence only, not the body's internal format.
+func (p Prefix) Is(s string) bool {
+	_, err := p.Parse(s)
+	return err == nil
+}
+
+// Prefix returns the bound prefix (for logging / diagnostics).
+func (p Prefix) Prefix() string { return p.prefix }
+
+// NewPrefixed returns a fresh "<prefix>_<short>" ID using the default Short
+// generator. Equivalent to NewPrefix(prefix).New(); it panics on an invalid prefix.
+func NewPrefixed(prefix string) string { return NewPrefix(prefix).New() }
+
+// ParsePrefixed validates prefix on s and returns the body. Equivalent to
+// NewPrefix(prefix).Parse(s).
+func ParsePrefixed(prefix, s string) (string, error) { return NewPrefix(prefix).Parse(s) }
+
+// IsPrefixed reports whether s carries prefix with a non-empty body. Equivalent to
+// NewPrefix(prefix).Is(s).
+func IsPrefixed(prefix, s string) bool { return NewPrefix(prefix).Is(s) }
+
+// validPrefix reports whether s is a non-empty [a-z0-9]+ string.
+func validPrefix(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := range len(s) {
+		c := s[i]
+		if !(c >= 'a' && c <= 'z' || c >= '0' && c <= '9') {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./core/id -run TestPrefix -v`
+Expected: PASS.
+
+- [ ] **Step 6: Format, lint, test, commit**
+
+```bash
+just fmt ./core/id/...
+just lint
+just test ./core/id/...
+git add core/id/prefix.go core/id/errors.go core/id/prefix_test.go
+git commit -m "feat(core/id): Prefix codec with pluggable generator and static aliases"
+```
+
+> Note: `just fmt` (betteralign) may reorder the `Prefix` struct fields for alignment — that is expected; commit the formatted result.
+
+---
+
+## Task 3: `web/problem` — `Decode` + `*Problem` as an error
+
+**Files:**
+- Modify: `web/problem/problem.go` (add `ErrNotProblem`, `Decode`, `(*Problem).Error`, `(*Problem).Is`)
+- Test: `web/problem/problem_test.go` (`package problem_test` — append)
+
+**Interfaces:**
+- Consumes: existing `problem.Problem` struct.
+- Produces:
+  - `var ErrNotProblem error`
+  - `func (*Problem) Error() string` · `func (*Problem) Is(target error) bool`
+  - `func Decode(resp *http.Response) (*Problem, error)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `web/problem/problem_test.go` (ensure `errors`, `io`, `net/http`, `strings` are imported in the test file):
+
+```go
+func TestProblem_ErrorString(t *testing.T) {
+	p := &problem.Problem{Status: 429, Title: "Too Many Requests", Code: "rate_limited"}
+	assert.Equal(t, "problem: 429 Too Many Requests [rate_limited]", p.Error())
+	p2 := &problem.Problem{Status: 400, Title: "Bad Request"}
+	assert.Equal(t, "problem: 400 Bad Request", p2.Error())
+}
+
+func TestProblem_Is(t *testing.T) {
+	p := &problem.Problem{Status: 429, Code: "rate_limited"}
+	assert.True(t, errors.Is(p, &problem.Problem{Code: "rate_limited"}))
+	assert.True(t, errors.Is(p, &problem.Problem{Status: 429}))
+	assert.True(t, errors.Is(p, &problem.Problem{}))
+	assert.False(t, errors.Is(p, &problem.Problem{Status: 400}))
+	assert.False(t, errors.Is(p, &problem.Problem{Code: "other"}))
+	assert.False(t, errors.Is(p, errors.New("nope")))
+}
+
+func TestDecode_ProblemJSON(t *testing.T) {
+	body := `{"type":"about:blank","title":"Too Many Requests","status":429,"code":"rate_limited"}`
+	resp := &http.Response{
+		StatusCode: 429,
+		Header:     http.Header{"Content-Type": []string{"application/problem+json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	p, err := problem.Decode(resp)
+	require.NoError(t, err)
+	assert.Equal(t, 429, p.Status)
+	assert.Equal(t, "rate_limited", p.Code)
+	assert.Equal(t, "Too Many Requests", p.Title)
+}
+
+func TestDecode_FillsStatusFromResponse(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 503,
+		Header:     http.Header{"Content-Type": []string{"application/problem+json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"title":"Service Unavailable"}`)),
+	}
+	p, err := problem.Decode(resp)
+	require.NoError(t, err)
+	assert.Equal(t, 503, p.Status)
+}
+
+func TestDecode_NotAProblem(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"text/html"}},
+		Body:       io.NopCloser(strings.NewReader("<html></html>")),
+	}
+	_, err := problem.Decode(resp)
+	assert.ErrorIs(t, err, problem.ErrNotProblem)
+}
+
+func TestDecode_LeavesBodyOpen(t *testing.T) {
+	rc := &trackCloser{Reader: strings.NewReader(`{"status":400,"code":"x"}`)}
+	resp := &http.Response{
+		StatusCode: 400,
+		Header:     http.Header{"Content-Type": []string{"application/problem+json"}},
+		Body:       rc,
+	}
+	_, err := problem.Decode(resp)
+	require.NoError(t, err)
+	assert.False(t, rc.closed, "Decode must not close the response body")
+}
+
+// trackCloser records whether Close was called.
+type trackCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (t *trackCloser) Close() error { t.closed = true; return nil }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./web/problem -run 'TestProblem_|TestDecode_' -v`
+Expected: FAIL — `undefined: problem.Decode` / `p.Error undefined`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `web/problem/problem.go` (add `encoding/json`, `fmt`, `io` to the import block):
+
+```go
+// ErrNotProblem is returned by Decode when the response body is not a problem
+// document. Match it with errors.Is.
+var ErrNotProblem = errors.New("problem: not a problem+json response")
+
+// maxProblemBytes caps the body Decode will read, guarding against a hostile or
+// runaway upstream.
+const maxProblemBytes = 1 << 20 // 1 MiB
+
+// Error implements error with a single-line summary. The response body written by
+// the responders is unaffected — this is for logs and errors.Is chains.
+func (p *Problem) Error() string {
+	if p.Code != "" {
+		return fmt.Sprintf("problem: %d %s [%s]", p.Status, p.Title, p.Code)
+	}
+	return fmt.Sprintf("problem: %d %s", p.Status, p.Title)
+}
+
+// Is matches target by its non-zero fields: a *Problem target matches when
+// (target.Status == 0 || target.Status == p.Status) &&
+// (target.Code == "" || target.Code == p.Code). So errors.Is(err,
+// &Problem{Code:"rate_limited"}) matches by code, &Problem{Status:429} by status,
+// and &Problem{} any Problem. A non-*Problem target never matches.
+func (p *Problem) Is(target error) bool {
+	t, ok := target.(*Problem)
+	if !ok {
+		return false
+	}
+	if t.Status != 0 && t.Status != p.Status {
+		return false
+	}
+	if t.Code != "" && t.Code != p.Code {
+		return false
+	}
+	return true
+}
+
+// Decode reads an RFC 9457 problem+json response body into a *Problem. It caps the
+// body at 1 MiB, fills Status from resp.StatusCode when the body omits it, and does
+// NOT close resp.Body (the caller owns it). A body that is not a problem document
+// returns ErrNotProblem.
+func Decode(resp *http.Response) (*Problem, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, ErrNotProblem
+	}
+	var p Problem
+	dec := json.NewDecoder(io.LimitReader(resp.Body, maxProblemBytes))
+	if err := dec.Decode(&p); err != nil {
+		return nil, ErrNotProblem
+	}
+	ct := resp.Header.Get("Content-Type")
+	looksProblem := strings.Contains(ct, "application/problem+json") ||
+		p.Status != 0 || p.Code != "" || p.Title != "" || p.Type != ""
+	if !looksProblem {
+		return nil, ErrNotProblem
+	}
+	if p.Status == 0 {
+		p.Status = resp.StatusCode
+	}
+	return &p, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./web/problem -run 'TestProblem_|TestDecode_' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Format, lint, test, commit**
+
+```bash
+just fmt ./web/problem/...
+just lint
+just test ./web/problem/...
+git add web/problem/problem.go web/problem/problem_test.go
+git commit -m "feat(web/problem): Decode response bodies and make *Problem an errors.Is-matchable error"
+```
+
+---
+
+## Task 4: `web/request` — `ValidateFile` + `Accept`/`AcceptsJSON`
+
+**Files:**
+- Modify: `web/request/body.go` (add `FileOption`, `fileConfig`, `WithAllowedMIME`, `WithMaxFileSize`, `ValidateFile`)
+- Create: `web/request/accept.go` (`Accept`, `AcceptsJSON` + helpers)
+- Test: `web/request/body_files_test.go` (`package request_test` — append) and `web/request/accept_test.go` (`package request_test`)
+
+**Interfaces:**
+- Consumes: `request.File`/`request.Files`, `request.Error`/`Kind`/`Source`/`StatusCode`, `core/filetype.DetectReader`, `multipart.FileHeader`.
+- Produces:
+  - `type FileOption func(*fileConfig)` · `func WithAllowedMIME(...string) FileOption` · `func WithMaxFileSize(int64) FileOption`
+  - `func ValidateFile(fh *multipart.FileHeader, opts ...FileOption) error`
+  - `func Accept(r *http.Request, mediaType string) bool` · `func AcceptsJSON(r *http.Request) bool`
+
+- [ ] **Step 1: Write the failing tests (ValidateFile)**
+
+Append to `web/request/body_files_test.go` (reuses the existing package's multipart helper style; add `bytes`, `mime/multipart`, `net/http/httptest` imports if not present):
+
+```go
+// pngBytes is a minimal PNG magic-byte header for sniff tests.
+var pngBytes = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D}
+
+func multipartFileReq(t *testing.T, field, filename string, content []byte) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile(field, filename)
+	require.NoError(t, err)
+	_, err = fw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
+	r := httptest.NewRequest(http.MethodPost, "/", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	return r
+}
+
+func TestValidateFile_AllowsSniffedPNG(t *testing.T) {
+	r := multipartFileReq(t, "avatar", "a.png", pngBytes)
+	fhs, err := request.Files(r, "avatar")
+	require.NoError(t, err)
+	require.Len(t, fhs, 1)
+	assert.NoError(t, request.ValidateFile(fhs[0], request.WithAllowedMIME("image/png")))
+}
+
+func TestValidateFile_RejectsSpoofedType(t *testing.T) {
+	// A .png filename whose bytes are plain text must be rejected by magic-byte sniff.
+	r := multipartFileReq(t, "avatar", "evil.png", []byte("#!/bin/sh\necho hi\n"))
+	fhs, err := request.Files(r, "avatar")
+	require.NoError(t, err)
+	err = request.ValidateFile(fhs[0], request.WithAllowedMIME("image/png"))
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnsupportedMediaType, request.StatusCode(err))
+}
+
+func TestValidateFile_TooLarge(t *testing.T) {
+	r := multipartFileReq(t, "avatar", "a.png", pngBytes)
+	fhs, err := request.Files(r, "avatar")
+	require.NoError(t, err)
+	err = request.ValidateFile(fhs[0], request.WithMaxFileSize(4))
+	require.Error(t, err)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, request.StatusCode(err))
+}
+
+func TestValidateFile_NilHeader(t *testing.T) {
+	err := request.ValidateFile(nil)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./web/request -run TestValidateFile -v`
+Expected: FAIL — `undefined: request.ValidateFile`.
+
+- [ ] **Step 3: Implement `ValidateFile`**
+
+Append to `web/request/body.go` (add `github.com/dmitrymomot/forge/core/filetype` to the import block):
+
+```go
+// FileOption configures ValidateFile.
+type FileOption func(*fileConfig)
+
+type fileConfig struct {
+	allowedMIME []string
+	maxSize     int64
+}
+
+// WithAllowedMIME restricts uploads to these magic-byte-sniffed MIME types (e.g.
+// "image/png", "application/pdf"). With no allowlist the MIME is not checked.
+func WithAllowedMIME(mimes ...string) FileOption {
+	return func(c *fileConfig) { c.allowedMIME = mimes }
+}
+
+// WithMaxFileSize rejects uploads whose declared size exceeds n bytes. With no
+// limit the size is not checked.
+func WithMaxFileSize(n int64) FileOption {
+	return func(c *fileConfig) { c.maxSize = n }
+}
+
+// ValidateFile validates an uploaded file by its magic bytes (core/filetype),
+// deliberately ignoring the client-declared Content-Type, plus an optional size
+// cap. It returns a *Error: KindTooLarge for an oversize file,
+// KindUnsupportedMediaType for a disallowed/undetectable type, KindMissing for a
+// nil header; nil on success. Consumers with multiple files loop over Files().
+func ValidateFile(fh *multipart.FileHeader, opts ...FileOption) error {
+	if fh == nil {
+		return &Error{Source: SourceForm, Kind: KindMissing}
+	}
+	var c fileConfig
+	for _, o := range opts {
+		o(&c)
+	}
+	if c.maxSize > 0 && fh.Size > c.maxSize {
+		return &Error{Source: SourceForm, Key: fh.Filename, Kind: KindTooLarge}
+	}
+	if len(c.allowedMIME) == 0 {
+		return nil
+	}
+	f, err := fh.Open()
+	if err != nil {
+		return &Error{Source: SourceForm, Key: fh.Filename, Kind: KindUnsupportedMediaType, Err: err}
+	}
+	defer func() { _ = f.Close() }()
+	typ, _, err := filetype.DetectReader(f)
+	if err != nil {
+		return &Error{Source: SourceForm, Key: fh.Filename, Kind: KindUnsupportedMediaType, Err: err}
+	}
+	for _, m := range c.allowedMIME {
+		if typ.MIME == m {
+			return nil
+		}
+	}
+	return &Error{Source: SourceForm, Key: fh.Filename, Kind: KindUnsupportedMediaType}
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./web/request -run TestValidateFile -v`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing tests (Accept)**
+
+Create `web/request/accept_test.go`:
+
+```go
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/request"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccept(t *testing.T) {
+	cases := []struct {
+		accept string
+		media  string
+		want   bool
+	}{
+		{"application/json", "application/json", true},
+		{"*/*", "application/json", true},
+		{"text/*", "text/html", true},
+		{"text/*", "application/json", false},
+		{"application/json;q=0", "application/json", false},
+		{"", "application/json", true},
+		{"text/html, application/json;q=0.9", "application/json", true},
+	}
+	for _, c := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		if c.accept != "" {
+			r.Header.Set("Accept", c.accept)
+		}
+		assert.Equalf(t, c.want, request.Accept(r, c.media), "Accept %q media %q", c.accept, c.media)
+	}
+}
+
+func TestAcceptsJSON(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Accept", "application/json")
+	assert.True(t, request.AcceptsJSON(r))
+}
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `go test ./web/request -run 'TestAccept' -v`
+Expected: FAIL — `undefined: request.Accept`.
+
+- [ ] **Step 7: Implement `Accept`**
+
+Create `web/request/accept.go`:
+
+```go
+package request
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// Accept reports whether the request's Accept header admits mediaType, honoring
+// "*/*", "type/*", and explicit "q=0" rejections. An absent or empty Accept header
+// admits everything (returns true), per RFC 9110.
+func Accept(r *http.Request, mediaType string) bool {
+	header := r.Header.Get("Accept")
+	if strings.TrimSpace(header) == "" {
+		return true
+	}
+	want := strings.SplitN(strings.ToLower(strings.TrimSpace(mediaType)), "/", 2)
+	if len(want) != 2 {
+		return false
+	}
+	best := -1.0
+	for _, part := range strings.Split(header, ",") {
+		rng, q := parseAcceptPart(part)
+		if rng == "" {
+			continue
+		}
+		if acceptMatches(rng, want) && q > best {
+			best = q
+		}
+	}
+	return best > 0
+}
+
+// AcceptsJSON reports whether the request admits application/json.
+func AcceptsJSON(r *http.Request) bool { return Accept(r, "application/json") }
+
+// parseAcceptPart splits one Accept list element into its lowercased media range
+// and q-value (default 1.0).
+func parseAcceptPart(part string) (string, float64) {
+	fields := strings.Split(part, ";")
+	rng := strings.ToLower(strings.TrimSpace(fields[0]))
+	q := 1.0
+	for _, p := range fields[1:] {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(p), "q="); ok {
+			if f, err := strconv.ParseFloat(strings.TrimSpace(v), 64); err == nil {
+				q = f
+			}
+		}
+	}
+	return rng, q
+}
+
+// acceptMatches reports whether a media range admits the wanted type/subtype.
+func acceptMatches(rng string, want []string) bool {
+	if rng == "*/*" {
+		return true
+	}
+	rp := strings.SplitN(rng, "/", 2)
+	if len(rp) != 2 {
+		return false
+	}
+	if rp[0] != want[0] {
+		return false
+	}
+	return rp[1] == "*" || rp[1] == want[1]
+}
+```
+
+- [ ] **Step 8: Run to verify it passes**
+
+Run: `go test ./web/request -run 'TestAccept' -v`
+Expected: PASS.
+
+- [ ] **Step 9: Format, lint, test, commit**
+
+```bash
+just fmt ./web/request/...
+just lint
+just test ./web/request/...
+git add web/request/body.go web/request/accept.go web/request/body_files_test.go web/request/accept_test.go
+git commit -m "feat(web/request): magic-byte ValidateFile and Accept/AcceptsJSON negotiation"
+```
+
+---
+
+## Task 5: `web/middleware` — `When` / `Skip`
+
+**Files:**
+- Modify: `web/middleware/middleware.go`
+- Test: `web/middleware/middleware_test.go` (`package middleware_test` — append)
+
+**Interfaces:**
+- Consumes: `middleware.Middleware`, `middleware.Wrap`.
+- Produces: `func When(pred func(*http.Request) bool, mw Middleware) Middleware` · `func Skip(pred func(*http.Request) bool, mw Middleware) Middleware`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `web/middleware/middleware_test.go`:
+
+```go
+func markHeader(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Marked", "1")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func TestWhen_AppliesOnlyWhenPredicateTrue(t *testing.T) {
+	h := middleware.Wrap(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		middleware.When(func(r *http.Request) bool { return r.URL.Path == "/on" }, markHeader),
+	)
+	on := httptest.NewRecorder()
+	h.ServeHTTP(on, httptest.NewRequest(http.MethodGet, "/on", nil))
+	assert.Equal(t, "1", on.Header().Get("X-Marked"))
+
+	off := httptest.NewRecorder()
+	h.ServeHTTP(off, httptest.NewRequest(http.MethodGet, "/off", nil))
+	assert.Empty(t, off.Header().Get("X-Marked"))
+}
+
+func TestSkip_IsInverseOfWhen(t *testing.T) {
+	h := middleware.Wrap(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		middleware.Skip(func(r *http.Request) bool { return r.URL.Path == "/skip" }, markHeader),
+	)
+	skip := httptest.NewRecorder()
+	h.ServeHTTP(skip, httptest.NewRequest(http.MethodGet, "/skip", nil))
+	assert.Empty(t, skip.Header().Get("X-Marked"))
+
+	apply := httptest.NewRecorder()
+	h.ServeHTTP(apply, httptest.NewRequest(http.MethodGet, "/other", nil))
+	assert.Equal(t, "1", apply.Header().Get("X-Marked"))
+}
+
+func TestWhen_BuildsMiddlewareOnce(t *testing.T) {
+	builds := 0
+	mw := func(next http.Handler) http.Handler {
+		builds++
+		return next
+	}
+	h := middleware.Wrap(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		middleware.When(func(*http.Request) bool { return true }, mw),
+	)
+	for range 3 {
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	}
+	assert.Equal(t, 1, builds)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./web/middleware -run 'TestWhen|TestSkip' -v`
+Expected: FAIL — `undefined: middleware.When`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `web/middleware/middleware.go`:
+
+```go
+// When returns a Middleware that applies mw only to requests for which pred
+// returns true; other requests pass to the next handler untouched. mw is built
+// once per next, so a stateful middleware is constructed a single time.
+func When(pred func(*http.Request) bool, mw Middleware) Middleware {
+	return func(next http.Handler) http.Handler {
+		wrapped := mw(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if pred(r) {
+				wrapped.ServeHTTP(w, r)
+			} else {
+				next.ServeHTTP(w, r)
+			}
+		})
+	}
+}
+
+// Skip is the inverse of When: mw applies unless pred returns true.
+func Skip(pred func(*http.Request) bool, mw Middleware) Middleware {
+	return When(func(r *http.Request) bool { return !pred(r) }, mw)
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./web/middleware -run 'TestWhen|TestSkip' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Format, lint, test, commit**
+
+```bash
+just fmt ./web/middleware/...
+just lint
+just test ./web/middleware/...
+git add web/middleware/middleware.go web/middleware/middleware_test.go
+git commit -m "feat(web/middleware): When/Skip conditional middleware combinators"
+```
+
+---
+
+## Task 6: `ops/supervisor` — `WithForceQuit`
+
+**Files:**
+- Modify: `ops/supervisor/context.go` (variadic `NewContext` + force-quit path)
+- Modify: `ops/supervisor/options.go` (add `ContextOption`, `contextConfig`, `WithForceQuit`)
+- Test: `ops/supervisor/context_test.go` (`package supervisor_test` — append)
+
+**Interfaces:**
+- Consumes: existing `signal.NotifyContext` behavior.
+- Produces: `type ContextOption func(*contextConfig)` · `func WithForceQuit() ContextOption` · `func NewContext(opts ...ContextOption) (context.Context, context.CancelFunc)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ops/supervisor/context_test.go` (add `os`, `os/exec`, `syscall`, `time` imports as needed):
+
+```go
+func TestNewContext_ForceQuit_FirstSignalCancels(t *testing.T) {
+	ctx, stop := supervisor.NewContext(supervisor.WithForceQuit())
+	defer stop()
+	require.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGTERM))
+	select {
+	case <-ctx.Done():
+		assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("context not cancelled after first signal")
+	}
+}
+
+func TestNewContext_ForceQuit_SecondSignalExits(t *testing.T) {
+	if os.Getenv("FORGE_FORCEQUIT_CHILD") == "1" {
+		_, stop := supervisor.NewContext(supervisor.WithForceQuit())
+		defer stop()
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		time.Sleep(100 * time.Millisecond)
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		time.Sleep(2 * time.Second) // parent expects exit(130) before this returns
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestNewContext_ForceQuit_SecondSignalExits")
+	cmd.Env = append(os.Environ(), "FORGE_FORCEQUIT_CHILD=1")
+	err := cmd.Run()
+	var ee *exec.ExitError
+	require.ErrorAs(t, err, &ee)
+	assert.Equal(t, 130, ee.ExitCode())
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./ops/supervisor -run TestNewContext_ForceQuit -v`
+Expected: FAIL — `undefined: supervisor.WithForceQuit`.
+
+- [ ] **Step 3: Add the option**
+
+Append to `ops/supervisor/options.go`:
+
+```go
+// ContextOption configures NewContext.
+type ContextOption func(*contextConfig)
+
+type contextConfig struct {
+	forceQuit bool
+}
+
+// WithForceQuit makes the second SIGINT/SIGTERM force an immediate os.Exit(130)
+// instead of being ignored. The first signal still cancels the returned context for
+// graceful drain; the second is the impatient-operator escape hatch. os.Exit
+// bypasses deferred cleanup by design.
+func WithForceQuit() ContextOption {
+	return func(c *contextConfig) { c.forceQuit = true }
+}
+```
+
+- [ ] **Step 4: Rewrite `NewContext`**
+
+Replace the body of `ops/supervisor/context.go` with (keep `package supervisor`):
+
+```go
+package supervisor
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// forceQuitCode is the process exit code used when WithForceQuit triggers on the
+// second signal (128 + SIGINT, the conventional forced-interrupt code).
+const forceQuitCode = 130
+
+// NewContext returns a context cancelled on the first SIGINT or SIGTERM. Call the
+// returned CancelFunc (typically deferred in main) to release the signal handler.
+// It is single-shot by default: after the first signal further signals are not
+// handled. With WithForceQuit, the first signal still cancels the context for a
+// graceful drain and a second signal forces os.Exit(130).
+func NewContext(opts ...ContextOption) (context.Context, context.CancelFunc) {
+	var cfg contextConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if !cfg.forceQuit {
+		return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan os.Signal, 2)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		select {
+		case <-ch:
+			cancel()
+		case <-ctx.Done():
+			return
+		}
+		select {
+		case <-ch:
+			os.Exit(forceQuitCode)
+		case <-ctx.Done():
+		}
+	}()
+	stop := func() {
+		signal.Stop(ch)
+		cancel()
+	}
+	return ctx, stop
+}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `go test ./ops/supervisor -run TestNewContext -v`
+Expected: PASS (existing `TestNewContext_*` still pass — the no-arg call still compiles; the new force-quit tests pass, including the subprocess exit-130 assertion).
+
+- [ ] **Step 6: Format, lint, test, commit**
+
+```bash
+just fmt ./ops/supervisor/...
+just lint
+just test ./ops/supervisor/...
+git add ops/supervisor/context.go ops/supervisor/options.go ops/supervisor/context_test.go
+git commit -m "feat(ops/supervisor): WithForceQuit second-signal os.Exit on NewContext"
+```
+
+---
+
+## Task 7: `ops/logger` — recording test handler
+
+**Files:**
+- Create: `ops/logger/record.go`
+- Test: `ops/logger/record_test.go` (`package logger_test` — black-box, since the whole API is exported)
+
+**Interfaces:**
+- Consumes: `log/slog`.
+- Produces: `type Record struct{…}` · `type Recorder struct{…}` · `func NewRecorder() (*slog.Logger, *Recorder)` · `func (*Recorder) Records() []Record` · `Len()` · `Reset()` · `Contains(slog.Level, string) bool`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `ops/logger/record_test.go`:
+
+```go
+package logger_test
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecorder_CapturesLevelAndMessage(t *testing.T) {
+	log, rec := logger.NewRecorder()
+	log.Info("hello")
+	log.Error("boom")
+	assert.Equal(t, 2, rec.Len())
+	assert.True(t, rec.Contains(slog.LevelInfo, "hello"))
+	assert.True(t, rec.Contains(slog.LevelError, "boom"))
+	assert.False(t, rec.Contains(slog.LevelWarn, "hello"))
+}
+
+func TestRecorder_FlattensGroupedAttrs(t *testing.T) {
+	log, rec := logger.NewRecorder()
+	log.Info("req", slog.Group("http", slog.Int("status", 200)))
+	recs := rec.Records()
+	require.Len(t, recs, 1)
+	assert.Equal(t, int64(200), recs[0].Attrs["http.status"])
+}
+
+func TestRecorder_WithGroupAndWithAttrs(t *testing.T) {
+	log, rec := logger.NewRecorder()
+	log.With(slog.String("svc", "api")).WithGroup("db").Info("query", slog.Int("rows", 3))
+	recs := rec.Records()
+	require.Len(t, recs, 1)
+	assert.Equal(t, "api", recs[0].Attrs["svc"])
+	assert.Equal(t, int64(3), recs[0].Attrs["db.rows"])
+}
+
+func TestRecorder_Reset(t *testing.T) {
+	log, rec := logger.NewRecorder()
+	log.Info("x")
+	rec.Reset()
+	assert.Equal(t, 0, rec.Len())
+	assert.Empty(t, rec.Records())
+}
+
+func TestRecorder_ConcurrentSafe(t *testing.T) {
+	log, rec := logger.NewRecorder()
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			log.Info("m", slog.Int("i", i))
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, 50, rec.Len())
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./ops/logger -run TestRecorder -v`
+Expected: FAIL — `undefined: logger.NewRecorder`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/logger/record.go`:
+
+```go
+package logger
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Record is one captured log record with attributes flattened to dotted keys (a
+// WithGroup("http") + Int("status", …) attr becomes "http.status").
+type Record struct {
+	Time    time.Time
+	Attrs   map[string]any
+	Message string
+	Level   slog.Level
+}
+
+// Recorder is a concurrency-safe slog.Handler sink that captures records for test
+// assertions. It is the seam owner's test double — there is no central fakes
+// package. Construct it with NewRecorder.
+type Recorder struct {
+	mu      sync.Mutex
+	records []Record
+}
+
+// NewRecorder returns a *slog.Logger writing into the returned *Recorder.
+func NewRecorder() (*slog.Logger, *Recorder) {
+	r := &Recorder{}
+	return slog.New(&recordHandler{rec: r}), r
+}
+
+// Records returns a snapshot copy of the captured records.
+func (r *Recorder) Records() []Record {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]Record, len(r.records))
+	copy(out, r.records)
+	return out
+}
+
+// Len returns the number of captured records.
+func (r *Recorder) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.records)
+}
+
+// Reset discards all captured records.
+func (r *Recorder) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = nil
+}
+
+// Contains reports whether any captured record has the given level and message.
+func (r *Recorder) Contains(level slog.Level, msg string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, rec := range r.records {
+		if rec.Level == level && rec.Message == msg {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Recorder) append(rec Record) {
+	r.mu.Lock()
+	r.records = append(r.records, rec)
+	r.mu.Unlock()
+}
+
+// recordHandler is the slog.Handler that flattens attributes and appends to the
+// shared Recorder. WithAttrs/WithGroup return fresh handlers (no mutation).
+type recordHandler struct {
+	rec    *Recorder
+	attrs  map[string]any // pre-bound (WithAttrs) attrs, already flattened
+	prefix string         // dotted group prefix, e.g. "http."
+}
+
+func (h *recordHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordHandler) Handle(_ context.Context, rec slog.Record) error {
+	flat := make(map[string]any, len(h.attrs)+rec.NumAttrs())
+	for k, v := range h.attrs {
+		flat[k] = v
+	}
+	rec.Attrs(func(a slog.Attr) bool {
+		flattenAttr(flat, h.prefix, a)
+		return true
+	})
+	h.rec.append(Record{
+		Time:    rec.Time,
+		Level:   rec.Level,
+		Message: rec.Message,
+		Attrs:   flat,
+	})
+	return nil
+}
+
+func (h *recordHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := h.clone()
+	for _, a := range attrs {
+		flattenAttr(next.attrs, h.prefix, a)
+	}
+	return next
+}
+
+func (h *recordHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	next := h.clone()
+	next.prefix = h.prefix + name + "."
+	return next
+}
+
+func (h *recordHandler) clone() *recordHandler {
+	attrs := make(map[string]any, len(h.attrs))
+	for k, v := range h.attrs {
+		attrs[k] = v
+	}
+	return &recordHandler{rec: h.rec, prefix: h.prefix, attrs: attrs}
+}
+
+// flattenAttr writes a into dst under prefix, recursing into group values so nested
+// keys become dotted (prefix + group + "." + key).
+func flattenAttr(dst map[string]any, prefix string, a slog.Attr) {
+	a.Value = a.Value.Resolve()
+	if a.Value.Kind() == slog.KindGroup {
+		gp := prefix
+		if a.Key != "" {
+			gp = prefix + a.Key + "."
+		}
+		for _, ga := range a.Value.Group() {
+			flattenAttr(dst, gp, ga)
+		}
+		return
+	}
+	dst[prefix+a.Key] = a.Value.Any()
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./ops/logger -run TestRecorder -race -v`
+Expected: PASS (including the `-race` concurrent test).
+
+- [ ] **Step 5: Format, lint, test, commit**
+
+```bash
+just fmt ./ops/logger/...
+just lint
+just test ./ops/logger/...
+git add ops/logger/record.go ops/logger/record_test.go
+git commit -m "feat(ops/logger): concurrency-safe recording slog test handler"
+```
+
+---
+
+## Task 8: `web/hostrouter` — DNS-rebinding doc note (doc-only)
+
+**Files:**
+- Modify: `web/hostrouter/doc.go`, `web/hostrouter/hostrouter.go` (New comment), `web/hostrouter/options.go` (WithFallback comment)
+- Test: none (existing `TestRouter_DefaultFallbackIs404` already covers the behavior)
+
+**Interfaces:** No API change.
+
+- [ ] **Step 1: Add the security note to `doc.go`**
+
+In `web/hostrouter/doc.go`, insert this paragraph after the existing wildcard/misconfiguration paragraph (before the `# Usage` heading):
+
+```go
+// # Security: default-deny is DNS-rebinding protection
+//
+// Unmatched hosts fall through to the fallback (http.NotFoundHandler(), 404, by
+// default). This default-deny is a DNS-rebinding defense: a handler is reachable
+// only for explicitly registered Host values, so an attacker who points their own
+// domain at your IP reaches the fallback, not a real handler. Do not install a
+// WithFallback that serves sensitive handlers without validating the Host itself.
+```
+
+- [ ] **Step 2: Add a note to the `New` comment**
+
+In `web/hostrouter/hostrouter.go`, extend the `New` doc comment. Change:
+
+```go
+// New builds a Router from options applied in order. With no WithHost options every
+// request is served by the fallback (HTTP 404 unless WithFallback overrides it).
+// New panics on any invalid registration. It does no I/O.
+```
+
+to:
+
+```go
+// New builds a Router from options applied in order. With no WithHost options every
+// request is served by the fallback (HTTP 404 unless WithFallback overrides it).
+// The default 404-for-unmatched-hosts is a deliberate default-deny that protects
+// against DNS rebinding. New panics on any invalid registration. It does no I/O.
+```
+
+- [ ] **Step 3: Add a warning to the `WithFallback` comment**
+
+In `web/hostrouter/options.go`, change:
+
+```go
+// WithFallback sets the handler for unmatched hosts. The default is
+// http.NotFoundHandler() (404). It panics (ErrNilHandler) if h is nil. Last wins.
+```
+
+to:
+
+```go
+// WithFallback sets the handler for unmatched hosts. The default is
+// http.NotFoundHandler() (404), a default-deny that guards against DNS rebinding;
+// overriding it to serve real content means unmatched (possibly rebound) hosts
+// reach h, so validate the Host inside h if it exposes anything sensitive. It
+// panics (ErrNilHandler) if h is nil. Last wins.
+```
+
+- [ ] **Step 4: Verify docs build and the existing test still passes**
+
+```bash
+just fmt ./web/hostrouter/...
+just lint
+just test ./web/hostrouter/...
+```
+
+Expected: all pass (no behavior change; `go build` and the existing 404 test are green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/hostrouter/doc.go web/hostrouter/hostrouter.go web/hostrouter/options.go
+git commit -m "docs(web/hostrouter): note default-deny as DNS-rebinding protection"
+```
+
+---
+
+## Task 9: `docs/packages.md` — prune the shipped-work table
+
+**Files:**
+- Modify: `docs/packages.md` (the "Shipped-package work items" table)
+
+**Interfaces:** No code change.
+
+- [ ] **Step 1: Replace the table body**
+
+In `docs/packages.md`, find the table under `## Shipped-package work items` and replace its full body (all rows) so only the deferred htmx row remains:
+
+Replace:
+
+```markdown
+| Package | Addition |
+|---|---|
+| `core/random` | `String(n, alphabet)`, `DigitCode(n)` (bias-free; `otp` needs it) |
+| `core/id` | Stripe-style `Prefixed` IDs with prefix-validating Parse |
+| `web/request` | `ValidateFile` (MIME allowlist + `filetype` sniff over File/Files); `Accept`/`AcceptsJSON` helpers |
+| `web/middleware` | `Skip`/`When(predicate)` combinator |
+| `web/problem` | Machine-readable `Code` field; `Decode(*http.Response)`; `errors.Is` on (Status, Code) |
+| `web/htmx` | SSE `SendComponent` bridge (moved out of sse's scope) |
+| `resilience/circuitbreaker` | Keyed `Group` (lazy per-key breakers); server-side HTTP middleware adapter (503 + Retry-After) |
+| `resilience/retry` | Honor `interface{ RetryAfter() time.Duration }` errors as the delay floor |
+| `resilience/cache` | Atomic SetNX in the Store contract |
+| `ops/supervisor` | `WithForceQuit` second-signal option on `NewContext` |
+| `ops/logger` | Recording slog test handler |
+| `web/hostrouter` | Doc note: unknown hosts default-deny = DNS-rebinding protection |
+```
+
+with:
+
+```markdown
+| Package | Addition |
+|---|---|
+| `web/htmx` | SSE `SendComponent` bridge — deferred to the realtime/sse wave |
+```
+
+- [ ] **Step 2: Verify and commit**
+
+```bash
+git add docs/packages.md
+git commit -m "docs(packages): drop completed Wave 1 unblocker rows; defer htmx SendComponent"
+```
+
+---
+
+## Final Verification (bundle gate)
+
+After all nine tasks are committed, run the full suite once to confirm the bundle is coherent:
+
+- [ ] **Run the whole check**
+
+```bash
+just check   # = just fmt ./... && just lint && just test ./...
+```
+
+Expected: `go vet`, `go build`, `golangci-lint`, `nilaway`, `betteralign`, `modernize` all clean; the full test suite green under `-race`.
+
+- [ ] **Confirm git state**
+
+```bash
+git status          # clean tree
+git log --oneline -10   # nine feature/docs commits present
+```
+
+---
+
+## Self-Review (author notes)
+
+- **Spec coverage:** Each of the eight spec items maps to a task (1–8); the packages.md housekeeping maps to Task 9. The spec's "deferred" items (htmx SendComponent, weighted random) are intentionally absent.
+- **Type consistency:** `filetype.Type.MIME`, `request.Error{Source,Key,Kind,Err}`, `request.Kind{TooLarge,UnsupportedMediaType,Missing}`, `request.StatusCode`, `id.ErrMalformed`, `Short.String`/`ParseShort`, `slog.Handler` method set, and `middleware.Middleware`/`Wrap` are all used exactly as they exist in the codebase (verified during recon).
+- **Independence:** No task consumes a symbol produced by another task — order is free; safe for parallel subagent execution.

--- a/docs/superpowers/specs/2026-07-05-wave1-unblockers-design.md
+++ b/docs/superpowers/specs/2026-07-05-wave1-unblockers-design.md
@@ -1,0 +1,573 @@
+# Wave 1 Unblocker Bundle — Design Spec
+
+> Date: 2026-07-05 · Status: awaiting approval · Ships as one PR.
+> Unblocks the core-tier cut-line: `web/httpclient`, `auth/{session,apikey,otp}`,
+> `ops/{envconfig,health}`, and the fleet error contract that `httpclient`
+> surfaces.
+
+Eight small API additions across seven already-shipped packages, plus one
+doc-only change and `docs/packages.md` housekeeping. No new packages, no new
+third-party dependencies. Every item is independent (touches a different
+package) and follows forge's DNA: options never builders, `errors.Is`-matchable
+sentinels, black-box tests only, crypto-secure by default.
+
+This is the first spec of the "finish core packages" effort. The target is the
+13 unshipped **core-tier** packages named in the packages.md "minimal-core
+cut-line"; this bundle clears the Wave 1 unblocker work-items that gate the
+rest. One spec per wave.
+
+---
+
+## Locked decisions (from brainstorming)
+
+1. **`core/random`** stays uniformly **crypto-secure**. We adopt the good ideas
+   from the old `github.com/dmitrymomot/random` — named charset constants and
+   variadic charset composition — but reject its `math/rand` fast-path (a
+   token-generation footgun), its silent length clamp, and its error-returning
+   OTP. `String`/`DigitCode` use crypto/rand + rejection sampling and **panic**
+   on RNG failure / misuse, consistent with the existing `Bytes`/`Int`.
+2. **Weighted random selection is dropped** — not shipped in any form. Consumers
+   who need lootbox/A-B weighting write it themselves; it does not belong in a
+   crypto-secure primitive.
+3. **`core/id.Prefixed`** is a **bound `Prefix` codec** (`NewPrefix("user")` →
+   `New`/`Parse`/`Is`/`Prefix`), underlying `Short`. Not a per-call helper (too
+   easy to typo the prefix), not a phantom-generic type (too much ceremony for
+   forge's "no magic" lean). Reuses the existing `id.ErrMalformed`; adds
+   `id.ErrWrongPrefix`.
+4. **`web/htmx.SendComponent` is deferred** to the `realtime/sse` wave so it can
+   reuse that writer. It stays as a re-tagged row in the packages.md table; it
+   is **not** in this bundle.
+5. **`web/problem`**: `*Problem` becomes an `error` (`Error` + `Is`); `Is`
+   matches on the target's non-zero `Status`/`Code`. `Decode` is lenient
+   (accepts `application/problem+json` or any JSON that looks like a problem),
+   caps the body at 1 MiB, fills `Status` from the response, and does **not**
+   close the body (the caller — `httpclient` — owns it).
+6. **`ops/supervisor.NewContext` gains variadic options**; the no-option call is
+   byte-for-byte the current behavior. `WithForceQuit` makes the **second**
+   signal `os.Exit(130)`.
+7. **`ops/logger` ships a recording test handler** (`Recorder`) as the seam
+   owner's test double — there is no central fakes package.
+
+## Design invariants (every symbol here)
+
+- **No global mutable state**: no `init`, no package singletons, no registries.
+  Every stateful object (`Prefix`, `Recorder`) is constructed and owned by the
+  caller. `random`'s functions are pure over crypto/rand.
+- **Options, never builders**: `ValidateFile`, `NewContext` take
+  `...Option`-style variadics with a private `config`.
+- **`errors.Is`-matchable single-line sentinels**: `id.ErrWrongPrefix`,
+  `problem.ErrNotProblem`. Reuse existing sentinels where present
+  (`id.ErrMalformed`, `request.Kind*`).
+- **Public methods never return unexported types**: `Prefix.Parse` returns the
+  exported `Short`; `Recorder.Records` returns `[]Record`.
+- **Black-box tests only** (`package x_test`). White-box only where asserting
+  unexported state is unavoidable (none expected here).
+
+---
+
+## 1. `core/random` — bias-free string & digit generators
+
+### API
+
+```go
+// Charset constants for String. Each is an ASCII byte string.
+const (
+	Lowercase    = "abcdefghijklmnopqrstuvwxyz"
+	Uppercase    = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	Digits       = "0123456789"
+	Alphabetic   = Lowercase + Uppercase
+	Alphanumeric = Alphabetic + Digits
+	Symbols      = "~!@#$%^&*()-_+={}[]|\\;:\"<>,./?`"
+)
+
+// String returns a cryptographically secure random string of n characters drawn
+// uniformly (bias-free, via crypto/rand rejection sampling) from the concatenation
+// of charsets. With no charsets it defaults to Alphanumeric. Overlapping charsets
+// are de-duplicated (first occurrence wins) so the distribution stays uniform over
+// the distinct characters. The charset is treated as bytes; multi-byte UTF-8
+// alphabets are not supported. Panics if n < 0 or the combined charset is empty.
+// n == 0 returns "".
+func String(n int, charsets ...string) string
+
+// DigitCode returns an n-digit decimal string with leading zeros preserved
+// (suitable for OTP / email verification codes). Equivalent to String(n, Digits).
+// Panics if n <= 0.
+func DigitCode(n int) string
+```
+
+### Semantics & rationale
+
+- **Bias-free.** Let `k = len(dedup(charset))`. For `k <= 256`, read random bytes
+  and reject any byte `>= 256 - (256 % k)` before taking `b % k` — the standard
+  modulo-bias rejection. For `k > 256` (only reachable with a caller-supplied
+  oversized alphabet) read the minimal number of bytes and apply the same
+  rejection against `k`. Bytes are drawn from a refillable buffer, not one
+  `crypto/rand.Int` per character.
+- **Panic, not error.** A crypto/rand failure is an unrecoverable broken-OS-RNG
+  condition (see existing `Bytes`); misuse (`n<0`, empty charset, `DigitCode`
+  `n<=0`) is a programming bug. `random.Read` remains the error-returning escape
+  hatch.
+- **`DigitCode` panics on `n<=0`** (stricter than `String(0)` returning `""`)
+  because a zero-length verification code is always a bug.
+
+### Reference: rejection sampler (illustrative)
+
+```go
+func String(n int, charsets ...string) string {
+	if n < 0 {
+		panic("random: String n must be >= 0")
+	}
+	set := dedup(charsets) // join + first-occurrence dedup; default Alphanumeric
+	k := len(set)
+	if k == 0 {
+		panic("random: String charset is empty")
+	}
+	out := make([]byte, n)
+	// max is the largest multiple of k that fits the sample width; bytes at or
+	// above it are rejected to remove modulo bias.
+	if k <= 256 {
+		max := 256 - (256 % k)
+		buf := make([]byte, 0, n+n/4+8)
+		for i := 0; i < n; {
+			if len(buf) == 0 {
+				buf = Bytes(cap(buf))
+			}
+			b := int(buf[len(buf)-1])
+			buf = buf[:len(buf)-1]
+			if b < max {
+				out[i] = set[b%k]
+				i++
+			}
+		}
+		return string(out)
+	}
+	// k > 256: 2-byte sampling with the same rejection rule against k.
+	// ... (uint16 draw, reject >= (65536 - 65536%k))
+}
+```
+
+### Tests (black-box, `random_test`)
+
+- Length: `len(String(n, …)) == n`; `String(0)==""`; `DigitCode(6)` is 6 chars,
+  all `[0-9]`, leading zeros possible (assert over many draws that a `0`-leading
+  code appears).
+- Alphabet membership: every rune of `String(n, Uppercase, Digits)` is in the
+  set; dedup verified by passing `Alphanumeric, Digits` and asserting the digit
+  frequency is ~1/62, not ~2/72.
+- Uniformity smoke test: chi-square-ish frequency check over a large sample for a
+  small alphabet (e.g. `Digits`) within a loose tolerance.
+- Panics: `String(-1)`, `String(3, "")`, `DigitCode(0)`, `DigitCode(-1)`.
+
+---
+
+## 2. `core/id` — bound `Prefix` codec (Stripe-style IDs)
+
+### API
+
+```go
+// Prefix is an immutable, concurrency-safe Stripe-style ID codec: a human prefix
+// joined to a Short by "_". The zero value is unusable; construct with NewPrefix.
+type Prefix struct { /* prefix string; joined string ("prefix_") */ }
+
+// NewPrefix returns a codec emitting IDs of the form "<prefix>_<short>". prefix
+// must be non-empty and match [a-z0-9]+ (Stripe convention; no "_" — it is the
+// separator). Panics on an invalid prefix: it is a compile-time constant, so a
+// bad one is a boot-time programming error.
+func NewPrefix(prefix string) Prefix
+
+// New returns a fresh ID: "<prefix>_" + NewShort().String().
+func (p Prefix) New() string
+
+// Parse validates that s carries p's prefix and a well-formed Short body,
+// returning the decoded Short. A wrong/absent prefix returns ErrWrongPrefix; a
+// malformed body returns ErrMalformed (both errors.Is-matchable).
+func (p Prefix) Parse(s string) (Short, error)
+
+// Is reports whether s is a syntactically valid ID for this prefix.
+func (p Prefix) Is(s string) bool
+
+// Prefix returns the bound prefix (for logging / diagnostics).
+func (p Prefix) Prefix() string
+```
+
+### Semantics & rationale
+
+- **Underlying = `Short`** (10 bytes, k-sortable, crockford base32) — compact and
+  URL-safe, the Stripe-ish look. Encoding/decoding inherit `Short.String()` /
+  `ParseShort` (case handling included).
+- **Separator `_`.** `Parse` requires the exact `prefix + "_"` head, then
+  `ParseShort` on the remainder.
+- **Errors:** reuse existing `id.ErrMalformed` for a bad body; add
+  `id.ErrWrongPrefix = errors.New("id: wrong prefix")`. `Parse` wraps
+  `ParseShort`'s error so `errors.Is(err, id.ErrMalformed)` holds.
+- **No options in Wave 1.** A `WithGenerator` (deterministic `New` in tests) is a
+  plausible later addition; deferred. `Parse`/`Is` are already deterministic and
+  fully testable.
+- **Immutable value**, safe to share across goroutines; `New` uses the package
+  default generator like `NewShort()`.
+
+### Tests (`id_test`)
+
+- Round-trip: `p := NewPrefix("user"); s := p.New(); assert strings.HasPrefix(s,
+  "user_"); parsed, err := p.Parse(s); err==nil && parsed == /* decoded */`.
+- `Is(p.New()) == true`.
+- Wrong prefix: `p.Parse("org_"+shortStr)` → `errors.Is(err, ErrWrongPrefix)`.
+- Malformed body: `p.Parse("user_@@@")` → `errors.Is(err, ErrMalformed)`.
+- No-separator / prefix-only / empty input → error (not panic).
+- `NewPrefix("")`, `NewPrefix("User")`, `NewPrefix("a_b")` panic.
+
+---
+
+## 3. `web/problem` — `Decode` + `*Problem` as an error
+
+### API
+
+```go
+// Error implements error with a single-line summary. The response body written by
+// the responders is unaffected — this is for logs and errors.Is chains.
+func (p *Problem) Error() string // "problem: 429 Too Many Requests [rate_limited]"
+
+// Is matches by target's non-zero fields: a *Problem target matches p when
+// (target.Status == 0 || target.Status == p.Status) &&
+// (target.Code   == "" || target.Code   == p.Code).
+// So errors.Is(err, &Problem{Code:"rate_limited"}) matches by code,
+// errors.Is(err, &Problem{Status:429}) matches by status, and &Problem{} matches
+// any Problem. A non-*Problem target never matches.
+func (p *Problem) Is(target error) bool
+
+// Decode reads an RFC 9457 problem+json response body into a *Problem. It caps the
+// body at 1 MiB (io.LimitReader), fills Status from resp.StatusCode when the body
+// omits it, and DOES NOT close resp.Body (the caller owns it). A body that is not
+// a problem document returns ErrNotProblem.
+func Decode(resp *http.Response) (*Problem, error)
+
+var ErrNotProblem = errors.New("problem: not a problem+json response")
+```
+
+### Semantics & rationale
+
+- **`Error()`**: `fmt.Sprintf("problem: %d %s", p.Status, p.Title)`, appending
+  `" ["+p.Code+"]"` when `Code != ""`. Single line, no field dump.
+- **`Is`**: enables the fleet error contract — `httpclient` returns a decoded
+  `*Problem` and callers match with `errors.Is` on status and/or machine code
+  without string comparison. Both-zero target matching "any Problem" is
+  intentional and documented.
+- **`Decode` lenience**: treat the body as a problem when the content type is
+  `application/problem+json` **or** the JSON unmarshals with a non-zero `Status`
+  or a non-empty `Code`/`Title`/`Type`. Otherwise `ErrNotProblem`. This tolerates
+  servers that send `application/json` for errors.
+- **Body ownership**: `Decode` drains up to the cap but never closes — parity with
+  stdlib decoders and required because `httpclient` may inspect/close the body
+  itself. A `nil` `resp` returns `ErrNotProblem` (defensive, not a panic).
+- **Fixed 1 MiB cap** (no option in Wave 1); a `WithMaxBytes` is a plausible later
+  addition, deferred.
+
+### Tests (`problem_test`)
+
+- `errors.Is`: build `&Problem{Status:429, Code:"rate_limited"}`; assert matches
+  for `{Code:"rate_limited"}`, `{Status:429}`, `{}`; non-match for
+  `{Status:400}`, `{Code:"other"}`, and a non-Problem error.
+- `Error()` format with and without `Code`.
+- `Decode` via `httptest`: a real `application/problem+json` body round-trips
+  (fields + status); an `application/json` problem-shaped body decodes; a plain
+  `{"ok":true}` / HTML body → `ErrNotProblem`; a body omitting `status` inherits
+  `resp.StatusCode`; an over-cap body is truncated safely (still decodes or errors
+  without OOM); body is left open (assert readable/closeable by the test after).
+
+---
+
+## 4. `web/request` — `ValidateFile` + `Accept`
+
+### API
+
+```go
+// FileOption configures ValidateFile.
+type FileOption func(*fileConfig)
+
+// WithAllowedMIME restricts uploads to these sniffed MIME types (e.g.
+// "image/png", "application/pdf"). With no allowlist, the MIME is not checked.
+func WithAllowedMIME(mimes ...string) FileOption
+
+// WithMaxFileSize rejects uploads whose declared size exceeds n bytes. With no
+// limit, size is not checked.
+func WithMaxFileSize(n int64) FileOption
+
+// ValidateFile validates an uploaded file by MAGIC BYTES (core/filetype sniff),
+// deliberately ignoring the client-declared Content-Type, plus an optional size
+// cap. Returns a *request.Error: KindTooLarge (413) for oversize,
+// KindUnsupportedMediaType (415) for a disallowed/undetectable type, KindMissing
+// for a nil header. nil on success. Callers with multiple files loop over Files().
+func ValidateFile(fh *multipart.FileHeader, opts ...FileOption) error
+
+// Accept reports whether the request's Accept header admits mediaType, honoring
+// "*/*", "type/*", and explicit "q=0" rejections. An absent/empty Accept header
+// admits everything (returns true), per RFC 9110.
+func Accept(r *http.Request, mediaType string) bool
+
+// AcceptsJSON is Accept(r, "application/json").
+func AcceptsJSON(r *http.Request) bool
+```
+
+### Semantics & rationale
+
+- **`ValidateFile` sniffs, never trusts the header.** Size check first (cheap,
+  from `fh.Size`), then `f, _ := fh.Open()` / `defer f.Close()` /
+  `filetype.DetectReader(f)`; compare the detected `Type.MIME` against the
+  allowlist. This defeats a spoofed `Content-Type` on the multipart part.
+- **Error mapping reuses the existing `Kind` enum** — no new Kind. `Source` is
+  `SourceForm`, `Key` is `fh.Filename` for a useful message.
+- **`Accept` parsing**: split on `,`, parse each media range with an optional
+  `;q=` (default `1.0`); a range matches `mediaType` by exact, `type/*`, or `*/*`.
+  If the most specific matching range has `q > 0` → true; `q == 0` → false; no
+  match → false; no header → true.
+
+### Tests (`request_test`)
+
+- `ValidateFile`: multipart fixtures with real PNG/PDF magic bytes; a `.png`
+  filename whose bytes are actually a script → `KindUnsupportedMediaType`
+  (spoof defeated); oversize vs `WithMaxFileSize` → `KindTooLarge`; empty
+  allowlist skips MIME check; nil header → `KindMissing`; `StatusCode(err)` maps
+  to 413/415/400 correctly.
+- `Accept`: table over `Accept: application/json`, `*/*`, `text/*`,
+  `application/json;q=0`, absent header, multi-range with q-values; `AcceptsJSON`
+  parallels.
+
+---
+
+## 5. `web/middleware` — `When` / `Skip` combinators
+
+### API
+
+```go
+// When returns a Middleware that applies mw only to requests for which pred
+// returns true; other requests pass to the next handler untouched.
+func When(pred func(*http.Request) bool, mw Middleware) Middleware
+
+// Skip is the inverse of When: mw applies unless pred returns true.
+func Skip(pred func(*http.Request) bool, mw Middleware) Middleware
+```
+
+### Semantics
+
+- Build the wrapped handler **once** per `next` (so a stateful `mw` is
+  constructed a single time), then branch per request:
+
+```go
+func When(pred func(*http.Request) bool, mw Middleware) Middleware {
+	return func(next http.Handler) http.Handler {
+		wrapped := mw(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if pred(r) {
+				wrapped.ServeHTTP(w, r)
+			} else {
+				next.ServeHTTP(w, r)
+			}
+		})
+	}
+}
+
+func Skip(pred func(*http.Request) bool, mw Middleware) Middleware {
+	return When(func(r *http.Request) bool { return !pred(r) }, mw)
+}
+```
+
+- Compose with the existing `Chain`. A `nil` `pred` or `mw` is a programming
+  error; document that both are required (guard-panic acceptable, or let a nil
+  `mw` panic naturally — decide in TDD; prefer an explicit panic message).
+
+### Tests (`middleware_test`)
+
+- `When` applies mw for matching paths, skips otherwise (assert a header the mw
+  sets is present/absent).
+- `Skip` is the exact inverse over the same predicate.
+- `mw` is built once (a construction counter increments a single time across many
+  requests).
+
+---
+
+## 6. `ops/supervisor` — `WithForceQuit`
+
+### API
+
+```go
+// ContextOption configures NewContext.
+type ContextOption func(*contextConfig)
+
+// WithForceQuit makes the SECOND SIGINT/SIGTERM force an immediate os.Exit(130)
+// instead of being ignored. The first signal still cancels the returned context
+// for graceful drain; the second is the impatient-operator escape hatch. os.Exit
+// bypasses deferred cleanup by design.
+func WithForceQuit() ContextOption
+
+// NewContext returns a context cancelled on the first SIGINT or SIGTERM. Call the
+// returned CancelFunc (typically deferred in main) to release the signal handler.
+func NewContext(opts ...ContextOption) (context.Context, context.CancelFunc)
+```
+
+### Semantics & rationale
+
+- **Back-compat**: with no options, `NewContext()` returns exactly today's
+  `signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)` —
+  no behavior change.
+- **With `WithForceQuit`**: use an explicit handler instead —
+  `context.WithCancel(Background)`, a buffered `signal.Notify` channel, and a
+  goroutine that cancels on the first signal and `os.Exit(130)` on the second. The
+  returned `CancelFunc` calls `signal.Stop` + stops the goroutine so nothing
+  leaks; guard against a double-exit / double-cancel.
+- Exit code **130** (128 + SIGINT), the conventional forced-interrupt code.
+
+### Reference (force-quit path)
+
+```go
+func NewContext(opts ...ContextOption) (context.Context, context.CancelFunc) {
+	var cfg contextConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if !cfg.forceQuit {
+		return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan os.Signal, 2)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-ch          // first signal → graceful
+		cancel()
+		<-ch          // second signal → impatient
+		os.Exit(130)
+	}()
+	stop := func() {
+		signal.Stop(ch)
+		cancel()
+	}
+	return ctx, stop
+}
+```
+
+### Tests (`supervisor_test`)
+
+- No-option `NewContext()` cancels on a delivered SIGTERM (existing behavior
+  preserved).
+- `WithForceQuit`: first signal cancels the context (deterministic).
+- Second-signal `os.Exit(130)`: the standard re-exec subprocess pattern — the
+  test binary re-invokes itself with an env flag, sends two signals, and asserts
+  exit code 130. Documented as the one os.Exit path.
+
+---
+
+## 7. `ops/logger` — recording test handler
+
+### API
+
+```go
+// Record is one captured log record with attributes flattened to dotted keys
+// (a WithGroup("http") + Int("status",…) attr becomes "http.status").
+type Record struct {
+	Time    time.Time
+	Level   slog.Level
+	Message string
+	Attrs   map[string]any
+}
+
+// Recorder is a concurrency-safe slog.Handler sink capturing records for test
+// assertions. It is the seam owner's test double — there is no central fakes
+// package.
+type Recorder struct { /* mu sync.Mutex; records []Record */ }
+
+// NewRecorder returns a *slog.Logger writing into the returned *Recorder.
+func NewRecorder() (*slog.Logger, *Recorder)
+
+// Records returns a snapshot copy of the captured records.
+func (r *Recorder) Records() []Record
+
+// Len returns the number of captured records.
+func (r *Recorder) Len() int
+
+// Reset discards all captured records.
+func (r *Recorder) Reset()
+
+// Contains reports whether any captured record has the given level and message.
+func (r *Recorder) Contains(level slog.Level, msg string) bool
+```
+
+### Semantics & rationale
+
+- The internal handler implements `slog.Handler`; `WithAttrs`/`WithGroup` return
+  child handlers carrying an accumulated dotted group prefix + pre-bound attrs,
+  all appending to the one shared `*Recorder` under its mutex. `Enabled` is always
+  true (record every level; asserts filter).
+- Attribute values are resolved (`attr.Value.Resolve()`) and stored as `any` under
+  dotted keys, so `LogValuer`s and groups are assertable by key.
+- `Records()` returns a copy so tests can't mutate internal state; all reads/writes
+  are mutex-guarded for logging from goroutines.
+
+### Tests (`logger_test`)
+
+- Emitting at multiple levels captures each with correct `Level`/`Message`.
+- `With(slog.Group("http", "status", 200))` produces `Attrs["http.status"] == 200`.
+- `Contains(slog.LevelError, "boom")` true/false cases.
+- `Reset()` clears; `Len()` tracks.
+- Race test: concurrent logging from N goroutines under `-race` with a final
+  count assertion.
+
+---
+
+## 8. `web/hostrouter` — DNS-rebinding doc note
+
+Doc-only. Add to `doc.go` (package overview) and the `New` / `WithFallback`
+comments:
+
+> Unmatched hosts fall through to the fallback (`http.NotFoundHandler()`, 404, by
+> default). This default-deny is a DNS-rebinding defense: a handler is reachable
+> only for explicitly registered `Host` values, so an attacker who points their
+> own domain at your IP reaches the fallback, not a real handler. Do not install a
+> catch-all fallback that serves sensitive handlers.
+
+No code change; no test change (an existing unmatched-host → 404 test already
+covers the behavior).
+
+---
+
+## Housekeeping — `docs/packages.md` (same PR)
+
+Edit the **Shipped-package work items** table:
+
+- Remove the three already-shipped resilience rows (`circuitbreaker`, `retry`,
+  `cache`) — this clears the pending post-merge cleanup from the prior bundle.
+- Remove each row landed by this bundle: `core/random`, `core/id`, `web/request`,
+  `web/middleware`, `web/problem`, `ops/supervisor`, `ops/logger`,
+  `web/hostrouter`.
+- Re-tag the `web/htmx` row to record the deferral, e.g.
+  `web/htmx | SSE SendComponent bridge — deferred to the realtime/sse wave`.
+
+The table should end containing only the deferred `htmx` row.
+
+---
+
+## Verification (per item, then bundle)
+
+- Black-box `X_test` packages only.
+- `just fmt ./<changed-pkg>/...` (package-path form — the single-file form trips a
+  spurious betteralign "undefined").
+- `just lint` clean.
+- `go test ./... -race` green (includes the uniformity, spoof-file, force-quit
+  subprocess, and concurrent-logger tests).
+- Run `modernize` (Go 1.26 idioms: `new(expr)`, `errors.AsType`).
+
+## Implementation notes
+
+- All eight items are **independent** (distinct packages, no cross-item deps), so
+  implementation parallelizes cleanly — one focused TDD change per item. The
+  packages.md housekeeping is done last as a single writer.
+- TDD each item (red → green → refactor); no shared state to sequence.
+
+## Out of scope / explicitly deferred
+
+- `web/htmx.SendComponent` → `realtime/sse` wave.
+- Weighted random selection → dropped entirely, not shipped.
+- `core/random` math/rand fast-path, silent length clamp, error-returning
+  generators → rejected (crypto-secure, panic-on-misuse instead).
+- `id.Prefix` `WithGenerator` option, `problem.Decode` `WithMaxBytes` option →
+  deferred to first concrete demand.
+- The four Wave 1 **packages** (`httpclient`, `ratelimit`, `envconfig`,
+  `health`) → their own specs, after these unblockers land.

--- a/docs/superpowers/specs/2026-07-05-wave1-unblockers-design.md
+++ b/docs/superpowers/specs/2026-07-05-wave1-unblockers-design.md
@@ -29,11 +29,15 @@ rest. One spec per wave.
 2. **Weighted random selection is dropped** — not shipped in any form. Consumers
    who need lootbox/A-B weighting write it themselves; it does not belong in a
    crypto-secure primitive.
-3. **`core/id.Prefixed`** is a **bound `Prefix` codec** (`NewPrefix("user")` →
-   `New`/`Parse`/`Is`/`Prefix`), underlying `Short`. Not a per-call helper (too
-   easy to typo the prefix), not a phantom-generic type (too much ceremony for
-   forge's "no magic" lean). Reuses the existing `id.ErrMalformed`; adds
-   `id.ErrWrongPrefix`.
+3. **`core/id.Prefixed`** is a **bound `Prefix` codec**
+   (`NewPrefix(prefix, ...opts)` → `New`/`Parse`/`Is`/`Prefix`) with a
+   **pluggable body generator** (`WithGenerator`, default `Short`; options are
+   optional) plus **package-level static aliases**
+   (`NewPrefixed`/`ParsePrefixed`/`IsPrefixed`) for the zero-config default.
+   `Parse` returns the body **string** — a pluggable generator precludes a typed
+   return; decode a default-Short body with `ParseShort`. Not a phantom-generic
+   type (too much ceremony for forge's "no magic" lean). Reuses the existing
+   `id.ErrMalformed`; adds `id.ErrWrongPrefix`.
 4. **`web/htmx.SendComponent` is deferred** to the `realtime/sse` wave so it can
    reuse that writer. It stays as a re-tagged row in the packages.md table; it
    is **not** in this bundle.
@@ -58,8 +62,8 @@ rest. One spec per wave.
 - **`errors.Is`-matchable single-line sentinels**: `id.ErrWrongPrefix`,
   `problem.ErrNotProblem`. Reuse existing sentinels where present
   (`id.ErrMalformed`, `request.Kind*`).
-- **Public methods never return unexported types**: `Prefix.Parse` returns the
-  exported `Short`; `Recorder.Records` returns `[]Record`.
+- **Public methods never return unexported types**: `Prefix.Parse` returns a
+  `string` body; `Recorder.Records` returns `[]Record`.
 - **Black-box tests only** (`package x_test`). White-box only where asserting
   unexported state is unavoidable (none expected here).
 
@@ -166,55 +170,99 @@ func String(n int, charsets ...string) string {
 
 ```go
 // Prefix is an immutable, concurrency-safe Stripe-style ID codec: a human prefix
-// joined to a Short by "_". The zero value is unusable; construct with NewPrefix.
-type Prefix struct { /* prefix string; joined string ("prefix_") */ }
+// joined to a generated body by "_". The zero value is unusable; construct with
+// NewPrefix. Options are optional; the default body generator is Short.
+type Prefix struct { /* prefix, joined ("prefix_"), gen func() string */ }
 
-// NewPrefix returns a codec emitting IDs of the form "<prefix>_<short>". prefix
-// must be non-empty and match [a-z0-9]+ (Stripe convention; no "_" — it is the
-// separator). Panics on an invalid prefix: it is a compile-time constant, so a
-// bad one is a boot-time programming error.
-func NewPrefix(prefix string) Prefix
+// PrefixOption configures NewPrefix.
+type PrefixOption func(*Prefix)
 
-// New returns a fresh ID: "<prefix>_" + NewShort().String().
+// WithGenerator sets the body generator — the part after "<prefix>_". The default
+// is Short (NewShort().String()); pass any func to mint ULID/UUID/random bodies,
+// e.g. WithGenerator(func() string { return NewULID().String() }). A nil gen
+// panics via NewPrefix.
+func WithGenerator(gen func() string) PrefixOption
+
+// NewPrefix returns a codec emitting IDs of the form "<prefix>_<body>". prefix
+// must be non-empty and match [a-z0-9]+ (Stripe convention; "_" is the
+// separator). Options are optional. Panics on an invalid prefix or a nil
+// generator — both are boot-time programming errors.
+func NewPrefix(prefix string, opts ...PrefixOption) Prefix
+
+// New returns a fresh ID: "<prefix>_" + gen().
 func (p Prefix) New() string
 
-// Parse validates that s carries p's prefix and a well-formed Short body,
-// returning the decoded Short. A wrong/absent prefix returns ErrWrongPrefix; a
-// malformed body returns ErrMalformed (both errors.Is-matchable).
-func (p Prefix) Parse(s string) (Short, error)
+// Parse validates that s carries p's prefix and a non-empty body, returning the
+// body (the part after "<prefix>_"). Because the body generator is pluggable, the
+// body is returned opaque — for the default Short generator, decode it with
+// ParseShort. A wrong/absent prefix returns ErrWrongPrefix; an empty body returns
+// ErrMalformed (both errors.Is-matchable).
+func (p Prefix) Parse(s string) (string, error)
 
-// Is reports whether s is a syntactically valid ID for this prefix.
+// Is reports whether s carries p's prefix and a non-empty body. It validates the
+// prefix and body presence only, not the body's internal format.
 func (p Prefix) Is(s string) bool
 
 // Prefix returns the bound prefix (for logging / diagnostics).
 func (p Prefix) Prefix() string
 ```
 
+### Static aliases (default Short generator, no codec to hold)
+
+```go
+// NewPrefixed returns a fresh "<prefix>_<short>" ID. Equivalent to
+// NewPrefix(prefix).New(); panics on an invalid prefix.
+func NewPrefixed(prefix string) string
+
+// ParsePrefixed validates prefix on s and returns the body. Equivalent to
+// NewPrefix(prefix).Parse(s).
+func ParsePrefixed(prefix, s string) (string, error)
+
+// IsPrefixed reports whether s carries prefix with a non-empty body. Equivalent
+// to NewPrefix(prefix).Is(s).
+func IsPrefixed(prefix, s string) bool
+```
+
 ### Semantics & rationale
 
-- **Underlying = `Short`** (10 bytes, k-sortable, crockford base32) — compact and
-  URL-safe, the Stripe-ish look. Encoding/decoding inherit `Short.String()` /
-  `ParseShort` (case handling included).
-- **Separator `_`.** `Parse` requires the exact `prefix + "_"` head, then
-  `ParseShort` on the remainder.
-- **Errors:** reuse existing `id.ErrMalformed` for a bad body; add
-  `id.ErrWrongPrefix = errors.New("id: wrong prefix")`. `Parse` wraps
-  `ParseShort`'s error so `errors.Is(err, id.ErrMalformed)` holds.
-- **No options in Wave 1.** A `WithGenerator` (deterministic `New` in tests) is a
-  plausible later addition; deferred. `Parse`/`Is` are already deterministic and
-  fully testable.
-- **Immutable value**, safe to share across goroutines; `New` uses the package
-  default generator like `NewShort()`.
+- **Pluggable body, opaque parse.** The body generator is `func() string`
+  (default `NewShort().String()`), so `New` composes `prefix + "_" + gen()`.
+  Because the generator is pluggable, `Parse` returns the body **string** rather
+  than a typed `Short` — the honest signature. Default-Short consumers recover the
+  typed value with `id.ParseShort(body)`; ULID/UUID/random-bodied codecs decode
+  with their own parser. (This supersedes the earlier "Parse returns Short"
+  decision, which pluggable generators make impossible.)
+- **Separator `_`** fixed. `Parse` requires the exact `prefix + "_"` head; the
+  remainder is the body. Empty body → `ErrMalformed`; wrong/absent prefix (no
+  matching head) → `ErrWrongPrefix`. Add
+  `id.ErrWrongPrefix = errors.New("id: wrong prefix")`; reuse `id.ErrMalformed`.
+- **Prefix validation** is a small `[a-z0-9]` byte-loop (no `regexp` dependency).
+  An invalid prefix or nil generator **panics** in `NewPrefix` (constants, caught
+  at boot). The static aliases delegate to `NewPrefix`, so they validate
+  identically.
+- **Static aliases** cover the zero-config default (Short body); reach for the
+  `Prefix` codec when you want a custom generator or a hot path that binds the
+  prefix once. Options are deliberately **not** exposed on the static aliases —
+  custom generation implies you hold a reusable codec.
+- **Immutable value**, safe to share across goroutines; the default generator uses
+  the package `defaultGen` like `NewShort()`.
 
 ### Tests (`id_test`)
 
-- Round-trip: `p := NewPrefix("user"); s := p.New(); assert strings.HasPrefix(s,
-  "user_"); parsed, err := p.Parse(s); err==nil && parsed == /* decoded */`.
-- `Is(p.New()) == true`.
-- Wrong prefix: `p.Parse("org_"+shortStr)` → `errors.Is(err, ErrWrongPrefix)`.
-- Malformed body: `p.Parse("user_@@@")` → `errors.Is(err, ErrMalformed)`.
-- No-separator / prefix-only / empty input → error (not panic).
-- `NewPrefix("")`, `NewPrefix("User")`, `NewPrefix("a_b")` panic.
+- Round-trip (default): `p := NewPrefix("user"); s := p.New()`;
+  `strings.HasPrefix(s, "user_")`; `body, err := p.Parse(s)` with `err==nil`;
+  `ParseShort(body)` succeeds.
+- Custom generator: `NewPrefix("tok", WithGenerator(func() string { return
+  NewULID().String() }))` → `New()` has a `tok_` head; `Parse` returns the ULID
+  body; `ParseULID(body)` succeeds.
+- `Is(p.New()) == true`; `Is("org_"+body) == false`.
+- Wrong prefix → `errors.Is(err, ErrWrongPrefix)`; empty body (`"user_"`) →
+  `errors.Is(err, ErrMalformed)`; no-separator / empty input → `ErrWrongPrefix`
+  (not a panic).
+- Static aliases mirror the codec on the default generator
+  (`NewPrefixed`/`ParsePrefixed`/`IsPrefixed`).
+- Panics: `NewPrefix("")`, `NewPrefix("User")`, `NewPrefix("a_b")`,
+  `NewPrefix("x", WithGenerator(nil))`, `NewPrefixed("")`.
 
 ---
 
@@ -567,7 +615,7 @@ The table should end containing only the deferred `htmx` row.
 - Weighted random selection → dropped entirely, not shipped.
 - `core/random` math/rand fast-path, silent length clamp, error-returning
   generators → rejected (crypto-secure, panic-on-misuse instead).
-- `id.Prefix` `WithGenerator` option, `problem.Decode` `WithMaxBytes` option →
-  deferred to first concrete demand.
+- `problem.Decode` `WithMaxBytes` option → deferred to first concrete demand
+  (fixed 1 MiB cap for now). (`id.Prefix.WithGenerator` is now **in** scope.)
 - The four Wave 1 **packages** (`httpclient`, `ratelimit`, `envconfig`,
   `health`) → their own specs, after these unblockers land.

--- a/ops/logger/record.go
+++ b/ops/logger/record.go
@@ -1,0 +1,139 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"sync"
+	"time"
+)
+
+// Record is one captured log record with attributes flattened to dotted keys (a
+// WithGroup("http") + Int("status", …) attr becomes "http.status").
+type Record struct {
+	Time    time.Time
+	Attrs   map[string]any
+	Message string
+	Level   slog.Level
+}
+
+// Recorder is a concurrency-safe slog.Handler sink that captures records for test
+// assertions. It is the seam owner's test double — there is no central fakes
+// package. Construct it with NewRecorder.
+type Recorder struct {
+	records []Record
+	mu      sync.Mutex
+}
+
+// NewRecorder returns a *slog.Logger writing into the returned *Recorder.
+func NewRecorder() (*slog.Logger, *Recorder) {
+	r := &Recorder{}
+	return slog.New(&recordHandler{rec: r}), r
+}
+
+// Records returns a snapshot copy of the captured records.
+func (r *Recorder) Records() []Record {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]Record, len(r.records))
+	copy(out, r.records)
+	return out
+}
+
+// Len returns the number of captured records.
+func (r *Recorder) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.records)
+}
+
+// Reset discards all captured records.
+func (r *Recorder) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = nil
+}
+
+// Contains reports whether any captured record has the given level and message.
+func (r *Recorder) Contains(level slog.Level, msg string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, rec := range r.records {
+		if rec.Level == level && rec.Message == msg {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Recorder) append(rec Record) {
+	r.mu.Lock()
+	r.records = append(r.records, rec)
+	r.mu.Unlock()
+}
+
+// recordHandler is the slog.Handler that flattens attributes and appends to the
+// shared Recorder. WithAttrs/WithGroup return fresh handlers (no mutation).
+type recordHandler struct {
+	rec    *Recorder
+	attrs  map[string]any // pre-bound (WithAttrs) attrs, already flattened
+	prefix string         // dotted group prefix, e.g. "http."
+}
+
+func (h *recordHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordHandler) Handle(_ context.Context, rec slog.Record) error {
+	flat := make(map[string]any, len(h.attrs)+rec.NumAttrs())
+	maps.Copy(flat, h.attrs)
+	rec.Attrs(func(a slog.Attr) bool {
+		flattenAttr(flat, h.prefix, a)
+		return true
+	})
+	h.rec.append(Record{
+		Time:    rec.Time,
+		Level:   rec.Level,
+		Message: rec.Message,
+		Attrs:   flat,
+	})
+	return nil
+}
+
+func (h *recordHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := h.clone()
+	for _, a := range attrs {
+		flattenAttr(next.attrs, h.prefix, a)
+	}
+	return next
+}
+
+func (h *recordHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	next := h.clone()
+	next.prefix = h.prefix + name + "."
+	return next
+}
+
+func (h *recordHandler) clone() *recordHandler {
+	attrs := make(map[string]any, len(h.attrs))
+	maps.Copy(attrs, h.attrs)
+	return &recordHandler{rec: h.rec, prefix: h.prefix, attrs: attrs}
+}
+
+// flattenAttr writes a into dst under prefix, recursing into group values so nested
+// keys become dotted (prefix + group + "." + key).
+func flattenAttr(dst map[string]any, prefix string, a slog.Attr) {
+	a.Value = a.Value.Resolve()
+	if a.Value.Kind() == slog.KindGroup {
+		gp := prefix
+		if a.Key != "" {
+			gp = prefix + a.Key + "."
+		}
+		for _, ga := range a.Value.Group() {
+			flattenAttr(dst, gp, ga)
+		}
+		return
+	}
+	dst[prefix+a.Key] = a.Value.Any()
+}

--- a/ops/logger/record_test.go
+++ b/ops/logger/record_test.go
@@ -1,0 +1,59 @@
+package logger_test
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+func TestRecorder_CapturesLevelAndMessage(t *testing.T) {
+	log, rec := logger.NewRecorder()
+	log.Info("hello")
+	log.Error("boom")
+	assert.Equal(t, 2, rec.Len())
+	assert.True(t, rec.Contains(slog.LevelInfo, "hello"))
+	assert.True(t, rec.Contains(slog.LevelError, "boom"))
+	assert.False(t, rec.Contains(slog.LevelWarn, "hello"))
+}
+
+func TestRecorder_FlattensGroupedAttrs(t *testing.T) {
+	log, rec := logger.NewRecorder()
+	log.Info("req", slog.Group("http", slog.Int("status", 200)))
+	recs := rec.Records()
+	require.Len(t, recs, 1)
+	assert.Equal(t, int64(200), recs[0].Attrs["http.status"])
+}
+
+func TestRecorder_WithGroupAndWithAttrs(t *testing.T) {
+	log, rec := logger.NewRecorder()
+	log.With(slog.String("svc", "api")).WithGroup("db").Info("query", slog.Int("rows", 3))
+	recs := rec.Records()
+	require.Len(t, recs, 1)
+	assert.Equal(t, "api", recs[0].Attrs["svc"])
+	assert.Equal(t, int64(3), recs[0].Attrs["db.rows"])
+}
+
+func TestRecorder_Reset(t *testing.T) {
+	log, rec := logger.NewRecorder()
+	log.Info("x")
+	rec.Reset()
+	assert.Equal(t, 0, rec.Len())
+	assert.Empty(t, rec.Records())
+}
+
+func TestRecorder_ConcurrentSafe(t *testing.T) {
+	log, rec := logger.NewRecorder()
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Go(func() {
+			log.Info("m", slog.Int("i", i))
+		})
+	}
+	wg.Wait()
+	assert.Equal(t, 50, rec.Len())
+}

--- a/ops/supervisor/context.go
+++ b/ops/supervisor/context.go
@@ -4,13 +4,52 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 )
 
-// NewContext returns a context that is cancelled on the first SIGINT or
-// SIGTERM, implemented with signal.NotifyContext. It is single-shot: after the
-// first signal the context is cancelled and further signals are not handled by
-// this helper. Call stop (typically deferred in main) to release the handler.
-func NewContext() (context.Context, context.CancelFunc) {
-	return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+// forceQuitCode is the process exit code used when WithForceQuit triggers on the
+// second signal (128 + SIGINT, the conventional forced-interrupt code).
+const forceQuitCode = 130
+
+// NewContext returns a context cancelled on the first SIGINT or SIGTERM. Call the
+// returned CancelFunc (typically deferred in main) to release the signal handler.
+// It is single-shot by default: after the first signal further signals are not
+// handled. With WithForceQuit, the first signal still cancels the context for a
+// graceful drain and a second signal forces os.Exit(130).
+func NewContext(opts ...ContextOption) (context.Context, context.CancelFunc) {
+	var cfg contextConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if !cfg.forceQuit {
+		return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan os.Signal, 2)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+	stopped := make(chan struct{})
+	go func() {
+		select {
+		case <-ch:
+			cancel()
+		case <-stopped:
+			return
+		}
+		select {
+		case <-ch:
+			os.Exit(forceQuitCode)
+		case <-stopped:
+		}
+	}()
+	var stopOnce sync.Once
+	stop := func() {
+		stopOnce.Do(func() {
+			signal.Stop(ch)
+			close(stopped)
+		})
+		cancel()
+	}
+	return ctx, stop
 }

--- a/ops/supervisor/context_test.go
+++ b/ops/supervisor/context_test.go
@@ -2,6 +2,8 @@ package supervisor_test
 
 import (
 	"context"
+	"os"
+	"os/exec"
 	"syscall"
 	"testing"
 	"time"
@@ -32,4 +34,34 @@ func TestNewContext_StopIsSafe(t *testing.T) {
 	ctx, stop := supervisor.NewContext()
 	stop() // releasing the handler must not panic
 	assert.ErrorIs(t, ctx.Err(), context.Canceled, "stop cancels the context")
+}
+
+func TestNewContext_ForceQuit_FirstSignalCancels(t *testing.T) {
+	ctx, stop := supervisor.NewContext(supervisor.WithForceQuit())
+	defer stop()
+	require.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGTERM))
+	select {
+	case <-ctx.Done():
+		assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("context not cancelled after first signal")
+	}
+}
+
+func TestNewContext_ForceQuit_SecondSignalExits(t *testing.T) {
+	if os.Getenv("FORGE_FORCEQUIT_CHILD") == "1" {
+		_, stop := supervisor.NewContext(supervisor.WithForceQuit())
+		defer stop()
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		time.Sleep(100 * time.Millisecond)
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		time.Sleep(2 * time.Second) // parent expects exit(130) before this returns
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestNewContext_ForceQuit_SecondSignalExits")
+	cmd.Env = append(os.Environ(), "FORGE_FORCEQUIT_CHILD=1")
+	err := cmd.Run()
+	var ee *exec.ExitError
+	require.ErrorAs(t, err, &ee)
+	assert.Equal(t, 130, ee.ExitCode())
 }

--- a/ops/supervisor/options.go
+++ b/ops/supervisor/options.go
@@ -74,3 +74,18 @@ func WithLogger(l *slog.Logger) Option {
 func WithRecover(enabled bool) Option {
 	return func(c *config) { c.Recover = enabled }
 }
+
+// ContextOption configures NewContext.
+type ContextOption func(*contextConfig)
+
+type contextConfig struct {
+	forceQuit bool
+}
+
+// WithForceQuit makes the second SIGINT/SIGTERM force an immediate os.Exit(130)
+// instead of being ignored. The first signal still cancels the returned context for
+// graceful drain; the second is the impatient-operator escape hatch. os.Exit
+// bypasses deferred cleanup by design.
+func WithForceQuit() ContextOption {
+	return func(c *contextConfig) { c.forceQuit = true }
+}

--- a/web/hostrouter/doc.go
+++ b/web/hostrouter/doc.go
@@ -9,6 +9,14 @@
 // the apex "example.com". Misconfiguration (nil handler, malformed or duplicate
 // pattern) panics at construction with an errors.Is-matchable sentinel.
 //
+// # Security: default-deny is DNS-rebinding protection
+//
+// Unmatched hosts fall through to the fallback (http.NotFoundHandler(), 404, by
+// default). This default-deny is a DNS-rebinding defense: a handler is reachable
+// only for explicitly registered Host values, so an attacker who points their own
+// domain at your IP reaches the fallback, not a real handler. Do not install a
+// WithFallback that serves sensitive handlers without validating the Host itself.
+//
 // # Usage
 //
 //	router := hostrouter.New(

--- a/web/hostrouter/hostrouter.go
+++ b/web/hostrouter/hostrouter.go
@@ -23,7 +23,8 @@ type Router struct {
 
 // New builds a Router from options applied in order. With no WithHost options every
 // request is served by the fallback (HTTP 404 unless WithFallback overrides it).
-// New panics on any invalid registration. It does no I/O.
+// The default 404-for-unmatched-hosts is a deliberate default-deny that protects
+// against DNS rebinding. New panics on any invalid registration. It does no I/O.
 func New(opts ...Option) *Router {
 	r := &Router{
 		exact:     make(map[string]http.Handler),

--- a/web/hostrouter/options.go
+++ b/web/hostrouter/options.go
@@ -41,7 +41,10 @@ func WithHost(pattern string, h http.Handler) Option {
 }
 
 // WithFallback sets the handler for unmatched hosts. The default is
-// http.NotFoundHandler() (404). It panics (ErrNilHandler) if h is nil. Last wins.
+// http.NotFoundHandler() (404), a default-deny that guards against DNS rebinding;
+// overriding it to serve real content means unmatched (possibly rebound) hosts
+// reach h, so validate the Host inside h if it exposes anything sensitive. It
+// panics (ErrNilHandler) if h is nil. Last wins.
 func WithFallback(h http.Handler) Option {
 	return func(r *Router) {
 		if h == nil {

--- a/web/middleware/middleware.go
+++ b/web/middleware/middleware.go
@@ -25,3 +25,24 @@ func Chain(mws ...Middleware) Middleware {
 func Wrap(h http.Handler, mws ...Middleware) http.Handler {
 	return Chain(mws...)(h)
 }
+
+// When returns a Middleware that applies mw only to requests for which pred
+// returns true; other requests pass to the next handler untouched. mw is built
+// once per next, so a stateful middleware is constructed a single time.
+func When(pred func(*http.Request) bool, mw Middleware) Middleware {
+	return func(next http.Handler) http.Handler {
+		wrapped := mw(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if pred(r) {
+				wrapped.ServeHTTP(w, r)
+			} else {
+				next.ServeHTTP(w, r)
+			}
+		})
+	}
+}
+
+// Skip is the inverse of When: mw applies unless pred returns true.
+func Skip(pred func(*http.Request) bool, mw Middleware) Middleware {
+	return When(func(r *http.Request) bool { return !pred(r) }, mw)
+}

--- a/web/middleware/middleware_test.go
+++ b/web/middleware/middleware_test.go
@@ -44,3 +44,54 @@ func TestChainEqualsWrap(t *testing.T) {
 		ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
 	assert.Equal(t, []string{"x:in", "y:in", "h", "y:out", "x:out"}, order)
 }
+
+func markHeader(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Marked", "1")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func TestWhen_AppliesOnlyWhenPredicateTrue(t *testing.T) {
+	h := middleware.Wrap(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		middleware.When(func(r *http.Request) bool { return r.URL.Path == "/on" }, markHeader),
+	)
+	on := httptest.NewRecorder()
+	h.ServeHTTP(on, httptest.NewRequest(http.MethodGet, "/on", nil))
+	assert.Equal(t, "1", on.Header().Get("X-Marked"))
+
+	off := httptest.NewRecorder()
+	h.ServeHTTP(off, httptest.NewRequest(http.MethodGet, "/off", nil))
+	assert.Empty(t, off.Header().Get("X-Marked"))
+}
+
+func TestSkip_IsInverseOfWhen(t *testing.T) {
+	h := middleware.Wrap(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		middleware.Skip(func(r *http.Request) bool { return r.URL.Path == "/skip" }, markHeader),
+	)
+	skip := httptest.NewRecorder()
+	h.ServeHTTP(skip, httptest.NewRequest(http.MethodGet, "/skip", nil))
+	assert.Empty(t, skip.Header().Get("X-Marked"))
+
+	apply := httptest.NewRecorder()
+	h.ServeHTTP(apply, httptest.NewRequest(http.MethodGet, "/other", nil))
+	assert.Equal(t, "1", apply.Header().Get("X-Marked"))
+}
+
+func TestWhen_BuildsMiddlewareOnce(t *testing.T) {
+	builds := 0
+	mw := func(next http.Handler) http.Handler {
+		builds++
+		return next
+	}
+	h := middleware.Wrap(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		middleware.When(func(*http.Request) bool { return true }, mw),
+	)
+	for range 3 {
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	}
+	assert.Equal(t, 1, builds)
+}

--- a/web/problem/problem.go
+++ b/web/problem/problem.go
@@ -1,7 +1,10 @@
 package problem
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -147,4 +150,65 @@ func extractFields(err error) map[string]string {
 		return map[string]string{key: re.Kind.String()}
 	}
 	return nil
+}
+
+// ErrNotProblem is returned by Decode when the response body is not a problem
+// document. Match it with errors.Is.
+var ErrNotProblem = errors.New("problem: not a problem+json response")
+
+// maxProblemBytes caps the body Decode will read, guarding against a hostile or
+// runaway upstream.
+const maxProblemBytes = 1 << 20 // 1 MiB
+
+// Error implements error with a single-line summary. The response body written by
+// the responders is unaffected — this is for logs and errors.Is chains.
+func (p *Problem) Error() string {
+	if p.Code != "" {
+		return fmt.Sprintf("problem: %d %s [%s]", p.Status, p.Title, p.Code)
+	}
+	return fmt.Sprintf("problem: %d %s", p.Status, p.Title)
+}
+
+// Is matches target by its non-zero fields: a *Problem target matches when
+// (target.Status == 0 || target.Status == p.Status) &&
+// (target.Code == "" || target.Code == p.Code). So errors.Is(err,
+// &Problem{Code:"rate_limited"}) matches by code, &Problem{Status:429} by status,
+// and &Problem{} any Problem. A non-*Problem target never matches.
+func (p *Problem) Is(target error) bool {
+	t, ok := target.(*Problem)
+	if !ok {
+		return false
+	}
+	if t.Status != 0 && t.Status != p.Status {
+		return false
+	}
+	if t.Code != "" && t.Code != p.Code {
+		return false
+	}
+	return true
+}
+
+// Decode reads an RFC 9457 problem+json response body into a *Problem. It caps the
+// body at 1 MiB, fills Status from resp.StatusCode when the body omits it, and does
+// NOT close resp.Body (the caller owns it). A body that is not a problem document
+// returns ErrNotProblem.
+func Decode(resp *http.Response) (*Problem, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, ErrNotProblem
+	}
+	var p Problem
+	dec := json.NewDecoder(io.LimitReader(resp.Body, maxProblemBytes))
+	if err := dec.Decode(&p); err != nil {
+		return nil, ErrNotProblem
+	}
+	ct := resp.Header.Get("Content-Type")
+	looksProblem := strings.Contains(ct, "application/problem+json") ||
+		p.Status != 0 || p.Code != "" || p.Title != "" || p.Type != ""
+	if !looksProblem {
+		return nil, ErrNotProblem
+	}
+	if p.Status == 0 {
+		p.Status = resp.StatusCode
+	}
+	return &p, nil
 }

--- a/web/problem/problem_test.go
+++ b/web/problem/problem_test.go
@@ -2,10 +2,13 @@ package problem_test
 
 import (
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dmitrymomot/forge/core/errorsx"
 	"github.com/dmitrymomot/forge/core/validate"
@@ -63,3 +66,77 @@ func TestFrom5xxHasNoDetail(t *testing.T) {
 	p := problem.From(errors.New("db exploded"), problem.WithStatus(http.StatusInternalServerError))
 	assert.Empty(t, p.Detail) // never leak internals on 5xx
 }
+
+func TestProblem_ErrorString(t *testing.T) {
+	p := &problem.Problem{Status: 429, Title: "Too Many Requests", Code: "rate_limited"}
+	assert.Equal(t, "problem: 429 Too Many Requests [rate_limited]", p.Error())
+	p2 := &problem.Problem{Status: 400, Title: "Bad Request"}
+	assert.Equal(t, "problem: 400 Bad Request", p2.Error())
+}
+
+func TestProblem_Is(t *testing.T) {
+	p := &problem.Problem{Status: 429, Code: "rate_limited"}
+	assert.True(t, errors.Is(p, &problem.Problem{Code: "rate_limited"}))
+	assert.True(t, errors.Is(p, &problem.Problem{Status: 429}))
+	assert.True(t, errors.Is(p, &problem.Problem{}))
+	assert.False(t, errors.Is(p, &problem.Problem{Status: 400}))
+	assert.False(t, errors.Is(p, &problem.Problem{Code: "other"}))
+	assert.False(t, errors.Is(p, errors.New("nope")))
+}
+
+func TestDecode_ProblemJSON(t *testing.T) {
+	body := `{"type":"about:blank","title":"Too Many Requests","status":429,"code":"rate_limited"}`
+	resp := &http.Response{
+		StatusCode: 429,
+		Header:     http.Header{"Content-Type": []string{"application/problem+json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	p, err := problem.Decode(resp)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, 429, p.Status)
+	assert.Equal(t, "rate_limited", p.Code)
+	assert.Equal(t, "Too Many Requests", p.Title)
+}
+
+func TestDecode_FillsStatusFromResponse(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 503,
+		Header:     http.Header{"Content-Type": []string{"application/problem+json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"title":"Service Unavailable"}`)),
+	}
+	p, err := problem.Decode(resp)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, 503, p.Status)
+}
+
+func TestDecode_NotAProblem(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"text/html"}},
+		Body:       io.NopCloser(strings.NewReader("<html></html>")),
+	}
+	_, err := problem.Decode(resp)
+	assert.ErrorIs(t, err, problem.ErrNotProblem)
+}
+
+func TestDecode_LeavesBodyOpen(t *testing.T) {
+	rc := &trackCloser{Reader: strings.NewReader(`{"status":400,"code":"x"}`)}
+	resp := &http.Response{
+		StatusCode: 400,
+		Header:     http.Header{"Content-Type": []string{"application/problem+json"}},
+		Body:       rc,
+	}
+	_, err := problem.Decode(resp)
+	require.NoError(t, err)
+	assert.False(t, rc.closed, "Decode must not close the response body")
+}
+
+// trackCloser records whether Close was called.
+type trackCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (t *trackCloser) Close() error { t.closed = true; return nil }

--- a/web/request/accept.go
+++ b/web/request/accept.go
@@ -1,0 +1,66 @@
+package request
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// Accept reports whether the request's Accept header admits mediaType, honoring
+// "*/*", "type/*", and explicit "q=0" rejections. An absent or empty Accept header
+// admits everything (returns true), per RFC 9110.
+func Accept(r *http.Request, mediaType string) bool {
+	header := r.Header.Get("Accept")
+	if strings.TrimSpace(header) == "" {
+		return true
+	}
+	want := strings.SplitN(strings.ToLower(strings.TrimSpace(mediaType)), "/", 2)
+	if len(want) != 2 {
+		return false
+	}
+	best := -1.0
+	for part := range strings.SplitSeq(header, ",") {
+		rng, q := parseAcceptPart(part)
+		if rng == "" {
+			continue
+		}
+		if acceptMatches(rng, want) && q > best {
+			best = q
+		}
+	}
+	return best > 0
+}
+
+// AcceptsJSON reports whether the request admits application/json.
+func AcceptsJSON(r *http.Request) bool { return Accept(r, "application/json") }
+
+// parseAcceptPart splits one Accept list element into its lowercased media range
+// and q-value (default 1.0).
+func parseAcceptPart(part string) (string, float64) {
+	fields := strings.Split(part, ";")
+	rng := strings.ToLower(strings.TrimSpace(fields[0]))
+	q := 1.0
+	for _, p := range fields[1:] {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(p), "q="); ok {
+			if f, err := strconv.ParseFloat(strings.TrimSpace(v), 64); err == nil {
+				q = f
+			}
+		}
+	}
+	return rng, q
+}
+
+// acceptMatches reports whether a media range admits the wanted type/subtype.
+func acceptMatches(rng string, want []string) bool {
+	if rng == "*/*" {
+		return true
+	}
+	rp := strings.SplitN(rng, "/", 2)
+	if len(rp) != 2 {
+		return false
+	}
+	if rp[0] != want[0] {
+		return false
+	}
+	return rp[1] == "*" || rp[1] == want[1]
+}

--- a/web/request/accept.go
+++ b/web/request/accept.go
@@ -7,8 +7,12 @@ import (
 )
 
 // Accept reports whether the request's Accept header admits mediaType, honoring
-// "*/*", "type/*", and explicit "q=0" rejections. An absent or empty Accept header
-// admits everything (returns true), per RFC 9110.
+// "*/*", "type/*", and explicit "q=0" rejections. Per RFC 9110 §12.5.1 the most
+// specific matching range decides: an exact "type/subtype" outranks "type/*",
+// which outranks "*/*", so an explicit "q=0" exclusion overrides a less-specific
+// wildcard (e.g. "*/*, application/json;q=0" rejects application/json). Among
+// ranges of equal specificity the highest q-value wins. An absent or empty Accept
+// header admits everything (returns true).
 func Accept(r *http.Request, mediaType string) bool {
 	header := r.Header.Get("Accept")
 	if strings.TrimSpace(header) == "" {
@@ -18,17 +22,24 @@ func Accept(r *http.Request, mediaType string) bool {
 	if len(want) != 2 {
 		return false
 	}
-	best := -1.0
+	bestSpec := -1
+	bestQ := 0.0
 	for part := range strings.SplitSeq(header, ",") {
 		rng, q := parseAcceptPart(part)
 		if rng == "" {
 			continue
 		}
-		if acceptMatches(rng, want) && q > best {
-			best = q
+		spec := acceptSpecificity(rng, want)
+		if spec < 0 {
+			continue // range does not match mediaType
+		}
+		// A more specific range takes precedence regardless of q; among equally
+		// specific ranges the higher q wins.
+		if spec > bestSpec || (spec == bestSpec && q > bestQ) {
+			bestSpec, bestQ = spec, q
 		}
 	}
-	return best > 0
+	return bestSpec >= 0 && bestQ > 0
 }
 
 // AcceptsJSON reports whether the request admits application/json.
@@ -50,17 +61,23 @@ func parseAcceptPart(part string) (string, float64) {
 	return rng, q
 }
 
-// acceptMatches reports whether a media range admits the wanted type/subtype.
-func acceptMatches(rng string, want []string) bool {
+// acceptSpecificity reports how specifically a media range matches the wanted
+// type/subtype, or -1 if it does not match: 2 for an exact "type/subtype", 1 for
+// "type/*", 0 for "*/*". Higher wins per RFC 9110 §12.5.1.
+func acceptSpecificity(rng string, want []string) int {
 	if rng == "*/*" {
-		return true
+		return 0
 	}
 	rp := strings.SplitN(rng, "/", 2)
-	if len(rp) != 2 {
-		return false
+	if len(rp) != 2 || rp[0] != want[0] {
+		return -1
 	}
-	if rp[0] != want[0] {
-		return false
+	switch rp[1] {
+	case want[1]:
+		return 2
+	case "*":
+		return 1
+	default:
+		return -1
 	}
-	return rp[1] == "*" || rp[1] == want[1]
 }

--- a/web/request/accept_test.go
+++ b/web/request/accept_test.go
@@ -1,0 +1,40 @@
+package request_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/web/request"
+)
+
+func TestAccept(t *testing.T) {
+	cases := []struct {
+		accept string
+		media  string
+		want   bool
+	}{
+		{"application/json", "application/json", true},
+		{"*/*", "application/json", true},
+		{"text/*", "text/html", true},
+		{"text/*", "application/json", false},
+		{"application/json;q=0", "application/json", false},
+		{"", "application/json", true},
+		{"text/html, application/json;q=0.9", "application/json", true},
+	}
+	for _, c := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		if c.accept != "" {
+			r.Header.Set("Accept", c.accept)
+		}
+		assert.Equalf(t, c.want, request.Accept(r, c.media), "Accept %q media %q", c.accept, c.media)
+	}
+}
+
+func TestAcceptsJSON(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Accept", "application/json")
+	assert.True(t, request.AcceptsJSON(r))
+}

--- a/web/request/accept_test.go
+++ b/web/request/accept_test.go
@@ -33,6 +33,29 @@ func TestAccept(t *testing.T) {
 	}
 }
 
+// TestAccept_SpecificityPrecedence verifies RFC 9110 §12.5.1: when several Accept
+// ranges match the wanted type, the most specific range decides admittance, so an
+// explicit q=0 exclusion overrides a less-specific wildcard rather than being
+// outvoted by it.
+func TestAccept_SpecificityPrecedence(t *testing.T) {
+	cases := []struct {
+		accept string
+		media  string
+		want   bool
+	}{
+		{"*/*, application/json;q=0", "application/json", false}, // exact exclusion beats */*
+		{"application/*;q=0, */*", "application/json", false},    // type/* exclusion beats */*
+		{"text/*, text/html;q=0", "text/html", false},            // exact exclusion beats type/*
+		{"text/*;q=0, text/html", "text/html", true},             // exact allow beats type/* exclusion
+		{"*/*, application/json;q=0", "text/html", true},         // unlisted type still admitted by */*
+	}
+	for _, c := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("Accept", c.accept)
+		assert.Equalf(t, c.want, request.Accept(r, c.media), "Accept %q media %q", c.accept, c.media)
+	}
+}
+
 func TestAcceptsJSON(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	r.Header.Set("Accept", "application/json")

--- a/web/request/body.go
+++ b/web/request/body.go
@@ -8,7 +8,10 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"slices"
 	"strings"
+
+	"github.com/dmitrymomot/forge/core/filetype"
 )
 
 const (
@@ -191,4 +194,58 @@ func parseMultipart(r *http.Request, opts []BodyOption) error {
 		return &Error{Source: SourceBody, Kind: kind, Err: err}
 	}
 	return nil
+}
+
+// FileOption configures ValidateFile.
+type FileOption func(*fileConfig)
+
+type fileConfig struct {
+	allowedMIME []string
+	maxSize     int64
+}
+
+// WithAllowedMIME restricts uploads to these magic-byte-sniffed MIME types (e.g.
+// "image/png", "application/pdf"). With no allowlist the MIME is not checked.
+func WithAllowedMIME(mimes ...string) FileOption {
+	return func(c *fileConfig) { c.allowedMIME = mimes }
+}
+
+// WithMaxFileSize rejects uploads whose declared size exceeds n bytes. With no
+// limit the size is not checked.
+func WithMaxFileSize(n int64) FileOption {
+	return func(c *fileConfig) { c.maxSize = n }
+}
+
+// ValidateFile validates an uploaded file by its magic bytes (core/filetype),
+// deliberately ignoring the client-declared Content-Type, plus an optional size
+// cap. It returns a *Error: KindTooLarge for an oversize file,
+// KindUnsupportedMediaType for a disallowed/undetectable type, KindMissing for a
+// nil header; nil on success. Consumers with multiple files loop over Files().
+func ValidateFile(fh *multipart.FileHeader, opts ...FileOption) error {
+	if fh == nil {
+		return &Error{Source: SourceForm, Kind: KindMissing}
+	}
+	var c fileConfig
+	for _, o := range opts {
+		o(&c)
+	}
+	if c.maxSize > 0 && fh.Size > c.maxSize {
+		return &Error{Source: SourceForm, Key: fh.Filename, Kind: KindTooLarge}
+	}
+	if len(c.allowedMIME) == 0 {
+		return nil
+	}
+	f, err := fh.Open()
+	if err != nil {
+		return &Error{Source: SourceForm, Key: fh.Filename, Kind: KindUnsupportedMediaType, Err: err}
+	}
+	defer func() { _ = f.Close() }()
+	typ, _, err := filetype.DetectReader(f)
+	if err != nil {
+		return &Error{Source: SourceForm, Key: fh.Filename, Kind: KindUnsupportedMediaType, Err: err}
+	}
+	if slices.Contains(c.allowedMIME, typ.MIME) {
+		return nil
+	}
+	return &Error{Source: SourceForm, Key: fh.Filename, Kind: KindUnsupportedMediaType}
 }

--- a/web/request/body_files_test.go
+++ b/web/request/body_files_test.go
@@ -127,3 +127,53 @@ func TestFileMissingKind(t *testing.T) {
 		assert.Equal(t, request.KindMissing, re.Kind) // absent, not malformed
 	}
 }
+
+// pngBytes is a minimal PNG magic-byte header for sniff tests.
+var pngBytes = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D}
+
+func multipartFileReq(t *testing.T, field, filename string, content []byte) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile(field, filename)
+	require.NoError(t, err)
+	_, err = fw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
+	r := httptest.NewRequest(http.MethodPost, "/", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	return r
+}
+
+func TestValidateFile_AllowsSniffedPNG(t *testing.T) {
+	r := multipartFileReq(t, "avatar", "a.png", pngBytes)
+	fhs, err := request.Files(r, "avatar")
+	require.NoError(t, err)
+	require.Len(t, fhs, 1)
+	assert.NoError(t, request.ValidateFile(fhs[0], request.WithAllowedMIME("image/png")))
+}
+
+func TestValidateFile_RejectsSpoofedType(t *testing.T) {
+	// A .png filename whose bytes are plain text must be rejected by magic-byte sniff.
+	r := multipartFileReq(t, "avatar", "evil.png", []byte("#!/bin/sh\necho hi\n"))
+	fhs, err := request.Files(r, "avatar")
+	require.NoError(t, err)
+	err = request.ValidateFile(fhs[0], request.WithAllowedMIME("image/png"))
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnsupportedMediaType, request.StatusCode(err))
+}
+
+func TestValidateFile_TooLarge(t *testing.T) {
+	r := multipartFileReq(t, "avatar", "a.png", pngBytes)
+	fhs, err := request.Files(r, "avatar")
+	require.NoError(t, err)
+	err = request.ValidateFile(fhs[0], request.WithMaxFileSize(4))
+	require.Error(t, err)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, request.StatusCode(err))
+}
+
+func TestValidateFile_NilHeader(t *testing.T) {
+	err := request.ValidateFile(nil)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, request.StatusCode(err))
+}


### PR DESCRIPTION
## Wave 1 Unblocker Bundle

Eight small, independent API additions across seven shipped packages, plus two doc edits, that unblock core-tier roadmap work. Each addition follows its package's existing conventions (options not builders, `errors.Is`-matchable single-line sentinels, black-box tests, Go 1.26 idioms) and is crypto-secure / stdlib-only where relevant.

Implements `docs/superpowers/plans/2026-07-05-wave1-unblockers.md` (design spec: `docs/superpowers/specs/2026-07-05-wave1-unblockers-design.md`).

### Changes

| Package | Addition |
|---|---|
| `core/random` | Bias-free `String(n, ...charsets)` + `DigitCode(n)` + charset constants (crypto/rand rejection sampling; overlapping charsets de-duplicated to keep the distribution uniform) |
| `core/id` | Stripe-style `Prefix` codec (`<prefix>_<body>`) with pluggable `WithGenerator`, static aliases `NewPrefixed`/`ParsePrefixed`/`IsPrefixed`, and `ErrWrongPrefix` |
| `web/problem` | `Decode(*http.Response)` (RFC 9457, 1 MiB cap, does not close the body), `*Problem` as an `errors.Is`-matchable error (`Error`/`Is` by non-zero Status/Code), `ErrNotProblem` |
| `web/request` | `ValidateFile` (magic-byte MIME sniff via `core/filetype`, ignores the client-declared type; optional size cap) + `Accept`/`AcceptsJSON` content negotiation |
| `web/middleware` | `When` / `Skip` conditional middleware combinators (inner middleware built once per `next`) |
| `ops/supervisor` | `WithForceQuit` — second SIGINT/SIGTERM forces `os.Exit(130)`; `NewContext` is now variadic (backward compatible) |
| `ops/logger` | Concurrency-safe recording slog test handler (`Recorder`/`NewRecorder`) that flattens grouped attrs to dotted keys |
| `web/hostrouter` | Doc note: unmatched-host default-deny is deliberate DNS-rebinding protection (doc-only) |
| `docs/packages.md` | Pruned the shipped-work table; only the deferred `web/htmx` SendComponent row remains |

### Verification

- Full `just check` green: `go vet`, `go build`, `golangci-lint`, `nilaway`, `betteralign`, `modernize` all clean; entire suite passes under `-race`.
- Black-box tests throughout; new coverage: middleware 100%, supervisor 96.7%, logger 95.9%, hostrouter 98.5%, problem 90.9%, request 86.4%.
- Every task passed an independent spec+quality review; a final whole-branch review returned **ready to merge** with no Critical/Important findings.

### Notes for review

- **`ops/supervisor` deviates from the plan's literal code — intentionally.** The plan's Step-4 snippet reused `ctx.Done()` (already closed by the first `cancel()`) as the second `select`'s sentinel, so a second signal would never fire and the process would exit 0 instead of 130. Fixed with a dedicated `stopped` channel closed only by `stop()` under `sync.Once`; the subprocess test asserts exit code 130.
- Non-blocking follow-ups surfaced in review (deferred): a doc note on `(*Problem).Error()` value-vs-pointer semantics; a `stop(); stop()` idempotency test for supervisor.
