### PR TITLE
feat: Wave 1 completion bundle (config, health, ratelimit, httpclient)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ go.work.sum
 
 # env file
 .env
+# but keep committed test fixtures literally named .env
+!ops/config/testdata/.env
 
 # Editor/IDE
 # .idea/

--- a/core/structfields/doc.go
+++ b/core/structfields/doc.go
@@ -12,10 +12,11 @@
 // What this is NOT: it does not flatten anonymous embedded structs — an
 // embedded struct is yielded as one field, and a caller needing recursion
 // re-Walks that field's value (embedded flattening + name prefixing may be
-// added later without an API break). It visits only exported fields. It does
-// not bind or populate structs from external data, does not validate, and does
-// not parse scalar values — struct-tag binding lives in the consumers, scalar
-// conversion in typeconv, and value validation in validate.
+// added later without an API break). It visits only exported fields. Walk
+// itself does not bind or populate structs from external data, does not
+// validate, and does not parse scalar values; SetString bridges a single
+// field to typeconv scalar conversion — struct-tag binding lives in the
+// consumers, scalar conversion in typeconv, and value validation in validate.
 //
 // # Usage
 //

--- a/core/structfields/errors.go
+++ b/core/structfields/errors.go
@@ -10,3 +10,7 @@ var ErrNotStruct = errors.New("structfields: not a struct")
 // assigned — either because Walk received a non-pointer struct (read-only) or
 // the field is otherwise unsettable.
 var ErrNotSettable = errors.New("structfields: field not settable")
+
+// ErrUnsupportedKind is returned by SetString when the field's kind cannot be
+// parsed from a string.
+var ErrUnsupportedKind = errors.New("structfields: unsupported kind")

--- a/core/structfields/setstring.go
+++ b/core/structfields/setstring.go
@@ -1,0 +1,69 @@
+package structfields
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/typeconv"
+)
+
+// SetString parses raw according to f's field type and assigns it via f.Set.
+// Supported: string, bool, all int/uint widths, float32/64, time.Duration,
+// time.Time (RFC3339), and []string (comma-separated). Other kinds return
+// ErrUnsupportedKind. A read-only (value-struct) field returns ErrNotSettable
+// through f.Set; a parse failure surfaces typeconv.ErrSyntax.
+func SetString(f Field, raw string) error {
+	switch f.Value.Type() {
+	case reflect.TypeFor[time.Duration]():
+		d, err := typeconv.ParseDuration(raw)
+		if err != nil {
+			return err
+		}
+		return f.Set(d)
+	case reflect.TypeFor[time.Time]():
+		tm, err := typeconv.ParseTime(raw)
+		if err != nil {
+			return err
+		}
+		return f.Set(tm)
+	}
+
+	switch f.Value.Kind() {
+	case reflect.String:
+		return f.Set(raw)
+	case reflect.Bool:
+		v, err := typeconv.ParseBool(raw)
+		if err != nil {
+			return err
+		}
+		return f.Set(v)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v, err := typeconv.ParseInt[int64](raw)
+		if err != nil {
+			return err
+		}
+		return f.Set(v)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v, err := typeconv.ParseUint[uint64](raw)
+		if err != nil {
+			return err
+		}
+		return f.Set(v)
+	case reflect.Float32, reflect.Float64:
+		v, err := typeconv.ParseFloat[float64](raw)
+		if err != nil {
+			return err
+		}
+		return f.Set(v)
+	case reflect.Slice:
+		if f.Value.Type().Elem().Kind() == reflect.String {
+			v, err := typeconv.ParseSlice[string](raw, ",")
+			if err != nil {
+				return err
+			}
+			return f.Set(v)
+		}
+	}
+	return fmt.Errorf("structfields: field %q: %w (%s)", f.Name, ErrUnsupportedKind, f.Value.Kind())
+}

--- a/core/structfields/setstring.go
+++ b/core/structfields/setstring.go
@@ -38,24 +38,32 @@ func SetString(f Field, raw string) error {
 			return err
 		}
 		return f.Set(v)
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		v, err := typeconv.ParseInt[int64](raw)
-		if err != nil {
-			return err
-		}
-		return f.Set(v)
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		v, err := typeconv.ParseUint[uint64](raw)
-		if err != nil {
-			return err
-		}
-		return f.Set(v)
-	case reflect.Float32, reflect.Float64:
-		v, err := typeconv.ParseFloat[float64](raw)
-		if err != nil {
-			return err
-		}
-		return f.Set(v)
+	case reflect.Int:
+		return setSigned[int](f, raw)
+	case reflect.Int8:
+		return setSigned[int8](f, raw)
+	case reflect.Int16:
+		return setSigned[int16](f, raw)
+	case reflect.Int32:
+		return setSigned[int32](f, raw)
+	case reflect.Int64:
+		return setSigned[int64](f, raw)
+	case reflect.Uint:
+		return setUnsigned[uint](f, raw)
+	case reflect.Uint8:
+		return setUnsigned[uint8](f, raw)
+	case reflect.Uint16:
+		return setUnsigned[uint16](f, raw)
+	case reflect.Uint32:
+		return setUnsigned[uint32](f, raw)
+	case reflect.Uint64:
+		return setUnsigned[uint64](f, raw)
+	case reflect.Uintptr:
+		return setUnsigned[uintptr](f, raw)
+	case reflect.Float32:
+		return setFloat[float32](f, raw)
+	case reflect.Float64:
+		return setFloat[float64](f, raw)
 	case reflect.Slice:
 		if f.Value.Type().Elem().Kind() == reflect.String {
 			v, err := typeconv.ParseSlice[string](raw, ",")
@@ -66,4 +74,28 @@ func SetString(f Field, raw string) error {
 		}
 	}
 	return fmt.Errorf("structfields: field %q: %w (%s)", f.Name, ErrUnsupportedKind, f.Value.Kind())
+}
+
+func setSigned[T int | int8 | int16 | int32 | int64](f Field, raw string) error {
+	v, err := typeconv.ParseInt[T](raw)
+	if err != nil {
+		return err
+	}
+	return f.Set(v)
+}
+
+func setUnsigned[T uint | uint8 | uint16 | uint32 | uint64 | uintptr](f Field, raw string) error {
+	v, err := typeconv.ParseUint[T](raw)
+	if err != nil {
+		return err
+	}
+	return f.Set(v)
+}
+
+func setFloat[T float32 | float64](f Field, raw string) error {
+	v, err := typeconv.ParseFloat[T](raw)
+	if err != nil {
+		return err
+	}
+	return f.Set(v)
 }

--- a/core/structfields/setstring_test.go
+++ b/core/structfields/setstring_test.go
@@ -1,0 +1,68 @@
+package structfields_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/structfields"
+)
+
+func TestSetString_SupportedKinds(t *testing.T) {
+	var s struct {
+		Name    string
+		Count   int
+		Small   int32
+		Size    uint16
+		Ratio   float64
+		On      bool
+		Timeout time.Duration
+		At      time.Time
+		Origins []string
+	}
+	apply := func(name, raw string) {
+		require.NoError(t, structfields.Walk(&s, "env", func(f structfields.Field) error {
+			if f.Name == name {
+				return structfields.SetString(f, raw)
+			}
+			return nil
+		}))
+	}
+	apply("Name", "forge")
+	apply("Count", "42")
+	apply("Small", "7")
+	apply("Size", "9")
+	apply("Ratio", "3.5")
+	apply("On", "true")
+	apply("Timeout", "1500ms")
+	apply("At", "2026-07-05T10:00:00Z")
+	apply("Origins", "a,b,c")
+
+	assert.Equal(t, "forge", s.Name)
+	assert.Equal(t, 42, s.Count)
+	assert.Equal(t, int32(7), s.Small)
+	assert.Equal(t, uint16(9), s.Size)
+	assert.InDelta(t, 3.5, s.Ratio, 1e-9)
+	assert.True(t, s.On)
+	assert.Equal(t, 1500*time.Millisecond, s.Timeout)
+	assert.Equal(t, 2026, s.At.Year())
+	assert.Equal(t, []string{"a", "b", "c"}, s.Origins)
+}
+
+func TestSetString_UnsupportedKind(t *testing.T) {
+	var s struct{ M map[string]string }
+	err := structfields.Walk(&s, "env", func(f structfields.Field) error {
+		return structfields.SetString(f, "x")
+	})
+	assert.ErrorIs(t, err, structfields.ErrUnsupportedKind)
+}
+
+func TestSetString_BadSyntax(t *testing.T) {
+	var s struct{ Count int }
+	err := structfields.Walk(&s, "env", func(f structfields.Field) error {
+		return structfields.SetString(f, "not-a-number")
+	})
+	require.Error(t, err)
+}

--- a/core/structfields/setstring_test.go
+++ b/core/structfields/setstring_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dmitrymomot/forge/core/structfields"
+	"github.com/dmitrymomot/forge/core/typeconv"
 )
 
 func TestSetString_SupportedKinds(t *testing.T) {
@@ -65,4 +66,19 @@ func TestSetString_BadSyntax(t *testing.T) {
 		return structfields.SetString(f, "not-a-number")
 	})
 	require.Error(t, err)
+}
+
+func TestSetString_OverflowRejected(t *testing.T) {
+	var s struct {
+		Small int8
+		Byte  uint8
+	}
+	err := structfields.Walk(&s, "env", func(f structfields.Field) error {
+		if f.Name == "Small" {
+			return structfields.SetString(f, "300") // overflows int8
+		}
+		return nil
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, typeconv.ErrSyntax)
 }

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -5,8 +5,8 @@
 > `package-set-v2.md` (consolidated 2026-07-04, after a cross-framework review
 > against kratos, go-kit, go-micro, fiber v3, fiber-contrib, and forge v1).
 >
-> **State: 57 shipped packages** across `core/ crypto/ resilience/ web/ data/ ops/`
-> · **64 roadmap** (committed) · **27 icebox** (demand-driven, no commitment).
+> **State: 61 shipped packages** across `core/ crypto/ resilience/ web/ data/ ops/`
+> · **60 roadmap** (committed) · **27 icebox** (demand-driven, no commitment).
 
 ## Design DNA every package follows
 
@@ -44,7 +44,8 @@ Forge optimizes for a small, auditable dependency surface — not stdlib purism:
   swappable leaf.
 
 Isolated deps today: `pgx`, goose (`migration`), the mongo/redis/opensearch
-clients, sentry. Sanctioned for the roadmap: aws-sdk-go-v2 (`objectstore/s3`),
+clients, sentry, `gopkg.in/yaml.v3` (`ops/config`'s YAML loader, its sole
+consumer). Sanctioned for the roadmap: aws-sdk-go-v2 (`objectstore/s3`),
 `coder/websocket` (`ws`), `go-webauthn` (`webauthn`), `x/crypto`
 (password/kdf/autocert), goldmark (`emailtemplate/markdown`), the official
 MCP go-sdk (`mcpserver`), `x/image` (`imageproc`), prometheus client
@@ -115,14 +116,13 @@ forge/                              # single go.mod at the root
 │
 ├── resilience/    # failure handling, concurrency, load control
 │   # shipped: backoff retry singleflight parallel circuitbreaker
-│   #          cache (cache/redis)
-│   # planned: ratelimit (ratelimit/redisstore) quota (quota/pgstore)
-│   #          loadshed lock (lock/pglock)
+│   #          cache (cache/redis) ratelimit (ratelimit/redisstore)
+│   # planned: quota (quota/pgstore) loadshed lock (lock/pglock)
 │
 ├── web/           # HTTP in and out: transport, responses, boundary security, client
 │   # shipped: httpserver hostrouter middleware request clientip problem
-│   #          recoverer reqlog requestid render htmx subroute
-│   # planned: httpclient cookie csrf secheaders cors timeout compress
+│   #          recoverer reqlog requestid render htmx subroute httpclient
+│   # planned: cookie csrf secheaders cors timeout compress
 │   #          assets idempotency iplist captcha (captcha/turnstile ...)
 │   #          webhookverify autocert
 │   # icebox:  geoip (geoip/maxmind) dnsverify maintenance
@@ -161,8 +161,8 @@ forge/                              # single go.mod at the root
 │   # icebox:  structured embeddings aiusage mcpserver
 │
 ├── ops/           # runtime, lifecycle, observability, app bootstrap
-│   # shipped: supervisor logger (logger/sentry)
-│   # planned: envconfig health buildinfo automaxprocs diag metrics
+│   # shipped: supervisor logger (logger/sentry) config health
+│   # planned: buildinfo automaxprocs diag metrics
 │   #          (metrics/prometheus) logredact auditlog (auditlog/pgsink)
 │   #          featureflag cli appmain
 │   # icebox:  tracing (tracing/otel) secretsource logsample configwatch term
@@ -234,11 +234,9 @@ doc.go example.
 
 ### resilience/
 
-Shipped: `backoff retry singleflight parallel circuitbreaker cache (cache/redis)`.
+Shipped: `backoff retry singleflight parallel circuitbreaker cache (cache/redis)
+ratelimit (ratelimit/redisstore)`.
 
-- **`ratelimit`** (+`ratelimit/redisstore`) — core. Keyed token-bucket /
-  sliding-window limiter over the counter Store contract; in-memory default;
-  HTTP middleware emits RateLimit-* headers. `ErrLimited`.
 - **`quota`** (+`quota/pgstore`) — recommended. Cumulative usage caps per
   subject over calendar/rolling windows (requests/month, seats, AI tokens) —
   the plan-entitlement counterpart to ratelimit. Subject is an opaque string;
@@ -256,14 +254,12 @@ Shipped: `backoff retry singleflight parallel circuitbreaker cache (cache/redis)
 ### web/
 
 Shipped: `httpserver hostrouter middleware request clientip problem recoverer
-reqlog requestid render htmx subroute`.
+reqlog requestid render htmx subroute httpclient`. (`httpclient` builds a
+resilient outbound `*http.Client` via a RoundTripper stack: per-attempt
+timeout, jittered retry, an OPT-IN per-host circuit breaker, before/after
+hooks, and ctx-driven header propagation — the transport under captcha,
+oauthclient, comms/*, and llm. Returns the stdlib type.)
 
-- **`httpclient`** — core, build early. Resilient outbound `*http.Client`
-  via a RoundTripper stack: per-attempt timeout, jittered retry, circuit
-  breaker, before/after hooks, and ctx-driven header propagation
-  (traceparent, request-id) so cross-service correlation actually works. The
-  transport under captcha, oauthclient, comms/*, and llm. Returns the stdlib
-  type.
 - **`cookie`** — recommended. Signed + encrypted cookie codec with secure
   defaults (HttpOnly, SameSite, `__Host-`) and keyset rotation. Foundation
   for csrf, flash, and session's cookie store.
@@ -513,18 +509,16 @@ Icebox:
 
 ### ops/
 
-Shipped: `supervisor logger (logger/sentry)`.
+Shipped: `supervisor logger (logger/sentry) config health`. (`config` —
+formerly planned as `envconfig`, shipped renamed — layers app config from
+YAML per-env files with `${VAR:default}` substitution, `.env` inheritance,
+and env-tagged structs via `structfields` + `typeconv`; exported `Profile`
+enum (dev/test/staging/prod) with predicates; boot-time only.
+`health` — a single pull-evaluated `Handler()` factory for liveness (no
+checks) and readiness (`WithCheck` checks, critical by default, `NonCritical`
+degrades instead of 503) plus a `Gate` for ordered pre-shutdown drain via
+`supervisor.WithPreShutdown`.)
 
-- **`envconfig`** — core. Populate env-tagged Config structs from environment
-  + .env (parser internal; `WithDotenv`), via `structfields` + `typeconv`;
-  exported `Profile` enum (dev/test/staging/prod) with predicates. Boot-time
-  only.
-- **`health`** — core. Liveness + readiness in one package: two registries,
-  `LivenessHandler` (/livez) and `ReadinessHandler` (/readyz), per-check
-  timeout + TTL cache, critical/non-critical flags, `SetReady`/`Shutdown()`
-  drain gating (flip not-ready *before* httpserver.Shutdown), and
-  `Heartbeat(name, maxAge)` kickers so a hung background loop fails /livez.
-  Driver-free core; concrete checks in `health/checks`.
 - **`buildinfo`** — recommended. Version/commit/build-time/dirty from ldflags
   + `ReadBuildInfo`; `slog.LogValuer` + /version handler.
 - **`automaxprocs`** — recommended. Set GOMAXPROCS/GOMEMLIMIT from cgroup
@@ -596,29 +590,26 @@ Queued API additions to shipped packages (each unblocks roadmap work):
 Each wave depends only on earlier ones. Icebox packages slot in wherever
 demand appears.
 
-1. **Unblockers** — the shipped-package work items above;
-   `httpclient` (transport under half the roadmap); `ratelimit` (counter
-   seam); `envconfig`; `health`.
-2. **Web boundary + ops glue** — `cookie` → `csrf`, `secheaders`, `cors`,
+1. **Web boundary + ops glue** — `cookie` → `csrf`, `secheaders`, `cors`,
    `timeout`, `compress`, `assets`, `iplist`, `webhookverify`, `autocert`,
    `captcha`, `idempotency`; `buildinfo`, `automaxprocs`, `diag`, `metrics`,
    `logredact`, `featureflag`, `cli`, `appmain`; `webtest`, `htmltest`,
    `dbtest` (harnesses pay off earliest).
-3. **Data + messaging** — `pagination`, `tenant`, `dataloader`,
+2. **Data + messaging** — `pagination`, `tenant`, `dataloader`,
    `objectstore`; `jobqueue` → `scheduler`, `eventbus`; `lock`, `loadshed`,
    `quota`; `auditlog`.
-4. **Auth** — `session`, `authmw`, `lockout`, `totp`, `otp`,
+3. **Auth** — `session`, `authmw`, `lockout`, `totp`, `otp`,
    `recoverycodes`, `apikey`, `magiclink`, `oauthclient`, `rbac`.
-5. **Views + i18n + delivery** — `flash`, `form`, `pagenav`; `catalog`,
+4. **Views + i18n + delivery** — `flash`, `form`, `pagenav`; `catalog`,
    `locale`, `numfmt`, `datefmt`; `email` → `emailtemplate`, `webhook`.
-6. **Realtime + AI** — `sse`, `fanout`, `ws`, `wshub`, `ssestream`; `llm`,
+5. **Realtime + AI** — `sse`, `fanout`, `ws`, `wshub`, `ssestream`; `llm`,
    `prompt`.
 
 **Minimal-core cut-line** (enough for a real API or htmx app end-to-end):
 `clock random id ctxkey typeconv slicex ptr validate` · `postgres migration`
 · `backoff retry ratelimit` · `middleware recoverer requestid problem
 httpclient` · `session authmw` · `sse fanout` · `email` · `catalog locale` ·
-`flash form` · `envconfig health`.
+`flash form` · `config health`.
 
 ## Anti-scope — what stays in consumer repos
 

--- a/docs/superpowers/plans/2026-07-05-wave1-completion-bundle.md
+++ b/docs/superpowers/plans/2026-07-05-wave1-completion-bundle.md
@@ -1,0 +1,2998 @@
+# Wave 1 Completion Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete build-order Wave 1 by shipping `ops/config`, `ops/health`, `resilience/ratelimit` (+`ratelimit/redisstore`), and `web/httpclient`, plus two shared unblockers (`core/structfields.SetString`, `ops/supervisor.WithPreShutdown`), as one PR.
+
+**Architecture:** Each package follows forge's design DNA: free-funcs or `New(...Option)` (never builders), `errors.Is`-matchable single-line sentinels, `doc.go` runnable example, black-box tests only. `config` layers YAML (per-env + `${VAR:default}` substitution) over `.env` inheritance and env-tag structs. `health` is a single pull handler factory. `ratelimit` establishes the counter `Store` seam (sliding-window). `httpclient` composes the shipped `retry`/`backoff`/`circuitbreaker` into a RoundTripper stack.
+
+**Tech Stack:** Go 1.26, stdlib, `gopkg.in/yaml.v3` (new — `config` only), `github.com/redis/go-redis/v9` (`redisstore` only), existing forge packages (`core/structfields`, `core/typeconv`, `core/clock`, `web/middleware`, `web/problem`, `resilience/{retry,backoff,circuitbreaker}`, `ops/supervisor`).
+
+## Global Constraints
+
+- Work ONLY in the current branch (`claude/heuristic-kepler-922e58`); never switch branches.
+- Module path: `github.com/dmitrymomot/forge`. Single `go.mod`, Go 1.26.
+- **Black-box tests only** — test files use `package <pkg>_test`.
+- Packages: max two levels (`domain/package`); a third level only for driver isolators (`ratelimit/redisstore`). Leaf directory = package name, unique across domains.
+- No builder pattern — use `type Option func(*config)` functional options.
+- Minimal dependencies: only `gopkg.in/yaml.v3` is added, used solely by `ops/config`.
+- Single-line, `errors.Is`-matchable sentinels in `errors.go`. Public methods never return unexported types.
+- After file changes run `just fmt ./<domain>/<pkg>/...` (package-path form — the single-file form trips a spurious betteralign "undefined"). Run `just lint` when the task is done. Run `modernize` (`go tool modernize ./...`) before finishing; prefer `errors.AsType` over `errors.As` where modernize suggests it (matches shipped code).
+- Test command: `just test ./<domain>/<pkg>/...` (runs `go test -race -cover`).
+- No Claude attribution in commits.
+
+---
+
+## Task 1: `core/structfields.SetString` (unblocker)
+
+Parses a string into a struct field by kind and assigns it via the existing `Field.Set`. Consumed by `ops/config`'s env-tag path.
+
+**Files:**
+- Create: `core/structfields/setstring.go`
+- Modify: `core/structfields/errors.go` (add `ErrUnsupportedKind`)
+- Test: `core/structfields/setstring_test.go`
+
+**Interfaces:**
+- Consumes: `structfields.Field` (`.Value reflect.Value`, `.Set func(any) error`, `.Name string`), `typeconv.{ParseBool,ParseInt,ParseUint,ParseFloat,ParseDuration,ParseTime,ParseSlice}`.
+- Produces: `func SetString(f Field, raw string) error`; `var ErrUnsupportedKind error`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package structfields_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/structfields"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetString_SupportedKinds(t *testing.T) {
+	var s struct {
+		Name    string
+		Count   int
+		Small   int32
+		Size    uint16
+		Ratio   float64
+		On      bool
+		Timeout time.Duration
+		At      time.Time
+		Origins []string
+	}
+	apply := func(name, raw string) {
+		require.NoError(t, structfields.Walk(&s, "env", func(f structfields.Field) error {
+			if f.Name == name {
+				return structfields.SetString(f, raw)
+			}
+			return nil
+		}))
+	}
+	apply("Name", "forge")
+	apply("Count", "42")
+	apply("Small", "7")
+	apply("Size", "9")
+	apply("Ratio", "3.5")
+	apply("On", "true")
+	apply("Timeout", "1500ms")
+	apply("At", "2026-07-05T10:00:00Z")
+	apply("Origins", "a,b,c")
+
+	assert.Equal(t, "forge", s.Name)
+	assert.Equal(t, 42, s.Count)
+	assert.Equal(t, int32(7), s.Small)
+	assert.Equal(t, uint16(9), s.Size)
+	assert.InDelta(t, 3.5, s.Ratio, 1e-9)
+	assert.True(t, s.On)
+	assert.Equal(t, 1500*time.Millisecond, s.Timeout)
+	assert.Equal(t, 2026, s.At.Year())
+	assert.Equal(t, []string{"a", "b", "c"}, s.Origins)
+}
+
+func TestSetString_UnsupportedKind(t *testing.T) {
+	var s struct{ M map[string]string }
+	err := structfields.Walk(&s, "env", func(f structfields.Field) error {
+		return structfields.SetString(f, "x")
+	})
+	assert.ErrorIs(t, err, structfields.ErrUnsupportedKind)
+}
+
+func TestSetString_BadSyntax(t *testing.T) {
+	var s struct{ Count int }
+	err := structfields.Walk(&s, "env", func(f structfields.Field) error {
+		return structfields.SetString(f, "not-a-number")
+	})
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./core/structfields/...`
+Expected: FAIL — `SetString`, `ErrUnsupportedKind` undefined.
+
+- [ ] **Step 3: Add the sentinel**
+
+In `core/structfields/errors.go`, append:
+
+```go
+// ErrUnsupportedKind is returned by SetString when the field's kind cannot be
+// parsed from a string.
+var ErrUnsupportedKind = errors.New("structfields: unsupported kind")
+```
+
+- [ ] **Step 4: Write the implementation**
+
+Create `core/structfields/setstring.go`:
+
+```go
+package structfields
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/typeconv"
+)
+
+// SetString parses raw according to f's field type and assigns it via f.Set.
+// Supported: string, bool, all int/uint widths, float32/64, time.Duration,
+// time.Time (RFC3339), and []string (comma-separated). Other kinds return
+// ErrUnsupportedKind. A read-only (value-struct) field returns ErrNotSettable
+// through f.Set; a parse failure surfaces typeconv.ErrSyntax.
+func SetString(f Field, raw string) error {
+	switch f.Value.Type() {
+	case reflect.TypeOf(time.Duration(0)):
+		d, err := typeconv.ParseDuration(raw)
+		if err != nil {
+			return err
+		}
+		return f.Set(d)
+	case reflect.TypeOf(time.Time{}):
+		tm, err := typeconv.ParseTime(raw)
+		if err != nil {
+			return err
+		}
+		return f.Set(tm)
+	}
+
+	switch f.Value.Kind() {
+	case reflect.String:
+		return f.Set(raw)
+	case reflect.Bool:
+		v, err := typeconv.ParseBool(raw)
+		if err != nil {
+			return err
+		}
+		return f.Set(v)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v, err := typeconv.ParseInt[int64](raw)
+		if err != nil {
+			return err
+		}
+		return f.Set(v)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v, err := typeconv.ParseUint[uint64](raw)
+		if err != nil {
+			return err
+		}
+		return f.Set(v)
+	case reflect.Float32, reflect.Float64:
+		v, err := typeconv.ParseFloat[float64](raw)
+		if err != nil {
+			return err
+		}
+		return f.Set(v)
+	case reflect.Slice:
+		if f.Value.Type().Elem().Kind() == reflect.String {
+			v, err := typeconv.ParseSlice[string](raw, ",")
+			if err != nil {
+				return err
+			}
+			return f.Set(v)
+		}
+	}
+	return fmt.Errorf("structfields: field %q: %w (%s)", f.Name, ErrUnsupportedKind, f.Value.Kind())
+}
+```
+
+Note: parsing to the widest type (`int64`/`uint64`/`float64`) then `f.Set` relies on `makeSetter`'s `ConvertibleTo` path to narrow to the field's actual width. Only `[]string` slices are supported in v1 (richer element types can be added later — flagged in the spec).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `just test ./core/structfields/...`
+Expected: PASS.
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+just fmt ./core/structfields/...
+just lint
+git add core/structfields/setstring.go core/structfields/errors.go core/structfields/setstring_test.go
+git commit -m "feat(core/structfields): SetString parses a string into a field by kind"
+```
+
+---
+
+## Task 2: `ops/supervisor.WithPreShutdown` (unblocker)
+
+Adds an ordered pre-shutdown phase: hooks run to completion (bounded) after the stop signal but BEFORE `runCtx` is cancelled, so `health`'s readiness flip lands before `httpserver` stops accepting.
+
+**Files:**
+- Modify: `ops/supervisor/options.go` (add `preHook` type, `WithPreShutdown`, `WithPreShutdownTimeout`, config fields + default)
+- Modify: `ops/supervisor/supervisor.go` (run hooks inside `beginShutdown` before `cancel()`)
+- Modify: `ops/supervisor/errors.go` (add `ErrPreShutdownTimeout`)
+- Test: `ops/supervisor/preshutdown_test.go`
+
+**Interfaces:**
+- Consumes: existing `config` struct, `Option`, `beginShutdown` closure in `Run`.
+- Produces: `func WithPreShutdown(name string, fn func(context.Context)) Option`; `func WithPreShutdownTimeout(d time.Duration) Option`; `var ErrPreShutdownTimeout error`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package supervisor_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/ops/supervisor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The hook must FINISH before the service observes ctx cancellation.
+func TestWithPreShutdown_RunsBeforeServiceCancel(t *testing.T) {
+	var order []string
+	var mu atomic.Int32 // sequence counter
+
+	hookSeq := int32(-1)
+	svcSeq := int32(-1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(20 * time.Millisecond); cancel() }()
+
+	err := supervisor.Run(ctx,
+		supervisor.WithPreShutdown("drain", func(context.Context) {
+			hookSeq = mu.Add(1)
+			_ = order
+		}),
+		supervisor.WithServiceFunc("svc", func(sctx context.Context) error {
+			<-sctx.Done()
+			svcSeq = mu.Add(1)
+			return nil
+		}),
+		supervisor.WithShutdownTimeout(time.Second),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), hookSeq, "hook should run first")
+	assert.Equal(t, int32(2), svcSeq, "service cancel should observe after hook")
+}
+
+func TestWithPreShutdown_TimeoutSurfaces(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(10 * time.Millisecond); cancel() }()
+
+	err := supervisor.Run(ctx,
+		supervisor.WithPreShutdownTimeout(20*time.Millisecond),
+		supervisor.WithPreShutdown("slow", func(hctx context.Context) {
+			<-hctx.Done() // never returns before the bound
+		}),
+		supervisor.WithServiceFunc("svc", func(sctx context.Context) error { <-sctx.Done(); return nil }),
+		supervisor.WithShutdownTimeout(time.Second),
+	)
+	assert.ErrorIs(t, err, supervisor.ErrPreShutdownTimeout)
+}
+
+func TestWithPreShutdown_NilFuncRejected(t *testing.T) {
+	err := supervisor.Run(context.Background(),
+		supervisor.WithPreShutdown("bad", nil),
+		supervisor.WithServiceFunc("svc", func(context.Context) error { return nil }),
+	)
+	assert.ErrorIs(t, err, supervisor.ErrInvalidConfig)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/supervisor/...`
+Expected: FAIL — `WithPreShutdown`, `WithPreShutdownTimeout`, `ErrPreShutdownTimeout` undefined.
+
+- [ ] **Step 3: Add the sentinel**
+
+In `ops/supervisor/errors.go`, add to the `var (...)` block:
+
+```go
+	// ErrPreShutdownTimeout is returned (joined) by Run when pre-shutdown hooks do not finish within the pre-shutdown timeout.
+	ErrPreShutdownTimeout = errors.New("supervisor: pre-shutdown timed out")
+```
+
+- [ ] **Step 4: Extend options and config**
+
+In `ops/supervisor/options.go`, add the hook type and fields, and set the default. Change the `config` struct and `defaultConfig`:
+
+```go
+// preHook is a named pre-shutdown callback.
+type preHook struct {
+	name string
+	fn   func(context.Context)
+}
+
+// (add these fields to the existing `config` struct)
+//	preShutdown        []preHook
+//	preShutdownTimeout time.Duration
+```
+
+Update `defaultConfig()` to seed `preShutdownTimeout: 30 * time.Second`. Then add the options:
+
+```go
+// WithPreShutdown registers a hook run after shutdown begins but BEFORE each
+// service's context is cancelled — so readiness can flip and load balancers can
+// deregister while services still serve. Hooks run concurrently; Run waits for
+// them, bounded by WithPreShutdownTimeout. A nil fn is rejected as ErrInvalidConfig.
+func WithPreShutdown(name string, fn func(context.Context)) Option {
+	return func(c *config) {
+		if fn == nil {
+			c.errs = append(c.errs, fmt.Errorf("%w: WithPreShutdown(%q) received a nil func", ErrInvalidConfig, name))
+			return
+		}
+		c.preShutdown = append(c.preShutdown, preHook{name: name, fn: fn})
+	}
+}
+
+// WithPreShutdownTimeout bounds the pre-shutdown phase. Default 30s; it must
+// exceed the longest grace a hook waits internally, or the hook is cut short.
+func WithPreShutdownTimeout(d time.Duration) Option {
+	return func(c *config) { c.preShutdownTimeout = d }
+}
+```
+
+- [ ] **Step 5: Run hooks before cancel in `beginShutdown`**
+
+In `ops/supervisor/supervisor.go`, add the runner function and call it from `beginShutdown` before `cancel()`. Add imports `context`, `sync` (both likely already present — `context` is). New function:
+
+```go
+// runPreShutdown runs all hooks concurrently, returning ErrPreShutdownTimeout if
+// they do not all finish within timeout (0 = wait indefinitely). A panicking hook
+// is recovered and logged.
+func runPreShutdown(hooks []preHook, timeout time.Duration, log *slog.Logger) error {
+	if len(hooks) == 0 {
+		return nil
+	}
+	ctx := context.Background()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	var wg sync.WaitGroup
+	for _, h := range hooks {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if p := recover(); p != nil {
+					log.Error("pre-shutdown hook panicked",
+						slog.String("hook", h.name), slog.Any("panic", p))
+				}
+			}()
+			log.Info("pre-shutdown hook started", slog.String("hook", h.name))
+			h.fn(ctx)
+		}()
+	}
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ErrPreShutdownTimeout
+	}
+}
+```
+
+Then modify `beginShutdown` (currently at `supervisor.go:75`) to run hooks before cancel:
+
+```go
+	beginShutdown := func(reason string) {
+		if shuttingDown {
+			return
+		}
+		shuttingDown = true
+		log.Info("shutdown started", slog.String("reason", reason))
+		if err := runPreShutdown(cfg.preShutdown, cfg.preShutdownTimeout, log); err != nil {
+			errs = append(errs, err)
+		}
+		cancel()
+		done = nil
+		if cfg.ShutdownTimeout > 0 {
+			graceCh = time.After(cfg.ShutdownTimeout)
+		}
+	}
+```
+
+(`errs` is the slice already declared above `beginShutdown`; appending inside the closure mutates it.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `just test ./ops/supervisor/...`
+Expected: PASS (including the existing supervisor tests — no-hooks path is unchanged).
+
+- [ ] **Step 7: Format, lint, commit**
+
+```bash
+just fmt ./ops/supervisor/...
+just lint
+git add ops/supervisor/
+git commit -m "feat(ops/supervisor): WithPreShutdown ordered pre-shutdown phase before service cancel"
+```
+
+---
+
+## Task 3: `ops/config` — `${VAR:default}` substitution
+
+**Files:**
+- Create: `ops/config/substitute.go`, `ops/config/errors.go`
+- Test: `ops/config/substitute_test.go`
+
+**Interfaces:**
+- Produces: `func Substitute(s string) (string, error)`; internal `func substitute(s string, lookup func(string) (string, bool)) (string, error)`; sentinels `ErrProfileFile, ErrSubstitute, ErrYAML, ErrDotenv, ErrRequiredMissing, ErrParse`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package config_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubstitute(t *testing.T) {
+	t.Setenv("HOST", "10.0.0.1")
+	t.Setenv("EMPTY", "")
+
+	got, err := config.Substitute("host: ${HOST:0.0.0.0}")
+	require.NoError(t, err)
+	assert.Equal(t, "host: 10.0.0.1", got)
+
+	got, err = config.Substitute("host: ${MISSING:0.0.0.0}")
+	require.NoError(t, err)
+	assert.Equal(t, "host: 0.0.0.0", got)
+
+	got, err = config.Substitute("host: ${EMPTY:fallback}") // empty -> default
+	require.NoError(t, err)
+	assert.Equal(t, "host: fallback", got)
+
+	got, err = config.Substitute("url: ${MISSING:http://x:8080}") // colon in default
+	require.NoError(t, err)
+	assert.Equal(t, "url: http://x:8080", got)
+
+	got, err = config.Substitute("price: $$5")
+	require.NoError(t, err)
+	assert.Equal(t, "price: $5", got)
+
+	_, err = config.Substitute("x: ${NOPE}") // unset, no default -> error
+	assert.ErrorIs(t, err, config.ErrSubstitute)
+
+	_, err = config.Substitute("x: ${UNTERMINATED")
+	assert.ErrorIs(t, err, config.ErrSubstitute)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/config/...`
+Expected: FAIL — package/symbols undefined.
+
+- [ ] **Step 3: Add sentinels**
+
+Create `ops/config/errors.go`:
+
+```go
+package config
+
+import "errors"
+
+var (
+	// ErrProfileFile is returned by Load when the {profile}.yaml file is missing or unreadable.
+	ErrProfileFile = errors.New("config: profile file")
+	// ErrSubstitute is returned when a ${VAR} placeholder is malformed or an unset no-default var is referenced.
+	ErrSubstitute = errors.New("config: substitution")
+	// ErrYAML is returned when the substituted YAML fails to unmarshal.
+	ErrYAML = errors.New("config: yaml")
+	// ErrDotenv is returned when a .env file cannot be read or applied.
+	ErrDotenv = errors.New("config: dotenv")
+	// ErrRequiredMissing is returned by LoadEnv/Populate when a required env key has no value.
+	ErrRequiredMissing = errors.New("config: required env missing")
+	// ErrParse is returned by LoadEnv/Populate when a value cannot be parsed into its field.
+	ErrParse = errors.New("config: parse")
+)
+```
+
+- [ ] **Step 4: Write the substitution implementation**
+
+Create `ops/config/substitute.go`:
+
+```go
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Substitute expands ${VAR} and ${VAR:default} placeholders in s against the
+// process environment. $$ yields a literal $. ${VAR} with VAR unset is an
+// error; ${VAR:default} falls back to default when VAR is unset OR empty. The
+// name/default split is on the first colon, so defaults may contain colons.
+func Substitute(s string) (string, error) {
+	return substitute(s, os.LookupEnv)
+}
+
+func substitute(s string, lookup func(string) (string, bool)) (string, error) {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] == '$' && i+1 < len(s) && s[i+1] == '$' {
+			b.WriteByte('$')
+			i += 2
+			continue
+		}
+		if s[i] == '$' && i+1 < len(s) && s[i+1] == '{' {
+			rel := strings.IndexByte(s[i+2:], '}')
+			if rel < 0 {
+				return "", fmt.Errorf("%w: unterminated placeholder", ErrSubstitute)
+			}
+			val, err := resolvePlaceholder(s[i+2:i+2+rel], lookup)
+			if err != nil {
+				return "", err
+			}
+			b.WriteString(val)
+			i += 2 + rel + 1
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String(), nil
+}
+
+func resolvePlaceholder(expr string, lookup func(string) (string, bool)) (string, error) {
+	name, def, hasDefault := strings.Cut(expr, ":")
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("%w: empty variable name", ErrSubstitute)
+	}
+	v, ok := lookup(name)
+	if hasDefault {
+		if !ok || v == "" {
+			return def, nil
+		}
+		return v, nil
+	}
+	if !ok {
+		return "", fmt.Errorf("%w: %s is not set", ErrSubstitute, name)
+	}
+	return v, nil
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `just test ./ops/config/...`
+Expected: PASS.
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+just fmt ./ops/config/...
+just lint
+git add ops/config/
+git commit -m "feat(ops/config): \${VAR:default} substitution with empty-or-unset defaults"
+```
+
+---
+
+## Task 4: `ops/config` — `.env` inheritance (`Dotenv`)
+
+**Files:**
+- Create: `ops/config/dotenv.go`
+- Test: `ops/config/dotenv_test.go` (+ `ops/config/testdata/.env.local`, `ops/config/testdata/.env`)
+
+**Interfaces:**
+- Produces: `func Dotenv(paths ...string) error`; internal `func parseDotenv(path string) (map[string]string, error)`.
+
+- [ ] **Step 1: Create fixtures**
+
+`ops/config/testdata/.env.local`:
+
+```
+# base
+HOST=localhost
+PORT=3000
+```
+
+`ops/config/testdata/.env`:
+
+```
+PORT=8080
+export TOKEN="a:b:c"
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```go
+package config_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDotenv_InheritanceAndEnvWins(t *testing.T) {
+	// real env wins over files
+	t.Setenv("HOST", "realhost")
+
+	require.NoError(t, config.Dotenv("testdata/.env.local", "testdata/.env"))
+
+	assert.Equal(t, "realhost", os.Getenv("HOST"))     // real env preserved
+	assert.Equal(t, "8080", os.Getenv("PORT"))         // later file (.env) overrides .env.local
+	assert.Equal(t, "a:b:c", os.Getenv("TOKEN"))       // quoted value, export prefix stripped
+}
+
+func TestDotenv_MissingFile(t *testing.T) {
+	assert.ErrorIs(t, config.Dotenv("testdata/nope.env"), config.ErrDotenv)
+}
+```
+
+Note: `os.Setenv` from `t.Setenv` is restored after the test. `Dotenv` writes into the process env; keep keys used here distinct from other tests, or those tests set their own via `t.Setenv`.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `just test ./ops/config/...`
+Expected: FAIL — `Dotenv` undefined.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `ops/config/dotenv.go`:
+
+```go
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Dotenv loads .env files in order — later files override earlier ones — and
+// applies the result to the process environment, but never overwrites a key
+// already present in the real environment. So precedence is: process env >
+// last file > ... > first file.
+func Dotenv(paths ...string) error {
+	merged := map[string]string{}
+	for _, p := range paths {
+		kv, err := parseDotenv(p)
+		if err != nil {
+			return err
+		}
+		for k, v := range kv {
+			merged[k] = v
+		}
+	}
+	for k, v := range merged {
+		if _, present := os.LookupEnv(k); present {
+			continue
+		}
+		if err := os.Setenv(k, v); err != nil {
+			return fmt.Errorf("%w: %v", ErrDotenv, err)
+		}
+	}
+	return nil
+}
+
+func parseDotenv(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrDotenv, err)
+	}
+	out := map[string]string{}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		out[strings.TrimSpace(k)] = unquoteEnv(strings.TrimSpace(v))
+	}
+	return out, nil
+}
+
+func unquoteEnv(v string) string {
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		if s, err := strconv.Unquote(v); err == nil {
+			return s
+		}
+	}
+	if len(v) >= 2 && v[0] == '\'' && v[len(v)-1] == '\'' {
+		return v[1 : len(v)-1]
+	}
+	return v
+}
+```
+
+(`strings.SplitSeq` is the Go 1.24+ iterator form modernize prefers; if lint objects, use `strings.Split`.)
+
+- [ ] **Step 5: Run tests, format, lint, commit**
+
+```bash
+just test ./ops/config/...
+just fmt ./ops/config/...
+just lint
+git add ops/config/dotenv.go ops/config/dotenv_test.go ops/config/testdata/
+git commit -m "feat(ops/config): .env inheritance with real-env precedence"
+```
+
+---
+
+## Task 5: `ops/config` — profile detection & options
+
+**Files:**
+- Create: `ops/config/profile.go`, `ops/config/options.go`
+- Test: `ops/config/profile_test.go`
+
+**Interfaces:**
+- Produces: `func Profile() string`, `IsDev/IsProd/IsTest/IsStaging() bool`; `type Option func(*config)`, `WithDotenv`, `WithProfile`, `WithFileName`, `WithLookup`; internal `config` struct with `newConfig`, `profile()`, `fileName()`, `lookup`, `applyDotenv()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package config_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProfilePredicates(t *testing.T) {
+	t.Setenv("APP_ENV", "production")
+	assert.Equal(t, "production", config.Profile())
+	assert.True(t, config.IsProd())
+	assert.False(t, config.IsDev())
+
+	t.Setenv("APP_ENV", "")
+	t.Setenv("ENV", "")
+	assert.Equal(t, "development", config.Profile()) // default
+	assert.True(t, config.IsDev())
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/config/...`
+Expected: FAIL — undefined.
+
+- [ ] **Step 3: Write profile + predicates**
+
+Create `ops/config/profile.go`:
+
+```go
+package config
+
+import (
+	"os"
+	"slices"
+	"strings"
+)
+
+// Profile returns the active deployment profile from APP_ENV, then ENV,
+// defaulting to "development". The raw string is also the {profile}.yaml stem.
+func Profile() string {
+	for _, k := range []string{"APP_ENV", "ENV"} {
+		if v, ok := os.LookupEnv(k); ok && v != "" {
+			return v
+		}
+	}
+	return "development"
+}
+
+func matches(p string, names ...string) bool {
+	return slices.Contains(names, strings.ToLower(strings.TrimSpace(p)))
+}
+
+// IsDev reports whether the profile is a development profile.
+func IsDev() bool { return matches(Profile(), "dev", "development", "local") }
+
+// IsProd reports whether the profile is a production profile.
+func IsProd() bool { return matches(Profile(), "prod", "production") }
+
+// IsTest reports whether the profile is a test profile.
+func IsTest() bool { return matches(Profile(), "test", "testing") }
+
+// IsStaging reports whether the profile is a staging profile.
+func IsStaging() bool { return matches(Profile(), "staging", "stage") }
+```
+
+- [ ] **Step 4: Write options + internal config**
+
+Create `ops/config/options.go`:
+
+```go
+package config
+
+import "os"
+
+type config struct {
+	dotenvPaths []string
+	profile     string
+	fileNameFn  func(profile string) string
+	lookup      func(string) (string, bool)
+}
+
+func newConfig(opts ...Option) config {
+	c := config{
+		fileNameFn: func(p string) string { return p + ".yaml" },
+		lookup:     os.LookupEnv,
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+func (c config) activeProfile() string {
+	if c.profile != "" {
+		return c.profile
+	}
+	return Profile()
+}
+
+func (c config) fileName() string { return c.fileNameFn(c.activeProfile()) }
+
+func (c config) applyDotenv() error {
+	if len(c.dotenvPaths) == 0 {
+		return nil
+	}
+	return Dotenv(c.dotenvPaths...)
+}
+
+// Option configures Load/LoadEnv/Populate.
+type Option func(*config)
+
+// WithDotenv loads these .env files (via Dotenv) before reading config.
+func WithDotenv(paths ...string) Option {
+	return func(c *config) { c.dotenvPaths = append(c.dotenvPaths, paths...) }
+}
+
+// WithProfile overrides APP_ENV/ENV detection for file selection.
+func WithProfile(name string) Option { return func(c *config) { c.profile = name } }
+
+// WithFileName customizes the profile→filename mapping (default profile+".yaml").
+func WithFileName(fn func(profile string) string) Option {
+	return func(c *config) {
+		if fn != nil {
+			c.fileNameFn = fn
+		}
+	}
+}
+
+// WithLookup overrides os.LookupEnv (test seam) for substitution and env reads.
+func WithLookup(fn func(key string) (string, bool)) Option {
+	return func(c *config) {
+		if fn != nil {
+			c.lookup = fn
+		}
+	}
+}
+```
+
+- [ ] **Step 5: Run tests, format, lint, commit**
+
+```bash
+just test ./ops/config/...
+just fmt ./ops/config/...
+just lint
+git add ops/config/profile.go ops/config/options.go ops/config/profile_test.go
+git commit -m "feat(ops/config): profile detection, predicates, and loader options"
+```
+
+---
+
+## Task 6: `ops/config` — `LoadEnv` / `Populate` (env-tag decode)
+
+**Files:**
+- Create: `ops/config/env.go`
+- Test: `ops/config/env_test.go`
+
+**Interfaces:**
+- Consumes: `structfields.Walk`, `structfields.SetString` (Task 1); the internal `config` (Task 5).
+- Produces: `func LoadEnv[T any](opts ...Option) (T, error)`; `func Populate(dst any, opts ...Option) error`.
+
+**Tag convention:** the env key is `env:"KEY"`; a default is the `default=` option (`env:"PORT,default=8080"`); required is the `required` option (`env:"PORT,required"`). Defaults live in the env tag (not a separate `default:` struct tag) because `structfields.Walk` surfaces only the walked tag key. Nested struct fields recurse, composing the prefix from the field's env tag name (`env:"DB"` → prefix `DB_`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package config_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type dbCfg struct {
+	Host string `env:"HOST,default=localhost"`
+	Port int    `env:"PORT,default=5432"`
+}
+
+type appCfg struct {
+	Name    string `env:"NAME,required"`
+	Debug   bool   `env:"DEBUG,default=false"`
+	DB      dbCfg  `env:"DB"`
+}
+
+func TestLoadEnv_DefaultsAndNesting(t *testing.T) {
+	lookup := func(k string) (string, bool) {
+		m := map[string]string{"NAME": "svc", "DB_PORT": "6543"}
+		v, ok := m[k]
+		return v, ok
+	}
+	got, err := config.LoadEnv[appCfg](config.WithLookup(lookup))
+	require.NoError(t, err)
+	assert.Equal(t, "svc", got.Name)
+	assert.False(t, got.Debug)               // default
+	assert.Equal(t, "localhost", got.DB.Host) // nested default
+	assert.Equal(t, 6543, got.DB.Port)        // nested env override, prefixed DB_
+}
+
+func TestLoadEnv_RequiredMissing(t *testing.T) {
+	lookup := func(string) (string, bool) { return "", false }
+	_, err := config.LoadEnv[appCfg](config.WithLookup(lookup))
+	assert.ErrorIs(t, err, config.ErrRequiredMissing)
+}
+
+func TestLoadEnv_ParseError(t *testing.T) {
+	lookup := func(k string) (string, bool) {
+		if k == "NAME" {
+			return "svc", true
+		}
+		if k == "DB_PORT" {
+			return "not-int", true
+		}
+		return "", false
+	}
+	_, err := config.LoadEnv[appCfg](config.WithLookup(lookup))
+	assert.ErrorIs(t, err, config.ErrParse)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/config/...`
+Expected: FAIL — `LoadEnv` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/config/env.go`:
+
+```go
+package config
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/structfields"
+)
+
+// LoadEnv populates a fresh T from environment variables via its `env` tags.
+func LoadEnv[T any](opts ...Option) (T, error) {
+	var t T
+	if err := Populate(&t, opts...); err != nil {
+		return t, err
+	}
+	return t, nil
+}
+
+// Populate fills dst (a non-nil *struct) from the environment via `env` tags,
+// applying `default=` options and failing on missing `required` keys. If dst
+// implements interface{ Validate() error }, that runs afterward.
+func Populate(dst any, opts ...Option) error {
+	c := newConfig(opts...)
+	if err := c.applyDotenv(); err != nil {
+		return err
+	}
+	if err := populateStruct(dst, "", c.lookup); err != nil {
+		return err
+	}
+	if v, ok := dst.(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func populateStruct(dst any, prefix string, lookup func(string) (string, bool)) error {
+	var errs []error
+	walkErr := structfields.Walk(dst, "env", func(f structfields.Field) error {
+		if f.Tag.Ignored() {
+			return nil
+		}
+		if f.Value.Kind() == reflect.Struct && f.Value.Type() != reflect.TypeOf(time.Time{}) {
+			sub := prefix
+			if f.Tag.Name != "" {
+				sub = prefix + f.Tag.Name + "_"
+			}
+			if err := populateStruct(f.Value.Addr().Interface(), sub, lookup); err != nil {
+				errs = append(errs, err)
+			}
+			return nil
+		}
+		if f.Tag.Name == "" {
+			return nil
+		}
+		key := prefix + f.Tag.Name
+		raw, ok := lookup(key)
+		if !ok || raw == "" {
+			def, hasDefault := defaultOption(f)
+			switch {
+			case hasDefault:
+				raw = def
+			case f.Tag.HasOption("required"):
+				errs = append(errs, fmt.Errorf("%w: %s", ErrRequiredMissing, key))
+				return nil
+			default:
+				return nil
+			}
+		}
+		if err := structfields.SetString(f, raw); err != nil {
+			errs = append(errs, fmt.Errorf("%w: %s: %v", ErrParse, key, err))
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+	return errors.Join(errs...)
+}
+
+func defaultOption(f structfields.Field) (string, bool) {
+	for _, o := range f.Tag.Options {
+		if v, ok := strings.CutPrefix(o, "default="); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+```
+
+- [ ] **Step 4: Run tests, format, lint, commit**
+
+```bash
+just test ./ops/config/...
+just fmt ./ops/config/...
+just lint
+git add ops/config/env.go ops/config/env_test.go
+git commit -m "feat(ops/config): LoadEnv/Populate env-tag decode with defaults, required, nesting"
+```
+
+---
+
+## Task 7: `ops/config` — `Load` (YAML per-env + substitution)
+
+**Files:**
+- Create: `ops/config/load.go`
+- Modify: `go.mod`, `go.sum` (add `gopkg.in/yaml.v3`)
+- Test: `ops/config/load_test.go` (+ `ops/config/testdata/development.yaml`, `ops/config/testdata/production.yaml`)
+
+**Interfaces:**
+- Consumes: internal `config` (Task 5), `substitute` (Task 3).
+- Produces: `func Load[T any](dir string, opts ...Option) (T, error)`.
+
+- [ ] **Step 1: Add the YAML dependency**
+
+```bash
+go get gopkg.in/yaml.v3@latest
+```
+
+Expected: `go.mod`/`go.sum` updated with `gopkg.in/yaml.v3`.
+
+- [ ] **Step 2: Create fixtures**
+
+`ops/config/testdata/development.yaml`:
+
+```yaml
+host: ${HOST:0.0.0.0}
+port: ${PORT:8080}
+name: dev-service
+```
+
+`ops/config/testdata/production.yaml`:
+
+```yaml
+host: ${HOST:0.0.0.0}
+port: 443
+name: prod-service
+```
+
+- [ ] **Step 3: Write the failing test**
+
+```go
+package config_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type serverCfg struct {
+	Host string `yaml:"host"`
+	Port int    `yaml:"port"`
+	Name string `yaml:"name"`
+}
+
+func (s *serverCfg) SetDefaults() {
+	if s.Host == "" {
+		s.Host = "127.0.0.1"
+	}
+}
+
+func TestLoad_YAMLWithSubstitution(t *testing.T) {
+	t.Setenv("HOST", "10.0.0.5")
+
+	got, err := config.Load[serverCfg]("testdata", config.WithProfile("development"))
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.0.5", got.Host) // ${HOST} substituted
+	assert.Equal(t, 8080, got.Port)       // ${PORT:8080} default
+	assert.Equal(t, "dev-service", got.Name)
+}
+
+func TestLoad_ProfileSelectionAndDefaults(t *testing.T) {
+	t.Setenv("HOST", "") // empty -> ${HOST:0.0.0.0} uses default
+	got, err := config.Load[serverCfg]("testdata", config.WithProfile("production"))
+	require.NoError(t, err)
+	assert.Equal(t, "0.0.0.0", got.Host)
+	assert.Equal(t, 443, got.Port)
+	assert.Equal(t, "prod-service", got.Name)
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	_, err := config.Load[serverCfg]("testdata", config.WithProfile("nope"))
+	assert.ErrorIs(t, err, config.ErrProfileFile)
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `just test ./ops/config/...`
+Expected: FAIL — `Load` undefined.
+
+- [ ] **Step 5: Write the implementation**
+
+Create `ops/config/load.go`:
+
+```go
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Load reads {dir}/{profile}.yaml, expands ${VAR:default} placeholders against
+// the environment layer, and unmarshals into T. If *T implements
+// interface{ SetDefaults() } it is applied before decode (yaml overwrites only
+// present keys); interface{ Validate() error } runs after.
+func Load[T any](dir string, opts ...Option) (T, error) {
+	var t T
+	c := newConfig(opts...)
+	if err := c.applyDotenv(); err != nil {
+		return t, err
+	}
+	path := filepath.Join(dir, c.fileName())
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return t, fmt.Errorf("%w: %v", ErrProfileFile, err)
+	}
+	expanded, err := substitute(string(data), c.lookup)
+	if err != nil {
+		return t, err
+	}
+	if sd, ok := any(&t).(interface{ SetDefaults() }); ok {
+		sd.SetDefaults()
+	}
+	if err := yaml.Unmarshal([]byte(expanded), &t); err != nil {
+		return t, fmt.Errorf("%w: %v", ErrYAML, err)
+	}
+	if v, ok := any(&t).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return t, err
+		}
+	}
+	return t, nil
+}
+```
+
+- [ ] **Step 6: Run tests, format, lint, commit**
+
+```bash
+just test ./ops/config/...
+just fmt ./ops/config/...
+just lint
+git add ops/config/load.go ops/config/load_test.go ops/config/testdata/ go.mod go.sum
+git commit -m "feat(ops/config): Load YAML per-env with substitution (gopkg.in/yaml.v3)"
+```
+
+---
+
+## Task 8: `ops/config` — `doc.go`
+
+**Files:**
+- Create: `ops/config/doc.go`
+
+**Interfaces:** none (documentation).
+
+- [ ] **Step 1: Write `doc.go`**
+
+Create `ops/config/doc.go`. Lead with the import-alias note (verified compile error), then usage:
+
+```go
+// Package config layers application configuration from YAML (per-env convention
+// with ${VAR:default} substitution), .env inheritance, and env-tagged structs.
+//
+// # Import alias required in packages that use the options idiom
+//
+// The package name "config" collides at compile time with the unexported
+// package-level `type config struct` that forge's options idiom puts in nearly
+// every package ("config already declared through import of package config").
+// Any package that both uses that idiom and imports this loader must alias it:
+//
+//	import appconfig "github.com/dmitrymomot/forge/ops/config"
+//
+// # YAML per-env
+//
+//	// config/development.yaml:  host: ${HOST:0.0.0.0}
+//	type Server struct {
+//		Host string `yaml:"host"`
+//		Port int    `yaml:"port"`
+//	}
+//	srv, err := config.Load[Server]("config/") // reads config/{APP_ENV}.yaml
+//
+// # .env inheritance (later files and the real env override earlier files)
+//
+//	err := config.Dotenv("config/.env.local", ".env")
+//
+// # Struct-from-env (12-factor, no YAML file)
+//
+//	type App struct {
+//		Name string `env:"NAME,required"`
+//		Port int    `env:"PORT,default=8080"`
+//	}
+//	app, err := config.LoadEnv[App](config.WithDotenv(".env"))
+//
+// ${VAR:default} uses the default when VAR is unset OR empty (shell :- form);
+// ${VAR} with no default errors when unset. Profile() reads APP_ENV then ENV
+// (default "development"); IsDev/IsProd/IsTest/IsStaging classify it.
+package config
+```
+
+- [ ] **Step 2: Verify build + example compiles, format, lint, commit**
+
+```bash
+just test ./ops/config/...
+just fmt ./ops/config/...
+just lint
+git add ops/config/doc.go
+git commit -m "docs(ops/config): package doc with import-alias note and usage"
+```
+
+---
+
+## Task 9: `resilience/ratelimit` — counter `Store` seam + memory store
+
+**Files:**
+- Create: `resilience/ratelimit/store.go`, `resilience/ratelimit/memory.go`
+- Test: `resilience/ratelimit/memory_test.go`
+
+**Interfaces:**
+- Consumes: `core/clock.{Clock,System,NewMock}`.
+- Produces: `type Store interface { Incr(ctx, key, delta, ttl) (int64, error); Get(ctx, key) (int64, error); Reset(ctx, key) error; Close() error }`; `func NewMemoryStore(opts ...MemoryOption) Store`; `type MemoryOption func(*memoryConfig)`; `WithMemoryClock(clock.Clock) MemoryOption`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package ratelimit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/resilience/ratelimit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryStore_IncrGetResetExpiry(t *testing.T) {
+	mk := clock.NewMock(time.Unix(1000, 0))
+	s := ratelimit.NewMemoryStore(ratelimit.WithMemoryClock(mk))
+	defer s.Close()
+	ctx := context.Background()
+
+	n, err := s.Incr(ctx, "k", 1, time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	n, err = s.Incr(ctx, "k", 2, time.Minute) // does not extend TTL
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), n)
+
+	got, err := s.Get(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), got)
+
+	mk.Advance(61 * time.Second) // past TTL
+	got, err = s.Get(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got) // expired
+
+	got, _ = s.Get(ctx, "absent")
+	assert.Equal(t, int64(0), got)
+}
+
+func TestMemoryStore_ConcurrentIncr(t *testing.T) {
+	s := ratelimit.NewMemoryStore()
+	defer s.Close()
+	ctx := context.Background()
+	const g = 100
+	done := make(chan struct{}, g)
+	for range g {
+		go func() { _, _ = s.Incr(ctx, "c", 1, time.Minute); done <- struct{}{} }()
+	}
+	for range g {
+		<-done
+	}
+	n, _ := s.Get(ctx, "c")
+	assert.Equal(t, int64(g), n)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./resilience/ratelimit/...`
+Expected: FAIL — undefined.
+
+- [ ] **Step 3: Write the seam**
+
+Create `resilience/ratelimit/store.go`:
+
+```go
+package ratelimit
+
+import (
+	"context"
+	"time"
+)
+
+// Store is the windowed atomic-counter seam shared by ratelimit (and, later,
+// quota and lockout). It is distinct from cache.Store (byte-KV): counters need
+// atomic increment-with-TTL, which Get/Set cannot express race-free.
+type Store interface {
+	// Incr atomically adds delta to key's counter and returns the new value. If
+	// this call creates the key, its TTL is set to ttl; Incr never extends the
+	// TTL of an existing (live) key.
+	Incr(ctx context.Context, key string, delta int64, ttl time.Duration) (int64, error)
+	// Get returns the current counter, or 0 if the key is absent or expired.
+	Get(ctx context.Context, key string) (int64, error)
+	// Reset deletes the counter for key.
+	Reset(ctx context.Context, key string) error
+	// Close releases resources (e.g. a janitor goroutine).
+	Close() error
+}
+```
+
+- [ ] **Step 4: Write the memory store**
+
+Create `resilience/ratelimit/memory.go`:
+
+```go
+package ratelimit
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type memoryConfig struct {
+	clk clock.Clock
+}
+
+// MemoryOption configures NewMemoryStore.
+type MemoryOption func(*memoryConfig)
+
+// WithMemoryClock injects a clock (for tests). Default clock.System().
+func WithMemoryClock(clk clock.Clock) MemoryOption {
+	return func(c *memoryConfig) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+type counter struct {
+	val       int64
+	expiresAt time.Time
+}
+
+type memoryStore struct {
+	mu  sync.Mutex
+	m   map[string]counter
+	clk clock.Clock
+}
+
+// NewMemoryStore returns an in-process counter Store. Lifecycle is the caller's
+// (Close). Suitable for single-instance use and tests; multi-instance limiting
+// needs ratelimit/redisstore.
+func NewMemoryStore(opts ...MemoryOption) Store {
+	c := memoryConfig{clk: clock.System()}
+	for _, o := range opts {
+		o(&c)
+	}
+	return &memoryStore{m: make(map[string]counter), clk: c.clk}
+}
+
+func (s *memoryStore) Incr(_ context.Context, key string, delta int64, ttl time.Duration) (int64, error) {
+	now := s.clk.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.m[key]
+	if !ok || now.After(e.expiresAt) {
+		e = counter{val: delta, expiresAt: now.Add(ttl)}
+	} else {
+		e.val += delta
+	}
+	s.m[key] = e
+	return e.val, nil
+}
+
+func (s *memoryStore) Get(_ context.Context, key string) (int64, error) {
+	now := s.clk.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.m[key]
+	if !ok || now.After(e.expiresAt) {
+		return 0, nil
+	}
+	return e.val, nil
+}
+
+func (s *memoryStore) Reset(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+	return nil
+}
+
+func (s *memoryStore) Close() error { return nil }
+```
+
+- [ ] **Step 5: Run tests, format, lint, commit**
+
+```bash
+just test ./resilience/ratelimit/...
+just fmt ./resilience/ratelimit/...
+just lint
+git add resilience/ratelimit/store.go resilience/ratelimit/memory.go resilience/ratelimit/memory_test.go
+git commit -m "feat(resilience/ratelimit): counter Store seam and in-memory store"
+```
+
+---
+
+## Task 10: `resilience/ratelimit` — sliding-window `Limiter`
+
+**Files:**
+- Create: `resilience/ratelimit/ratelimit.go`, `resilience/ratelimit/errors.go`
+- Test: `resilience/ratelimit/ratelimit_test.go`
+
+**Interfaces:**
+- Consumes: `Store` (Task 9), `core/clock`.
+- Produces: `type Limiter`, `func New(store Store, opts ...Option) *Limiter`, `func (*Limiter) Allow(ctx, key) (Result, error)`, `type Result`, `type Option`, `WithLimit(n int64, per time.Duration)`, `WithClock(clock.Clock)`, `var ErrLimited`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package ratelimit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/resilience/ratelimit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimiter_AllowsUpToLimit(t *testing.T) {
+	mk := clock.NewMock(time.Unix(0, 0))
+	l := ratelimit.New(
+		ratelimit.NewMemoryStore(ratelimit.WithMemoryClock(mk)),
+		ratelimit.WithLimit(3, time.Minute),
+		ratelimit.WithClock(mk),
+	)
+	ctx := context.Background()
+
+	for i := 1; i <= 3; i++ {
+		res, err := l.Allow(ctx, "user")
+		require.NoError(t, err)
+		assert.True(t, res.Allowed, "request %d should pass", i)
+		assert.Equal(t, int64(3), res.Limit)
+	}
+	res, err := l.Allow(ctx, "user")
+	require.NoError(t, err)
+	assert.False(t, res.Allowed)
+	assert.Equal(t, int64(0), res.Remaining)
+	assert.Positive(t, res.RetryAfter)
+}
+
+func TestLimiter_KeysAreIsolated(t *testing.T) {
+	l := ratelimit.New(ratelimit.NewMemoryStore(), ratelimit.WithLimit(1, time.Minute))
+	ctx := context.Background()
+	a, _ := l.Allow(ctx, "a")
+	b, _ := l.Allow(ctx, "b")
+	assert.True(t, a.Allowed)
+	assert.True(t, b.Allowed)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./resilience/ratelimit/...`
+Expected: FAIL — `New`, `Allow` undefined.
+
+- [ ] **Step 3: Write the sentinel + limiter**
+
+Create `resilience/ratelimit/errors.go`:
+
+```go
+package ratelimit
+
+import "errors"
+
+// ErrLimited indicates the subject exceeded its rate; used by the middleware's
+// responder and available to non-HTTP callers.
+var ErrLimited = errors.New("ratelimit: limit exceeded")
+```
+
+Create `resilience/ratelimit/ratelimit.go`:
+
+```go
+package ratelimit
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// Result reports a limiter decision for one key.
+type Result struct {
+	Allowed    bool
+	Limit      int64
+	Remaining  int64
+	Reset      time.Time     // when the current window rolls
+	RetryAfter time.Duration // 0 when Allowed
+}
+
+type config struct {
+	limit  int64
+	window time.Duration
+	clk    clock.Clock
+}
+
+// Option configures a Limiter.
+type Option func(*config)
+
+// WithLimit sets n requests allowed per window. Required.
+func WithLimit(n int64, per time.Duration) Option {
+	return func(c *config) {
+		c.limit = n
+		c.window = per
+	}
+}
+
+// WithClock injects a clock (for tests). Default clock.System().
+func WithClock(clk clock.Clock) Option {
+	return func(c *config) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+// Limiter is a keyed sliding-window-counter limiter over a Store.
+type Limiter struct {
+	store Store
+	cfg   config
+}
+
+// New builds a Limiter. The Store's lifecycle is the caller's.
+func New(store Store, opts ...Option) *Limiter {
+	c := config{limit: 100, window: time.Minute, clk: clock.System()}
+	for _, o := range opts {
+		o(&c)
+	}
+	if c.window <= 0 {
+		c.window = time.Minute
+	}
+	return &Limiter{store: store, cfg: c}
+}
+
+// Allow records one hit against key and reports whether it is within the limit,
+// using a weighted current+previous fixed-window estimate.
+func (l *Limiter) Allow(ctx context.Context, key string) (Result, error) {
+	now := l.cfg.clk.Now()
+	win := now.Truncate(l.cfg.window)
+	elapsed := now.Sub(win)
+
+	curKey := key + ":" + strconv.FormatInt(win.Unix(), 10)
+	prevKey := key + ":" + strconv.FormatInt(win.Add(-l.cfg.window).Unix(), 10)
+
+	cur, err := l.store.Incr(ctx, curKey, 1, 2*l.cfg.window)
+	if err != nil {
+		return Result{}, err
+	}
+	prev, err := l.store.Get(ctx, prevKey)
+	if err != nil {
+		return Result{}, err
+	}
+
+	weight := 1 - float64(elapsed)/float64(l.cfg.window)
+	est := float64(cur) + float64(prev)*weight
+
+	res := Result{Limit: l.cfg.limit, Reset: win.Add(l.cfg.window)}
+	if est > float64(l.cfg.limit) {
+		res.Allowed = false
+		res.Remaining = 0
+		res.RetryAfter = res.Reset.Sub(now) // conservative: wait for the window to roll
+		if res.RetryAfter < 0 {
+			res.RetryAfter = 0
+		}
+		return res, nil
+	}
+	res.Allowed = true
+	rem := l.cfg.limit - int64(math.Ceil(est))
+	if rem < 0 {
+		rem = 0
+	}
+	res.Remaining = rem
+	return res, nil
+}
+```
+
+- [ ] **Step 4: Run tests, format, lint, commit**
+
+```bash
+just test ./resilience/ratelimit/...
+just fmt ./resilience/ratelimit/...
+just lint
+git add resilience/ratelimit/ratelimit.go resilience/ratelimit/errors.go resilience/ratelimit/ratelimit_test.go
+git commit -m "feat(resilience/ratelimit): sliding-window Limiter over the counter Store"
+```
+
+---
+
+## Task 11: `resilience/ratelimit` — HTTP middleware
+
+**Files:**
+- Create: `resilience/ratelimit/middleware.go`
+- Test: `resilience/ratelimit/middleware_test.go`
+
+**Interfaces:**
+- Consumes: `Limiter` (Task 10), `web/middleware.Middleware`.
+- Produces: `type KeyFunc func(*http.Request) string`; `func (*Limiter) Middleware(key KeyFunc, opts ...MiddlewareOption) middleware.Middleware`; `type MiddlewareOption`; `WithResponder(func(http.ResponseWriter, *http.Request, Result))`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package ratelimit_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/resilience/ratelimit"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMiddleware_HeadersAnd429(t *testing.T) {
+	l := ratelimit.New(ratelimit.NewMemoryStore(), ratelimit.WithLimit(1, time.Minute))
+	key := func(*http.Request) string { return "fixed" }
+	h := l.Middleware(key)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusOK, rec1.Code)
+	assert.Equal(t, "1", rec1.Header().Get("RateLimit-Limit"))
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusTooManyRequests, rec2.Code)
+	assert.NotEmpty(t, rec2.Header().Get("Retry-After"))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./resilience/ratelimit/...`
+Expected: FAIL — `Middleware` undefined.
+
+- [ ] **Step 3: Write the middleware**
+
+Create `resilience/ratelimit/middleware.go`:
+
+```go
+package ratelimit
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+// KeyFunc selects the limiter key for a request (e.g. client IP or user ID).
+type KeyFunc func(*http.Request) string
+
+type middlewareConfig struct {
+	responder func(http.ResponseWriter, *http.Request, Result)
+}
+
+// MiddlewareOption configures Middleware.
+type MiddlewareOption func(*middlewareConfig)
+
+// WithResponder overrides the 429 response (default plain text). Use it to emit
+// problem+json via web/problem.
+func WithResponder(fn func(http.ResponseWriter, *http.Request, Result)) MiddlewareOption {
+	return func(c *middlewareConfig) {
+		if fn != nil {
+			c.responder = fn
+		}
+	}
+}
+
+// Middleware limits by key, emitting RateLimit-* headers and a 429 (with
+// Retry-After) when exceeded. On a Store error it fails open (serves the
+// request) to avoid turning a limiter outage into an app outage.
+func (l *Limiter) Middleware(key KeyFunc, opts ...MiddlewareOption) middleware.Middleware {
+	cfg := middlewareConfig{responder: defaultResponder}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			res, err := l.Allow(r.Context(), key(r))
+			if err != nil {
+				next.ServeHTTP(w, r) // fail open
+				return
+			}
+			writeRateLimitHeaders(w, res)
+			if !res.Allowed {
+				w.Header().Set("Retry-After", strconv.Itoa(int(math.Ceil(res.RetryAfter.Seconds()))))
+				cfg.responder(w, r, res)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func writeRateLimitHeaders(w http.ResponseWriter, res Result) {
+	w.Header().Set("RateLimit-Limit", strconv.FormatInt(res.Limit, 10))
+	w.Header().Set("RateLimit-Remaining", strconv.FormatInt(res.Remaining, 10))
+	reset := int(math.Ceil(res.RetryAfter.Seconds()))
+	if res.Allowed {
+		reset = 0
+	}
+	w.Header().Set("RateLimit-Reset", strconv.Itoa(reset))
+}
+
+func defaultResponder(w http.ResponseWriter, _ *http.Request, _ Result) {
+	http.Error(w, ErrLimited.Error(), http.StatusTooManyRequests)
+}
+```
+
+- [ ] **Step 4: Run tests, format, lint, commit**
+
+```bash
+just test ./resilience/ratelimit/...
+just fmt ./resilience/ratelimit/...
+just lint
+git add resilience/ratelimit/middleware.go resilience/ratelimit/middleware_test.go
+git commit -m "feat(resilience/ratelimit): HTTP middleware with RateLimit-* headers and 429"
+```
+
+---
+
+## Task 12: `resilience/ratelimit/redisstore` — Redis counter Store
+
+**Files:**
+- Create: `resilience/ratelimit/redisstore/redisstore.go`, `resilience/ratelimit/redisstore/doc.go`
+- Test: `resilience/ratelimit/redisstore/redisstore_test.go`
+
+**Interfaces:**
+- Consumes: `github.com/redis/go-redis/v9`, the `ratelimit.Store` contract.
+- Produces: `func New(client redis.UniversalClient, opts ...Option) *Store`; `*Store` implements `ratelimit.Store`; `type Option`, `WithPrefix(string)`.
+
+**Redis gating:** the test needs a live Redis. Mirror `data/redis`'s integration test gating — read the address from an env var (e.g. `REDIS_ADDR`) and `t.Skip` when unset. Check `data/redis/*_test.go` for the exact env var/helper this repo uses and reuse it.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package redisstore_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/resilience/ratelimit/redisstore"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func dial(t *testing.T) redis.UniversalClient {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		t.Skip("REDIS_ADDR not set")
+	}
+	c := redis.NewClient(&redis.Options{Addr: addr})
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func TestRedisStore_IncrTTLAtomic(t *testing.T) {
+	client := dial(t)
+	s := redisstore.New(client, redisstore.WithPrefix("rltest:"))
+	ctx := context.Background()
+	key := "k-" + t.Name()
+	require.NoError(t, s.Reset(ctx, key))
+
+	n, err := s.Incr(ctx, key, 1, 500*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	n, err = s.Incr(ctx, key, 1, 500*time.Millisecond) // must NOT re-arm TTL
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+
+	time.Sleep(600 * time.Millisecond)
+	got, err := s.Get(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got) // expired at the FIRST incr's TTL, not extended
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (or skips)**
+
+Run: `REDIS_ADDR= just test ./resilience/ratelimit/redisstore/...`
+Expected: FAIL to compile (undefined) — after implementation, SKIP without `REDIS_ADDR`, PASS with it.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `resilience/ratelimit/redisstore/redisstore.go`:
+
+```go
+package redisstore
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// incrScript increments the key and sets the TTL only on creation (when the new
+// value equals the delta), so a window's expiry is fixed at its first hit.
+var incrScript = redis.NewScript(`
+local v = redis.call('INCRBY', KEYS[1], ARGV[1])
+if v == tonumber(ARGV[1]) then
+  redis.call('PEXPIRE', KEYS[1], ARGV[2])
+end
+return v`)
+
+type config struct {
+	prefix string
+}
+
+// Option configures the Store.
+type Option func(*config)
+
+// WithPrefix namespaces all keys (e.g. "rl:").
+func WithPrefix(p string) Option { return func(c *config) { c.prefix = p } }
+
+// Store implements ratelimit.Store over a go-redis client. The client's
+// lifecycle is the caller's; Close is a no-op.
+type Store struct {
+	client redis.UniversalClient
+	prefix string
+}
+
+// New builds a Redis-backed counter Store.
+func New(client redis.UniversalClient, opts ...Option) *Store {
+	var c config
+	for _, o := range opts {
+		o(&c)
+	}
+	return &Store{client: client, prefix: c.prefix}
+}
+
+func (s *Store) key(k string) string { return s.prefix + k }
+
+// Incr atomically adds delta and sets ttl only when the key is newly created.
+func (s *Store) Incr(ctx context.Context, key string, delta int64, ttl time.Duration) (int64, error) {
+	return incrScript.Run(ctx, s.client, []string{s.key(key)}, delta, ttl.Milliseconds()).Int64()
+}
+
+// Get returns the counter, or 0 when absent.
+func (s *Store) Get(ctx context.Context, key string) (int64, error) {
+	n, err := s.client.Get(ctx, s.key(key)).Int64()
+	if errors.Is(err, redis.Nil) {
+		return 0, nil
+	}
+	return n, err
+}
+
+// Reset deletes the counter.
+func (s *Store) Reset(ctx context.Context, key string) error {
+	return s.client.Del(ctx, s.key(key)).Err()
+}
+
+// Close is a no-op; the client is owned by the caller.
+func (s *Store) Close() error { return nil }
+```
+
+Create `resilience/ratelimit/redisstore/doc.go`:
+
+```go
+// Package redisstore implements ratelimit.Store over a go-redis client, so a
+// sliding-window Limiter shares one counter across instances. Incr is a Lua
+// script that INCRBYs and sets the TTL only on the window's first hit; the
+// client's lifecycle stays with the caller.
+//
+//	store := redisstore.New(client, redisstore.WithPrefix("rl:"))
+//	limiter := ratelimit.New(store, ratelimit.WithLimit(100, time.Minute))
+package redisstore
+```
+
+- [ ] **Step 4: Add a compile-time interface assertion**
+
+Add to `redisstore.go` (ensures `*Store` satisfies the seam without importing it into the package API):
+
+```go
+// (in redisstore_test.go, black-box) — assert the contract:
+// var _ ratelimit.Store = (*redisstore.Store)(nil)
+```
+
+Put that assertion in `redisstore_test.go`:
+
+```go
+var _ ratelimit.Store = (*redisstore.Store)(nil)
+```
+
+(add the `ratelimit` import to the test file).
+
+- [ ] **Step 5: Run tests (skips without Redis), format, lint, commit**
+
+```bash
+just test ./resilience/ratelimit/redisstore/...
+just fmt ./resilience/ratelimit/redisstore/...
+just lint
+git add resilience/ratelimit/redisstore/ go.mod go.sum
+git commit -m "feat(resilience/ratelimit/redisstore): Redis counter Store with atomic per-window TTL"
+```
+
+---
+
+## Task 13: `ops/health` — pull handler + checks
+
+**Files:**
+- Create: `ops/health/health.go`, `ops/health/errors.go`
+- Test: `ops/health/health_test.go`
+
+**Interfaces:**
+- Produces: `func Handler(opts ...Option) http.Handler`; `type Check func(context.Context) error`; `type Option`, `WithCheck(name, Check, ...CheckOption)`, `WithTimeout(time.Duration)`, `WithResponder(func(http.ResponseWriter, *http.Request, Report))`; `type CheckOption`, `NonCritical()`; `type Report`, `type CheckResult`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package health_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/ops/health"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func do(h http.Handler) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	return rec
+}
+
+func TestHandler_LivenessNoChecks(t *testing.T) {
+	rec := do(health.Handler())
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandler_CriticalFailureIs503(t *testing.T) {
+	rec := do(health.Handler(
+		health.WithCheck("ok", func(context.Context) error { return nil }),
+		health.WithCheck("db", func(context.Context) error { return errors.New("down") }),
+	))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	var rep health.Report
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rep))
+	assert.Equal(t, "unavailable", rep.Status)
+}
+
+func TestHandler_NonCriticalDegrades200(t *testing.T) {
+	rec := do(health.Handler(
+		health.WithCheck("cache", func(context.Context) error { return errors.New("down") }, health.NonCritical()),
+	))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rep health.Report
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rep))
+	assert.Equal(t, "degraded", rep.Status)
+}
+
+func TestHandler_TimeoutIsFailureNotHang(t *testing.T) {
+	rec := do(health.Handler(
+		health.WithCheck("slow", func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}),
+		health.WithTimeout(20*time.Millisecond),
+	))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/health/...`
+Expected: FAIL — undefined.
+
+- [ ] **Step 3: Write errors + handler**
+
+Create `ops/health/errors.go`:
+
+```go
+package health
+
+import "errors"
+
+// ErrDraining is returned by a down Gate's Check while the app is shutting down.
+var ErrDraining = errors.New("health: draining")
+```
+
+Create `ops/health/health.go`:
+
+```go
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Check reports the health of one dependency; nil means healthy.
+type Check func(ctx context.Context) error
+
+// Report is the aggregate result of one scrape.
+type Report struct {
+	Status string        `json:"status"` // "ok" | "degraded" | "unavailable"
+	Checks []CheckResult `json:"checks"`
+}
+
+// CheckResult is one check's outcome.
+type CheckResult struct {
+	Name     string `json:"name"`
+	OK       bool   `json:"ok"`
+	Critical bool   `json:"critical"`
+	Err      string `json:"err,omitempty"`
+}
+
+type checkEntry struct {
+	name     string
+	check    Check
+	critical bool
+}
+
+type config struct {
+	checks    []checkEntry
+	timeout   time.Duration
+	responder func(http.ResponseWriter, *http.Request, Report)
+}
+
+// Option configures a Handler.
+type Option func(*config)
+
+type checkConfig struct{ critical bool }
+
+// CheckOption configures a single check.
+type CheckOption func(*checkConfig)
+
+// NonCritical marks a check as degrade-not-evict: its failure yields a
+// "degraded" 200 instead of a 503.
+func NonCritical() CheckOption { return func(c *checkConfig) { c.critical = false } }
+
+// WithCheck registers a named check. Checks are critical by default.
+func WithCheck(name string, check Check, opts ...CheckOption) Option {
+	cc := checkConfig{critical: true}
+	for _, o := range opts {
+		o(&cc)
+	}
+	return func(c *config) {
+		c.checks = append(c.checks, checkEntry{name: name, check: check, critical: cc.critical})
+	}
+}
+
+// WithTimeout bounds each check's context per scrape. 0 inherits the request ctx.
+func WithTimeout(d time.Duration) Option { return func(c *config) { c.timeout = d } }
+
+// WithResponder overrides the default JSON body/format.
+func WithResponder(fn func(http.ResponseWriter, *http.Request, Report)) Option {
+	return func(c *config) {
+		if fn != nil {
+			c.responder = fn
+		}
+	}
+}
+
+// Handler returns an http.Handler that runs every registered check on each
+// request and reports the aggregate. With no checks it always returns 200 — the
+// canonical liveness probe.
+func Handler(opts ...Option) http.Handler {
+	c := config{responder: defaultResponder}
+	for _, o := range opts {
+		o(&c)
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.responder(w, r, evaluate(r.Context(), c))
+	})
+}
+
+func evaluate(ctx context.Context, c config) Report {
+	results := make([]CheckResult, len(c.checks))
+	var wg sync.WaitGroup
+	for i, e := range c.checks {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cctx := ctx
+			if c.timeout > 0 {
+				var cancel context.CancelFunc
+				cctx, cancel = context.WithTimeout(ctx, c.timeout)
+				defer cancel()
+			}
+			err := e.check(cctx)
+			results[i] = CheckResult{Name: e.name, OK: err == nil, Critical: e.critical}
+			if err != nil {
+				results[i].Err = err.Error()
+			}
+		}()
+	}
+	wg.Wait()
+	return summarize(results)
+}
+
+func summarize(results []CheckResult) Report {
+	status := "ok"
+	for _, r := range results {
+		if r.OK {
+			continue
+		}
+		if r.Critical {
+			return Report{Status: "unavailable", Checks: results}
+		}
+		status = "degraded"
+	}
+	return Report{Status: status, Checks: results}
+}
+
+func defaultResponder(w http.ResponseWriter, _ *http.Request, rep Report) {
+	code := http.StatusOK
+	if rep.Status == "unavailable" {
+		code = http.StatusServiceUnavailable
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(rep)
+}
+```
+
+- [ ] **Step 4: Run tests, format, lint, commit**
+
+```bash
+just test ./ops/health/...
+just fmt ./ops/health/...
+just lint
+git add ops/health/health.go ops/health/errors.go ops/health/health_test.go
+git commit -m "feat(ops/health): pull handler with critical/degraded checks and JSON report"
+```
+
+---
+
+## Task 14: `ops/health` — `Gate` + `doc.go`
+
+**Files:**
+- Create: `ops/health/gate.go`, `ops/health/doc.go`
+- Test: `ops/health/gate_test.go`
+
+**Interfaces:**
+- Consumes: `ErrDraining` (Task 13).
+- Produces: `type Gate`, `func NewGate() *Gate`, `func (*Gate) Check(context.Context) error`, `Up()`, `Down()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package health_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/health"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGate_FlipsReadiness(t *testing.T) {
+	gate := health.NewGate()
+	require.NoError(t, gate.Check(context.Background())) // up by default
+
+	h := health.Handler(health.WithCheck("accepting", gate.Check))
+
+	rec := do(h)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	gate.Down()
+	assert.ErrorIs(t, gate.Check(context.Background()), health.ErrDraining)
+
+	rec = do(h)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	gate.Up()
+	rec = do(h)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/health/...`
+Expected: FAIL — `NewGate` undefined.
+
+- [ ] **Step 3: Write the Gate**
+
+Create `ops/health/gate.go`:
+
+```go
+package health
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// Gate is a flippable readiness signal exposed as a Check — the drain primitive.
+// It starts up (healthy); Down makes its Check report ErrDraining.
+type Gate struct {
+	up atomic.Bool
+}
+
+// NewGate returns a Gate in the "up" state.
+func NewGate() *Gate {
+	g := &Gate{}
+	g.up.Store(true)
+	return g
+}
+
+// Check reports nil while up, ErrDraining once Down.
+func (g *Gate) Check(context.Context) error {
+	if g.up.Load() {
+		return nil
+	}
+	return ErrDraining
+}
+
+// Up marks the gate healthy.
+func (g *Gate) Up() { g.up.Store(true) }
+
+// Down marks the gate draining.
+func (g *Gate) Down() { g.up.Store(false) }
+```
+
+- [ ] **Step 4: Write `doc.go` (four-store example + drain)**
+
+Create `ops/health/doc.go`. The multi-store example is a documentation comment (not compiled), so `health` takes no `data/*` dependency:
+
+```go
+// Package health is a single pull-evaluated handler factory for liveness and
+// readiness. Handler() with no checks always returns 200 (liveness); the same
+// function with checks is readiness. Checks run on each scrape (no cache, no
+// background workers); they are critical by default (failure → 503) unless
+// marked NonCritical (failure → "degraded" 200).
+//
+// # Liveness + readiness over datastores
+//
+// Each forge data client already exposes a func(ctx) error healthcheck, which
+// IS a health.Check — so they plug straight in:
+//
+//	mux.Handle("GET /livez", health.Handler()) // process is up
+//
+//	mux.Handle("GET /readyz", health.Handler(
+//		health.WithCheck("postgres", postgres.Healthcheck(pool)),                // critical
+//		health.WithCheck("mongo", mongo.Healthcheck(mdb)),                       // critical
+//		health.WithCheck("redis", redis.Healthcheck(rdb), health.NonCritical()), // degrade
+//		health.WithCheck("opensearch", opensearch.Healthcheck(osc), health.NonCritical()),
+//		health.WithTimeout(2*time.Second),
+//	))
+//
+// # Graceful drain (readiness 503 before the server stops)
+//
+// A Gate check plus supervisor's ordered pre-shutdown phase flips /readyz to 503
+// and waits so the load balancer deregisters while the server still serves:
+//
+//	gate := health.NewGate()
+//	readyz := health.Handler(health.WithCheck("accepting", gate.Check) /* + store checks */)
+//	supervisor.Run(ctx,
+//		supervisor.WithPreShutdown("drain", func(ctx context.Context) {
+//			gate.Down() // next /readyz scrape is 503; server keeps serving
+//			select {
+//			case <-time.After(5 * time.Second): // ≥ probeInterval × failureThreshold
+//			case <-ctx.Done():
+//			}
+//		}),
+//		supervisor.WithService(srv), // listener closes only after the hook returns
+//	)
+//
+// An HTTP-dependency check is a one-liner (GET → 2xx, drain+close body, honor
+// ctx); it is not a package export.
+package health
+```
+
+- [ ] **Step 5: Run tests, format, lint, commit**
+
+```bash
+just test ./ops/health/...
+just fmt ./ops/health/...
+just lint
+git add ops/health/gate.go ops/health/doc.go ops/health/gate_test.go
+git commit -m "feat(ops/health): Gate drain primitive and package doc with datastore + drain examples"
+```
+
+---
+
+## Task 15: `web/httpclient` — resilient transport (retry + timeouts + hooks + propagation)
+
+**Files:**
+- Create: `web/httpclient/httpclient.go`, `web/httpclient/options.go`
+- Test: `web/httpclient/httpclient_test.go`
+
+**Interfaces:**
+- Consumes: `resilience/retry`, `resilience/backoff`.
+- Produces: `func New(opts ...Option) *http.Client`; `type Option`; `WithTimeout`, `WithPerAttemptTimeout`, `WithRetry(...retry.Option)`, `WithRetryMethods(...string)`, `WithBaseTransport(http.RoundTripper)`, `WithBefore`, `WithAfter`, `WithContextHeaders`, `WithHeader`, `WithUserAgent`. (Breaker option added in Task 16.)
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package httpclient_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/httpclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_RetriesTransient503ThenSucceeds(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := httpclient.New()
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestNew_DoesNotRetryPOSTByDefault(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	client := httpclient.New()
+	resp, err := client.Post(srv.URL, "text/plain", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, int32(1), calls.Load()) // POST not retried
+}
+
+func TestNew_PropagatesContextHeaders(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("X-Request-ID")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := httpclient.New(
+		httpclient.WithContextHeaders(func(ctx context.Context) http.Header {
+			h := http.Header{}
+			if v, ok := ctx.Value(ctxKey{}).(string); ok {
+				h.Set("X-Request-ID", v)
+			}
+			return h
+		}),
+	)
+	req, _ := http.NewRequestWithContext(context.WithValue(context.Background(), ctxKey{}, "rid-1"), http.MethodGet, srv.URL, nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	assert.Equal(t, "rid-1", got)
+}
+
+type ctxKey struct{}
+```
+
+(Add `context` to the test imports.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./web/httpclient/...`
+Expected: FAIL — undefined.
+
+- [ ] **Step 3: Write options**
+
+Create `web/httpclient/options.go`:
+
+```go
+package httpclient
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/dmitrymomot/forge/resilience/retry"
+)
+
+type config struct {
+	timeout      time.Duration
+	perAttempt   time.Duration
+	retryOpts    []retry.Option
+	retryMethods map[string]bool
+	base         http.RoundTripper
+	before       []func(*http.Request)
+	after        []func(*http.Request, *http.Response)
+	ctxHeaders   []func(context.Context) http.Header
+	headers      http.Header
+	userAgent    string
+	useBreaker   bool
+	breakerOpts  []any // populated in Task 16 (circuitbreaker.GroupOption)
+}
+
+func newConfig(opts ...Option) config {
+	c := config{
+		base:         http.DefaultTransport,
+		retryMethods: map[string]bool{http.MethodGet: true, http.MethodHead: true, http.MethodPut: true, http.MethodDelete: true, http.MethodOptions: true},
+		headers:      http.Header{},
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// Option configures the client.
+type Option func(*config)
+
+// WithTimeout sets the overall http.Client timeout.
+func WithTimeout(d time.Duration) Option { return func(c *config) { c.timeout = d } }
+
+// WithPerAttemptTimeout bounds each individual attempt via context.
+func WithPerAttemptTimeout(d time.Duration) Option { return func(c *config) { c.perAttempt = d } }
+
+// WithRetry tunes the retry policy (default 3 attempts, jittered backoff).
+func WithRetry(opts ...retry.Option) Option { return func(c *config) { c.retryOpts = append(c.retryOpts, opts...) } }
+
+// WithRetryMethods sets which HTTP methods are retried (default idempotent: GET,HEAD,PUT,DELETE,OPTIONS).
+func WithRetryMethods(methods ...string) Option {
+	return func(c *config) {
+		c.retryMethods = map[string]bool{}
+		for _, m := range methods {
+			c.retryMethods[m] = true
+		}
+	}
+}
+
+// WithBaseTransport sets the innermost RoundTripper (default http.DefaultTransport).
+func WithBaseTransport(rt http.RoundTripper) Option {
+	return func(c *config) {
+		if rt != nil {
+			c.base = rt
+		}
+	}
+}
+
+// WithBefore runs fn on each outbound request before it is sent.
+func WithBefore(fn func(*http.Request)) Option { return func(c *config) { c.before = append(c.before, fn) } }
+
+// WithAfter runs fn after each response is received.
+func WithAfter(fn func(*http.Request, *http.Response)) Option { return func(c *config) { c.after = append(c.after, fn) } }
+
+// WithContextHeaders copies headers derived from the request context onto the
+// outbound request (e.g. X-Request-ID, traceparent).
+func WithContextHeaders(fn func(context.Context) http.Header) Option {
+	return func(c *config) { c.ctxHeaders = append(c.ctxHeaders, fn) }
+}
+
+// WithHeader sets a static header on every request.
+func WithHeader(key, value string) Option { return func(c *config) { c.headers.Set(key, value) } }
+
+// WithUserAgent sets the User-Agent header on every request.
+func WithUserAgent(ua string) Option { return func(c *config) { c.userAgent = ua } }
+```
+
+- [ ] **Step 4: Write the transport**
+
+Create `web/httpclient/httpclient.go`:
+
+```go
+package httpclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/dmitrymomot/forge/resilience/retry"
+)
+
+// New returns a resilient *http.Client: a RoundTripper stack that decorates the
+// request (static/context headers, hooks), retries idempotent methods on
+// transient failures with jittered backoff (honoring Retry-After), and bounds
+// each attempt. It returns the stdlib type; problem+json surfacing is a
+// companion problem.Decode(resp) call.
+func New(opts ...Option) *http.Client {
+	c := newConfig(opts...)
+	return &http.Client{Transport: &transport{cfg: c, breaker: buildBreaker(c)}, Timeout: c.timeout}
+}
+
+type transport struct {
+	cfg     config
+	breaker breakerFunc // nil unless WithBreakerGroup set (Task 16)
+}
+
+// breakerFunc runs fn under a per-host breaker; nil means no breaker.
+type breakerFunc func(ctx context.Context, host string, fn func(context.Context) error) error
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.decorate(req)
+
+	var resp *http.Response
+	attempt := func(ctx context.Context) error {
+		r := req.Clone(ctx)
+		if req.GetBody != nil { // replay the body on retried methods (PUT/DELETE with a body)
+			b, gErr := req.GetBody()
+			if gErr != nil {
+				return retry.Permanent(gErr)
+			}
+			r.Body = b
+		}
+		call := func(ctx context.Context) error {
+			cctx := ctx
+			if t.cfg.perAttempt > 0 {
+				var cancel context.CancelFunc
+				cctx, cancel = context.WithTimeout(ctx, t.cfg.perAttempt)
+				defer cancel()
+			}
+			out, err := t.cfg.base.RoundTrip(r.WithContext(cctx))
+			if err != nil {
+				return err
+			}
+			resp = out
+			for _, fn := range t.cfg.after {
+				fn(r, out)
+			}
+			if retryableStatus(out.StatusCode) {
+				return statusError{code: out.StatusCode, retryAfter: parseRetryAfter(out)}
+			}
+			return nil
+		}
+		if t.breaker != nil {
+			return t.breaker(ctx, req.URL.Host, call)
+		}
+		return call(ctx)
+	}
+
+	ctx := req.Context()
+	var err error
+	if t.cfg.retryMethods[req.Method] {
+		err = retry.Do(ctx, attempt, append([]retry.Option{retry.WithRetryIf(isRetryable)}, t.cfg.retryOpts...)...)
+	} else {
+		err = attempt(ctx)
+	}
+
+	// A bad-status "error" is internal to drive retry; return the response, not an error.
+	if _, ok := errors.AsType[statusError](err); ok {
+		return resp, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (t *transport) decorate(req *http.Request) {
+	for k, vs := range t.cfg.headers {
+		for _, v := range vs {
+			req.Header.Set(k, v)
+		}
+	}
+	if t.cfg.userAgent != "" {
+		req.Header.Set("User-Agent", t.cfg.userAgent)
+	}
+	for _, fn := range t.cfg.ctxHeaders {
+		for k, vs := range fn(req.Context()) {
+			for _, v := range vs {
+				req.Header.Set(k, v)
+			}
+		}
+	}
+	for _, fn := range t.cfg.before {
+		fn(req)
+	}
+}
+
+// statusError carries a retryable HTTP status and any Retry-After hint, so
+// retry (which honors retry.RetryAfterError) can raise the delay floor.
+type statusError struct {
+	code       int
+	retryAfter time.Duration
+}
+
+func (e statusError) Error() string          { return fmt.Sprintf("httpclient: server returned %d", e.code) }
+func (e statusError) RetryAfter() time.Duration { return e.retryAfter }
+
+func retryableStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code >= 500
+}
+
+func isRetryable(err error) bool {
+	if _, ok := errors.AsType[statusError](err); ok {
+		return true
+	}
+	// network/transport errors are retryable; context cancellation is not.
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
+}
+
+func parseRetryAfter(resp *http.Response) time.Duration {
+	v := resp.Header.Get("Retry-After")
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if when, err := http.ParseTime(v); err == nil {
+		if d := time.Until(when); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+```
+
+- [ ] **Step 5: Add a no-op breaker builder (real one in Task 16)**
+
+Create `web/httpclient/breaker.go`:
+
+```go
+package httpclient
+
+// buildBreaker returns nil until WithBreakerGroup is wired in Task 16.
+func buildBreaker(c config) breakerFunc { return nil }
+```
+
+- [ ] **Step 6: Run tests, format, lint, commit**
+
+```bash
+just test ./web/httpclient/...
+just fmt ./web/httpclient/...
+just lint
+git add web/httpclient/httpclient.go web/httpclient/options.go web/httpclient/breaker.go web/httpclient/httpclient_test.go
+git commit -m "feat(web/httpclient): resilient transport with retry, timeouts, hooks, propagation"
+```
+
+---
+
+## Task 16: `web/httpclient` — opt-in per-host breaker + `doc.go`
+
+**Files:**
+- Modify: `web/httpclient/options.go` (add `WithBreakerGroup`), `web/httpclient/breaker.go` (build the Group)
+- Create: `web/httpclient/doc.go`
+- Test: `web/httpclient/breaker_test.go`
+
+**Interfaces:**
+- Consumes: `resilience/circuitbreaker.{NewGroup,Group,GroupOption,ErrOpen}`.
+- Produces: `func WithBreakerGroup(opts ...circuitbreaker.GroupOption) Option`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package httpclient_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/resilience/circuitbreaker"
+	"github.com/dmitrymomot/forge/web/httpclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBreaker_OptInTripsAfterFailures(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := httpclient.New(
+		httpclient.WithRetryMethods(), // disable retry to isolate the breaker
+		httpclient.WithBreakerGroup(circuitbreaker.WithBreakerOptions(circuitbreaker.WithFailureThreshold(2))),
+	)
+	// Drive failures past the threshold.
+	for range 3 {
+		resp, err := client.Get(srv.URL)
+		if err == nil {
+			resp.Body.Close()
+		}
+	}
+	// Next call should fast-fail with ErrOpen.
+	_, err := client.Get(srv.URL)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, circuitbreaker.ErrOpen))
+}
+
+func TestBreaker_OffByDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := httpclient.New(httpclient.WithRetryMethods())
+	for range 10 {
+		resp, err := client.Get(srv.URL)
+		require.NoError(t, err) // 500 is a response, not an error; never ErrOpen
+		resp.Body.Close()
+	}
+}
+```
+
+Verify the exact circuitbreaker option names against `resilience/circuitbreaker/group.go` and `circuitbreaker.go` (`WithBreakerOptions`, `WithFailureThreshold`) before running; adjust the test to the real names if they differ.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./web/httpclient/...`
+Expected: FAIL — `WithBreakerGroup` undefined.
+
+- [ ] **Step 3: Add the option**
+
+In `web/httpclient/options.go`, add the import `"github.com/dmitrymomot/forge/resilience/circuitbreaker"`, change the `breakerOpts` field type from `[]any` to `[]circuitbreaker.GroupOption`, and add:
+
+```go
+// WithBreakerGroup enables a per-host circuit breaker (off by default). Each
+// attempt runs inside a circuitbreaker.Group keyed by request host; the breaker's
+// open error carries Retry-After, so retry and breaker cooperate.
+func WithBreakerGroup(opts ...circuitbreaker.GroupOption) Option {
+	return func(c *config) {
+		c.useBreaker = true
+		c.breakerOpts = append(c.breakerOpts, opts...)
+	}
+}
+```
+
+- [ ] **Step 4: Build the breaker**
+
+Replace `web/httpclient/breaker.go`:
+
+```go
+package httpclient
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/resilience/circuitbreaker"
+)
+
+// buildBreaker returns a per-host breaker func, or nil when the breaker is off.
+func buildBreaker(c config) breakerFunc {
+	if !c.useBreaker {
+		return nil
+	}
+	group := circuitbreaker.NewGroup(c.breakerOpts...)
+	return func(ctx context.Context, host string, fn func(context.Context) error) error {
+		return group.Do(ctx, host, fn)
+	}
+}
+```
+
+- [ ] **Step 5: Write `doc.go`**
+
+Create `web/httpclient/doc.go`:
+
+```go
+// Package httpclient builds a resilient *http.Client (the stdlib type) from a
+// RoundTripper stack over the shipped retry/backoff/circuitbreaker packages:
+// static + context-derived headers and before/after hooks, jittered retry of
+// idempotent methods on transient failures (5xx/429/network, honoring
+// Retry-After), a per-attempt timeout, and an OPT-IN per-host circuit breaker.
+//
+//	client := httpclient.New(
+//		httpclient.WithPerAttemptTimeout(2*time.Second),
+//		httpclient.WithContextHeaders(func(ctx context.Context) http.Header {
+//			h := http.Header{}
+//			if id, ok := requestid.From(ctx); ok {
+//				h.Set("X-Request-ID", id)
+//			}
+//			return h
+//		}),
+//		httpclient.WithBreakerGroup(), // enable per-host breaker
+//	)
+//
+//	resp, err := client.Get(url)
+//	if err != nil { /* transport/breaker error */ }
+//	if err := problem.Decode(resp); err != nil { /* 4xx/5xx problem+json */ }
+//
+// Retry is on by default (3 attempts) for GET/HEAD/PUT/DELETE/OPTIONS only —
+// POST is excluded to avoid silent double-submits (override with
+// WithRetryMethods). New returns the stdlib *http.Client, so problem surfacing
+// is the companion problem.Decode call rather than a changed Do signature.
+package httpclient
+```
+
+- [ ] **Step 6: Run tests, format, lint, commit**
+
+```bash
+just test ./web/httpclient/...
+just fmt ./web/httpclient/...
+just lint
+git add web/httpclient/options.go web/httpclient/breaker.go web/httpclient/doc.go web/httpclient/breaker_test.go
+git commit -m "feat(web/httpclient): opt-in per-host circuit breaker and package doc"
+```
+
+---
+
+## Task 17: Update `docs/packages.md` + full verification
+
+**Files:**
+- Modify: `docs/packages.md`
+
+- [ ] **Step 1: Move the four packages to shipped**
+
+In `docs/packages.md`: move `config` (as `ops/config`), `health`, `ratelimit` (+`ratelimit/redisstore`), and `httpclient` from *planned* to *shipped* in their domain lists; update the shipped-count header line; drop the Wave 1 rows from the build-order section. Note the new `gopkg.in/yaml.v3` isolated dep in the dependency-philosophy section.
+
+- [ ] **Step 2: Full-tree verification**
+
+```bash
+just test ./...
+just lint
+go tool modernize ./...
+```
+
+Expected: all tests PASS (race + cover), lint clean, modernize reports no changes. Fix anything that surfaces.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/packages.md
+git commit -m "docs(packages): mark Wave 1 completion bundle shipped (config, health, ratelimit, httpclient)"
+```
+
+---
+
+## Self-Review Notes (author checklist — verify during execution)
+
+- **Spec coverage:** SetString (§0.1)→T1; WithPreShutdown (§0.2)→T2; config substitution/dotenv/profile/LoadEnv/Load/doc (§1)→T3–T8; ratelimit seam/limiter/middleware/redisstore (§3)→T9–T12; health handler/Gate/doc (§2)→T13–T14; httpclient transport/breaker/doc (§4)→T15–T16; packages.md + verification→T17. All spec sections mapped.
+- **Deviations from spec (intentional, within the structfields seam):** (a) env-tag defaults use the `default=` tag OPTION (`env:"PORT,default=8080"`) not a separate `default:"…"` struct tag — `structfields.Walk` surfaces only the walked tag; (b) nested-struct prefix derives from the field's `env` tag name (`env:"DB"` → `DB_`) rather than a `config:"prefix=…"` tag, for the same reason; (c) `SetString` slices support `[]string` only in v1. Update spec §1 if these should be reconciled there.
+- **Type consistency:** `Store` signatures identical across `store.go`, `memory.go`, `redisstore` (`Incr(ctx,key,delta int64,ttl)`, `Get`, `Reset`, `Close`). `breakerFunc`/`buildBreaker` signature matches between T15 (no-op) and T16 (real). `Result`, `Report`, `CheckResult` field names match their tests.
+- **Verify-before-run gotchas flagged inline:** exact `circuitbreaker` option names (T16), `data/redis` integration-test gating pattern (T12), and `strings.SplitSeq` vs `strings.Split` under lint (T4).

--- a/docs/superpowers/specs/2026-07-05-wave1-completion-design.md
+++ b/docs/superpowers/specs/2026-07-05-wave1-completion-design.md
@@ -4,8 +4,8 @@
 > in `docs/packages.md`. The shipped-package API additions portion of Wave 1
 > landed in PR #31; this bundle adds the four *new* packages that finish the
 > wave: `web/httpclient`, `resilience/ratelimit` (+`ratelimit/redisstore`),
-> `ops/envconfig`, `ops/health`, plus one shared unblocker
-> (`structfields.SetString`).
+> `ops/envconfig`, `ops/health`, plus two shared unblockers
+> (`structfields.SetString`, `supervisor.WithPreShutdown`).
 
 ## Goal
 
@@ -30,7 +30,8 @@ real deps isolated in driver subpackages, black-box tests only.
 ## Scope
 
 **In:** the four packages above, the `ratelimit/redisstore` driver subpackage,
-and one shared shipped-package addition (`core/structfields.SetString`).
+and two shared shipped-package additions (`core/structfields.SetString`,
+`ops/supervisor.WithPreShutdown`).
 
 **Out (explicit non-goals):**
 
@@ -46,7 +47,12 @@ and one shared shipped-package addition (`core/structfields.SetString`).
 
 ---
 
-## 0. Shared unblocker — `core/structfields.SetString`
+## 0. Shared unblockers
+
+Two small, backward-compatible additions to shipped packages, each TDD'd first
+because a Wave 1 package depends on it.
+
+### 0.1 — `core/structfields.SetString`
 
 `envconfig` must turn an env *string* into a typed struct field. `typeconv` is
 documented "converts strings to Go scalars **without reflection**" (generic
@@ -78,6 +84,40 @@ right sentinel; value-struct (non-pointer) `Field.Set` still returns
 `ErrNotSettable`; empty `raw` leaves defaults for optional fields (caller
 decides — `SetString` on empty string parses "" per kind, so `envconfig` skips
 calling it when the env var is absent).
+
+### 0.2 — `ops/supervisor.WithPreShutdown`
+
+`health`'s graceful drain requires flipping readiness to 503 and letting the
+load balancer deregister **before** `httpserver` stops accepting connections.
+The shipped supervisor cancels the shared `runCtx` **once** and every service
+observes `ctx.Done()` simultaneously (`supervisor.go:75`, `beginShutdown`) —
+there is no shutdown ordering, so a peer "drain service" flips readiness
+*concurrently* with the server closing its listener, which defeats the grace
+window. This adds an ordered pre-shutdown phase:
+
+```go
+// WithPreShutdown registers a hook run after the stop signal (or a service
+// exit) but BEFORE runCtx is cancelled. All hooks run concurrently; Run waits
+// for them to return, bounded by WithPreShutdownTimeout, then cancels runCtx so
+// services drain. Hooks receive a fresh context (the parent is already
+// cancelled) carrying the pre-shutdown deadline.
+func WithPreShutdown(name string, fn func(context.Context)) Option
+func WithPreShutdownTimeout(d time.Duration) Option // default 30s; must exceed the longest grace
+```
+
+**Run change:** `beginShutdown` currently calls `cancel()` immediately. It
+becomes: log shutdown → run pre-shutdown hooks to completion (or timeout) →
+`cancel()` → existing drain loop. The hook phase runs once, is skipped when
+there are no hooks (zero behavior change for current callers), and a hook panic
+is recovered and logged like a service panic. New sentinel
+`ErrPreShutdownTimeout` (joined into the returned error, non-fatal — shutdown
+still proceeds).
+
+**Test expectations (black-box):** hooks complete before any service observes
+cancellation (a hook that records order vs a service that records its
+`ctx.Done()` time); multiple hooks run concurrently; `WithPreShutdownTimeout`
+bounds a slow hook and surfaces `ErrPreShutdownTimeout` without blocking
+shutdown; no hooks → identical behavior to today; a panicking hook is recovered.
 
 ---
 
@@ -157,85 +197,132 @@ round-trip a real shipped Config shape (e.g. a struct mirroring
 
 ## 2. `ops/health`
 
-Liveness + readiness in one package, with per-check timeout/TTL, drain gating,
-and heartbeat kickers.
+A **single handler factory**. No `Health` struct, no registry, no cache, no
+background goroutine, no lifecycle. Checks are pull-evaluated on each scrape and
+added purely as options. `Handler()` with no options is an always-200 handler —
+the canonical liveness probe; the same function with checks is readiness.
 
 ### Public API
 
 ```go
-func New(opts ...Option) *Health
-
-func (h *Health) Liveness(name string, c Check, opts ...CheckOption)
-func (h *Health) Readiness(name string, c Check, opts ...CheckOption)
-
-func (h *Health) LivenessHandler() http.Handler   // GET /livez
-func (h *Health) ReadinessHandler() http.Handler  // GET /readyz
-
-func (h *Health) SetReady(ready bool)
-func (h *Health) Heartbeat(name string, maxAge time.Duration) (kick func())
-func (h *Health) DrainService(grace time.Duration) supervisor.Service
+// Handler runs every registered check on each request and reports the
+// aggregate: 200 when all pass (or only non-critical checks fail, "degraded"),
+// 503 when any critical check fails. With no checks it always returns 200.
+func Handler(opts ...Option) http.Handler
 
 type Check func(ctx context.Context) error
 
-// Built-in check adapters (driver-free — they take interfaces / stdlib types,
-// so they carry no data/* or web/httpclient imports and live in this package).
-func Ping(p interface{ Ping(ctx context.Context) error }) Check   // 2xx of a driver ping
-func HTTPGet(client *http.Client, url string) Check               // 2xx = healthy
-
 type Option func(*config)
-func WithDefaultTimeout(d time.Duration) Option   // default per-check ctx deadline
-func WithDefaultCacheTTL(d time.Duration) Option  // default result cache window
-func WithLogger(l *slog.Logger) Option
+func WithCheck(name string, check Check, opts ...CheckOption) Option
+func WithTimeout(d time.Duration) Option   // per-check ctx bound; 0 = inherit request ctx
+func WithResponder(fn func(http.ResponseWriter, *http.Request, Report)) Option // default JSON
 
 type CheckOption func(*checkConfig)
-func WithCritical() CheckOption                  // failure flips readiness to 503
-func WithTimeout(d time.Duration) CheckOption    // per-check override of default timeout
-func WithCacheTTL(d time.Duration) CheckOption   // per-check override of default cache TTL
+func NonCritical() CheckOption   // failure → 200 "degraded" instead of 503
+
+type Report struct {
+    Status string        // "ok" | "degraded" | "unavailable"
+    Checks []CheckResult
+}
+type CheckResult struct {
+    Name     string
+    OK       bool
+    Critical bool
+    Err      string
+}
+
+// Gate is a flippable readiness signal exposed as a Check — the drain primitive.
+type Gate struct{ /* atomic.Bool, starts up */ }
+func NewGate() *Gate
+func (g *Gate) Check(ctx context.Context) error // nil while up; ErrDraining once Down
+func (g *Gate) Up()
+func (g *Gate) Down()
 ```
 
 ### Semantics
 
-- **Two registries.** `/livez` reflects only liveness checks + heartbeat
-  freshness; a hung background loop that stops calling its `kick()` makes
-  `/livez` fail after `maxAge`. `/readyz` reflects readiness checks AND the
-  `SetReady` flag.
-- **Result shape.** Handlers return `200`/`503` with a JSON body:
-  `{"status":"ok|degraded|unavailable","checks":{"name":{"ok":bool,"error":"…","critical":bool}}}`.
-  Non-critical readiness failure → `status:"degraded"` but still `200`; any
-  critical failure or `SetReady(false)` → `503`.
-- **Per-check execution.** Each check runs under its timeout; results are cached
-  for the TTL so a scrape storm can't hammer the database. Checks run
-  concurrently on scrape.
-- **Drain gating.** `DrainService(grace)` returns a `supervisor.Service`
-  (`Name()="health-drain"`, blocking `Run`). On ctx cancel it calls
-  `SetReady(false)`, sleeps `grace` (so the load balancer observes `/readyz`
-  going 503 and deregisters), then returns nil. Registered **before**
-  `httpserver` in `supervisor.Run` so readiness flips before the server drains.
-  Documented ordering in `doc.go`.
+- **Pull only.** Every scrape runs the registered checks and reports the
+  aggregate — no caching, no background workers. Freshness == the scrape; the
+  operator picks a sane probe interval (a 1s probe pings the datastores once a
+  second, by design). `WithTimeout` bounds each check so one hung store can't
+  hang the probe; checks also observe the request context.
+- **Concurrency.** Checks run concurrently *within a single request* (ephemeral,
+  request-scoped — not a background worker) so N store pings don't serialize.
+  All complete before the response is written.
+- **Criticality.** Checks are **critical by default** (failure → 503);
+  `NonCritical()` makes a check degrade-not-evict — its failure yields
+  `status:"degraded"` with a still-`200` response.
+- **Result shape (default responder).** JSON:
+  `{"status":"ok|degraded|unavailable","checks":[{"name":…,"ok":…,"critical":…,"err":…}]}`.
+  Empty check set → `{"status":"ok","checks":[]}` at `200`. `WithResponder`
+  swaps the body format (e.g. a `problem`-shaped body) without touching check
+  logic.
+- **No built-in check adapters.** A `Check` is just `func(ctx) error`; forge's
+  data clients already expose exactly that (`postgres.Healthcheck(pool)`,
+  `redis.Healthcheck(c)`, `opensearch.Healthcheck(c)`, `mongo.Healthcheck(db)`),
+  so a `Ping` adapter would be dead weight. An HTTP-dependency check is a
+  documented `doc.go` recipe (GET → 2xx, drain+close body, honor ctx), not a
+  package export.
 
-### Built-in checks (in-package)
+### Drain (composed with `supervisor.WithPreShutdown`)
 
-`Ping` and `HTTPGet` live in `health` itself — they are interface/stdlib
-adapters, not driver code, so they add no imports and a separate `health/checks`
-package would be redundant. `data/postgres` and `data/redis` clients satisfy the
-`Ping` shape; `HTTPGet` takes any `*http.Client` (typically one built by the new
-`httpclient`, but only the stdlib type is referenced, so no import of
-`web/httpclient`).
+Readiness-flip-for-shutdown is **just a `Gate` check**, not special machinery.
+Register `gate.Check` in the readyz handler; flip it in a pre-shutdown hook so
+`/readyz` reports 503 while the server keeps serving, then the ordered
+pre-shutdown phase (§0.2) lets the LB deregister before `httpserver` stops:
+
+```go
+gate := health.NewGate()
+readyz := health.Handler(
+    health.WithCheck("accepting", gate.Check),
+    health.WithCheck("postgres", postgres.Healthcheck(pool)),
+    // …
+)
+supervisor.Run(ctx,
+    supervisor.WithPreShutdown("drain", func(ctx context.Context) {
+        gate.Down()                 // next /readyz scrape = 503, server still serving
+        select {                    // wait grace ≥ probeInterval × failureThreshold + margin
+        case <-time.After(5 * time.Second):
+        case <-ctx.Done():
+        }
+    }),
+    supervisor.WithService(srv),    // listener closes only AFTER the hook returns
+)
+```
+
+### `doc.go` example — liveness + readiness over the four datastores
+
+```go
+mux.Handle("GET /livez", health.Handler()) // always 200: process is up
+
+mux.Handle("GET /readyz", health.Handler(
+    health.WithCheck("postgres", postgres.Healthcheck(pool)),                 // critical
+    health.WithCheck("mongo", mongo.Healthcheck(mdb)),                        // critical
+    health.WithCheck("redis", redis.Healthcheck(rdb), health.NonCritical()),  // degrade
+    health.WithCheck("opensearch", opensearch.Healthcheck(osc), health.NonCritical()),
+    health.WithTimeout(2*time.Second),
+))
+```
+
+`/readyz` with redis down → `200 {"status":"degraded", …}`; with postgres or
+mongo down → `503 {"status":"unavailable", …}`.
 
 ### Errors
 
-`health` checks return caller errors verbatim in the JSON; the package needs no
-exported error sentinels beyond what handlers encode.
+`ErrDraining` (returned by a down `Gate.Check`), single-line and
+`errors.Is`-matchable. Checks otherwise return caller errors verbatim into the
+`Report`.
 
 ### Tests (black-box)
 
-`/livez` 200 with healthy checks, 503 when a liveness check errors; heartbeat
-staleness flips `/livez`; `/readyz` 503 on `SetReady(false)`; critical vs
-non-critical readiness distinction (503 vs degraded-200); per-check timeout
-surfaces as failure not hang; result caching (a slow check invoked once within
-TTL — assert call count); `DrainService` flips readiness on ctx cancel and
-returns after `grace` (use `clock.Mock` or a tiny real grace); `Ping` maps a
-stub pinger's error; `HTTPGet` reports a stub server's non-2xx as unhealthy.
+`Handler()` with no checks → 200 (liveness); all-pass → 200 `"ok"`; a critical
+failure → 503 `"unavailable"`; a `NonCritical` failure → 200 `"degraded"` while
+criticals pass; `WithTimeout` turns a hung check into a failure not a hang;
+checks receive and honor the request context (cancel mid-scrape); concurrent
+execution (two slow checks finish in ~max, not sum); `Gate` flips
+`Check`↔`ErrDraining` on `Down`/`Up` and the handler goes 503↔200 accordingly;
+`WithResponder` overrides the body; the four-store `doc.go` example compiles and
+degrades/evicts per criticality (stub `func(ctx) error` checks, no real DBs).
 
 ---
 
@@ -431,8 +518,10 @@ maps a 422 problem+json body.
 
 ## Build order (within the bundle)
 
-1. `core/structfields.SetString` (unblocker leaf).
-2. In parallel: `ops/envconfig` (needs #1), `ops/health`,
+1. Unblocker leaves, in parallel: `core/structfields.SetString` and
+   `ops/supervisor.WithPreShutdown`.
+2. In parallel: `ops/envconfig` (needs #1's `SetString`), `ops/health` (needs
+   `WithPreShutdown` only for its drain `doc.go` example, not to compile),
    `resilience/ratelimit` (+`ratelimit/redisstore`), `web/httpclient`.
 3. Update `docs/packages.md`: move the four from *planned* to *shipped*, bump
    the shipped-count line, drop the Wave 1 rows from build order.
@@ -441,6 +530,10 @@ One bundled PR via `subagent-driven-dev`.
 
 ## Risks / notes
 
+- **`WithPreShutdown` ordering is the crux of the drain story.** The pre-shutdown
+  phase must complete *before* `runCtx` is cancelled — the ordering test
+  (hook-finished-before-service-sees-cancel) is the guard; a regression silently
+  reverts to the broken concurrent drain.
 - **redisstore fixed-TTL-per-window** must be atomic (Lua) or a concurrent
   first-incr race re-arms the TTL and stretches a window. Called out in the plan
   as a must-test.
@@ -448,6 +541,9 @@ One bundled PR via `subagent-driven-dev`.
   boundary-crossing test with a mock clock is the guard.
 - **POST-retry default off** is a deliberate safety choice (no silent
   double-submit); `WithRetryMethods` is the documented escape hatch.
-- `health.HTTPGet` references only the stdlib `*http.Client`, so `health` has no
-  build-order dependency on `httpclient` — the four packages are fully
-  independent after the `structfields.SetString` unblocker.
+- **`health` is pull-only, no cache** — a fast probe pings datastores every
+  interval by design; the operator owns the probe cadence. `WithTimeout` is the
+  guard against a hung store hanging the probe.
+- The four packages are independent after the two unblockers; `health` needs no
+  import of `httpclient` (HTTP-dependency checks are an inline recipe, not an
+  export).

--- a/docs/superpowers/specs/2026-07-05-wave1-completion-design.md
+++ b/docs/superpowers/specs/2026-07-05-wave1-completion-design.md
@@ -1,0 +1,451 @@
+# Wave 1 Completion Bundle — Design Spec
+
+> Status: approved 2026-07-05. Completes the build-order **Wave 1 (Unblockers)**
+> in `docs/packages.md`. The shipped-package API additions portion of Wave 1
+> landed in PR #31; this bundle adds the four *new* packages that finish the
+> wave: `web/httpclient`, `resilience/ratelimit` (+`ratelimit/redisstore`),
+> `ops/envconfig`, `ops/health`, plus one shared unblocker
+> (`structfields.SetString`).
+
+## Goal
+
+Ship the four Wave 1 packages as one bundled PR via `subagent-driven-dev`. Each
+is `core` tier, independently buildable on already-shipped dependencies, and
+unblocks large parts of Wave 2+:
+
+- `httpclient` — the outbound transport under `captcha`, `oauthclient`,
+  `comms/*`, `llm`.
+- `ratelimit` — establishes the **counter `Store` seam** shared later by
+  `quota` and `lockout`.
+- `envconfig` — env→Config loading that every shipped `Config` (`logger`,
+  `httpserver`, …) is already tagged for.
+- `health` — liveness/readiness + drain gating, needed by `appmain` and any
+  real deployment.
+
+All four follow the design DNA in `docs/packages.md`: `New(...Option)` (never
+builders), env-loadable `Config`+`DefaultConfig`+`Validate` where stateful,
+`errors.Is`-matchable single-line sentinels, `doc.go` with a runnable example,
+real deps isolated in driver subpackages, black-box tests only.
+
+## Scope
+
+**In:** the four packages above, their driver subpackages
+(`ratelimit/redisstore`, `health/checks`), and one shared shipped-package
+addition (`core/structfields.SetString`).
+
+**Out (explicit non-goals):**
+
+- Config *watching*/hot-reload — that is icebox `ops/configwatch`.
+- Token-bucket / GCRA / fixed-window rate-limit algorithms — sliding-window
+  counter is the only algorithm shipped now (the seam allows adding others
+  later without a breaking change).
+- Tracing propagation internals — `httpclient` propagates whatever headers the
+  caller's extractor returns; the OTel `traceparent` *source* is icebox
+  `ops/tracing`.
+- Changing `httpclient.Do` to return a typed error — it returns the stdlib
+  `*http.Client`; problem+json surfacing is a documented companion call.
+
+---
+
+## 0. Shared unblocker — `core/structfields.SetString`
+
+`envconfig` must turn an env *string* into a typed struct field. `typeconv` is
+documented "converts strings to Go scalars **without reflection**" (generic
+`Parse[T]`), so it cannot host a `Kind`-dispatched parser. Per the design DNA
+("no reflection except the one sanctioned helper, `structfields`"), the dispatch
+lives in `structfields`, where it is also reusable by `view/form`, `ops/cli`,
+and `web/request` later.
+
+```go
+// SetString parses raw into f's field according to its kind and assigns it,
+// returning an ErrNotSettable/parse error on failure. Supported kinds: string,
+// bool, all int/uint widths, float32/64, time.Duration, time.Time (RFC3339),
+// and []T of the above (comma-separated). Unsupported kinds return ErrUnsupportedKind.
+func SetString(f Field, raw string) error
+```
+
+- Implemented as a `switch f.Value.Kind()` (plus special-casing `time.Duration`
+  and `time.Time` by concrete type) that calls the matching `typeconv.ParseX`
+  and then `f.Set(parsed)`. No new reflection machinery beyond what `Walk`
+  already exposes.
+- New sentinel `ErrUnsupportedKind` in `structfields/errors.go`.
+- Slices use `typeconv.ParseSlice[T]` with `","` as the separator.
+- TDD'd and merged conceptually first; the other three packages depend only on
+  it (via `envconfig`).
+
+**Test expectations (black-box):** round-trips each supported kind; pointer
+fields are allocated and set; type mismatch and unsupported kind return the
+right sentinel; value-struct (non-pointer) `Field.Set` still returns
+`ErrNotSettable`; empty `raw` leaves defaults for optional fields (caller
+decides — `SetString` on empty string parses "" per kind, so `envconfig` skips
+calling it when the env var is absent).
+
+---
+
+## 1. `ops/envconfig`
+
+Populate `env`-tagged Config structs from the environment plus an optional
+`.env` file. Boot-time only.
+
+### Public API
+
+```go
+func Load[T any](opts ...Option) (T, error)   // parse and return a fresh T
+func Populate(dst any, opts ...Option) error  // fill an existing non-nil *struct
+
+type Option func(*config)
+func WithPrefix(prefix string) Option                       // e.g. "APP_"
+func WithDotenv(paths ...string) Option                     // load these .env files first
+func WithLookup(fn func(key string) (string, bool)) Option  // override os.LookupEnv (test seam)
+
+// Deployment profile.
+type Profile string
+const (
+    ProfileDev     Profile = "dev"
+    ProfileTest    Profile = "test"
+    ProfileStaging Profile = "staging"
+    ProfileProd    Profile = "prod"
+)
+func (p Profile) IsDev() bool
+func (p Profile) IsTest() bool
+func (p Profile) IsStaging() bool
+func (p Profile) IsProd() bool
+func ResolveProfile(opts ...Option) Profile  // reads APP_ENV then ENV; unknown/empty -> ProfileDev
+```
+
+### Semantics
+
+- **Field walk:** `structfields.Walk(dst, "env", ...)`; each field's env key is
+  `prefix + tag.Name`. Missing `env` tag → field skipped.
+- **Value resolution order per key:** real environment (via the `WithLookup`
+  func, default `os.LookupEnv`) wins; `.env` values are loaded into a fallback
+  map consulted only when the env var is absent. `.env` is parsed by an internal
+  `KEY=VALUE` reader (comments `#`, blank lines, optional `export ` prefix,
+  single/double-quoted values with escape handling) — no godotenv dependency.
+- **Assignment:** present values go through `structfields.SetString`; absent
+  values fall back to the `default:"..."` struct tag (also via `SetString`);
+  fields tagged `required` (an option in the `env` tag, `env:"PORT,required"`)
+  with no value and no default cause `Load`/`Populate` to fail.
+- **Nested structs:** recurse; a nested field may carry
+  `envconfig:"prefix=DB_"` to compose an additional key prefix. Anonymous
+  embedded structs recurse with the parent prefix.
+- **Validation:** if `dst` (or `*T`) implements `interface{ Validate() error }`,
+  `envconfig` calls it after populating and joins any error. This is how it
+  cooperates with every shipped `Config.Validate`.
+
+### Errors
+
+`ErrNotStruct` (wrap of the structfields sentinel is fine), `ErrRequiredMissing`
+(carries the key name), `ErrParse` (carries key + kind), `ErrDotenv` (file read
+failure). All single-line, `errors.Is`-matchable. Multiple field errors are
+`errors.Join`-ed so one call reports every problem.
+
+### Config / DNA note
+
+`envconfig` is itself optionless-stateful (it *is* the loader), so it uses the
+free-func + `Option` idiom, not a `New`/`Config` struct.
+
+### Tests (black-box)
+
+Populate a multi-field struct from a `WithLookup` map (no real env); `.env`
+fallback and precedence; prefix and nested prefix composition; `required`
+missing → `ErrRequiredMissing`; bad value → `ErrParse`; `Validate()` hook
+invoked and its error surfaced; `ResolveProfile` mapping and predicates;
+round-trip a real shipped Config shape (e.g. a struct mirroring
+`logger.Config`) to prove tag compatibility.
+
+---
+
+## 2. `ops/health`
+
+Liveness + readiness in one package, with per-check timeout/TTL, drain gating,
+and heartbeat kickers.
+
+### Public API
+
+```go
+func New(opts ...Option) *Health
+
+func (h *Health) Liveness(name string, c Check, opts ...CheckOption)
+func (h *Health) Readiness(name string, c Check, opts ...CheckOption)
+
+func (h *Health) LivenessHandler() http.Handler   // GET /livez
+func (h *Health) ReadinessHandler() http.Handler  // GET /readyz
+
+func (h *Health) SetReady(ready bool)
+func (h *Health) Heartbeat(name string, maxAge time.Duration) (kick func())
+func (h *Health) DrainService(grace time.Duration) supervisor.Service
+
+type Check func(ctx context.Context) error
+
+type Option func(*config)
+func WithDefaultTimeout(d time.Duration) Option   // default per-check ctx deadline
+func WithDefaultCacheTTL(d time.Duration) Option  // default result cache window
+func WithLogger(l *slog.Logger) Option
+
+type CheckOption func(*checkConfig)
+func WithCritical() CheckOption                  // failure flips readiness to 503
+func WithTimeout(d time.Duration) CheckOption    // per-check override of default timeout
+func WithCacheTTL(d time.Duration) CheckOption   // per-check override of default cache TTL
+```
+
+### Semantics
+
+- **Two registries.** `/livez` reflects only liveness checks + heartbeat
+  freshness; a hung background loop that stops calling its `kick()` makes
+  `/livez` fail after `maxAge`. `/readyz` reflects readiness checks AND the
+  `SetReady` flag.
+- **Result shape.** Handlers return `200`/`503` with a JSON body:
+  `{"status":"ok|degraded|unavailable","checks":{"name":{"ok":bool,"error":"…","critical":bool}}}`.
+  Non-critical readiness failure → `status:"degraded"` but still `200`; any
+  critical failure or `SetReady(false)` → `503`.
+- **Per-check execution.** Each check runs under its timeout; results are cached
+  for the TTL so a scrape storm can't hammer the database. Checks run
+  concurrently on scrape.
+- **Drain gating.** `DrainService(grace)` returns a `supervisor.Service`
+  (`Name()="health-drain"`, blocking `Run`). On ctx cancel it calls
+  `SetReady(false)`, sleeps `grace` (so the load balancer observes `/readyz`
+  going 503 and deregisters), then returns nil. Registered **before**
+  `httpserver` in `supervisor.Run` so readiness flips before the server drains.
+  Documented ordering in `doc.go`.
+
+### `health/checks` subpackage
+
+Driver-free adapters so concrete checks don't pull deps into core `health`:
+
+```go
+func Ping(p interface{ Ping(ctx context.Context) error }) health.Check
+func HTTPGet(client *http.Client, url string) health.Check   // 2xx = healthy
+```
+
+`data/postgres` and `data/redis` clients satisfy the `Ping` shape; `HTTPGet`
+composes the new `httpclient`. No imports of `data/*` from `health`.
+
+### Errors
+
+`health` checks return caller errors verbatim in the JSON; the package needs no
+exported error sentinels beyond what handlers encode.
+
+### Tests (black-box)
+
+`/livez` 200 with healthy checks, 503 when a liveness check errors; heartbeat
+staleness flips `/livez`; `/readyz` 503 on `SetReady(false)`; critical vs
+non-critical readiness distinction (503 vs degraded-200); per-check timeout
+surfaces as failure not hang; result caching (a slow check invoked once within
+TTL — assert call count); `DrainService` flips readiness on ctx cancel and
+returns after `grace` (use `clock.Mock` or a tiny real grace); `checks.Ping`
+maps a stub pinger's error.
+
+---
+
+## 3. `resilience/ratelimit` (+ `ratelimit/redisstore`)
+
+Keyed sliding-window-counter limiter over the **counter `Store` seam** — the
+second framework store seam (byte-KV is the first, owned by `cache`).
+
+### The counter Store seam (the important artifact)
+
+```go
+// Store is the windowed atomic-counter seam. ratelimit owns it; quota and
+// lockout consume the same contract. Distinct from cache.Store (byte-KV):
+// counters need atomic increment-with-TTL, which Get/Set cannot express
+// race-free.
+type Store interface {
+    // Incr atomically adds delta to key's counter and returns the new value.
+    // If the key is created by this call, its TTL is set to ttl; Incr never
+    // extends the TTL of an existing key (fixed expiry per window).
+    Incr(ctx context.Context, key string, delta int64, ttl time.Duration) (int64, error)
+    // Get returns the current counter value, or 0 if the key is absent/expired.
+    Get(ctx context.Context, key string) (int64, error)
+    // Reset deletes the counter for key.
+    Reset(ctx context.Context, key string) error
+    Close() error
+}
+
+func NewMemoryStore(opts ...MemoryOption) Store   // sweeps expired keys; caller Closes
+```
+
+### Limiter
+
+```go
+func New(store Store, opts ...Option) *Limiter
+
+func (l *Limiter) Allow(ctx context.Context, key string) (Result, error)
+func (l *Limiter) Middleware(key KeyFunc, opts ...MiddlewareOption) middleware.Middleware
+
+type Result struct {
+    Allowed    bool
+    Limit      int64
+    Remaining  int64
+    Reset      time.Time     // when the window rolls
+    RetryAfter time.Duration // 0 when Allowed
+}
+
+type KeyFunc func(*http.Request) string   // e.g. clientip-based
+
+type Option func(*config)
+func WithLimit(n int64, per time.Duration) Option   // required; n requests per window
+func WithClock(c clock.Clock) Option                 // testability
+
+var ErrLimited = errors.New("ratelimit: limit exceeded")
+```
+
+### Algorithm — sliding-window counter
+
+For window size `per` and current time `t`:
+
+- `curr = floor(t / per)`, `prev = curr - 1`.
+- On `Allow`: `c = Incr(key:curr, 1, ttl=2*per)`; `p = Get(key:prev)`.
+- Weighted estimate `est = c + p * (1 - (t mod per)/per)`.
+- Allowed iff `est <= n`. On rejection the counter is still incremented but the
+  request is denied (standard sliding-window behavior); `RetryAfter` is the time
+  until `est` would drop below `n`, bounded by the window roll.
+- `Reset` = start of next window.
+
+The two-key composition means the `Store` primitive stays a plain
+`Incr`/`Get` — `quota` (calendar/rolling windows) and `lockout` (failure counts
+with delay) reuse it unchanged.
+
+### HTTP middleware
+
+Emits IETF draft headers on every response: `RateLimit-Limit`,
+`RateLimit-Remaining`, `RateLimit-Reset` (delta-seconds). On limit: `429` +
+`Retry-After` + `RateLimit-*`, body via a configurable responder (default
+plain 429; a `problem`-based responder is a documented option so API callers get
+problem+json). `MiddlewareOption`: `WithResponder`, `WithHeadersDisabled`.
+
+### `ratelimit/redisstore`
+
+Implements `Store` over the caller's `data/redis` client. `Incr` = a Lua script
+doing `INCRBY` then `PEXPIRE … NX`-equivalent (set TTL only when the key was
+just created — check `INCRBY` result == delta, or use `PTTL < 0` guard inside
+the script) to guarantee fixed per-window expiry. `Get` = `GET` (nil→0),
+`Reset` = `DEL`, `Close` = no-op (client lifecycle is the caller's).
+
+### Tests (black-box)
+
+Memory store: `Incr` atomicity under concurrency (race test), TTL expiry, `Get`
+absent→0, `Reset`. Limiter: allows up to `n` then `ErrLimited`; sliding weight
+prevents 2× edge burst (drive `clock.Mock` across a boundary and assert the
+denied request mid-window); `Result` fields correct; `Remaining` never
+negative. Middleware: header values, 429 + `Retry-After`, custom responder,
+`KeyFunc` isolation between keys. `redisstore` is tested behind the same
+black-box Store contract test (shared test against a real/miniredis-free
+`data/redis` — if no Redis in CI, gate with the existing `data/redis` test
+pattern).
+
+---
+
+## 4. `web/httpclient`
+
+Resilient outbound `*http.Client` (the stdlib type) via a RoundTripper stack
+composing the shipped `retry` + `circuitbreaker` + `backoff`.
+
+### Public API
+
+```go
+func New(opts ...Option) *http.Client
+
+type Option func(*config)
+func WithTimeout(d time.Duration) Option            // overall client timeout
+func WithPerAttemptTimeout(d time.Duration) Option  // per try, via ctx
+func WithRetry(opts ...retry.Option) Option         // tune attempts/backoff
+func WithRetryMethods(methods ...string) Option     // default {GET,HEAD,PUT,DELETE,OPTIONS}
+func WithBreakerGroup(opts ...circuitbreaker.GroupOption) Option  // per-host breaker; OFF unless set
+func WithBaseTransport(rt http.RoundTripper) Option // default http.DefaultTransport clone
+func WithBefore(fn func(*http.Request)) Option
+func WithAfter(fn func(*http.Request, *http.Response)) Option
+func WithContextHeaders(fn func(context.Context) http.Header) Option  // propagation extractor
+func WithHeader(key, value string) Option
+func WithUserAgent(ua string) Option
+```
+
+### Transport stack (outer → inner)
+
+1. **hooks + static headers + propagation** — `WithBefore`, `WithHeader`,
+   `WithUserAgent`, and `WithContextHeaders(fn)` (copies e.g. `X-Request-ID`,
+   `traceparent` from ctx onto the outbound request); `WithAfter` runs on the
+   response.
+2. **retry** — `retry.Do` around the attempt. Default classifier retries on
+   network errors, `429`, and `5xx`, **only** for idempotent methods (the
+   `WithRetryMethods` set; POST excluded by default to avoid double-submit).
+   Default `retry.WithMaxAttempts(3)` with jittered exponential backoff. A
+   `Retry-After` header on `429`/`503` is surfaced as a `RetryAfterError` so the
+   shipped `retry` raises the delay floor automatically.
+3. **per-attempt timeout** — `WithPerAttemptTimeout` via `context.WithTimeout`
+   per try.
+4. **circuit breaker (opt-in)** — when `WithBreakerGroup` is set, each attempt
+   runs inside `circuitbreaker.Group.Do(ctx, req.URL.Host, …)`. The breaker's
+   open error already implements `RetryAfter()`, so retry and breaker cooperate.
+   Off by default (Fork C).
+5. **base transport** — `WithBaseTransport` or a cloned `http.DefaultTransport`.
+
+Defaults with no options: retry on (3 attempts, idempotent methods), timeouts
+unset (caller's ctx governs), breaker off.
+
+### Propagation & problem surfacing
+
+- `httpclient` takes **no** hard dependency on `web/requestid`. `doc.go` shows
+  the one-liner extractor: `WithContextHeaders(func(ctx) http.Header { h :=
+  http.Header{}; if id, ok := requestid.From(ctx); ok { h.Set("X-Request-ID",
+  id) }; return h })`.
+- Problem+json surfacing stays a companion call — `doc.go` shows
+  `problem.Decode(resp)` on non-2xx — because `New` returns the stdlib
+  `*http.Client` and we will not change `Do`'s signature.
+
+### Errors
+
+No new sentinels: transient failures surface as the stdlib transport/`retry`
+errors; `retry.Permanent` short-circuits non-retryable ones. The breaker's
+`circuitbreaker.ErrOpen` surfaces through when tripped.
+
+### Tests (black-box)
+
+Use `testkit`-style `httptest.Server` stubs (webtest not yet shipped — use
+stdlib `net/http/httptest`): retries a flaky 503-then-200 and succeeds; does
+**not** retry POST by default; honors `Retry-After` (assert elapsed floor with a
+mock/short clock); per-attempt timeout aborts a slow attempt and retries;
+`WithContextHeaders` propagates `X-Request-ID`; `WithBefore/After` invoked;
+breaker opt-in trips after N host failures and fast-fails with `ErrOpen`, and
+does NOT engage when `WithBreakerGroup` is absent; `problem.Decode` companion
+maps a 422 problem+json body.
+
+---
+
+## Cross-cutting
+
+- **Idioms:** `envconfig` = free-func + Option; `health`/`ratelimit`/
+  `httpclient` = `New(...Option)`. No builders anywhere.
+- **Anatomy per package:** `doc.go` (runnable example), `errors.go`
+  (single-line sentinels), `options.go` (`type Option func(*config)`), impl,
+  black-box `_test.go` in `package X_test`.
+- **Dependencies added:** none new — all four compose stdlib + already-isolated
+  deps (`data/redis` for `redisstore`, the shipped resilience trio for
+  `httpclient`). `x/crypto` etc. untouched.
+- **Test doubles live with the seam owner:** `ratelimit.NewMemoryStore` is the
+  in-memory counter double; there is no central fakes package.
+- **`just fmt ./pkg/...` + `just lint`** run clean before the PR (use the
+  package-path form of `just fmt`, not single-file, per the known betteralign
+  quirk); `modernize` run before done; race tests green.
+
+## Build order (within the bundle)
+
+1. `core/structfields.SetString` (unblocker leaf).
+2. In parallel: `ops/envconfig` (needs #1), `ops/health` (+`health/checks`),
+   `resilience/ratelimit` (+`ratelimit/redisstore`), `web/httpclient`.
+3. Update `docs/packages.md`: move the four from *planned* to *shipped*, bump
+   the shipped-count line, drop the Wave 1 rows from build order.
+
+One bundled PR via `subagent-driven-dev`.
+
+## Risks / notes
+
+- **redisstore fixed-TTL-per-window** must be atomic (Lua) or a concurrent
+  first-incr race re-arms the TTL and stretches a window. Called out in the plan
+  as a must-test.
+- **Sliding-window `RetryAfter`** math is the subtle part of `ratelimit`; the
+  boundary-crossing test with a mock clock is the guard.
+- **POST-retry default off** is a deliberate safety choice (no silent
+  double-submit); `WithRetryMethods` is the documented escape hatch.
+- `health/checks.HTTPGet` depends on `httpclient`, so it is authored after
+  `httpclient` even though both land in the same PR.

--- a/docs/superpowers/specs/2026-07-05-wave1-completion-design.md
+++ b/docs/superpowers/specs/2026-07-05-wave1-completion-design.md
@@ -29,9 +29,8 @@ real deps isolated in driver subpackages, black-box tests only.
 
 ## Scope
 
-**In:** the four packages above, their driver subpackages
-(`ratelimit/redisstore`, `health/checks`), and one shared shipped-package
-addition (`core/structfields.SetString`).
+**In:** the four packages above, the `ratelimit/redisstore` driver subpackage,
+and one shared shipped-package addition (`core/structfields.SetString`).
 
 **Out (explicit non-goals):**
 
@@ -178,6 +177,11 @@ func (h *Health) DrainService(grace time.Duration) supervisor.Service
 
 type Check func(ctx context.Context) error
 
+// Built-in check adapters (driver-free — they take interfaces / stdlib types,
+// so they carry no data/* or web/httpclient imports and live in this package).
+func Ping(p interface{ Ping(ctx context.Context) error }) Check   // 2xx of a driver ping
+func HTTPGet(client *http.Client, url string) Check               // 2xx = healthy
+
 type Option func(*config)
 func WithDefaultTimeout(d time.Duration) Option   // default per-check ctx deadline
 func WithDefaultCacheTTL(d time.Duration) Option  // default result cache window
@@ -209,17 +213,14 @@ func WithCacheTTL(d time.Duration) CheckOption   // per-check override of defaul
   `httpserver` in `supervisor.Run` so readiness flips before the server drains.
   Documented ordering in `doc.go`.
 
-### `health/checks` subpackage
+### Built-in checks (in-package)
 
-Driver-free adapters so concrete checks don't pull deps into core `health`:
-
-```go
-func Ping(p interface{ Ping(ctx context.Context) error }) health.Check
-func HTTPGet(client *http.Client, url string) health.Check   // 2xx = healthy
-```
-
-`data/postgres` and `data/redis` clients satisfy the `Ping` shape; `HTTPGet`
-composes the new `httpclient`. No imports of `data/*` from `health`.
+`Ping` and `HTTPGet` live in `health` itself — they are interface/stdlib
+adapters, not driver code, so they add no imports and a separate `health/checks`
+package would be redundant. `data/postgres` and `data/redis` clients satisfy the
+`Ping` shape; `HTTPGet` takes any `*http.Client` (typically one built by the new
+`httpclient`, but only the stdlib type is referenced, so no import of
+`web/httpclient`).
 
 ### Errors
 
@@ -233,8 +234,8 @@ staleness flips `/livez`; `/readyz` 503 on `SetReady(false)`; critical vs
 non-critical readiness distinction (503 vs degraded-200); per-check timeout
 surfaces as failure not hang; result caching (a slow check invoked once within
 TTL — assert call count); `DrainService` flips readiness on ctx cancel and
-returns after `grace` (use `clock.Mock` or a tiny real grace); `checks.Ping`
-maps a stub pinger's error.
+returns after `grace` (use `clock.Mock` or a tiny real grace); `Ping` maps a
+stub pinger's error; `HTTPGet` reports a stub server's non-2xx as unhealthy.
 
 ---
 
@@ -431,7 +432,7 @@ maps a 422 problem+json body.
 ## Build order (within the bundle)
 
 1. `core/structfields.SetString` (unblocker leaf).
-2. In parallel: `ops/envconfig` (needs #1), `ops/health` (+`health/checks`),
+2. In parallel: `ops/envconfig` (needs #1), `ops/health`,
    `resilience/ratelimit` (+`ratelimit/redisstore`), `web/httpclient`.
 3. Update `docs/packages.md`: move the four from *planned* to *shipped*, bump
    the shipped-count line, drop the Wave 1 rows from build order.
@@ -447,5 +448,6 @@ One bundled PR via `subagent-driven-dev`.
   boundary-crossing test with a mock clock is the guard.
 - **POST-retry default off** is a deliberate safety choice (no silent
   double-submit); `WithRetryMethods` is the documented escape hatch.
-- `health/checks.HTTPGet` depends on `httpclient`, so it is authored after
-  `httpclient` even though both land in the same PR.
+- `health.HTTPGet` references only the stdlib `*http.Client`, so `health` has no
+  build-order dependency on `httpclient` — the four packages are fully
+  independent after the `structfields.SetString` unblocker.

--- a/docs/superpowers/specs/2026-07-05-wave1-completion-design.md
+++ b/docs/superpowers/specs/2026-07-05-wave1-completion-design.md
@@ -4,7 +4,7 @@
 > in `docs/packages.md`. The shipped-package API additions portion of Wave 1
 > landed in PR #31; this bundle adds the four *new* packages that finish the
 > wave: `web/httpclient`, `resilience/ratelimit` (+`ratelimit/redisstore`),
-> `ops/envconfig`, `ops/health`, plus two shared unblockers
+> `ops/config`, `ops/health`, plus two shared unblockers
 > (`structfields.SetString`, `supervisor.WithPreShutdown`).
 
 ## Goal
@@ -17,8 +17,8 @@ unblocks large parts of Wave 2+:
   `comms/*`, `llm`.
 - `ratelimit` — establishes the **counter `Store` seam** shared later by
   `quota` and `lockout`.
-- `envconfig` — env→Config loading that every shipped `Config` (`logger`,
-  `httpserver`, …) is already tagged for.
+- `config` — layered config loading (YAML per-env + `${VAR}` substitution +
+  `.env` inheritance + env-tag structs), modeled on `modo::config`.
 - `health` — liveness/readiness + drain gating, needed by `appmain` and any
   real deployment.
 
@@ -54,7 +54,8 @@ because a Wave 1 package depends on it.
 
 ### 0.1 — `core/structfields.SetString`
 
-`envconfig` must turn an env *string* into a typed struct field. `typeconv` is
+`config`'s `LoadEnv`/`Populate` path must turn an env *string* into a typed
+struct field. `typeconv` is
 documented "converts strings to Go scalars **without reflection**" (generic
 `Parse[T]`), so it cannot host a `Kind`-dispatched parser. Per the design DNA
 ("no reflection except the one sanctioned helper, `structfields`"), the dispatch
@@ -75,14 +76,13 @@ func SetString(f Field, raw string) error
   already exposes.
 - New sentinel `ErrUnsupportedKind` in `structfields/errors.go`.
 - Slices use `typeconv.ParseSlice[T]` with `","` as the separator.
-- TDD'd and merged conceptually first; the other three packages depend only on
-  it (via `envconfig`).
+- TDD'd first; only `config`'s env-tag path depends on it.
 
 **Test expectations (black-box):** round-trips each supported kind; pointer
 fields are allocated and set; type mismatch and unsupported kind return the
 right sentinel; value-struct (non-pointer) `Field.Set` still returns
 `ErrNotSettable`; empty `raw` leaves defaults for optional fields (caller
-decides — `SetString` on empty string parses "" per kind, so `envconfig` skips
+decides — `SetString` on empty string parses "" per kind, so `config` skips
 calling it when the env var is absent).
 
 ### 0.2 — `ops/supervisor.WithPreShutdown`
@@ -121,77 +121,114 @@ shutdown; no hooks → identical behavior to today; a panicking hook is recovere
 
 ---
 
-## 1. `ops/envconfig`
+## 1. `ops/config`
 
-Populate `env`-tagged Config structs from the environment plus an optional
-`.env` file. Boot-time only.
+Layered application configuration, modeled on `modo::config` (single-YAML per
+env + `${VAR}` substitution) and extended with real `.env` inheritance and
+shell-style empty-or-unset defaults. Three composable capabilities over one
+"environment layer" (loaded `.env` values + process env) and one profile. Boot
+time only. First forge package to take a **YAML** dependency (`gopkg.in/yaml.v3`,
+confined here — YAML is a wire format, unsafe to hand-roll, so it fits "buy the
+wire, isolate the dep").
 
 ### Public API
 
 ```go
-func Load[T any](opts ...Option) (T, error)   // parse and return a fresh T
-func Populate(dst any, opts ...Option) error  // fill an existing non-nil *struct
+// (1) YAML per-env convention + ${VAR:default} substitution (the modo path).
+//     Reads {dir}/{Profile()}.yaml, substitutes against the environment layer,
+//     unmarshals via yaml.v3. If *T implements interface{ SetDefaults() } it is
+//     applied before decode (yaml only overwrites present keys); if it
+//     implements interface{ Validate() error } that runs after.
+func Load[T any](dir string, opts ...Option) (T, error)
+
+// (2) Struct-from-env (12-factor, no YAML file), via structfields.Walk +
+//     structfields.SetString, with `default:"…"` fallback and `env:"K,required"`.
+func LoadEnv[T any](opts ...Option) (T, error)
+func Populate(dst any, opts ...Option) error  // env-tag overlay onto an existing
+                                              // struct (e.g. logger.DefaultConfig())
+
+// (3) .env inheritance — left = base, each later file overrides it; the REAL
+//     process env is never overwritten (env wins). Applies into the process env.
+func Dotenv(paths ...string) error
+
+// Shared helpers
+func Substitute(s string) (string, error)  // public ${VAR:default} expander
+func Profile() string                      // APP_ENV → ENV → "development"
+func IsDev() bool                          // profile ∈ {"", "dev", "development"}
+func IsProd() bool                         // {"prod", "production"}
+func IsTest() bool                         // {"test", "testing"}
+func IsStaging() bool                      // {"staging", "stage"}
 
 type Option func(*config)
-func WithPrefix(prefix string) Option                       // e.g. "APP_"
-func WithDotenv(paths ...string) Option                     // load these .env files first
-func WithLookup(fn func(key string) (string, bool)) Option  // override os.LookupEnv (test seam)
-
-// Deployment profile.
-type Profile string
-const (
-    ProfileDev     Profile = "dev"
-    ProfileTest    Profile = "test"
-    ProfileStaging Profile = "staging"
-    ProfileProd    Profile = "prod"
-)
-func (p Profile) IsDev() bool
-func (p Profile) IsTest() bool
-func (p Profile) IsStaging() bool
-func (p Profile) IsProd() bool
-func ResolveProfile(opts ...Option) Profile  // reads APP_ENV then ENV; unknown/empty -> ProfileDev
+func WithDotenv(paths ...string) Option                 // Load/LoadEnv load these .env first
+func WithProfile(name string) Option                    // override APP_ENV detection
+func WithFileName(fn func(profile string) string) Option // default: profile + ".yaml"
+func WithLookup(fn func(key string) (string, bool)) Option // test seam over os.LookupEnv
 ```
 
-### Semantics
+### `${VAR:default}` substitution semantics
 
-- **Field walk:** `structfields.Walk(dst, "env", ...)`; each field's env key is
-  `prefix + tag.Name`. Missing `env` tag → field skipped.
-- **Value resolution order per key:** real environment (via the `WithLookup`
-  func, default `os.LookupEnv`) wins; `.env` values are loaded into a fallback
-  map consulted only when the env var is absent. `.env` is parsed by an internal
-  `KEY=VALUE` reader (comments `#`, blank lines, optional `export ` prefix,
-  single/double-quoted values with escape handling) — no godotenv dependency.
-- **Assignment:** present values go through `structfields.SetString`; absent
-  values fall back to the `default:"..."` struct tag (also via `SetString`);
-  fields tagged `required` (an option in the `env` tag, `env:"PORT,required"`)
-  with no value and no default cause `Load`/`Populate` to fail.
-- **Nested structs:** recurse; a nested field may carry
-  `envconfig:"prefix=DB_"` to compose an additional key prefix. Anonymous
-  embedded structs recurse with the parent prefix.
-- **Validation:** if `dst` (or `*T`) implements `interface{ Validate() error }`,
-  `envconfig` calls it after populating and joins any error. This is how it
-  cooperates with every shipped `Config.Validate`.
+- Split on the **first** `:` — the variable name is left of it, the default
+  (which may itself contain `:` or `}`) is right of it.
+- `${VAR:default}` → the default when `VAR` is **unset _or_ empty** (shell `:-`
+  semantics — your `${HOST:0.0.0.0}` requirement, a deliberate departure from
+  modo's unset-only rule).
+- `${VAR}` (no default) → error if `VAR` is unset (catches typos); a set-empty
+  `VAR` substitutes empty.
+- `$$` escapes a literal `$`. No nesting. An unterminated `${…` is
+  `ErrSubstitute`.
+
+### `.env` inheritance & precedence
+
+- `Dotenv("config/.env.local", ".env")`: parse each file (KEY=VALUE; `#`
+  comments; blank lines; optional `export ` prefix; single/double-quoted values
+  with escapes) into an accumulator where **later files override earlier**, then
+  apply to the process env **only for keys not already present in the real
+  environment** — so real env > `.env` > `.env.local`. Internal parser, no
+  godotenv.
+- `Load`/`LoadEnv` with `WithDotenv(...)` run this first, so substitution and
+  env-tag reads both see the merged layer.
+
+### Decode-path precedence
+
+- **`Load` (YAML):** the file is the config; env influences it **only through
+  `${VAR}` placeholders** written in the YAML — explicit, no hidden env-over-yaml
+  deep-merge. `SetDefaults()` (if present) seeds defaults that absent YAML keys
+  retain.
+- **`LoadEnv`/`Populate` (env tags):** process env (incl. loaded `.env`) →
+  field via `env:"KEY"` → `default:"…"` tag fallback → `required` failure if
+  neither. Uses `structfields.SetString` (unblocker §0.1). Nested structs recurse
+  with an optional `config:"prefix=DB_"` field tag.
+
+### Name-collision note (documented in `doc.go`)
+
+The package name `config` collides at compile time with the unexported
+package-level `type config struct` that forge's options idiom puts in nearly
+every package (verified: *"config already declared through import of package
+config"*, a hard error, not shadowing). Any package that both uses that idiom
+and imports this loader (notably `ops/appmain`) **must alias the import**:
+`import appconfig "github.com/dmitrymomot/forge/ops/config"`. `doc.go` leads with
+this.
 
 ### Errors
 
-`ErrNotStruct` (wrap of the structfields sentinel is fine), `ErrRequiredMissing`
-(carries the key name), `ErrParse` (carries key + kind), `ErrDotenv` (file read
-failure). All single-line, `errors.Is`-matchable. Multiple field errors are
-`errors.Join`-ed so one call reports every problem.
-
-### Config / DNA note
-
-`envconfig` is itself optionless-stateful (it *is* the loader), so it uses the
-free-func + `Option` idiom, not a `New`/`Config` struct.
+`ErrProfileFile` (yaml missing/unreadable), `ErrSubstitute` (bad placeholder or
+unset no-default var — carries the var name), `ErrYAML` (unmarshal), `ErrDotenv`
+(file read), `ErrRequiredMissing` (LoadEnv, carries the key), `ErrParse`
+(LoadEnv, carries key + kind). All single-line, `errors.Is`-matchable; field
+errors `errors.Join`-ed.
 
 ### Tests (black-box)
 
-Populate a multi-field struct from a `WithLookup` map (no real env); `.env`
-fallback and precedence; prefix and nested prefix composition; `required`
-missing → `ErrRequiredMissing`; bad value → `ErrParse`; `Validate()` hook
-invoked and its error surfaced; `ResolveProfile` mapping and predicates;
-round-trip a real shipped Config shape (e.g. a struct mirroring
-`logger.Config`) to prove tag compatibility.
+Substitute: `${VAR}`/`${VAR:default}` for unset/empty/set, first-colon split,
+`:` in default, `$$` escape, unterminated → `ErrSubstitute`. Dotenv: later file
+overrides earlier, real env overrides files, quoting/comments/`export`. Load:
+`{profile}.yaml` selection via `WithProfile`/`WithFileName`, substitution before
+unmarshal, `SetDefaults` retained for absent keys, `Validate` surfaced, missing
+file → `ErrProfileFile` (all via a `testdata/` dir + `WithLookup`, no real env).
+LoadEnv/Populate: env→struct, `default` fallback, `required` missing →
+`ErrRequiredMissing`, bad value → `ErrParse`, overlay onto a `logger.Config`-shaped
+struct to prove tag compatibility. Profile predicates over the alias sets.
 
 ---
 
@@ -502,14 +539,16 @@ maps a 422 problem+json body.
 
 ## Cross-cutting
 
-- **Idioms:** `envconfig` = free-func + Option; `health`/`ratelimit`/
-  `httpclient` = `New(...Option)`. No builders anywhere.
+- **Idioms:** `config` and `health` = free-funcs/handler factory + Option;
+  `ratelimit`/`httpclient` = `New(...Option)`. No builders anywhere.
 - **Anatomy per package:** `doc.go` (runnable example), `errors.go`
   (single-line sentinels), `options.go` (`type Option func(*config)`), impl,
   black-box `_test.go` in `package X_test`.
-- **Dependencies added:** none new — all four compose stdlib + already-isolated
-  deps (`data/redis` for `redisstore`, the shipped resilience trio for
-  `httpclient`). `x/crypto` etc. untouched.
+- **Dependencies added:** one — `gopkg.in/yaml.v3`, used **only** by `ops/config`
+  (forge's first YAML dep; a wire format, isolated to this one package). The
+  other three packages compose stdlib + already-isolated deps (`data/redis` for
+  `redisstore`, the shipped resilience trio for `httpclient`). `x/crypto` etc.
+  untouched.
 - **Test doubles live with the seam owner:** `ratelimit.NewMemoryStore` is the
   in-memory counter double; there is no central fakes package.
 - **`just fmt ./pkg/...` + `just lint`** run clean before the PR (use the
@@ -520,8 +559,9 @@ maps a 422 problem+json body.
 
 1. Unblocker leaves, in parallel: `core/structfields.SetString` and
    `ops/supervisor.WithPreShutdown`.
-2. In parallel: `ops/envconfig` (needs #1's `SetString`), `ops/health` (needs
-   `WithPreShutdown` only for its drain `doc.go` example, not to compile),
+2. In parallel: `ops/config` (its env-tag path needs #1's `SetString`; adds the
+   `gopkg.in/yaml.v3` dep), `ops/health` (needs `WithPreShutdown` only for its
+   drain `doc.go` example, not to compile),
    `resilience/ratelimit` (+`ratelimit/redisstore`), `web/httpclient`.
 3. Update `docs/packages.md`: move the four from *planned* to *shipped*, bump
    the shipped-count line, drop the Wave 1 rows from build order.

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	go.mongodb.org/mongo-driver/v2 v2.7.0
 	golang.org/x/crypto v0.50.0
 	golang.org/x/text v0.37.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -269,7 +270,6 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.7.0 // indirect
 	mvdan.cc/gofumpt v0.9.2 // indirect
 	mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 // indirect

--- a/ops/config/doc.go
+++ b/ops/config/doc.go
@@ -1,0 +1,37 @@
+// Package config layers application configuration from YAML (per-env convention
+// with ${VAR:default} substitution), .env inheritance, and env-tagged structs.
+//
+// # Import alias required in packages that use the options idiom
+//
+// The package name "config" collides at compile time with the unexported
+// package-level `type config struct` that forge's options idiom puts in nearly
+// every package ("config already declared through import of package config").
+// Any package that both uses that idiom and imports this loader must alias it:
+//
+//	import appconfig "github.com/dmitrymomot/forge/ops/config"
+//
+// # YAML per-env
+//
+//	// config/development.yaml:  host: ${HOST:0.0.0.0}
+//	type Server struct {
+//		Host string `yaml:"host"`
+//		Port int    `yaml:"port"`
+//	}
+//	srv, err := config.Load[Server]("config/") // reads config/{APP_ENV}.yaml
+//
+// # .env inheritance (later files and the real env override earlier files)
+//
+//	err := config.Dotenv("config/.env.local", ".env")
+//
+// # Struct-from-env (12-factor, no YAML file)
+//
+//	type App struct {
+//		Name string `env:"NAME,required"`
+//		Port int    `env:"PORT,default=8080"`
+//	}
+//	app, err := config.LoadEnv[App](config.WithDotenv(".env"))
+//
+// ${VAR:default} uses the default when VAR is unset OR empty (shell :- form);
+// ${VAR} with no default errors when unset. Profile() reads APP_ENV then ENV
+// (default "development"); IsDev/IsProd/IsTest/IsStaging classify it.
+package config

--- a/ops/config/dotenv.go
+++ b/ops/config/dotenv.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Dotenv loads .env files in order — later files override earlier ones — and
+// applies the result to the process environment, but never overwrites a key
+// already present in the real environment. So precedence is: process env >
+// last file > ... > first file.
+func Dotenv(paths ...string) error {
+	merged := map[string]string{}
+	for _, p := range paths {
+		kv, err := parseDotenv(p)
+		if err != nil {
+			return err
+		}
+		maps.Copy(merged, kv)
+	}
+	for k, v := range merged {
+		if _, present := os.LookupEnv(k); present {
+			continue
+		}
+		if err := os.Setenv(k, v); err != nil {
+			return fmt.Errorf("%w: %v", ErrDotenv, err)
+		}
+	}
+	return nil
+}
+
+func parseDotenv(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrDotenv, err)
+	}
+	out := map[string]string{}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		out[strings.TrimSpace(k)] = unquoteEnv(strings.TrimSpace(v))
+	}
+	return out, nil
+}
+
+func unquoteEnv(v string) string {
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		if s, err := strconv.Unquote(v); err == nil {
+			return s
+		}
+	}
+	if len(v) >= 2 && v[0] == '\'' && v[len(v)-1] == '\'' {
+		return v[1 : len(v)-1]
+	}
+	return v
+}

--- a/ops/config/dotenv_test.go
+++ b/ops/config/dotenv_test.go
@@ -1,0 +1,34 @@
+package config_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/config"
+)
+
+func TestDotenv_InheritanceAndEnvWins(t *testing.T) {
+	// Dotenv writes into the real process env via os.Setenv, which t.Setenv
+	// does not restore. Clean up the keys Dotenv introduces so they don't
+	// leak into sibling tests in this package.
+	t.Cleanup(func() {
+		_ = os.Unsetenv("PORT")
+		_ = os.Unsetenv("TOKEN")
+	})
+
+	// real env wins over files
+	t.Setenv("HOST", "realhost")
+
+	require.NoError(t, config.Dotenv("testdata/.env.local", "testdata/.env"))
+
+	assert.Equal(t, "realhost", os.Getenv("HOST")) // real env preserved
+	assert.Equal(t, "8080", os.Getenv("PORT"))     // later file (.env) overrides .env.local
+	assert.Equal(t, "a:b:c", os.Getenv("TOKEN"))   // quoted value, export prefix stripped
+}
+
+func TestDotenv_MissingFile(t *testing.T) {
+	assert.ErrorIs(t, config.Dotenv("testdata/nope.env"), config.ErrDotenv)
+}

--- a/ops/config/env.go
+++ b/ops/config/env.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/structfields"
+)
+
+// LoadEnv populates a fresh T from environment variables via its `env` tags.
+func LoadEnv[T any](opts ...Option) (T, error) {
+	var t T
+	if err := Populate(&t, opts...); err != nil {
+		return t, err
+	}
+	return t, nil
+}
+
+// Populate fills dst (a non-nil *struct) from the environment via `env` tags,
+// applying `default=` options and failing on missing `required` keys. If dst
+// implements interface{ Validate() error }, that runs afterward.
+func Populate(dst any, opts ...Option) error {
+	c := newConfig(opts...)
+	if err := c.applyDotenv(); err != nil {
+		return err
+	}
+	if err := populateStruct(dst, "", c.lookup); err != nil {
+		return err
+	}
+	if v, ok := dst.(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func populateStruct(dst any, prefix string, lookup func(string) (string, bool)) error {
+	var errs []error
+	walkErr := structfields.Walk(dst, "env", func(f structfields.Field) error {
+		if f.Tag.Ignored() {
+			return nil
+		}
+		if f.Value.Kind() == reflect.Struct && f.Value.Type() != reflect.TypeFor[time.Time]() {
+			sub := prefix
+			if f.Tag.Name != "" {
+				sub = prefix + f.Tag.Name + "_"
+			}
+			if err := populateStruct(f.Value.Addr().Interface(), sub, lookup); err != nil {
+				errs = append(errs, err)
+			}
+			return nil
+		}
+		if f.Tag.Name == "" {
+			return nil
+		}
+		key := prefix + f.Tag.Name
+		raw, ok := lookup(key)
+		if !ok || raw == "" {
+			def, hasDefault := defaultOption(f)
+			switch {
+			case hasDefault:
+				raw = def
+			case f.Tag.HasOption("required"):
+				errs = append(errs, fmt.Errorf("%w: %s", ErrRequiredMissing, key))
+				return nil
+			default:
+				return nil
+			}
+		}
+		if err := structfields.SetString(f, raw); err != nil {
+			errs = append(errs, fmt.Errorf("%w: %s: %v", ErrParse, key, err))
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+	return errors.Join(errs...)
+}
+
+func defaultOption(f structfields.Field) (string, bool) {
+	for _, o := range f.Tag.Options {
+		if v, ok := strings.CutPrefix(o, "default="); ok {
+			return v, true
+		}
+	}
+	return "", false
+}

--- a/ops/config/env_test.go
+++ b/ops/config/env_test.go
@@ -1,0 +1,55 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/config"
+)
+
+type dbCfg struct {
+	Host string `env:"HOST,default=localhost"`
+	Port int    `env:"PORT,default=5432"`
+}
+
+type appCfg struct {
+	Name  string `env:"NAME,required"`
+	Debug bool   `env:"DEBUG,default=false"`
+	DB    dbCfg  `env:"DB"`
+}
+
+func TestLoadEnv_DefaultsAndNesting(t *testing.T) {
+	lookup := func(k string) (string, bool) {
+		m := map[string]string{"NAME": "svc", "DB_PORT": "6543"}
+		v, ok := m[k]
+		return v, ok
+	}
+	got, err := config.LoadEnv[appCfg](config.WithLookup(lookup))
+	require.NoError(t, err)
+	assert.Equal(t, "svc", got.Name)
+	assert.False(t, got.Debug)                // default
+	assert.Equal(t, "localhost", got.DB.Host) // nested default
+	assert.Equal(t, 6543, got.DB.Port)        // nested env override, prefixed DB_
+}
+
+func TestLoadEnv_RequiredMissing(t *testing.T) {
+	lookup := func(string) (string, bool) { return "", false }
+	_, err := config.LoadEnv[appCfg](config.WithLookup(lookup))
+	assert.ErrorIs(t, err, config.ErrRequiredMissing)
+}
+
+func TestLoadEnv_ParseError(t *testing.T) {
+	lookup := func(k string) (string, bool) {
+		if k == "NAME" {
+			return "svc", true
+		}
+		if k == "DB_PORT" {
+			return "not-int", true
+		}
+		return "", false
+	}
+	_, err := config.LoadEnv[appCfg](config.WithLookup(lookup))
+	assert.ErrorIs(t, err, config.ErrParse)
+}

--- a/ops/config/errors.go
+++ b/ops/config/errors.go
@@ -1,0 +1,18 @@
+package config
+
+import "errors"
+
+var (
+	// ErrProfileFile is returned by Load when the {profile}.yaml file is missing or unreadable.
+	ErrProfileFile = errors.New("config: profile file")
+	// ErrSubstitute is returned when a ${VAR} placeholder is malformed or an unset no-default var is referenced.
+	ErrSubstitute = errors.New("config: substitution")
+	// ErrYAML is returned when the substituted YAML fails to unmarshal.
+	ErrYAML = errors.New("config: yaml")
+	// ErrDotenv is returned when a .env file cannot be read or applied.
+	ErrDotenv = errors.New("config: dotenv")
+	// ErrRequiredMissing is returned by LoadEnv/Populate when a required env key has no value.
+	ErrRequiredMissing = errors.New("config: required env missing")
+	// ErrParse is returned by LoadEnv/Populate when a value cannot be parsed into its field.
+	ErrParse = errors.New("config: parse")
+)

--- a/ops/config/load.go
+++ b/ops/config/load.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Load reads {dir}/{profile}.yaml, expands ${VAR:default} placeholders against
+// the environment layer, and unmarshals into T. If *T implements
+// interface{ SetDefaults() } it is applied before decode (yaml overwrites only
+// present keys); interface{ Validate() error } runs after.
+func Load[T any](dir string, opts ...Option) (T, error) {
+	var t T
+	c := newConfig(opts...)
+	if err := c.applyDotenv(); err != nil {
+		return t, err
+	}
+	path := filepath.Join(dir, c.fileName())
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return t, fmt.Errorf("%w: %v", ErrProfileFile, err)
+	}
+	expanded, err := substitute(string(data), c.lookup)
+	if err != nil {
+		return t, err
+	}
+	if sd, ok := any(&t).(interface{ SetDefaults() }); ok {
+		sd.SetDefaults()
+	}
+	if err := yaml.Unmarshal([]byte(expanded), &t); err != nil {
+		return t, fmt.Errorf("%w: %v", ErrYAML, err)
+	}
+	if v, ok := any(&t).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return t, err
+		}
+	}
+	return t, nil
+}

--- a/ops/config/load_test.go
+++ b/ops/config/load_test.go
@@ -1,0 +1,46 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/config"
+)
+
+type serverCfg struct {
+	Host string `yaml:"host"`
+	Port int    `yaml:"port"`
+	Name string `yaml:"name"`
+}
+
+func (s *serverCfg) SetDefaults() {
+	if s.Host == "" {
+		s.Host = "127.0.0.1"
+	}
+}
+
+func TestLoad_YAMLWithSubstitution(t *testing.T) {
+	t.Setenv("HOST", "10.0.0.5")
+
+	got, err := config.Load[serverCfg]("testdata", config.WithProfile("development"))
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.0.5", got.Host) // ${HOST} substituted
+	assert.Equal(t, 8080, got.Port)       // ${PORT:8080} default
+	assert.Equal(t, "dev-service", got.Name)
+}
+
+func TestLoad_ProfileSelectionAndDefaults(t *testing.T) {
+	t.Setenv("HOST", "") // empty -> ${HOST:0.0.0.0} uses default
+	got, err := config.Load[serverCfg]("testdata", config.WithProfile("production"))
+	require.NoError(t, err)
+	assert.Equal(t, "0.0.0.0", got.Host)
+	assert.Equal(t, 443, got.Port)
+	assert.Equal(t, "prod-service", got.Name)
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	_, err := config.Load[serverCfg]("testdata", config.WithProfile("nope"))
+	assert.ErrorIs(t, err, config.ErrProfileFile)
+}

--- a/ops/config/options.go
+++ b/ops/config/options.go
@@ -9,7 +9,7 @@ type config struct {
 	dotenvPaths []string
 }
 
-func newConfig(opts ...Option) config { //nolint:unused // consumed by LoadEnv/Populate/Load added in later tasks
+func newConfig(opts ...Option) config {
 	c := config{
 		fileNameFn: func(p string) string { return p + ".yaml" },
 		lookup:     os.LookupEnv,
@@ -31,7 +31,7 @@ func (c config) fileName() string { //nolint:unused // consumed by Load added in
 	return c.fileNameFn(c.activeProfile())
 }
 
-func (c config) applyDotenv() error { //nolint:unused // consumed by LoadEnv/Populate/Load added in later tasks
+func (c config) applyDotenv() error {
 	if len(c.dotenvPaths) == 0 {
 		return nil
 	}

--- a/ops/config/options.go
+++ b/ops/config/options.go
@@ -1,0 +1,68 @@
+package config
+
+import "os"
+
+type config struct {
+	fileNameFn  func(profile string) string
+	lookup      func(string) (string, bool)
+	profile     string
+	dotenvPaths []string
+}
+
+func newConfig(opts ...Option) config { //nolint:unused // consumed by LoadEnv/Populate/Load added in later tasks
+	c := config{
+		fileNameFn: func(p string) string { return p + ".yaml" },
+		lookup:     os.LookupEnv,
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+func (c config) activeProfile() string { //nolint:unused // consumed by LoadEnv/Populate/Load added in later tasks
+	if c.profile != "" {
+		return c.profile
+	}
+	return Profile()
+}
+
+func (c config) fileName() string { //nolint:unused // consumed by Load added in a later task
+	return c.fileNameFn(c.activeProfile())
+}
+
+func (c config) applyDotenv() error { //nolint:unused // consumed by LoadEnv/Populate/Load added in later tasks
+	if len(c.dotenvPaths) == 0 {
+		return nil
+	}
+	return Dotenv(c.dotenvPaths...)
+}
+
+// Option configures Load/LoadEnv/Populate.
+type Option func(*config)
+
+// WithDotenv loads these .env files (via Dotenv) before reading config.
+func WithDotenv(paths ...string) Option {
+	return func(c *config) { c.dotenvPaths = append(c.dotenvPaths, paths...) }
+}
+
+// WithProfile overrides APP_ENV/ENV detection for file selection.
+func WithProfile(name string) Option { return func(c *config) { c.profile = name } }
+
+// WithFileName customizes the profile→filename mapping (default profile+".yaml").
+func WithFileName(fn func(profile string) string) Option {
+	return func(c *config) {
+		if fn != nil {
+			c.fileNameFn = fn
+		}
+	}
+}
+
+// WithLookup overrides os.LookupEnv (test seam) for substitution and env reads.
+func WithLookup(fn func(key string) (string, bool)) Option {
+	return func(c *config) {
+		if fn != nil {
+			c.lookup = fn
+		}
+	}
+}

--- a/ops/config/options.go
+++ b/ops/config/options.go
@@ -20,14 +20,14 @@ func newConfig(opts ...Option) config {
 	return c
 }
 
-func (c config) activeProfile() string { //nolint:unused // consumed by LoadEnv/Populate/Load added in later tasks
+func (c config) activeProfile() string {
 	if c.profile != "" {
 		return c.profile
 	}
 	return Profile()
 }
 
-func (c config) fileName() string { //nolint:unused // consumed by Load added in a later task
+func (c config) fileName() string {
 	return c.fileNameFn(c.activeProfile())
 }
 

--- a/ops/config/profile.go
+++ b/ops/config/profile.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"os"
+	"slices"
+	"strings"
+)
+
+// Profile returns the active deployment profile from APP_ENV, then ENV,
+// defaulting to "development". The raw string is also the {profile}.yaml stem.
+func Profile() string {
+	for _, k := range []string{"APP_ENV", "ENV"} {
+		if v, ok := os.LookupEnv(k); ok && v != "" {
+			return v
+		}
+	}
+	return "development"
+}
+
+func matches(p string, names ...string) bool {
+	return slices.Contains(names, strings.ToLower(strings.TrimSpace(p)))
+}
+
+// IsDev reports whether the profile is a development profile.
+func IsDev() bool { return matches(Profile(), "dev", "development", "local") }
+
+// IsProd reports whether the profile is a production profile.
+func IsProd() bool { return matches(Profile(), "prod", "production") }
+
+// IsTest reports whether the profile is a test profile.
+func IsTest() bool { return matches(Profile(), "test", "testing") }
+
+// IsStaging reports whether the profile is a staging profile.
+func IsStaging() bool { return matches(Profile(), "staging", "stage") }

--- a/ops/config/profile_test.go
+++ b/ops/config/profile_test.go
@@ -1,0 +1,21 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/ops/config"
+)
+
+func TestProfilePredicates(t *testing.T) {
+	t.Setenv("APP_ENV", "production")
+	assert.Equal(t, "production", config.Profile())
+	assert.True(t, config.IsProd())
+	assert.False(t, config.IsDev())
+
+	t.Setenv("APP_ENV", "")
+	t.Setenv("ENV", "")
+	assert.Equal(t, "development", config.Profile()) // default
+	assert.True(t, config.IsDev())
+}

--- a/ops/config/substitute.go
+++ b/ops/config/substitute.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Substitute expands ${VAR} and ${VAR:default} placeholders in s against the
+// process environment. $$ yields a literal $. ${VAR} with VAR unset is an
+// error; ${VAR:default} falls back to default when VAR is unset OR empty. The
+// name/default split is on the first colon, so defaults may contain colons.
+func Substitute(s string) (string, error) {
+	return substitute(s, os.LookupEnv)
+}
+
+func substitute(s string, lookup func(string) (string, bool)) (string, error) {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] == '$' && i+1 < len(s) && s[i+1] == '$' {
+			b.WriteByte('$')
+			i += 2
+			continue
+		}
+		if s[i] == '$' && i+1 < len(s) && s[i+1] == '{' {
+			rel := strings.IndexByte(s[i+2:], '}')
+			if rel < 0 {
+				return "", fmt.Errorf("%w: unterminated placeholder", ErrSubstitute)
+			}
+			val, err := resolvePlaceholder(s[i+2:i+2+rel], lookup)
+			if err != nil {
+				return "", err
+			}
+			b.WriteString(val)
+			i += 2 + rel + 1
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String(), nil
+}
+
+func resolvePlaceholder(expr string, lookup func(string) (string, bool)) (string, error) {
+	name, def, hasDefault := strings.Cut(expr, ":")
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("%w: empty variable name", ErrSubstitute)
+	}
+	v, ok := lookup(name)
+	if hasDefault {
+		if !ok || v == "" {
+			return def, nil
+		}
+		return v, nil
+	}
+	if !ok {
+		return "", fmt.Errorf("%w: %s is not set", ErrSubstitute, name)
+	}
+	return v, nil
+}

--- a/ops/config/substitute_test.go
+++ b/ops/config/substitute_test.go
@@ -1,0 +1,41 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/config"
+)
+
+func TestSubstitute(t *testing.T) {
+	t.Setenv("HOST", "10.0.0.1")
+	t.Setenv("EMPTY", "")
+
+	got, err := config.Substitute("host: ${HOST:0.0.0.0}")
+	require.NoError(t, err)
+	assert.Equal(t, "host: 10.0.0.1", got)
+
+	got, err = config.Substitute("host: ${MISSING:0.0.0.0}")
+	require.NoError(t, err)
+	assert.Equal(t, "host: 0.0.0.0", got)
+
+	got, err = config.Substitute("host: ${EMPTY:fallback}") // empty -> default
+	require.NoError(t, err)
+	assert.Equal(t, "host: fallback", got)
+
+	got, err = config.Substitute("url: ${MISSING:http://x:8080}") // colon in default
+	require.NoError(t, err)
+	assert.Equal(t, "url: http://x:8080", got)
+
+	got, err = config.Substitute("price: $$5")
+	require.NoError(t, err)
+	assert.Equal(t, "price: $5", got)
+
+	_, err = config.Substitute("x: ${NOPE}") // unset, no default -> error
+	assert.ErrorIs(t, err, config.ErrSubstitute)
+
+	_, err = config.Substitute("x: ${UNTERMINATED")
+	assert.ErrorIs(t, err, config.ErrSubstitute)
+}

--- a/ops/config/substitute_test.go
+++ b/ops/config/substitute_test.go
@@ -38,4 +38,23 @@ func TestSubstitute(t *testing.T) {
 
 	_, err = config.Substitute("x: ${UNTERMINATED")
 	assert.ErrorIs(t, err, config.ErrSubstitute)
+
+	t.Setenv("SUBHOST", "10.0.0.1")
+	got, err = config.Substitute("x: ${SUBHOST}") // set, no default -> substitutes
+	require.NoError(t, err)
+	assert.Equal(t, "x: 10.0.0.1", got)
+
+	_, err = config.Substitute("${}") // empty variable name -> error
+	assert.ErrorIs(t, err, config.ErrSubstitute)
+
+	_, err = config.Substitute("${:default}") // empty name rejected before default is considered
+	assert.ErrorIs(t, err, config.ErrSubstitute)
+
+	got, err = config.Substitute("a$") // lone trailing $ at end-of-string is a literal
+	require.NoError(t, err)
+	assert.Equal(t, "a$", got)
+
+	got, err = config.Substitute("a$$") // $$ at end-of-string collapses to one literal $
+	require.NoError(t, err)
+	assert.Equal(t, "a$", got)
 }

--- a/ops/config/testdata/.env
+++ b/ops/config/testdata/.env
@@ -1,0 +1,2 @@
+PORT=8080
+export TOKEN="a:b:c"

--- a/ops/config/testdata/.env.local
+++ b/ops/config/testdata/.env.local
@@ -1,0 +1,3 @@
+# base
+HOST=localhost
+PORT=3000

--- a/ops/config/testdata/development.yaml
+++ b/ops/config/testdata/development.yaml
@@ -1,0 +1,3 @@
+host: ${HOST:0.0.0.0}
+port: ${PORT:8080}
+name: dev-service

--- a/ops/config/testdata/production.yaml
+++ b/ops/config/testdata/production.yaml
@@ -1,0 +1,3 @@
+host: ${HOST:0.0.0.0}
+port: 443
+name: prod-service

--- a/ops/health/doc.go
+++ b/ops/health/doc.go
@@ -1,0 +1,42 @@
+// Package health is a single pull-evaluated handler factory for liveness and
+// readiness. Handler() with no checks always returns 200 (liveness); the same
+// function with checks is readiness. Checks run on each scrape (no cache, no
+// background workers); they are critical by default (failure → 503) unless
+// marked NonCritical (failure → "degraded" 200).
+//
+// # Liveness + readiness over datastores
+//
+// Each forge data client already exposes a func(ctx) error healthcheck, which
+// IS a health.Check — so they plug straight in:
+//
+//	mux.Handle("GET /livez", health.Handler()) // process is up
+//
+//	mux.Handle("GET /readyz", health.Handler(
+//		health.WithCheck("postgres", postgres.Healthcheck(pool)),                // critical
+//		health.WithCheck("mongo", mongo.Healthcheck(mdb)),                       // critical
+//		health.WithCheck("redis", redis.Healthcheck(rdb), health.NonCritical()), // degrade
+//		health.WithCheck("opensearch", opensearch.Healthcheck(osc), health.NonCritical()),
+//		health.WithTimeout(2*time.Second),
+//	))
+//
+// # Graceful drain (readiness 503 before the server stops)
+//
+// A Gate check plus supervisor's ordered pre-shutdown phase flips /readyz to 503
+// and waits so the load balancer deregisters while the server still serves:
+//
+//	gate := health.NewGate()
+//	readyz := health.Handler(health.WithCheck("accepting", gate.Check) /* + store checks */)
+//	supervisor.Run(ctx,
+//		supervisor.WithPreShutdown("drain", func(ctx context.Context) {
+//			gate.Down() // next /readyz scrape is 503; server keeps serving
+//			select {
+//			case <-time.After(5 * time.Second): // ≥ probeInterval × failureThreshold
+//			case <-ctx.Done():
+//			}
+//		}),
+//		supervisor.WithService(srv), // listener closes only after the hook returns
+//	)
+//
+// An HTTP-dependency check is a one-liner (GET → 2xx, drain+close body, honor
+// ctx); it is not a package export.
+package health

--- a/ops/health/errors.go
+++ b/ops/health/errors.go
@@ -1,0 +1,6 @@
+package health
+
+import "errors"
+
+// ErrDraining is returned by a down Gate's Check while the app is shutting down.
+var ErrDraining = errors.New("health: draining")

--- a/ops/health/gate.go
+++ b/ops/health/gate.go
@@ -1,0 +1,33 @@
+package health
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// Gate is a flippable readiness signal exposed as a Check — the drain primitive.
+// It starts up (healthy); Down makes its Check report ErrDraining.
+type Gate struct {
+	up atomic.Bool
+}
+
+// NewGate returns a Gate in the "up" state.
+func NewGate() *Gate {
+	g := &Gate{}
+	g.up.Store(true)
+	return g
+}
+
+// Check reports nil while up, ErrDraining once Down.
+func (g *Gate) Check(context.Context) error {
+	if g.up.Load() {
+		return nil
+	}
+	return ErrDraining
+}
+
+// Up marks the gate healthy.
+func (g *Gate) Up() { g.up.Store(true) }
+
+// Down marks the gate draining.
+func (g *Gate) Down() { g.up.Store(false) }

--- a/ops/health/gate_test.go
+++ b/ops/health/gate_test.go
@@ -1,0 +1,32 @@
+package health_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/health"
+)
+
+func TestGate_FlipsReadiness(t *testing.T) {
+	gate := health.NewGate()
+	require.NoError(t, gate.Check(context.Background())) // up by default
+
+	h := health.Handler(health.WithCheck("accepting", gate.Check))
+
+	rec := do(h)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	gate.Down()
+	assert.ErrorIs(t, gate.Check(context.Background()), health.ErrDraining)
+
+	rec = do(h)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	gate.Up()
+	rec = do(h)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/ops/health/health.go
+++ b/ops/health/health.go
@@ -1,0 +1,132 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Check reports the health of one dependency; nil means healthy.
+type Check func(ctx context.Context) error
+
+// Report is the aggregate result of one scrape.
+type Report struct {
+	Status string        `json:"status"` // "ok" | "degraded" | "unavailable"
+	Checks []CheckResult `json:"checks"`
+}
+
+// CheckResult is one check's outcome.
+type CheckResult struct {
+	Name     string `json:"name"`
+	Err      string `json:"err,omitempty"`
+	OK       bool   `json:"ok"`
+	Critical bool   `json:"critical"`
+}
+
+type checkEntry struct {
+	check    Check
+	name     string
+	critical bool
+}
+
+type config struct {
+	responder func(http.ResponseWriter, *http.Request, Report)
+	checks    []checkEntry
+	timeout   time.Duration
+}
+
+// Option configures a Handler.
+type Option func(*config)
+
+type checkConfig struct{ critical bool }
+
+// CheckOption configures a single check.
+type CheckOption func(*checkConfig)
+
+// NonCritical marks a check as degrade-not-evict: its failure yields a
+// "degraded" 200 instead of a 503.
+func NonCritical() CheckOption { return func(c *checkConfig) { c.critical = false } }
+
+// WithCheck registers a named check. Checks are critical by default.
+func WithCheck(name string, check Check, opts ...CheckOption) Option {
+	cc := checkConfig{critical: true}
+	for _, o := range opts {
+		o(&cc)
+	}
+	return func(c *config) {
+		c.checks = append(c.checks, checkEntry{name: name, check: check, critical: cc.critical})
+	}
+}
+
+// WithTimeout bounds each check's context per scrape. 0 inherits the request ctx.
+func WithTimeout(d time.Duration) Option { return func(c *config) { c.timeout = d } }
+
+// WithResponder overrides the default JSON body/format.
+func WithResponder(fn func(http.ResponseWriter, *http.Request, Report)) Option {
+	return func(c *config) {
+		if fn != nil {
+			c.responder = fn
+		}
+	}
+}
+
+// Handler returns an http.Handler that runs every registered check on each
+// request and reports the aggregate. With no checks it always returns 200 — the
+// canonical liveness probe.
+func Handler(opts ...Option) http.Handler {
+	c := config{responder: defaultResponder}
+	for _, o := range opts {
+		o(&c)
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.responder(w, r, evaluate(r.Context(), c))
+	})
+}
+
+func evaluate(ctx context.Context, c config) Report {
+	results := make([]CheckResult, len(c.checks))
+	var wg sync.WaitGroup
+	for i, e := range c.checks {
+		wg.Go(func() {
+			cctx := ctx
+			if c.timeout > 0 {
+				var cancel context.CancelFunc
+				cctx, cancel = context.WithTimeout(ctx, c.timeout)
+				defer cancel()
+			}
+			err := e.check(cctx)
+			results[i] = CheckResult{Name: e.name, OK: err == nil, Critical: e.critical}
+			if err != nil {
+				results[i].Err = err.Error()
+			}
+		})
+	}
+	wg.Wait()
+	return summarize(results)
+}
+
+func summarize(results []CheckResult) Report {
+	status := "ok"
+	for _, r := range results {
+		if r.OK {
+			continue
+		}
+		if r.Critical {
+			return Report{Status: "unavailable", Checks: results}
+		}
+		status = "degraded"
+	}
+	return Report{Status: status, Checks: results}
+}
+
+func defaultResponder(w http.ResponseWriter, _ *http.Request, rep Report) {
+	code := http.StatusOK
+	if rep.Status == "unavailable" {
+		code = http.StatusServiceUnavailable
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(rep)
+}

--- a/ops/health/health.go
+++ b/ops/health/health.go
@@ -3,6 +3,7 @@ package health
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -96,7 +97,7 @@ func evaluate(ctx context.Context, c config) Report {
 				cctx, cancel = context.WithTimeout(ctx, c.timeout)
 				defer cancel()
 			}
-			err := e.check(cctx)
+			err := runCheck(cctx, e.check)
 			results[i] = CheckResult{Name: e.name, OK: err == nil, Critical: e.critical}
 			if err != nil {
 				results[i].Err = err.Error()
@@ -105,6 +106,17 @@ func evaluate(ctx context.Context, c config) Report {
 	}
 	wg.Wait()
 	return summarize(results)
+}
+
+// runCheck invokes check, converting a panic into an error so one bad check
+// degrades the report instead of crashing the process.
+func runCheck(ctx context.Context, check Check) (err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			err = fmt.Errorf("panic: %v", p)
+		}
+	}()
+	return check(ctx)
 }
 
 func summarize(results []CheckResult) Report {

--- a/ops/health/health_test.go
+++ b/ops/health/health_test.go
@@ -1,0 +1,60 @@
+package health_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/health"
+)
+
+func do(h http.Handler) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	return rec
+}
+
+func TestHandler_LivenessNoChecks(t *testing.T) {
+	rec := do(health.Handler())
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandler_CriticalFailureIs503(t *testing.T) {
+	rec := do(health.Handler(
+		health.WithCheck("ok", func(context.Context) error { return nil }),
+		health.WithCheck("db", func(context.Context) error { return errors.New("down") }),
+	))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	var rep health.Report
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rep))
+	assert.Equal(t, "unavailable", rep.Status)
+}
+
+func TestHandler_NonCriticalDegrades200(t *testing.T) {
+	rec := do(health.Handler(
+		health.WithCheck("cache", func(context.Context) error { return errors.New("down") }, health.NonCritical()),
+	))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rep health.Report
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rep))
+	assert.Equal(t, "degraded", rep.Status)
+}
+
+func TestHandler_TimeoutIsFailureNotHang(t *testing.T) {
+	rec := do(health.Handler(
+		health.WithCheck("slow", func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}),
+		health.WithTimeout(20*time.Millisecond),
+	))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}

--- a/ops/health/health_test.go
+++ b/ops/health/health_test.go
@@ -58,3 +58,28 @@ func TestHandler_TimeoutIsFailureNotHang(t *testing.T) {
 	))
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
+
+func TestHandler_PanickingCheckIsContained(t *testing.T) {
+	rec := do(health.Handler(
+		health.WithCheck("panicky", func(context.Context) error { panic("boom") }),
+	))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	var rep health.Report
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rep))
+	require.Len(t, rep.Checks, 1)
+	assert.False(t, rep.Checks[0].OK)
+	assert.Contains(t, rep.Checks[0].Err, "panic")
+}
+
+func TestHandler_MixedCriticalAndNonCriticalFailureIsUnavailable(t *testing.T) {
+	rec := do(health.Handler(
+		health.WithCheck("db", func(context.Context) error { return errors.New("down") }),
+		health.WithCheck("cache", func(context.Context) error { return errors.New("down") }, health.NonCritical()),
+	))
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	var rep health.Report
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rep))
+	assert.Equal(t, "unavailable", rep.Status)
+}

--- a/ops/supervisor/doc.go
+++ b/ops/supervisor/doc.go
@@ -21,10 +21,12 @@
 //	}
 //
 // The first service to return (nil or error), or cancellation of ctx, begins a
-// coordinated shutdown: the shared context is cancelled so every service drains
-// itself, and Run waits up to the shutdown timeout (default 30s; 0 means wait
-// indefinitely) before abandoning any service that has not stopped. All
+// coordinated shutdown: any hooks registered via WithPreShutdown run to
+// completion first, then the shared context is cancelled so every service
+// drains itself, and Run waits up to the shutdown timeout (default 30s; 0 means
+// wait indefinitely) before abandoning any service that has not stopped. All
 // diagnostics are emitted as structured slog attributes; the values returned by
 // Run are single-line errors that can be matched with errors.Is against
-// ErrNoServices, ErrUnnamedService, ErrShutdownTimeout, and ErrPanic.
+// ErrNoServices, ErrUnnamedService, ErrShutdownTimeout, ErrPreShutdownTimeout,
+// ErrInvalidConfig, and ErrPanic.
 package supervisor

--- a/ops/supervisor/errors.go
+++ b/ops/supervisor/errors.go
@@ -14,4 +14,6 @@ var (
 	ErrPanic = errors.New("supervisor: service panicked")
 	// ErrInvalidConfig is returned (joined) by Run when an option or Config field has an invalid value.
 	ErrInvalidConfig = errors.New("supervisor: invalid config")
+	// ErrPreShutdownTimeout is returned (joined) by Run when pre-shutdown hooks do not finish within the pre-shutdown timeout.
+	ErrPreShutdownTimeout = errors.New("supervisor: pre-shutdown timed out")
 )

--- a/ops/supervisor/options.go
+++ b/ops/supervisor/options.go
@@ -9,17 +9,26 @@ import (
 
 // config holds resolved settings for a single Run call.
 type config struct {
-	logger   *slog.Logger
-	services []Service
-	errs     []error
+	logger             *slog.Logger
+	services           []Service
+	errs               []error
+	preShutdown        []preHook
+	preShutdownTimeout time.Duration
 	Config
 }
 
 func defaultConfig() config {
 	return config{
-		Config: DefaultConfig(),
-		logger: slog.Default(),
+		Config:             DefaultConfig(),
+		logger:             slog.Default(),
+		preShutdownTimeout: 30 * time.Second,
 	}
+}
+
+// preHook is a named pre-shutdown callback.
+type preHook struct {
+	fn   func(context.Context)
+	name string
 }
 
 // Option configures a Run call: it registers services and tunes behavior.
@@ -60,6 +69,26 @@ func WithConfig(cfg Config) Option {
 // shutdown begins. Default 30s. A value of 0 means wait indefinitely.
 func WithShutdownTimeout(d time.Duration) Option {
 	return func(c *config) { c.ShutdownTimeout = d }
+}
+
+// WithPreShutdown registers a hook run after shutdown begins but BEFORE each
+// service's context is cancelled — so readiness can flip and load balancers can
+// deregister while services still serve. Hooks run concurrently; Run waits for
+// them, bounded by WithPreShutdownTimeout. A nil fn is rejected as ErrInvalidConfig.
+func WithPreShutdown(name string, fn func(context.Context)) Option {
+	return func(c *config) {
+		if fn == nil {
+			c.errs = append(c.errs, fmt.Errorf("%w: WithPreShutdown(%q) received a nil func", ErrInvalidConfig, name))
+			return
+		}
+		c.preShutdown = append(c.preShutdown, preHook{name: name, fn: fn})
+	}
+}
+
+// WithPreShutdownTimeout bounds the pre-shutdown phase. Default 30s; it must
+// exceed the longest grace a hook waits internally, or the hook is cut short.
+func WithPreShutdownTimeout(d time.Duration) Option {
+	return func(c *config) { c.preShutdownTimeout = d }
 }
 
 // WithLogger sets the slog.Logger used for lifecycle logging. Default

--- a/ops/supervisor/preshutdown_test.go
+++ b/ops/supervisor/preshutdown_test.go
@@ -1,0 +1,62 @@
+package supervisor_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/supervisor"
+)
+
+// The hook must FINISH before the service observes ctx cancellation.
+func TestWithPreShutdown_RunsBeforeServiceCancel(t *testing.T) {
+	var mu atomic.Int32 // sequence counter
+
+	hookSeq := int32(-1)
+	svcSeq := int32(-1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(20 * time.Millisecond); cancel() }()
+
+	err := supervisor.Run(ctx,
+		supervisor.WithPreShutdown("drain", func(context.Context) {
+			hookSeq = mu.Add(1)
+		}),
+		supervisor.WithServiceFunc("svc", func(sctx context.Context) error {
+			<-sctx.Done()
+			svcSeq = mu.Add(1)
+			return nil
+		}),
+		supervisor.WithShutdownTimeout(time.Second),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), hookSeq, "hook should run first")
+	assert.Equal(t, int32(2), svcSeq, "service cancel should observe after hook")
+}
+
+func TestWithPreShutdown_TimeoutSurfaces(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(10 * time.Millisecond); cancel() }()
+
+	err := supervisor.Run(ctx,
+		supervisor.WithPreShutdownTimeout(20*time.Millisecond),
+		supervisor.WithPreShutdown("slow", func(hctx context.Context) {
+			<-hctx.Done() // never returns before the bound
+		}),
+		supervisor.WithServiceFunc("svc", func(sctx context.Context) error { <-sctx.Done(); return nil }),
+		supervisor.WithShutdownTimeout(time.Second),
+	)
+	assert.ErrorIs(t, err, supervisor.ErrPreShutdownTimeout)
+}
+
+func TestWithPreShutdown_NilFuncRejected(t *testing.T) {
+	err := supervisor.Run(context.Background(),
+		supervisor.WithPreShutdown("bad", nil),
+		supervisor.WithServiceFunc("svc", func(context.Context) error { return nil }),
+	)
+	assert.ErrorIs(t, err, supervisor.ErrInvalidConfig)
+}

--- a/ops/supervisor/supervisor.go
+++ b/ops/supervisor/supervisor.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"runtime/debug"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -47,7 +48,14 @@ func Run(ctx context.Context, opts ...Option) error {
 		return nil
 	}
 
-	runCtx, cancel := context.WithCancel(ctx)
+	// runCtx carries ctx's values but deliberately NOT its cancellation: services
+	// must only observe cancellation through our own cancel() below, called from
+	// beginShutdown AFTER pre-shutdown hooks finish. If runCtx propagated ctx's
+	// cancellation directly, cancelling ctx would close runCtx.Done() immediately,
+	// racing services against the pre-shutdown phase instead of waiting behind it.
+	// ctx's own cancellation is instead observed via ctx.Done() below and only
+	// *triggers* beginShutdown.
+	runCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	defer cancel()
 
 	type result struct {
@@ -69,7 +77,7 @@ func Run(ctx context.Context, opts ...Option) error {
 
 	var (
 		errs         []error
-		done         = runCtx.Done()
+		done         = ctx.Done()
 		graceCh      <-chan time.Time // nil until shutdown begins; never armed when timeout == 0
 		shuttingDown bool
 	)
@@ -80,6 +88,9 @@ func Run(ctx context.Context, opts ...Option) error {
 		}
 		shuttingDown = true
 		log.Info("shutdown started", slog.String("reason", reason))
+		if err := runPreShutdown(cfg.preShutdown, cfg.preShutdownTimeout, log); err != nil {
+			errs = append(errs, err)
+		}
 		cancel()
 		done = nil
 		if cfg.ShutdownTimeout > 0 {
@@ -132,6 +143,42 @@ func runService(ctx context.Context, svc Service, log *slog.Logger, recoverPanic
 		}
 	}()
 	return svc.Run(ctx)
+}
+
+// runPreShutdown runs all hooks concurrently, returning ErrPreShutdownTimeout if
+// they do not all finish within timeout (0 = wait indefinitely). A panicking hook
+// is recovered and logged.
+func runPreShutdown(hooks []preHook, timeout time.Duration, log *slog.Logger) error {
+	if len(hooks) == 0 {
+		return nil
+	}
+	ctx := context.Background()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	var wg sync.WaitGroup
+	for _, h := range hooks {
+		wg.Go(func() {
+			defer func() {
+				if p := recover(); p != nil {
+					log.Error("pre-shutdown hook panicked",
+						slog.String("hook", h.name), slog.Any("panic", p))
+				}
+			}()
+			log.Info("pre-shutdown hook started", slog.String("hook", h.name))
+			h.fn(ctx)
+		})
+	}
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ErrPreShutdownTimeout
+	}
 }
 
 // resolveLogger returns l, or a discard logger when l is nil.

--- a/ops/supervisor/supervisor.go
+++ b/ops/supervisor/supervisor.go
@@ -14,7 +14,9 @@ import (
 
 // Run starts every registered service, supervises them, and blocks until
 // shutdown completes. The first service to return (nil or error), or
-// cancellation of ctx, begins a coordinated shutdown: the shared context is
+// cancellation of ctx, begins a coordinated shutdown: any hooks registered via
+// WithPreShutdown first run to completion (bounded by WithPreShutdownTimeout,
+// default 30s, surfaced as ErrPreShutdownTimeout), then the shared context is
 // cancelled so every service drains, and Run waits for them all to return.
 // Run returns the joined non-context.Canceled service errors, or nil on a
 // clean stop.
@@ -54,7 +56,9 @@ func Run(ctx context.Context, opts ...Option) error {
 	// cancellation directly, cancelling ctx would close runCtx.Done() immediately,
 	// racing services against the pre-shutdown phase instead of waiting behind it.
 	// ctx's own cancellation is instead observed via ctx.Done() below and only
-	// *triggers* beginShutdown.
+	// *triggers* beginShutdown. context.WithoutCancel also strips ctx's deadline,
+	// so runCtx.Deadline() never propagates the parent's deadline; a service that
+	// needs one must set its own.
 	runCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	defer cancel()
 

--- a/resilience/ratelimit/errors.go
+++ b/resilience/ratelimit/errors.go
@@ -1,0 +1,7 @@
+package ratelimit
+
+import "errors"
+
+// ErrLimited indicates the subject exceeded its rate; used by the middleware's
+// responder and available to non-HTTP callers.
+var ErrLimited = errors.New("ratelimit: limit exceeded")

--- a/resilience/ratelimit/memory.go
+++ b/resilience/ratelimit/memory.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"hash/maphash"
 	"sync"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 type memoryConfig struct {
 	clk             clock.Clock
 	janitorInterval time.Duration
+	shards          int
 }
 
 // MemoryOption configures NewMemoryStore.
@@ -36,35 +38,75 @@ func WithMemoryJanitor(interval time.Duration) MemoryOption {
 	}
 }
 
+// WithShards splits the store into n independently-locked shards, keyed by a
+// hash of the key. This lifts the single-mutex throughput ceiling under high
+// concurrency and bounds each janitor sweep to one shard at a time, so a large
+// map no longer blocks every request for the duration of a full sweep. Default
+// 1 — a single lock, identical to the unsharded behavior; values < 1 are
+// ignored. The single-lock default already sustains well over a million
+// ops/sec, so only very high throughput or high-cardinality-with-janitor
+// workloads benefit; a small multiple of GOMAXPROCS (e.g. 16–64) is ample.
+func WithShards(n int) MemoryOption {
+	return func(c *memoryConfig) {
+		if n >= 1 {
+			c.shards = n
+		}
+	}
+}
+
 type counter struct {
 	expiresAt time.Time
 	val       int64
 }
 
+// memShard is one independently-locked partition of the store's keyspace.
+type memShard struct {
+	m  map[string]counter
+	mu sync.Mutex
+}
+
 type memoryStore struct {
-	clk  clock.Clock
-	m    map[string]counter
-	stop chan struct{}
-	wg   sync.WaitGroup
+	clk    clock.Clock
+	stop   chan struct{}
+	shards []memShard
+	wg     sync.WaitGroup
+
+	seed maphash.Seed
 
 	closeOnce sync.Once
-	mu        sync.Mutex
 }
 
 // NewMemoryStore returns an in-process counter Store. Lifecycle is the caller's
 // (Close). Suitable for single-instance use and tests; multi-instance limiting
 // needs ratelimit/redisstore.
 func NewMemoryStore(opts ...MemoryOption) Store {
-	c := memoryConfig{clk: clock.System()}
+	c := memoryConfig{clk: clock.System(), shards: 1}
 	for _, o := range opts {
 		o(&c)
 	}
-	s := &memoryStore{m: make(map[string]counter), clk: c.clk}
+	s := &memoryStore{
+		clk:    c.clk,
+		shards: make([]memShard, c.shards),
+		seed:   maphash.MakeSeed(),
+	}
+	for i := range s.shards {
+		s.shards[i].m = make(map[string]counter)
+	}
 	if c.janitorInterval > 0 {
 		s.stop = make(chan struct{})
 		s.startJanitor(c.janitorInterval)
 	}
 	return s
+}
+
+// shardFor returns the shard owning key. With a single shard the hash is
+// skipped so the common (unsharded) path stays hash-free.
+func (s *memoryStore) shardFor(key string) *memShard {
+	if len(s.shards) == 1 {
+		return &s.shards[0]
+	}
+	h := maphash.String(s.seed, key)
+	return &s.shards[h%uint64(len(s.shards))]
 }
 
 // startJanitor runs the eviction sweep every interval until stop is closed.
@@ -83,46 +125,57 @@ func (s *memoryStore) startJanitor(interval time.Duration) {
 	})
 }
 
-// sweep deletes entries expired as of the store's clock.
+// sweep deletes entries expired as of the store's clock, locking one shard at a
+// time so a large map never blocks all requests for a full O(n) scan.
 func (s *memoryStore) sweep() {
 	now := s.clk.Now()
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for key, e := range s.m {
-		if now.After(e.expiresAt) {
-			delete(s.m, key)
+	for i := range s.shards {
+		sh := &s.shards[i]
+		sh.mu.Lock()
+		for key, e := range sh.m {
+			if now.After(e.expiresAt) {
+				delete(sh.m, key)
+			}
 		}
+		sh.mu.Unlock()
 	}
 }
 
-// Len returns the number of entries currently held, including any not yet
-// evicted by lazy expiry or the janitor. Useful for metrics/debugging and for
+// Len returns the number of entries currently held across all shards, including
+// any not yet evicted by lazy expiry or the janitor. Useful for metrics and for
 // tests asserting physical eviction.
 func (s *memoryStore) Len() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return len(s.m)
+	n := 0
+	for i := range s.shards {
+		sh := &s.shards[i]
+		sh.mu.Lock()
+		n += len(sh.m)
+		sh.mu.Unlock()
+	}
+	return n
 }
 
 func (s *memoryStore) Incr(_ context.Context, key string, delta int64, ttl time.Duration) (int64, error) {
 	now := s.clk.Now()
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	e, ok := s.m[key]
+	sh := s.shardFor(key)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	e, ok := sh.m[key]
 	if !ok || now.After(e.expiresAt) {
 		e = counter{val: delta, expiresAt: now.Add(ttl)}
 	} else {
 		e.val += delta
 	}
-	s.m[key] = e
+	sh.m[key] = e
 	return e.val, nil
 }
 
 func (s *memoryStore) Get(_ context.Context, key string) (int64, error) {
 	now := s.clk.Now()
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	e, ok := s.m[key]
+	sh := s.shardFor(key)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	e, ok := sh.m[key]
 	if !ok || now.After(e.expiresAt) {
 		return 0, nil
 	}
@@ -130,9 +183,10 @@ func (s *memoryStore) Get(_ context.Context, key string) (int64, error) {
 }
 
 func (s *memoryStore) Reset(_ context.Context, key string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	delete(s.m, key)
+	sh := s.shardFor(key)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	delete(sh.m, key)
 	return nil
 }
 

--- a/resilience/ratelimit/memory.go
+++ b/resilience/ratelimit/memory.go
@@ -1,0 +1,81 @@
+package ratelimit
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type memoryConfig struct {
+	clk clock.Clock
+}
+
+// MemoryOption configures NewMemoryStore.
+type MemoryOption func(*memoryConfig)
+
+// WithMemoryClock injects a clock (for tests). Default clock.System().
+func WithMemoryClock(clk clock.Clock) MemoryOption {
+	return func(c *memoryConfig) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+type counter struct {
+	expiresAt time.Time
+	val       int64
+}
+
+type memoryStore struct {
+	clk clock.Clock
+	m   map[string]counter
+	mu  sync.Mutex
+}
+
+// NewMemoryStore returns an in-process counter Store. Lifecycle is the caller's
+// (Close). Suitable for single-instance use and tests; multi-instance limiting
+// needs ratelimit/redisstore.
+func NewMemoryStore(opts ...MemoryOption) Store {
+	c := memoryConfig{clk: clock.System()}
+	for _, o := range opts {
+		o(&c)
+	}
+	return &memoryStore{m: make(map[string]counter), clk: c.clk}
+}
+
+func (s *memoryStore) Incr(_ context.Context, key string, delta int64, ttl time.Duration) (int64, error) {
+	now := s.clk.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.m[key]
+	if !ok || now.After(e.expiresAt) {
+		e = counter{val: delta, expiresAt: now.Add(ttl)}
+	} else {
+		e.val += delta
+	}
+	s.m[key] = e
+	return e.val, nil
+}
+
+func (s *memoryStore) Get(_ context.Context, key string) (int64, error) {
+	now := s.clk.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.m[key]
+	if !ok || now.After(e.expiresAt) {
+		return 0, nil
+	}
+	return e.val, nil
+}
+
+func (s *memoryStore) Reset(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+	return nil
+}
+
+func (s *memoryStore) Close() error { return nil }

--- a/resilience/ratelimit/memory.go
+++ b/resilience/ratelimit/memory.go
@@ -9,7 +9,8 @@ import (
 )
 
 type memoryConfig struct {
-	clk clock.Clock
+	clk             clock.Clock
+	janitorInterval time.Duration
 }
 
 // MemoryOption configures NewMemoryStore.
@@ -24,15 +25,30 @@ func WithMemoryClock(clk clock.Clock) MemoryOption {
 	}
 }
 
+// WithMemoryJanitor starts a background goroutine that periodically deletes
+// expired entries, so the map does not grow unbounded under high-cardinality
+// (e.g. per-IP) keys. It ticks every interval; expiry is still decided by the
+// store's clock. Default (option not passed, or interval <= 0) is no janitor:
+// Close remains a no-op and the map is only pruned lazily by Get/Incr.
+func WithMemoryJanitor(interval time.Duration) MemoryOption {
+	return func(c *memoryConfig) {
+		c.janitorInterval = interval
+	}
+}
+
 type counter struct {
 	expiresAt time.Time
 	val       int64
 }
 
 type memoryStore struct {
-	clk clock.Clock
-	m   map[string]counter
-	mu  sync.Mutex
+	clk  clock.Clock
+	m    map[string]counter
+	stop chan struct{}
+	wg   sync.WaitGroup
+
+	closeOnce sync.Once
+	mu        sync.Mutex
 }
 
 // NewMemoryStore returns an in-process counter Store. Lifecycle is the caller's
@@ -43,7 +59,49 @@ func NewMemoryStore(opts ...MemoryOption) Store {
 	for _, o := range opts {
 		o(&c)
 	}
-	return &memoryStore{m: make(map[string]counter), clk: c.clk}
+	s := &memoryStore{m: make(map[string]counter), clk: c.clk}
+	if c.janitorInterval > 0 {
+		s.stop = make(chan struct{})
+		s.startJanitor(c.janitorInterval)
+	}
+	return s
+}
+
+// startJanitor runs the eviction sweep every interval until stop is closed.
+func (s *memoryStore) startJanitor(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	s.wg.Go(func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				s.sweep()
+			case <-s.stop:
+				return
+			}
+		}
+	})
+}
+
+// sweep deletes entries expired as of the store's clock.
+func (s *memoryStore) sweep() {
+	now := s.clk.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, e := range s.m {
+		if now.After(e.expiresAt) {
+			delete(s.m, key)
+		}
+	}
+}
+
+// Len returns the number of entries currently held, including any not yet
+// evicted by lazy expiry or the janitor. Useful for metrics/debugging and for
+// tests asserting physical eviction.
+func (s *memoryStore) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.m)
 }
 
 func (s *memoryStore) Incr(_ context.Context, key string, delta int64, ttl time.Duration) (int64, error) {
@@ -78,4 +136,14 @@ func (s *memoryStore) Reset(_ context.Context, key string) error {
 	return nil
 }
 
-func (s *memoryStore) Close() error { return nil }
+// Close stops the janitor goroutine, if one was started, and waits for it to
+// exit. Idempotent and safe to call even when no janitor was started.
+func (s *memoryStore) Close() error {
+	s.closeOnce.Do(func() {
+		if s.stop != nil {
+			close(s.stop)
+		}
+	})
+	s.wg.Wait()
+	return nil
+}

--- a/resilience/ratelimit/memory_bench_test.go
+++ b/resilience/ratelimit/memory_bench_test.go
@@ -1,0 +1,120 @@
+package ratelimit_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/resilience/ratelimit"
+)
+
+// keySet builds n distinct keys with the given prefix; n must be a power of two
+// so callers can index with i&(n-1) cheaply inside the hot loop (no per-op
+// allocation, so the benchmark measures the store/limiter, not fmt.Sprintf).
+func keySet(prefix string, n int) []string {
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = prefix + strconv.Itoa(i)
+	}
+	return keys
+}
+
+// BenchmarkMemoryStore_Incr_HotKey is the worst case: every parallel goroutine
+// contends on the single global mutex AND the same map entry.
+func BenchmarkMemoryStore_Incr_HotKey(b *testing.B) {
+	s := ratelimit.NewMemoryStore()
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = s.Incr(ctx, "hot", 1, time.Minute)
+		}
+	})
+}
+
+// BenchmarkMemoryStore_Incr_ManyKeys spreads writes across a bounded keyspace
+// (realistic per-IP working set): only the global mutex is contended, not
+// individual entries.
+func BenchmarkMemoryStore_Incr_ManyKeys(b *testing.B) {
+	const n = 4096
+	keys := keySet("k", n)
+	s := ratelimit.NewMemoryStore()
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			_, _ = s.Incr(ctx, keys[i&(n-1)], 1, time.Minute)
+			i++
+		}
+	})
+}
+
+// BenchmarkMemoryStore_GetMostlyMiss exercises the read path on absent keys.
+func BenchmarkMemoryStore_GetMostlyMiss(b *testing.B) {
+	const n = 4096
+	keys := keySet("miss", n)
+	s := ratelimit.NewMemoryStore()
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			_, _ = s.Get(ctx, keys[i&(n-1)])
+			i++
+		}
+	})
+}
+
+// BenchmarkLimiter_Allow is the end-to-end request path (1 Incr + 1 Get + the
+// sliding-window math). Its ops/sec maps directly to sustainable requests/sec.
+func BenchmarkLimiter_Allow(b *testing.B) {
+	const n = 4096
+	keys := keySet("user", n)
+	l := ratelimit.New(ratelimit.NewMemoryStore(), ratelimit.WithLimit(1_000_000, time.Minute))
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			_, _ = l.Allow(ctx, keys[i&(n-1)])
+			i++
+		}
+	})
+}
+
+// BenchmarkLimiter_Allow_WithJanitorAndLargeMap is a pathological stress case: a
+// 200k-entry map of long-lived entries (so nothing is ever evicted) swept by an
+// aggressive 1ms janitor, so every sweep is a full O(200k) scan holding the
+// global lock while Allow runs concurrently. Real deployments use far larger
+// intervals and never sweep this hard; this bounds worst-case sweep-vs-request
+// contention. Compare its ns/op against BenchmarkLimiter_Allow to isolate the
+// sweep's impact.
+func BenchmarkLimiter_Allow_WithJanitorAndLargeMap(b *testing.B) {
+	const n = 4096
+	keys := keySet("live", n)
+	store := ratelimit.NewMemoryStore(ratelimit.WithMemoryJanitor(time.Millisecond))
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+	for i := range 200_000 { // 1h TTL: every sweep scans all of them and deletes none
+		_, _ = store.Incr(ctx, "stale"+strconv.Itoa(i), 1, time.Hour)
+	}
+	l := ratelimit.New(store, ratelimit.WithLimit(1_000_000, time.Minute))
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			_, _ = l.Allow(ctx, keys[i&(n-1)])
+			i++
+		}
+	})
+}

--- a/resilience/ratelimit/memory_bench_test.go
+++ b/resilience/ratelimit/memory_bench_test.go
@@ -74,7 +74,8 @@ func BenchmarkMemoryStore_GetMostlyMiss(b *testing.B) {
 }
 
 // BenchmarkLimiter_Allow is the end-to-end request path (1 Incr + 1 Get + the
-// sliding-window math). Its ops/sec maps directly to sustainable requests/sec.
+// sliding-window math) on the default single-lock store. Its ops/sec maps
+// directly to sustainable requests/sec.
 func BenchmarkLimiter_Allow(b *testing.B) {
 	const n = 4096
 	keys := keySet("user", n)
@@ -91,13 +92,31 @@ func BenchmarkLimiter_Allow(b *testing.B) {
 	})
 }
 
+// BenchmarkLimiter_Allow_Sharded is the same end-to-end path over a 16-shard
+// store; compare its ns/op against BenchmarkLimiter_Allow to see the sharding
+// lift the single-mutex contention ceiling.
+func BenchmarkLimiter_Allow_Sharded(b *testing.B) {
+	const n = 4096
+	keys := keySet("user", n)
+	l := ratelimit.New(ratelimit.NewMemoryStore(ratelimit.WithShards(16)), ratelimit.WithLimit(1_000_000, time.Minute))
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			_, _ = l.Allow(ctx, keys[i&(n-1)])
+			i++
+		}
+	})
+}
+
 // BenchmarkLimiter_Allow_WithJanitorAndLargeMap is a pathological stress case: a
 // 200k-entry map of long-lived entries (so nothing is ever evicted) swept by an
 // aggressive 1ms janitor, so every sweep is a full O(200k) scan holding the
-// global lock while Allow runs concurrently. Real deployments use far larger
-// intervals and never sweep this hard; this bounds worst-case sweep-vs-request
-// contention. Compare its ns/op against BenchmarkLimiter_Allow to isolate the
-// sweep's impact.
+// single global lock while Allow runs concurrently. Compare against
+// BenchmarkLimiter_Allow to isolate the sweep's impact, and against the sharded
+// variant below to see the per-shard sweep flatten the cliff.
 func BenchmarkLimiter_Allow_WithJanitorAndLargeMap(b *testing.B) {
 	const n = 4096
 	keys := keySet("live", n)
@@ -105,6 +124,30 @@ func BenchmarkLimiter_Allow_WithJanitorAndLargeMap(b *testing.B) {
 	defer func() { _ = store.Close() }()
 	ctx := context.Background()
 	for i := range 200_000 { // 1h TTL: every sweep scans all of them and deletes none
+		_, _ = store.Incr(ctx, "stale"+strconv.Itoa(i), 1, time.Hour)
+	}
+	l := ratelimit.New(store, ratelimit.WithLimit(1_000_000, time.Minute))
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			_, _ = l.Allow(ctx, keys[i&(n-1)])
+			i++
+		}
+	})
+}
+
+// BenchmarkLimiter_Allow_WithJanitorAndLargeMap_Sharded is the same pathological
+// case over 16 shards: each sweep locks one shard (~1/16 of the map) at a time,
+// so concurrent Allow no longer stalls behind a full-map scan.
+func BenchmarkLimiter_Allow_WithJanitorAndLargeMap_Sharded(b *testing.B) {
+	const n = 4096
+	keys := keySet("live", n)
+	store := ratelimit.NewMemoryStore(ratelimit.WithShards(16), ratelimit.WithMemoryJanitor(time.Millisecond))
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+	for i := range 200_000 {
 		_, _ = store.Incr(ctx, "stale"+strconv.Itoa(i), 1, time.Hour)
 	}
 	l := ratelimit.New(store, ratelimit.WithLimit(1_000_000, time.Minute))

--- a/resilience/ratelimit/memory_test.go
+++ b/resilience/ratelimit/memory_test.go
@@ -1,0 +1,56 @@
+package ratelimit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/resilience/ratelimit"
+)
+
+func TestMemoryStore_IncrGetResetExpiry(t *testing.T) {
+	mk := clock.NewMock(time.Unix(1000, 0))
+	s := ratelimit.NewMemoryStore(ratelimit.WithMemoryClock(mk))
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+
+	n, err := s.Incr(ctx, "k", 1, time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	n, err = s.Incr(ctx, "k", 2, time.Minute) // does not extend TTL
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), n)
+
+	got, err := s.Get(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), got)
+
+	mk.Advance(61 * time.Second) // past TTL
+	got, err = s.Get(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got) // expired
+
+	got, _ = s.Get(ctx, "absent")
+	assert.Equal(t, int64(0), got)
+}
+
+func TestMemoryStore_ConcurrentIncr(t *testing.T) {
+	s := ratelimit.NewMemoryStore()
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+	const g = 100
+	done := make(chan struct{}, g)
+	for range g {
+		go func() { _, _ = s.Incr(ctx, "c", 1, time.Minute); done <- struct{}{} }()
+	}
+	for range g {
+		<-done
+	}
+	n, _ := s.Get(ctx, "c")
+	assert.Equal(t, int64(g), n)
+}

--- a/resilience/ratelimit/memory_test.go
+++ b/resilience/ratelimit/memory_test.go
@@ -54,3 +54,46 @@ func TestMemoryStore_ConcurrentIncr(t *testing.T) {
 	n, _ := s.Get(ctx, "c")
 	assert.Equal(t, int64(g), n)
 }
+
+func TestMemoryStore_JanitorEvictsExpiredEntries(t *testing.T) {
+	mk := clock.NewMock(time.Unix(1000, 0))
+	s := ratelimit.NewMemoryStore(ratelimit.WithMemoryClock(mk), ratelimit.WithMemoryJanitor(5*time.Millisecond))
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+
+	lener, ok := s.(interface{ Len() int })
+	require.True(t, ok, "memoryStore must expose Len() int")
+
+	_, err := s.Incr(ctx, "a", 1, time.Minute)
+	require.NoError(t, err)
+	_, err = s.Incr(ctx, "b", 1, time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, 2, lener.Len())
+
+	mk.Advance(2 * time.Minute) // both entries now expired by the clock
+
+	assert.Eventually(t, func() bool {
+		return lener.Len() == 0
+	}, time.Second, 5*time.Millisecond, "janitor should evict expired entries")
+}
+
+func TestMemoryStore_CloseStopsJanitorCleanlyAndIsIdempotent(t *testing.T) {
+	mk := clock.NewMock(time.Unix(1000, 0))
+	s := ratelimit.NewMemoryStore(ratelimit.WithMemoryClock(mk), ratelimit.WithMemoryJanitor(5*time.Millisecond))
+	ctx := context.Background()
+
+	_, err := s.Incr(ctx, "a", 1, time.Minute)
+	require.NoError(t, err)
+
+	require.NoError(t, s.Close())
+	require.NoError(t, s.Close()) // idempotent, must not hang or panic
+
+	lener, ok := s.(interface{ Len() int })
+	require.True(t, ok)
+	before := lener.Len()
+
+	mk.Advance(2 * time.Minute)
+	time.Sleep(20 * time.Millisecond) // give a leaked goroutine a chance to misbehave
+
+	assert.Equal(t, before, lener.Len(), "janitor must not run after Close")
+}

--- a/resilience/ratelimit/memory_test.go
+++ b/resilience/ratelimit/memory_test.go
@@ -2,6 +2,8 @@ package ratelimit_test
 
 import (
 	"context"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -96,4 +98,93 @@ func TestMemoryStore_CloseStopsJanitorCleanlyAndIsIdempotent(t *testing.T) {
 	time.Sleep(20 * time.Millisecond) // give a leaked goroutine a chance to misbehave
 
 	assert.Equal(t, before, lener.Len(), "janitor must not run after Close")
+}
+
+// TestMemoryStore_ShardedIncrGetReset confirms that with sharding a key routes
+// consistently to one shard, so counts accumulate and Reset clears correctly.
+func TestMemoryStore_ShardedIncrGetReset(t *testing.T) {
+	s := ratelimit.NewMemoryStore(ratelimit.WithShards(8))
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+
+	for range 5 {
+		_, err := s.Incr(ctx, "k", 1, time.Minute)
+		require.NoError(t, err)
+	}
+	got, err := s.Get(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), got)
+
+	require.NoError(t, s.Reset(ctx, "k"))
+	got, err = s.Get(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got)
+}
+
+// TestMemoryStore_ShardedConcurrentIncr hammers several keys across shards from
+// many goroutines and asserts no updates are lost (race-clean under -race).
+func TestMemoryStore_ShardedConcurrentIncr(t *testing.T) {
+	s := ratelimit.NewMemoryStore(ratelimit.WithShards(16))
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+
+	keys := []string{"a", "b", "c", "d"}
+	const goroutines = 200
+	const perG = 50
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Go(func() {
+			for i := range perG {
+				_, _ = s.Incr(ctx, keys[(g+i)%len(keys)], 1, time.Minute)
+			}
+		})
+	}
+	wg.Wait()
+
+	var total int64
+	for _, k := range keys {
+		v, _ := s.Get(ctx, k)
+		total += v
+	}
+	assert.Equal(t, int64(goroutines*perG), total, "no updates lost across shards")
+}
+
+// TestMemoryStore_ShardedJanitorEvictsAcrossShards confirms the per-shard sweep
+// evicts expired entries from every shard, not just one.
+func TestMemoryStore_ShardedJanitorEvictsAcrossShards(t *testing.T) {
+	mk := clock.NewMock(time.Unix(1000, 0))
+	s := ratelimit.NewMemoryStore(
+		ratelimit.WithMemoryClock(mk),
+		ratelimit.WithShards(8),
+		ratelimit.WithMemoryJanitor(5*time.Millisecond),
+	)
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+
+	lener, ok := s.(interface{ Len() int })
+	require.True(t, ok)
+
+	for i := range 500 {
+		_, err := s.Incr(ctx, "key"+strconv.Itoa(i), 1, time.Minute)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 500, lener.Len())
+
+	mk.Advance(2 * time.Minute)
+	assert.Eventually(t, func() bool {
+		return lener.Len() == 0
+	}, time.Second, 5*time.Millisecond, "janitor should evict expired entries across all shards")
+}
+
+// TestMemoryStore_WithShardsInvalidDefaultsToOne confirms an invalid shard count
+// is ignored (store still works as the single-lock default).
+func TestMemoryStore_WithShardsInvalidDefaultsToOne(t *testing.T) {
+	ctx := context.Background()
+	for _, n := range []int{0, -1} {
+		s := ratelimit.NewMemoryStore(ratelimit.WithShards(n))
+		got, err := s.Incr(ctx, "k", 3, time.Minute)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), got)
+		require.NoError(t, s.Close())
+	}
 }

--- a/resilience/ratelimit/middleware.go
+++ b/resilience/ratelimit/middleware.go
@@ -43,7 +43,7 @@ func (l *Limiter) Middleware(key KeyFunc, opts ...MiddlewareOption) middleware.M
 				next.ServeHTTP(w, r) // fail open
 				return
 			}
-			writeRateLimitHeaders(w, res)
+			l.writeRateLimitHeaders(w, res)
 			if !res.Allowed {
 				w.Header().Set("Retry-After", strconv.Itoa(int(math.Ceil(res.RetryAfter.Seconds()))))
 				cfg.responder(w, r, res)
@@ -54,13 +54,10 @@ func (l *Limiter) Middleware(key KeyFunc, opts ...MiddlewareOption) middleware.M
 	}
 }
 
-func writeRateLimitHeaders(w http.ResponseWriter, res Result) {
+func (l *Limiter) writeRateLimitHeaders(w http.ResponseWriter, res Result) {
 	w.Header().Set("RateLimit-Limit", strconv.FormatInt(res.Limit, 10))
 	w.Header().Set("RateLimit-Remaining", strconv.FormatInt(res.Remaining, 10))
-	reset := int(math.Ceil(res.RetryAfter.Seconds()))
-	if res.Allowed {
-		reset = 0
-	}
+	reset := max(int(math.Ceil(res.Reset.Sub(l.cfg.clk.Now()).Seconds())), 0)
 	w.Header().Set("RateLimit-Reset", strconv.Itoa(reset))
 }
 

--- a/resilience/ratelimit/middleware.go
+++ b/resilience/ratelimit/middleware.go
@@ -1,0 +1,69 @@
+package ratelimit
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+// KeyFunc selects the limiter key for a request (e.g. client IP or user ID).
+type KeyFunc func(*http.Request) string
+
+type middlewareConfig struct {
+	responder func(http.ResponseWriter, *http.Request, Result)
+}
+
+// MiddlewareOption configures Middleware.
+type MiddlewareOption func(*middlewareConfig)
+
+// WithResponder overrides the 429 response (default plain text). Use it to emit
+// problem+json via web/problem.
+func WithResponder(fn func(http.ResponseWriter, *http.Request, Result)) MiddlewareOption {
+	return func(c *middlewareConfig) {
+		if fn != nil {
+			c.responder = fn
+		}
+	}
+}
+
+// Middleware limits by key, emitting RateLimit-* headers and a 429 (with
+// Retry-After) when exceeded. On a Store error it fails open (serves the
+// request) to avoid turning a limiter outage into an app outage.
+func (l *Limiter) Middleware(key KeyFunc, opts ...MiddlewareOption) middleware.Middleware {
+	cfg := middlewareConfig{responder: defaultResponder}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			res, err := l.Allow(r.Context(), key(r))
+			if err != nil {
+				next.ServeHTTP(w, r) // fail open
+				return
+			}
+			writeRateLimitHeaders(w, res)
+			if !res.Allowed {
+				w.Header().Set("Retry-After", strconv.Itoa(int(math.Ceil(res.RetryAfter.Seconds()))))
+				cfg.responder(w, r, res)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func writeRateLimitHeaders(w http.ResponseWriter, res Result) {
+	w.Header().Set("RateLimit-Limit", strconv.FormatInt(res.Limit, 10))
+	w.Header().Set("RateLimit-Remaining", strconv.FormatInt(res.Remaining, 10))
+	reset := int(math.Ceil(res.RetryAfter.Seconds()))
+	if res.Allowed {
+		reset = 0
+	}
+	w.Header().Set("RateLimit-Reset", strconv.Itoa(reset))
+}
+
+func defaultResponder(w http.ResponseWriter, _ *http.Request, _ Result) {
+	http.Error(w, ErrLimited.Error(), http.StatusTooManyRequests)
+}

--- a/resilience/ratelimit/middleware_test.go
+++ b/resilience/ratelimit/middleware_test.go
@@ -1,0 +1,30 @@
+package ratelimit_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/resilience/ratelimit"
+)
+
+func TestMiddleware_HeadersAnd429(t *testing.T) {
+	l := ratelimit.New(ratelimit.NewMemoryStore(), ratelimit.WithLimit(1, time.Minute))
+	key := func(*http.Request) string { return "fixed" }
+	h := l.Middleware(key)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusOK, rec1.Code)
+	assert.Equal(t, "1", rec1.Header().Get("RateLimit-Limit"))
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusTooManyRequests, rec2.Code)
+	assert.NotEmpty(t, rec2.Header().Get("Retry-After"))
+}

--- a/resilience/ratelimit/middleware_test.go
+++ b/resilience/ratelimit/middleware_test.go
@@ -1,6 +1,8 @@
 package ratelimit_test
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/resilience/ratelimit"
 )
 
@@ -27,4 +30,84 @@ func TestMiddleware_HeadersAnd429(t *testing.T) {
 	h.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/", nil))
 	assert.Equal(t, http.StatusTooManyRequests, rec2.Code)
 	assert.NotEmpty(t, rec2.Header().Get("Retry-After"))
+}
+
+// TestMiddleware_ResetIsDeltaSecondsOnAllow guards against RateLimit-Reset
+// being hardcoded to "0" on the allowed path: it must always report
+// seconds-until-window-reset, per the IETF draft header semantics mandated by
+// the design spec.
+func TestMiddleware_ResetIsDeltaSecondsOnAllow(t *testing.T) {
+	mk := clock.NewMock(time.Unix(0, 0))
+	l := ratelimit.New(
+		ratelimit.NewMemoryStore(ratelimit.WithMemoryClock(mk)),
+		ratelimit.WithLimit(5, time.Minute),
+		ratelimit.WithClock(mk),
+	)
+	key := func(*http.Request) string { return "fixed" }
+	h := l.Middleware(key)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "60", rec.Header().Get("RateLimit-Reset"))
+	assert.NotEqual(t, "0", rec.Header().Get("RateLimit-Reset"))
+}
+
+// erroringStore is a black-box Store double whose Incr always errors, used to
+// exercise the middleware's fail-open path.
+type erroringStore struct{}
+
+func (erroringStore) Incr(context.Context, string, int64, time.Duration) (int64, error) {
+	return 0, errors.New("store unavailable")
+}
+
+func (erroringStore) Get(context.Context, string) (int64, error) { return 0, nil }
+
+func (erroringStore) Reset(context.Context, string) error { return nil }
+
+func (erroringStore) Close() error { return nil }
+
+// TestMiddleware_FailsOpenOnStoreError asserts that a Store error serves the
+// request via next (no 5xx, no limiting) and writes no RateLimit-* headers.
+func TestMiddleware_FailsOpenOnStoreError(t *testing.T) {
+	l := ratelimit.New(erroringStore{}, ratelimit.WithLimit(1, time.Minute))
+	key := func(*http.Request) string { return "fixed" }
+	h := l.Middleware(key)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get("RateLimit-Limit"))
+	assert.Empty(t, rec.Header().Get("RateLimit-Remaining"))
+	assert.Empty(t, rec.Header().Get("RateLimit-Reset"))
+}
+
+// TestMiddleware_WithResponderOverride asserts a custom WithResponder replaces
+// the default 429 plain-text body on a denied request.
+func TestMiddleware_WithResponderOverride(t *testing.T) {
+	const customBody = "custom rate limit response"
+	responder := func(w http.ResponseWriter, _ *http.Request, _ ratelimit.Result) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(customBody))
+	}
+
+	l := ratelimit.New(ratelimit.NewMemoryStore(), ratelimit.WithLimit(1, time.Minute))
+	key := func(*http.Request) string { return "fixed" }
+	h := l.Middleware(key, ratelimit.WithResponder(responder))(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusOK, rec1.Code)
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusServiceUnavailable, rec2.Code)
+	assert.Equal(t, customBody, rec2.Body.String())
 }

--- a/resilience/ratelimit/ratelimit.go
+++ b/resilience/ratelimit/ratelimit.go
@@ -1,0 +1,99 @@
+package ratelimit
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// Result reports a limiter decision for one key.
+type Result struct {
+	Reset      time.Time // when the current window rolls
+	Limit      int64
+	Remaining  int64
+	RetryAfter time.Duration // 0 when Allowed
+	Allowed    bool
+}
+
+type config struct {
+	clk    clock.Clock
+	limit  int64
+	window time.Duration
+}
+
+// Option configures a Limiter.
+type Option func(*config)
+
+// WithLimit sets n requests allowed per window. Required.
+func WithLimit(n int64, per time.Duration) Option {
+	return func(c *config) {
+		c.limit = n
+		c.window = per
+	}
+}
+
+// WithClock injects a clock (for tests). Default clock.System().
+func WithClock(clk clock.Clock) Option {
+	return func(c *config) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+// Limiter is a keyed sliding-window-counter limiter over a Store.
+type Limiter struct {
+	store Store
+	cfg   config
+}
+
+// New builds a Limiter. The Store's lifecycle is the caller's.
+func New(store Store, opts ...Option) *Limiter {
+	c := config{limit: 100, window: time.Minute, clk: clock.System()}
+	for _, o := range opts {
+		o(&c)
+	}
+	if c.window <= 0 {
+		c.window = time.Minute
+	}
+	return &Limiter{store: store, cfg: c}
+}
+
+// Allow records one hit against key and reports whether it is within the limit,
+// using a weighted current+previous fixed-window estimate.
+func (l *Limiter) Allow(ctx context.Context, key string) (Result, error) {
+	now := l.cfg.clk.Now()
+	win := now.Truncate(l.cfg.window)
+	elapsed := now.Sub(win)
+
+	curKey := key + ":" + strconv.FormatInt(win.Unix(), 10)
+	prevKey := key + ":" + strconv.FormatInt(win.Add(-l.cfg.window).Unix(), 10)
+
+	cur, err := l.store.Incr(ctx, curKey, 1, 2*l.cfg.window)
+	if err != nil {
+		return Result{}, err
+	}
+	prev, err := l.store.Get(ctx, prevKey)
+	if err != nil {
+		return Result{}, err
+	}
+
+	weight := 1 - float64(elapsed)/float64(l.cfg.window)
+	est := float64(cur) + float64(prev)*weight
+
+	res := Result{Limit: l.cfg.limit, Reset: win.Add(l.cfg.window)}
+	if est > float64(l.cfg.limit) {
+		res.Allowed = false
+		res.Remaining = 0
+		// conservative: wait for the window to roll
+		res.RetryAfter = max(res.Reset.Sub(now), 0)
+		return res, nil
+	}
+	res.Allowed = true
+	rem := max(l.cfg.limit-int64(math.Ceil(est)), 0)
+	res.Remaining = rem
+	return res, nil
+}

--- a/resilience/ratelimit/ratelimit_test.go
+++ b/resilience/ratelimit/ratelimit_test.go
@@ -1,0 +1,44 @@
+package ratelimit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/resilience/ratelimit"
+)
+
+func TestLimiter_AllowsUpToLimit(t *testing.T) {
+	mk := clock.NewMock(time.Unix(0, 0))
+	l := ratelimit.New(
+		ratelimit.NewMemoryStore(ratelimit.WithMemoryClock(mk)),
+		ratelimit.WithLimit(3, time.Minute),
+		ratelimit.WithClock(mk),
+	)
+	ctx := context.Background()
+
+	for i := 1; i <= 3; i++ {
+		res, err := l.Allow(ctx, "user")
+		require.NoError(t, err)
+		assert.True(t, res.Allowed, "request %d should pass", i)
+		assert.Equal(t, int64(3), res.Limit)
+	}
+	res, err := l.Allow(ctx, "user")
+	require.NoError(t, err)
+	assert.False(t, res.Allowed)
+	assert.Equal(t, int64(0), res.Remaining)
+	assert.Positive(t, res.RetryAfter)
+}
+
+func TestLimiter_KeysAreIsolated(t *testing.T) {
+	l := ratelimit.New(ratelimit.NewMemoryStore(), ratelimit.WithLimit(1, time.Minute))
+	ctx := context.Background()
+	a, _ := l.Allow(ctx, "a")
+	b, _ := l.Allow(ctx, "b")
+	assert.True(t, a.Allowed)
+	assert.True(t, b.Allowed)
+}

--- a/resilience/ratelimit/redisstore/doc.go
+++ b/resilience/ratelimit/redisstore/doc.go
@@ -1,0 +1,8 @@
+// Package redisstore implements ratelimit.Store over a go-redis client, so a
+// sliding-window Limiter shares one counter across instances. Incr is a Lua
+// script that INCRBYs and sets the TTL only on the window's first hit; the
+// client's lifecycle stays with the caller.
+//
+//	store := redisstore.New(client, redisstore.WithPrefix("rl:"))
+//	limiter := ratelimit.New(store, ratelimit.WithLimit(100, time.Minute))
+package redisstore

--- a/resilience/ratelimit/redisstore/redisstore.go
+++ b/resilience/ratelimit/redisstore/redisstore.go
@@ -1,0 +1,68 @@
+package redisstore
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// incrScript increments the key and sets the TTL only on creation (when the new
+// value equals the delta), so a window's expiry is fixed at its first hit.
+var incrScript = redis.NewScript(`
+local v = redis.call('INCRBY', KEYS[1], ARGV[1])
+if v == tonumber(ARGV[1]) then
+  redis.call('PEXPIRE', KEYS[1], ARGV[2])
+end
+return v`)
+
+type config struct {
+	prefix string
+}
+
+// Option configures the Store.
+type Option func(*config)
+
+// WithPrefix namespaces all keys (e.g. "rl:").
+func WithPrefix(p string) Option { return func(c *config) { c.prefix = p } }
+
+// Store implements ratelimit.Store over a go-redis client. The client's
+// lifecycle is the caller's; Close is a no-op.
+type Store struct {
+	client redis.UniversalClient
+	prefix string
+}
+
+// New builds a Redis-backed counter Store.
+func New(client redis.UniversalClient, opts ...Option) *Store {
+	var c config
+	for _, o := range opts {
+		o(&c)
+	}
+	return &Store{client: client, prefix: c.prefix}
+}
+
+func (s *Store) key(k string) string { return s.prefix + k }
+
+// Incr atomically adds delta and sets ttl only when the key is newly created.
+func (s *Store) Incr(ctx context.Context, key string, delta int64, ttl time.Duration) (int64, error) {
+	return incrScript.Run(ctx, s.client, []string{s.key(key)}, delta, ttl.Milliseconds()).Int64()
+}
+
+// Get returns the counter, or 0 when absent.
+func (s *Store) Get(ctx context.Context, key string) (int64, error) {
+	n, err := s.client.Get(ctx, s.key(key)).Int64()
+	if errors.Is(err, redis.Nil) {
+		return 0, nil
+	}
+	return n, err
+}
+
+// Reset deletes the counter.
+func (s *Store) Reset(ctx context.Context, key string) error {
+	return s.client.Del(ctx, s.key(key)).Err()
+}
+
+// Close is a no-op; the client is owned by the caller.
+func (s *Store) Close() error { return nil }

--- a/resilience/ratelimit/redisstore/redisstore_test.go
+++ b/resilience/ratelimit/redisstore/redisstore_test.go
@@ -1,0 +1,48 @@
+package redisstore_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/resilience/ratelimit"
+	"github.com/dmitrymomot/forge/resilience/ratelimit/redisstore"
+)
+
+var _ ratelimit.Store = (*redisstore.Store)(nil)
+
+func dial(t *testing.T) redis.UniversalClient {
+	addr := os.Getenv("FORGE_TEST_REDIS_URL")
+	if addr == "" {
+		t.Skip("set FORGE_TEST_REDIS_URL (host:port) to run the redis integration test")
+	}
+	c := redis.NewClient(&redis.Options{Addr: addr})
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func TestRedisStore_IncrTTLAtomic(t *testing.T) {
+	client := dial(t)
+	s := redisstore.New(client, redisstore.WithPrefix("rltest:"))
+	ctx := context.Background()
+	key := "k-" + t.Name()
+	require.NoError(t, s.Reset(ctx, key))
+
+	n, err := s.Incr(ctx, key, 1, 500*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	n, err = s.Incr(ctx, key, 1, 500*time.Millisecond) // must NOT re-arm TTL
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+
+	time.Sleep(600 * time.Millisecond)
+	got, err := s.Get(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got) // expired at the FIRST incr's TTL, not extended
+}

--- a/resilience/ratelimit/store.go
+++ b/resilience/ratelimit/store.go
@@ -1,0 +1,22 @@
+package ratelimit
+
+import (
+	"context"
+	"time"
+)
+
+// Store is the windowed atomic-counter seam shared by ratelimit (and, later,
+// quota and lockout). It is distinct from cache.Store (byte-KV): counters need
+// atomic increment-with-TTL, which Get/Set cannot express race-free.
+type Store interface {
+	// Incr atomically adds delta to key's counter and returns the new value. If
+	// this call creates the key, its TTL is set to ttl; Incr never extends the
+	// TTL of an existing (live) key.
+	Incr(ctx context.Context, key string, delta int64, ttl time.Duration) (int64, error)
+	// Get returns the current counter, or 0 if the key is absent or expired.
+	Get(ctx context.Context, key string) (int64, error)
+	// Reset deletes the counter for key.
+	Reset(ctx context.Context, key string) error
+	// Close releases resources (e.g. a janitor goroutine).
+	Close() error
+}

--- a/web/httpclient/breaker.go
+++ b/web/httpclient/breaker.go
@@ -1,4 +1,18 @@
 package httpclient
 
-// buildBreaker returns nil until WithBreakerGroup is wired in Task 16.
-func buildBreaker(_ config) breakerFunc { return nil }
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/resilience/circuitbreaker"
+)
+
+// buildBreaker returns a per-host breaker func, or nil when the breaker is off.
+func buildBreaker(c config) breakerFunc {
+	if !c.useBreaker {
+		return nil
+	}
+	group := circuitbreaker.NewGroup(c.breakerOpts...)
+	return func(ctx context.Context, host string, fn func(context.Context) error) error {
+		return group.Do(ctx, host, fn)
+	}
+}

--- a/web/httpclient/breaker.go
+++ b/web/httpclient/breaker.go
@@ -1,0 +1,4 @@
+package httpclient
+
+// buildBreaker returns nil until WithBreakerGroup is wired in Task 16.
+func buildBreaker(_ config) breakerFunc { return nil }

--- a/web/httpclient/breaker_test.go
+++ b/web/httpclient/breaker_test.go
@@ -1,0 +1,52 @@
+package httpclient_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/resilience/circuitbreaker"
+	"github.com/dmitrymomot/forge/web/httpclient"
+)
+
+func TestBreaker_OptInTripsAfterFailures(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := httpclient.New(
+		httpclient.WithRetryMethods(), // disable retry to isolate the breaker
+		httpclient.WithBreakerGroup(circuitbreaker.WithBreakerOptions(circuitbreaker.WithFailureThreshold(2))),
+	)
+	// Drive failures past the threshold.
+	for range 3 {
+		resp, err := client.Get(srv.URL)
+		if err == nil && resp != nil {
+			_ = resp.Body.Close()
+		}
+	}
+	// Next call should fast-fail with ErrOpen.
+	_, err := client.Get(srv.URL)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, circuitbreaker.ErrOpen))
+}
+
+func TestBreaker_OffByDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := httpclient.New(httpclient.WithRetryMethods())
+	for range 10 {
+		resp, err := client.Get(srv.URL)
+		require.NoError(t, err) // 500 is a response, not an error; never ErrOpen
+		require.NotNil(t, resp)
+		_ = resp.Body.Close()
+	}
+}

--- a/web/httpclient/doc.go
+++ b/web/httpclient/doc.go
@@ -1,0 +1,27 @@
+// Package httpclient builds a resilient *http.Client (the stdlib type) from a
+// RoundTripper stack over the shipped retry/backoff/circuitbreaker packages:
+// static + context-derived headers and before/after hooks, jittered retry of
+// idempotent methods on transient failures (5xx/429/network, honoring
+// Retry-After), a per-attempt timeout, and an OPT-IN per-host circuit breaker.
+//
+//	client := httpclient.New(
+//		httpclient.WithPerAttemptTimeout(2*time.Second),
+//		httpclient.WithContextHeaders(func(ctx context.Context) http.Header {
+//			h := http.Header{}
+//			if id, ok := requestid.From(ctx); ok {
+//				h.Set("X-Request-ID", id)
+//			}
+//			return h
+//		}),
+//		httpclient.WithBreakerGroup(), // enable per-host breaker
+//	)
+//
+//	resp, err := client.Get(url)
+//	if err != nil { /* transport/breaker error */ }
+//	if err := problem.Decode(resp); err != nil { /* 4xx/5xx problem+json */ }
+//
+// Retry is on by default (3 attempts) for GET/HEAD/PUT/DELETE/OPTIONS only —
+// POST is excluded to avoid silent double-submits (override with
+// WithRetryMethods). New returns the stdlib *http.Client, so problem surfacing
+// is the companion problem.Decode call rather than a changed Do signature.
+package httpclient

--- a/web/httpclient/httpclient.go
+++ b/web/httpclient/httpclient.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -34,6 +35,11 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	var resp *http.Response
 	attempt := func(ctx context.Context) error {
+		if resp != nil { // a prior attempt's response is being superseded — release its connection
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			resp = nil
+		}
 		r := req.Clone(ctx)
 		if req.GetBody != nil { // replay the body on retried methods (PUT/DELETE with a body)
 			b, gErr := req.GetBody()

--- a/web/httpclient/httpclient.go
+++ b/web/httpclient/httpclient.go
@@ -75,9 +75,19 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	ctx := req.Context()
+	// The outer request context being canceled or hitting its overall deadline is
+	// terminal — never retry past it. Everything else is retryable: a retryable
+	// HTTP status (statusError), a network error, or a per-attempt timeout from
+	// WithPerAttemptTimeout — the latter surfaces as context.DeadlineExceeded but
+	// the outer ctx is still live (checked below), so the next attempt should run.
+	// The error alone can't distinguish an outer-ctx timeout from a per-attempt
+	// sub-context timeout (both wrap context.DeadlineExceeded), so this closure
+	// checks the outer ctx directly instead of inspecting err.
+	retryIf := func(err error) bool { return ctx.Err() == nil }
+
 	var err error
 	if t.cfg.retryMethods[req.Method] {
-		err = retry.Do(ctx, attempt, append([]retry.Option{retry.WithRetryIf(isRetryable)}, t.cfg.retryOpts...)...)
+		err = retry.Do(ctx, attempt, append([]retry.Option{retry.WithRetryIf(retryIf)}, t.cfg.retryOpts...)...)
 	} else {
 		err = attempt(ctx)
 	}
@@ -125,14 +135,6 @@ func (e statusError) RetryAfter() time.Duration { return e.retryAfter }
 
 func retryableStatus(code int) bool {
 	return code == http.StatusTooManyRequests || code >= 500
-}
-
-func isRetryable(err error) bool {
-	if _, ok := errors.AsType[statusError](err); ok {
-		return true
-	}
-	// network/transport errors are retryable; context cancellation is not.
-	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
 }
 
 func parseRetryAfter(resp *http.Response) time.Duration {

--- a/web/httpclient/httpclient.go
+++ b/web/httpclient/httpclient.go
@@ -1,0 +1,146 @@
+package httpclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/dmitrymomot/forge/resilience/retry"
+)
+
+// New returns a resilient *http.Client: a RoundTripper stack that decorates the
+// request (static/context headers, hooks), retries idempotent methods on
+// transient failures with jittered backoff (honoring Retry-After), and bounds
+// each attempt. It returns the stdlib type; problem+json surfacing is a
+// companion problem.Decode(resp) call.
+func New(opts ...Option) *http.Client {
+	c := newConfig(opts...)
+	return &http.Client{Transport: &transport{cfg: c, breaker: buildBreaker(c)}, Timeout: c.timeout}
+}
+
+type transport struct {
+	breaker breakerFunc // nil unless WithBreakerGroup set (Task 16)
+	cfg     config
+}
+
+// breakerFunc runs fn under a per-host breaker; nil means no breaker.
+type breakerFunc func(ctx context.Context, host string, fn func(context.Context) error) error
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.decorate(req)
+
+	var resp *http.Response
+	attempt := func(ctx context.Context) error {
+		r := req.Clone(ctx)
+		if req.GetBody != nil { // replay the body on retried methods (PUT/DELETE with a body)
+			b, gErr := req.GetBody()
+			if gErr != nil {
+				return retry.Permanent(gErr)
+			}
+			r.Body = b
+		}
+		call := func(ctx context.Context) error {
+			cctx := ctx
+			if t.cfg.perAttempt > 0 {
+				var cancel context.CancelFunc
+				cctx, cancel = context.WithTimeout(ctx, t.cfg.perAttempt)
+				defer cancel()
+			}
+			out, err := t.cfg.base.RoundTrip(r.WithContext(cctx))
+			if err != nil {
+				return err
+			}
+			resp = out
+			for _, fn := range t.cfg.after {
+				fn(r, out)
+			}
+			if retryableStatus(out.StatusCode) {
+				return statusError{code: out.StatusCode, retryAfter: parseRetryAfter(out)}
+			}
+			return nil
+		}
+		if t.breaker != nil {
+			return t.breaker(ctx, req.URL.Host, call)
+		}
+		return call(ctx)
+	}
+
+	ctx := req.Context()
+	var err error
+	if t.cfg.retryMethods[req.Method] {
+		err = retry.Do(ctx, attempt, append([]retry.Option{retry.WithRetryIf(isRetryable)}, t.cfg.retryOpts...)...)
+	} else {
+		err = attempt(ctx)
+	}
+
+	// A bad-status "error" is internal to drive retry; return the response, not an error.
+	if _, ok := errors.AsType[statusError](err); ok {
+		return resp, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (t *transport) decorate(req *http.Request) {
+	for k, vs := range t.cfg.headers {
+		for _, v := range vs {
+			req.Header.Set(k, v)
+		}
+	}
+	if t.cfg.userAgent != "" {
+		req.Header.Set("User-Agent", t.cfg.userAgent)
+	}
+	for _, fn := range t.cfg.ctxHeaders {
+		for k, vs := range fn(req.Context()) {
+			for _, v := range vs {
+				req.Header.Set(k, v)
+			}
+		}
+	}
+	for _, fn := range t.cfg.before {
+		fn(req)
+	}
+}
+
+// statusError carries a retryable HTTP status and any Retry-After hint, so
+// retry (which honors retry.RetryAfterError) can raise the delay floor.
+type statusError struct {
+	code       int
+	retryAfter time.Duration
+}
+
+func (e statusError) Error() string             { return fmt.Sprintf("httpclient: server returned %d", e.code) }
+func (e statusError) RetryAfter() time.Duration { return e.retryAfter }
+
+func retryableStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code >= 500
+}
+
+func isRetryable(err error) bool {
+	if _, ok := errors.AsType[statusError](err); ok {
+		return true
+	}
+	// network/transport errors are retryable; context cancellation is not.
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
+}
+
+func parseRetryAfter(resp *http.Response) time.Duration {
+	v := resp.Header.Get("Retry-After")
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if when, err := http.ParseTime(v); err == nil {
+		if d := time.Until(when); d > 0 {
+			return d
+		}
+	}
+	return 0
+}

--- a/web/httpclient/httpclient.go
+++ b/web/httpclient/httpclient.go
@@ -23,7 +23,7 @@ func New(opts ...Option) *http.Client {
 }
 
 type transport struct {
-	breaker breakerFunc // nil unless WithBreakerGroup set (Task 16)
+	breaker breakerFunc // nil unless WithBreakerGroup is set
 	cfg     config
 }
 

--- a/web/httpclient/httpclient_test.go
+++ b/web/httpclient/httpclient_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,6 +76,36 @@ func TestNew_PropagatesContextHeaders(t *testing.T) {
 	_, _ = io.Copy(io.Discard, resp.Body)
 	_ = resp.Body.Close()
 	assert.Equal(t, "rid-1", got)
+}
+
+// TestNew_RetriesPerAttemptTimeout proves WithPerAttemptTimeout aborts a slow
+// attempt and retries the next one, rather than failing the whole request.
+// The outer request context has no deadline, so only the per-attempt
+// sub-context should expire on the first (slow) call.
+func TestNew_RetriesPerAttemptTimeout(t *testing.T) {
+	const perAttempt = 50 * time.Millisecond
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			select {
+			case <-r.Context().Done(): // client canceled the slow first attempt
+			case <-time.After(10 * perAttempt): // safety net if not canceled
+			}
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := httpclient.New(httpclient.WithPerAttemptTimeout(perAttempt))
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.GreaterOrEqual(t, calls.Load(), int32(2), "per-attempt timeout must be retried")
 }
 
 type ctxKey struct{}

--- a/web/httpclient/httpclient_test.go
+++ b/web/httpclient/httpclient_test.go
@@ -1,6 +1,7 @@
 package httpclient_test
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -77,3 +78,54 @@ func TestNew_PropagatesContextHeaders(t *testing.T) {
 }
 
 type ctxKey struct{}
+
+// trackedBody wraps a response body and records whether Close was called, so
+// tests can prove a superseded (retried-past) response was released.
+type trackedBody struct {
+	io.Reader
+	closed atomic.Bool
+}
+
+func (b *trackedBody) Close() error {
+	b.closed.Store(true)
+	return nil
+}
+
+// roundTripFunc adapts a function to http.RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestNew_ClosesSupersededRetryResponseBody(t *testing.T) {
+	firstBody := &trackedBody{Reader: bytes.NewBufferString("first")}
+	secondBody := &trackedBody{Reader: bytes.NewBufferString("second")}
+
+	var calls atomic.Int32
+	base := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Body:       firstBody,
+				Header:     make(http.Header),
+				Request:    r,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       secondBody,
+			Header:     make(http.Header),
+			Request:    r,
+		}, nil
+	})
+
+	client := httpclient.New(httpclient.WithBaseTransport(base))
+	resp, err := client.Get("http://example.invalid/")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), calls.Load())
+	assert.True(t, firstBody.closed.Load(), "superseded 503 response body must be drained and closed")
+	assert.False(t, secondBody.closed.Load(), "final 200 response body must remain open for the caller")
+}

--- a/web/httpclient/httpclient_test.go
+++ b/web/httpclient/httpclient_test.go
@@ -1,0 +1,79 @@
+package httpclient_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/web/httpclient"
+)
+
+func TestNew_RetriesTransient503ThenSucceeds(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := httpclient.New()
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestNew_DoesNotRetryPOSTByDefault(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	client := httpclient.New()
+	resp, err := client.Post(srv.URL, "text/plain", nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, int32(1), calls.Load()) // POST not retried
+}
+
+func TestNew_PropagatesContextHeaders(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("X-Request-ID")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := httpclient.New(
+		httpclient.WithContextHeaders(func(ctx context.Context) http.Header {
+			h := http.Header{}
+			if v, ok := ctx.Value(ctxKey{}).(string); ok {
+				h.Set("X-Request-ID", v)
+			}
+			return h
+		}),
+	)
+	req, _ := http.NewRequestWithContext(context.WithValue(context.Background(), ctxKey{}, "rid-1"), http.MethodGet, srv.URL, nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	assert.Equal(t, "rid-1", got)
+}
+
+type ctxKey struct{}

--- a/web/httpclient/options.go
+++ b/web/httpclient/options.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/dmitrymomot/forge/resilience/circuitbreaker"
 	"github.com/dmitrymomot/forge/resilience/retry"
 )
 
@@ -17,8 +18,10 @@ type config struct {
 	before       []func(*http.Request)
 	after        []func(*http.Request, *http.Response)
 	ctxHeaders   []func(context.Context) http.Header
+	breakerOpts  []circuitbreaker.GroupOption
 	timeout      time.Duration
 	perAttempt   time.Duration
+	useBreaker   bool
 }
 
 func newConfig(opts ...Option) config {
@@ -87,3 +90,13 @@ func WithHeader(key, value string) Option { return func(c *config) { c.headers.S
 
 // WithUserAgent sets the User-Agent header on every request.
 func WithUserAgent(ua string) Option { return func(c *config) { c.userAgent = ua } }
+
+// WithBreakerGroup enables a per-host circuit breaker (off by default). Each
+// attempt runs inside a circuitbreaker.Group keyed by request host; the breaker's
+// open error carries Retry-After, so retry and breaker cooperate.
+func WithBreakerGroup(opts ...circuitbreaker.GroupOption) Option {
+	return func(c *config) {
+		c.useBreaker = true
+		c.breakerOpts = append(c.breakerOpts, opts...)
+	}
+}

--- a/web/httpclient/options.go
+++ b/web/httpclient/options.go
@@ -1,0 +1,89 @@
+package httpclient
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/dmitrymomot/forge/resilience/retry"
+)
+
+type config struct {
+	base         http.RoundTripper
+	retryMethods map[string]bool
+	headers      http.Header
+	userAgent    string
+	retryOpts    []retry.Option
+	before       []func(*http.Request)
+	after        []func(*http.Request, *http.Response)
+	ctxHeaders   []func(context.Context) http.Header
+	timeout      time.Duration
+	perAttempt   time.Duration
+}
+
+func newConfig(opts ...Option) config {
+	c := config{
+		base:         http.DefaultTransport,
+		retryMethods: map[string]bool{http.MethodGet: true, http.MethodHead: true, http.MethodPut: true, http.MethodDelete: true, http.MethodOptions: true},
+		headers:      http.Header{},
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// Option configures the client.
+type Option func(*config)
+
+// WithTimeout sets the overall http.Client timeout.
+func WithTimeout(d time.Duration) Option { return func(c *config) { c.timeout = d } }
+
+// WithPerAttemptTimeout bounds each individual attempt via context.
+func WithPerAttemptTimeout(d time.Duration) Option { return func(c *config) { c.perAttempt = d } }
+
+// WithRetry tunes the retry policy (default 3 attempts, jittered backoff).
+func WithRetry(opts ...retry.Option) Option {
+	return func(c *config) { c.retryOpts = append(c.retryOpts, opts...) }
+}
+
+// WithRetryMethods sets which HTTP methods are retried (default idempotent: GET,HEAD,PUT,DELETE,OPTIONS).
+func WithRetryMethods(methods ...string) Option {
+	return func(c *config) {
+		c.retryMethods = map[string]bool{}
+		for _, m := range methods {
+			c.retryMethods[m] = true
+		}
+	}
+}
+
+// WithBaseTransport sets the innermost RoundTripper (default http.DefaultTransport).
+func WithBaseTransport(rt http.RoundTripper) Option {
+	return func(c *config) {
+		if rt != nil {
+			c.base = rt
+		}
+	}
+}
+
+// WithBefore runs fn on each outbound request before it is sent.
+func WithBefore(fn func(*http.Request)) Option {
+	return func(c *config) { c.before = append(c.before, fn) }
+}
+
+// WithAfter runs fn after each response is received.
+func WithAfter(fn func(*http.Request, *http.Response)) Option {
+	return func(c *config) { c.after = append(c.after, fn) }
+}
+
+// WithContextHeaders copies headers derived from the request context onto the
+// outbound request (e.g. X-Request-ID, traceparent).
+func WithContextHeaders(fn func(context.Context) http.Header) Option {
+	return func(c *config) { c.ctxHeaders = append(c.ctxHeaders, fn) }
+}
+
+// WithHeader sets a static header on every request.
+func WithHeader(key, value string) Option { return func(c *config) { c.headers.Set(key, value) } }
+
+// WithUserAgent sets the User-Agent header on every request.
+func WithUserAgent(ua string) Option { return func(c *config) { c.userAgent = ua } }


### PR DESCRIPTION
## Wave 1 completion bundle

Completes build-order Wave 1 by shipping four packages plus two shared unblockers, all following forge's design DNA (free-funcs or `New(...Option)`, single-line `errors.Is`-matchable sentinels, `doc.go` runnable examples, black-box tests only).

### What's included

**Unblockers**
- **`core/structfields.SetString`** — parses a string into a struct field by its kind (string/bool/all int-uint widths/float/`time.Duration`/`time.Time`/`[]string`), dispatching to concrete widths so `typeconv`'s overflow check rejects out-of-range values instead of silently truncating.
- **`ops/supervisor.WithPreShutdown`** — ordered pre-shutdown phase: hooks run to completion (bounded by `WithPreShutdownTimeout`, default 30s) after the stop signal but **before** each service's context is cancelled, so readiness can flip and load balancers can deregister while services still serve. `Run`'s context wiring was corrected to `context.WithCancel(context.WithoutCancel(ctx))` + watching `ctx.Done()` as a trigger, so parent-ctx cancellation routes through the pre-shutdown phase instead of racing it.

**`ops/config`** — layered application config:
- `Load[T]` reads `{dir}/{profile}.yaml` with `${VAR:default}` substitution (default used when the var is unset **or** empty; first-colon split so defaults may contain URLs), `SetDefaults()` before decode / `Validate()` after.
- `Dotenv` — `.env` inheritance with real-env-wins precedence.
- `LoadEnv[T]`/`Populate` — 12-factor env-tag struct decode with `default=`/`required` options and nested-struct prefixing.
- `Profile()` + `IsDev/IsProd/IsTest/IsStaging`.
- Adds `gopkg.in/yaml.v3` as an isolated dependency used solely by this package.

**`resilience/ratelimit`** (+ `ratelimit/redisstore`):
- A counter `Store` seam (atomic increment-with-TTL, distinct from `cache.Store`) with an in-memory backend and a Redis backend (Lua `INCRBY` + create-only `PEXPIRE`, so a window's expiry is fixed at its first hit).
- A sliding-window-counter `Limiter` and an HTTP middleware emitting IETF `RateLimit-*` headers on every response, a `429` + `Retry-After` on limit, and failing **open** on a store error.

**`ops/health`** — a single pull-evaluated handler factory:
- No checks → `200` (liveness); critical check failure → `503`; non-critical failure → `"degraded"` `200`. Per-check timeout; panicking checks are recovered into failed results rather than crashing the process.
- A `Gate` drain primitive that flips `/readyz` to `503`, composing with `supervisor.WithPreShutdown` for graceful drain.

**`web/httpclient`** — a resilient `*http.Client` (the stdlib type):
- RoundTripper stack over the shipped `retry`/`backoff`/`circuitbreaker` packages: static + context-derived headers and before/after hooks, jittered retry of idempotent methods on transient failures (5xx/429/network, honoring `Retry-After`; POST excluded), a per-attempt timeout, and an opt-in per-host circuit breaker.
- Discarded retry responses are drained and closed so connections return to the pool.

### Testing & verification

- `just test ./...` — all packages pass under `-race` (the `redisstore` integration test skips without `FORGE_TEST_REDIS_URL`).
- `just lint` — 0 issues (vet, build, golangci-lint, nilaway, betteralign, modernize).
- `go tool modernize ./...` — no changes.
- Per-package coverage: structfields 83%, config 84.9%, health 94.8%, supervisor 96.8%, ratelimit 93%, httpclient 65.4%.

### Follow-ups (backlog, not blocking)

- `resilience/ratelimit` in-memory store never evicts expired entries — wire a janitor into the reserved `Store.Close` before using the memory backend for untrusted per-IP keys in production.
- `web/httpclient` `RoundTrip` decorates the request before cloning (harmless under `http.Client.Do`; clone-before-decorate would satisfy the `http.RoundTripper` contract strictly).
- A few `ops/config` godoc clarifications (nested-struct option semantics, `Load` hook ordering).

`docs/packages.md` is updated to mark these packages shipped.
