### PR TITLE
feat(ops): runtime-bootstrap bundle (buildinfo, automaxprocs, logredact, bootstrap + supervisor.WithContext)

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -166,9 +166,9 @@ forge/                              # single go.mod at the root
 │
 ├── ops/           # runtime, lifecycle, observability, app bootstrap
 │   # shipped: supervisor logger (logger/sentry) config health
-│   # planned: buildinfo automaxprocs diag metrics
-│   #          (metrics/prometheus) logredact auditlog (auditlog/pgsink)
-│   #          featureflag cli appmain
+│   #          buildinfo automaxprocs logredact bootstrap
+│   # planned: diag metrics (metrics/prometheus)
+│   #          auditlog (auditlog/pgsink) featureflag cli
 │   # icebox:  tracing (tracing/otel) secretsource logsample configwatch term
 │
 └── testkit/       # black-box test harnesses
@@ -502,7 +502,8 @@ Icebox:
 
 ### ops/
 
-Shipped: `supervisor logger (logger/sentry) config health`. (`config` —
+Shipped: `supervisor logger (logger/sentry) config health buildinfo
+automaxprocs logredact bootstrap`. (`config` —
 formerly planned as `envconfig`, shipped renamed — layers app config from
 YAML per-env files with `${VAR:default}` substitution, `.env` inheritance,
 and env-tagged structs via `structfields` + `typeconv`; exported `Profile`
@@ -510,13 +511,25 @@ enum (dev/test/staging/prod) with predicates; boot-time only.
 `health` — a single pull-evaluated `Handler()` factory for liveness (no
 checks) and readiness (`WithCheck` checks, critical by default, `NonCritical`
 degrades instead of 503) plus a `Gate` for ordered pre-shutdown drain via
-`supervisor.WithPreShutdown`.)
+`supervisor.WithPreShutdown`.
+`buildinfo` — value type merging ldflags over `ReadBuildInfo` for
+version/commit/build-time/dirty; `fmt.Stringer` + `slog.LogValuer` +
+`/version` JSON handler.
+`automaxprocs` — sets GOMAXPROCS/GOMEMLIMIT from cgroup CPU/memory quotas at
+startup via a local stdlib parser (v2 primary, v1 fallback, no uber dep);
+fail-open logged no-op outside containers, honors explicit env vars.
+`logredact` — `slog.Handler` wrapper replacing attribute values by leaf key
+or dotted group path before they reach the next handler; unconditional at
+every level (no bypass knob), redacts `WithAttrs`-baked attrs and tracks the
+`WithGroup` prefix. `crypto/redact` covers values you wrap; this is the
+safety net for attrs you don't control.
+`bootstrap` — thin runtime integrator (replaces the planned `appmain` name):
+`Run` / generic `RunWithConfig[T]` wire logger → automaxprocs → build-info
+log → config autoload → signal context (via `supervisor.NewContext`) → exit
+code; the callback owns `supervisor.Run` and `defer` cleanup. NOT a DI
+container. This bundle also added `supervisor.WithContext(parent)` so the
+signal context can root at a caller's context.)
 
-- **`buildinfo`** — recommended. Version/commit/build-time/dirty from ldflags
-  + `ReadBuildInfo`; `slog.LogValuer` + /version handler.
-- **`automaxprocs`** — recommended. Set GOMAXPROCS/GOMEMLIMIT from cgroup
-  quotas at startup (local parser, no uber dep); logged no-op outside
-  containers.
 - **`diag`** — recommended. One internal diagnostics surface:
   `/debug/pprof/*`, `/debug/stats` (runtime/GC/goroutines JSON),
   `/debug/vars`, with an auth guard and a dedicated-port
@@ -524,10 +537,6 @@ degrades instead of 503) plus a `Gate` for ordered pre-shutdown drain via
 - **`metrics`** (+`metrics/prometheus`) — recommended. Counter/Gauge/
   Histogram `Recorder` facade with an expvar default + request middleware;
   prometheus is the only adapter.
-- **`logredact`** — recommended. `slog.Handler` wrapper redacting attribute
-  values by key/dotted path before they reach the next handler (MinLevel
-  bypass). `crypto/redact` covers values you wrap; this is the safety net for
-  attrs you don't control.
 - **`auditlog`** (+`auditlog/pgsink`) — recommended. Append-only structured
   audit events (actor/action/resource/outcome) over a `Sink` seam; slog +
   JSONL sinks in core; `pgsink` adds the pgx insert + keyset-paginated
@@ -537,9 +546,6 @@ degrades instead of 503) plus a `Gate` for ordered pre-shutdown drain via
 - **`cli`** — recommended. Struct-described command tree over stdlib
   `flag.FlagSet`, ctx-aware Run, auto help; no cobra, no global registry.
   Covers serve/migrate/worker/seed/version.
-- **`appmain`** — recommended. main() glue: signal context (via
-  `supervisor.NewContext`) + logger + supervisor + automaxprocs → exit code.
-  Explicit build callback; NOT a DI container.
 
 Icebox:
 
@@ -584,9 +590,8 @@ Each wave depends only on earlier ones. Icebox packages slot in wherever
 demand appears.
 
 1. **Web boundary + ops glue** — `assets`, `iplist`, `webhookverify`,
-   `autocert`, `captcha`, `idempotency`; `buildinfo`, `automaxprocs`, `diag`,
-   `metrics`, `logredact`, `featureflag`, `cli`, `appmain`; `webtest`,
-   `htmltest`, `dbtest` (harnesses pay off earliest).
+   `autocert`, `captcha`, `idempotency`; `diag`, `metrics`, `featureflag`,
+   `cli`; `webtest`, `htmltest`, `dbtest` (harnesses pay off earliest).
 2. **Data + messaging** — `pagination`, `tenant`, `dataloader`,
    `objectstore`; `jobqueue` → `scheduler`, `eventbus`; `lock`, `loadshed`,
    `quota`; `auditlog`.

--- a/docs/superpowers/plans/2026-07-07-ops-runtime-bootstrap-bundle.md
+++ b/docs/superpowers/plans/2026-07-07-ops-runtime-bootstrap-bundle.md
@@ -1,0 +1,889 @@
+# Ops Runtime-Bootstrap Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship four `ops/` packages — `buildinfo`, `automaxprocs`, `logredact`, `bootstrap` — plus a `supervisor.WithContext` addition, giving a forge app a one-line `main()` with runtime tuning, build identity, log redaction, and generic config autoload.
+
+**Architecture:** Three independent leaf packages (`buildinfo`, `automaxprocs`, `logredact`) and one shipped-package addition (`supervisor.WithContext`) are built first, in any order. `bootstrap` composes all of them plus `logger`/`config` into `Run` / `RunWithConfig[T]`, delegating signal handling to `supervisor.NewContext` and owning only the runtime edges (logger → automaxprocs → buildinfo log → config load → signal ctx → exit code). The app body it calls owns `supervisor.Run` and `defer`-based cleanup.
+
+**Tech Stack:** Go 1.26, stdlib only for the leaves (`runtime`, `runtime/debug`, `log/slog`, `net/http`, `os`, `os/signal`); `bootstrap` imports its `ops/` siblings. Companion design spec with complete reference implementations: [`docs/superpowers/specs/2026-07-07-ops-runtime-bootstrap-bundle-design.md`](../specs/2026-07-07-ops-runtime-bootstrap-bundle-design.md).
+
+## Global Constraints
+
+- **Module:** `github.com/dmitrymomot/forge`; Go 1.26 (`new(expr)` allowed, no `ptr.To` wrappers).
+- **Black-box tests ONLY** — every test file is `package <pkg>_test`.
+- **Options pattern, never builders** — `type Option func(*config)`.
+- **`errors.Is`-matchable sentinels** where a package returns errors (none of the leaves define new sentinels; they either don't error or return stdlib/loader errors).
+- **`doc.go` per package** with a runnable `Example`.
+- **Reference implementations are authoritative in the spec.** Each implementation step names the spec section (e.g. "spec §1a") whose code block you reproduce **verbatim**. Read that section before implementing. Do not paraphrase.
+- **Formatting:** after editing a package run `just fmt ./ops/<pkg>/...` (package-path form — the single-file form trips a spurious betteralign error).
+- **Linting:** run `just lint` once at the end of the bundle; fix everything it reports.
+- **Commits:** conventional-commit subjects; **no Claude attribution / co-author trailers** in any commit message.
+- Tasks 1–4 are independent leaves and may be implemented in any order or in parallel. Task 5 (`bootstrap`) depends on all four.
+
+## File Structure
+
+```
+ops/buildinfo/buildinfo.go       Info value type + Read/String/LogValue/Handler + ldflags vars
+ops/buildinfo/buildinfo_test.go  black-box tests
+ops/buildinfo/doc.go             package doc + runnable Example
+
+ops/automaxprocs/automaxprocs.go config/options (+WithCgroupRoot), Set, applyCPU, applyMemory
+ops/automaxprocs/cgroup.go       cpuQuota(root)/memoryLimit(root) + pure parseCPUMax/parseMemMax/validMem + readInt
+ops/automaxprocs/automaxprocs_test.go  black-box tests via WithCgroupRoot fixtures
+ops/automaxprocs/doc.go          package doc
+
+ops/logredact/logredact.go       config/options + slog.Handler (Enabled/Handle/WithAttrs/WithGroup) + redact
+ops/logredact/logredact_test.go  black-box tests
+ops/logredact/doc.go             package doc + runnable Example
+
+ops/supervisor/options.go        + WithContext(parent) ContextOption; contextConfig.parent field (MODIFY)
+ops/supervisor/context.go        NewContext resolves parent, default context.Background (MODIFY)
+ops/supervisor/context_withcontext_test.go  black-box tests for the addition
+
+ops/bootstrap/bootstrap.go       Func, ConfigFunc[T], options, Run, RunWithConfig[T], run, buildLogger, loadConfig
+ops/bootstrap/bootstrap_test.go  black-box tests
+ops/bootstrap/doc.go             package doc + canonical RunWithConfig main() Example
+```
+
+---
+
+### Task 1: `ops/buildinfo`
+
+**Files:**
+- Create: `ops/buildinfo/buildinfo.go`
+- Create: `ops/buildinfo/doc.go`
+- Test: `ops/buildinfo/buildinfo_test.go`
+
+**Interfaces:**
+- Consumes: nothing (stdlib only).
+- Produces:
+  - `type Info struct { Version, Commit, BuildTime, GoVersion string; Dirty bool }` (JSON tags per spec §1a)
+  - `func Read() Info`
+  - `func (Info) String() string`
+  - `func (Info) LogValue() slog.Value`
+  - `func (Info) Handler() http.Handler`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/buildinfo/buildinfo_test.go`:
+
+```go
+package buildinfo_test
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/buildinfo"
+)
+
+func TestReadPopulatesGoVersion(t *testing.T) {
+	if buildinfo.Read().GoVersion == "" {
+		t.Fatal("Read().GoVersion must be populated from runtime.Version()")
+	}
+}
+
+func TestInfoString(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   buildinfo.Info
+		want string
+	}{
+		{"empty renders dev", buildinfo.Info{}, "dev"},
+		{"version only", buildinfo.Info{Version: "1.2.3"}, "1.2.3"},
+		{"version commit time", buildinfo.Info{Version: "1.2.3", Commit: "abcdef1234567890", BuildTime: "2026-07-07T12:00:00Z"}, "1.2.3 (abcdef123456 2026-07-07T12:00:00Z)"},
+		{"short commit kept whole", buildinfo.Info{Version: "1.2.3", Commit: "abc1234"}, "1.2.3 (abc1234)"},
+		{"dirty flag", buildinfo.Info{Version: "1.2.3", Commit: "abc1234", Dirty: true}, "1.2.3 (abc1234, dirty)"},
+		{"dev dirty no meta", buildinfo.Info{Dirty: true}, "dev (dirty)"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.in.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInfoLogValueGroups(t *testing.T) {
+	var buf strings.Builder
+	slog.New(slog.NewJSONHandler(&buf, nil)).
+		Info("msg", slog.Any("build", buildinfo.Info{Version: "1.2.3", Commit: "abc1234def", GoVersion: "go1.26", Dirty: true}))
+
+	var rec map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &rec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	grp, ok := rec["build"].(map[string]any)
+	if !ok {
+		t.Fatalf("build attr is not a group: %T", rec["build"])
+	}
+	if grp["version"] != "1.2.3" {
+		t.Errorf("version = %v", grp["version"])
+	}
+	if grp["dirty"] != true {
+		t.Errorf("dirty = %v", grp["dirty"])
+	}
+}
+
+func TestInfoLogValueOmitsDirtyWhenFalse(t *testing.T) {
+	var buf strings.Builder
+	slog.New(slog.NewJSONHandler(&buf, nil)).
+		Info("msg", slog.Any("build", buildinfo.Info{Version: "1.2.3"}))
+	if strings.Contains(buf.String(), "dirty") {
+		t.Errorf("dirty should be omitted when false: %s", buf.String())
+	}
+}
+
+func TestInfoHandlerServesJSON(t *testing.T) {
+	rr := httptest.NewRecorder()
+	buildinfo.Info{Version: "1.2.3", Commit: "abc"}.Handler().
+		ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/version", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q", ct)
+	}
+	var got buildinfo.Info
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Version != "1.2.3" || got.Commit != "abc" {
+		t.Errorf("decoded = %+v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./ops/buildinfo/`
+Expected: FAIL — `package .../buildinfo: no Go files` / undefined `buildinfo.Info`, `Read`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/buildinfo/buildinfo.go` by reproducing **spec §1a** verbatim (the `Info` type, ldflags vars, `Read`, `versionOrDev`, `shortCommit`, `String`, `LogValue`, `Handler`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./ops/buildinfo/`
+Expected: PASS (all sub-tests).
+
+- [ ] **Step 5: Write doc.go**
+
+Create `ops/buildinfo/doc.go`: package comment plus a runnable `Example` that prints `buildinfo.Read().String()` shape (per spec §1b). Keep the `Example` output deterministic (assert on a constructed `Info{}`, not `Read()`, if you add `// Output:`).
+
+- [ ] **Step 6: Format**
+
+Run: `just fmt ./ops/buildinfo/...`
+Expected: no diff errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ops/buildinfo/
+git commit -m "feat(ops/buildinfo): build identity from ldflags + ReadBuildInfo"
+```
+
+---
+
+### Task 2: `ops/automaxprocs`
+
+**Files:**
+- Create: `ops/automaxprocs/automaxprocs.go`
+- Create: `ops/automaxprocs/cgroup.go`
+- Create: `ops/automaxprocs/doc.go`
+- Test: `ops/automaxprocs/automaxprocs_test.go`
+
+**Interfaces:**
+- Consumes: nothing (stdlib only).
+- Produces:
+  - `func Set(log *slog.Logger, opts ...Option) (undo func())`
+  - Options: `WithMemoryHeadroom(float64)`, `WithMinProcs(int)`, `WithCPU(bool)`, `WithMemory(bool)`, `WithCgroupRoot(string)`
+  - Unexported (tested via `Set(WithCgroupRoot(tmp))`): `cpuQuota(root)`, `memoryLimit(root)`, `parseCPUMax`, `parseMemMax`, `validMem`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/automaxprocs/automaxprocs_test.go`:
+
+```go
+package automaxprocs_test
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/automaxprocs"
+)
+
+func nopLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// clearRuntimeEnv blanks GOMAXPROCS/GOMEMLIMIT for the test; Set treats "" as
+// unset. t.Setenv restores originals on cleanup.
+func clearRuntimeEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("GOMAXPROCS", "")
+	t.Setenv("GOMEMLIMIT", "")
+}
+
+func writeV2(t *testing.T, cpuMax, memMax string) string {
+	t.Helper()
+	root := t.TempDir()
+	if cpuMax != "" {
+		if err := os.WriteFile(filepath.Join(root, "cpu.max"), []byte(cpuMax), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if memMax != "" {
+		if err := os.WriteFile(filepath.Join(root, "memory.max"), []byte(memMax), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestSetV2CPUQuota(t *testing.T) {
+	clearRuntimeEnv(t)
+	prev := runtime.GOMAXPROCS(0)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "300000 100000", "")),
+		automaxprocs.WithMemory(false))
+	if got := runtime.GOMAXPROCS(0); got != 3 {
+		t.Errorf("GOMAXPROCS = %d, want 3", got)
+	}
+	undo()
+	if got := runtime.GOMAXPROCS(0); got != prev {
+		t.Errorf("undo left GOMAXPROCS = %d, want %d", got, prev)
+	}
+}
+
+func TestSetV2CPUFloorsToMinOne(t *testing.T) {
+	clearRuntimeEnv(t)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "150000 100000", "")), // 1.5 -> floor 1
+		automaxprocs.WithMemory(false))
+	defer undo()
+	if got := runtime.GOMAXPROCS(0); got != 1 {
+		t.Errorf("GOMAXPROCS = %d, want 1", got)
+	}
+}
+
+func TestSetV2CPUUnlimitedLeavesDefault(t *testing.T) {
+	clearRuntimeEnv(t)
+	prev := runtime.GOMAXPROCS(0)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "max 100000", "")),
+		automaxprocs.WithMemory(false))
+	defer undo()
+	if got := runtime.GOMAXPROCS(0); got != prev {
+		t.Errorf("GOMAXPROCS = %d, want unchanged %d", got, prev)
+	}
+}
+
+func TestSetV1CPUQuota(t *testing.T) {
+	clearRuntimeEnv(t)
+	root := t.TempDir()
+	cpuDir := filepath.Join(root, "cpu")
+	if err := os.MkdirAll(cpuDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(cpuDir, "cpu.cfs_quota_us"), []byte("400000"), 0o644)
+	os.WriteFile(filepath.Join(cpuDir, "cpu.cfs_period_us"), []byte("100000"), 0o644)
+	undo := automaxprocs.Set(nopLogger(), automaxprocs.WithCgroupRoot(root), automaxprocs.WithMemory(false))
+	defer undo()
+	if got := runtime.GOMAXPROCS(0); got != 4 {
+		t.Errorf("v1 GOMAXPROCS = %d, want 4", got)
+	}
+}
+
+func TestSetV2MemoryHeadroom(t *testing.T) {
+	clearRuntimeEnv(t)
+	prev := debug.SetMemoryLimit(-1)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "", "1000000000")),
+		automaxprocs.WithCPU(false),
+		automaxprocs.WithMemoryHeadroom(0.9))
+	if got := debug.SetMemoryLimit(-1); got != 900000000 {
+		t.Errorf("GOMEMLIMIT = %d, want 900000000", got)
+	}
+	undo()
+	if got := debug.SetMemoryLimit(-1); got != prev {
+		t.Errorf("undo left GOMEMLIMIT = %d, want %d", got, prev)
+	}
+}
+
+func TestSetV2MemoryUnlimited(t *testing.T) {
+	clearRuntimeEnv(t)
+	prev := debug.SetMemoryLimit(-1)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "", "max")),
+		automaxprocs.WithCPU(false))
+	defer undo()
+	if got := debug.SetMemoryLimit(-1); got != prev {
+		t.Errorf("GOMEMLIMIT = %d, want unchanged %d", got, prev)
+	}
+}
+
+func TestSetEnvPresentSkipsCPU(t *testing.T) {
+	t.Setenv("GOMAXPROCS", "7") // runtime read env at startup; Set must not override
+	t.Setenv("GOMEMLIMIT", "")
+	prev := runtime.GOMAXPROCS(0)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "300000 100000", "")),
+		automaxprocs.WithMemory(false))
+	defer undo()
+	if got := runtime.GOMAXPROCS(0); got != prev {
+		t.Errorf("env present must skip CPU leg; GOMAXPROCS = %d, want %d", got, prev)
+	}
+}
+
+func TestSetMissingRootIsNoOp(t *testing.T) {
+	clearRuntimeEnv(t)
+	prevP, prevM := runtime.GOMAXPROCS(0), debug.SetMemoryLimit(-1)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(filepath.Join(t.TempDir(), "nonexistent")))
+	defer undo()
+	if runtime.GOMAXPROCS(0) != prevP || debug.SetMemoryLimit(-1) != prevM {
+		t.Error("missing cgroup root should be a no-op")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./ops/automaxprocs/`
+Expected: FAIL — undefined `automaxprocs.Set` / `WithCgroupRoot`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/automaxprocs/automaxprocs.go` from **spec §2a** (config, all options incl. `WithCgroupRoot`, `Set`, `applyCPU`, `applyMemory`) and `ops/automaxprocs/cgroup.go` from **spec §2b** (`cpuQuota(root)`, `parseCPUMax`, `memoryLimit(root)`, `parseMemMax`, `validMem`, `readInt`, `unlimited`). Reproduce both verbatim.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./ops/automaxprocs/`
+Expected: PASS. (Tests mutate process-global GOMAXPROCS/GOMEMLIMIT and restore via `undo`; they must not use `t.Parallel()`.)
+
+- [ ] **Step 5: Write doc.go**
+
+Create `ops/automaxprocs/doc.go` per spec §2c: package comment noting the cgroup root default (`/sys/fs/cgroup`, overridable via `WithCgroupRoot`), the containerized-use assumption, and the fail-open contract.
+
+- [ ] **Step 6: Format**
+
+Run: `just fmt ./ops/automaxprocs/...`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ops/automaxprocs/
+git commit -m "feat(ops/automaxprocs): set GOMAXPROCS/GOMEMLIMIT from cgroup quotas, fail-open"
+```
+
+---
+
+### Task 3: `ops/logredact`
+
+**Files:**
+- Create: `ops/logredact/logredact.go`
+- Create: `ops/logredact/doc.go`
+- Test: `ops/logredact/logredact_test.go`
+
+**Interfaces:**
+- Consumes: nothing (stdlib only).
+- Produces:
+  - `func New(next slog.Handler, opts ...Option) slog.Handler`
+  - Options: `WithKeys(...string)`, `WithPaths(...string)`, `WithReplacement(string)`
+  - `const DefaultReplacement = "[REDACTED]"`
+  - (No level knob — redaction is unconditional.)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/logredact/logredact_test.go`:
+
+```go
+package logredact_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/logredact"
+)
+
+func newLog(buf *bytes.Buffer, opts ...logredact.Option) *slog.Logger {
+	return slog.New(logredact.New(slog.NewJSONHandler(buf, nil), opts...))
+}
+
+func decode(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("unmarshal %q: %v", buf.String(), err)
+	}
+	return m
+}
+
+func TestRedactTopLevelKey(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, logredact.WithKeys("password")).Info("login", "password", "hunter2", "user", "alice")
+	m := decode(t, &buf)
+	if m["password"] != "[REDACTED]" {
+		t.Errorf("password = %v, want [REDACTED]", m["password"])
+	}
+	if m["user"] != "alice" {
+		t.Errorf("user = %v, want alice (untouched)", m["user"])
+	}
+}
+
+func TestRedactKeyInsideGroupValue(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, logredact.WithKeys("password")).
+		Info("m", slog.Group("creds", slog.String("password", "hunter2"), slog.String("kind", "basic")))
+	creds := decode(t, &buf)["creds"].(map[string]any)
+	if creds["password"] != "[REDACTED]" {
+		t.Errorf("creds.password = %v", creds["password"])
+	}
+	if creds["kind"] != "basic" {
+		t.Errorf("creds.kind = %v", creds["kind"])
+	}
+}
+
+func TestRedactKeyUnderWithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, logredact.WithKeys("password")).WithGroup("auth").Info("m", "password", "hunter2")
+	auth := decode(t, &buf)["auth"].(map[string]any)
+	if auth["password"] != "[REDACTED]" {
+		t.Errorf("auth.password = %v", auth["password"])
+	}
+}
+
+func TestRedactByDottedPath(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, logredact.WithPaths("user.ssn")).Info("m",
+		slog.Group("user", slog.String("ssn", "123-45-6789"), slog.String("name", "alice")),
+		slog.String("ssn", "top"))
+	m := decode(t, &buf)
+	if user := m["user"].(map[string]any); user["ssn"] != "[REDACTED]" {
+		t.Errorf("user.ssn = %v, want redacted", user["ssn"])
+	}
+	if m["ssn"] != "top" {
+		t.Errorf("top-level ssn = %v, want untouched", m["ssn"])
+	}
+}
+
+func TestRedactWithAttrsBakedIn(t *testing.T) {
+	var buf bytes.Buffer
+	// With(...) routes through WithAttrs, not Handle's record attrs — the
+	// regression a naive Handle-only redactor misses.
+	newLog(&buf, logredact.WithKeys("token")).With("token", "secret-abc").Info("m")
+	if decode(t, &buf)["token"] != "[REDACTED]" {
+		t.Errorf("WithAttrs-baked token not redacted: %s", buf.String())
+	}
+}
+
+func TestCustomReplacement(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, logredact.WithKeys("password"), logredact.WithReplacement("***")).Info("m", "password", "x")
+	if got := decode(t, &buf)["password"]; got != "***" {
+		t.Errorf("replacement = %v, want ***", got)
+	}
+}
+
+func TestNonMatchingPassThrough(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, logredact.WithKeys("password")).Info("m", "count", 42, "name", "alice")
+	m := decode(t, &buf)
+	if m["count"] != float64(42) || m["name"] != "alice" {
+		t.Errorf("non-matching attrs altered: %+v", m)
+	}
+}
+
+func TestEnabledDelegates(t *testing.T) {
+	var buf bytes.Buffer
+	h := logredact.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	if h.Enabled(context.Background(), slog.LevelInfo) {
+		t.Error("Enabled(Info) should be false (delegates to Warn-level next)")
+	}
+	if !h.Enabled(context.Background(), slog.LevelError) {
+		t.Error("Enabled(Error) should be true")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./ops/logredact/`
+Expected: FAIL — undefined `logredact.New` / `WithKeys`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/logredact/logredact.go` from **spec §3a** verbatim (config with `keys`/`paths`/`replacement` only — no level fields; `WithKeys`/`WithPaths`/`WithReplacement`; the `handler` with `Enabled`/`Handle` (no level-bypass branch)/`WithAttrs`/`WithGroup`; `redact`, `matches`, `joinPath`; `DefaultReplacement`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./ops/logredact/`
+Expected: PASS (all sub-tests, especially `TestRedactWithAttrsBakedIn`).
+
+- [ ] **Step 5: Write doc.go**
+
+Create `ops/logredact/doc.go` per spec §3b: package comment + a runnable `Example` wrapping a `slog.NewJSONHandler` and showing a `password` attr emitted as `[REDACTED]`, including one under a `WithGroup`. Use `// Output:` with stable field ordering (a single attr keeps output deterministic).
+
+- [ ] **Step 6: Format**
+
+Run: `just fmt ./ops/logredact/...`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ops/logredact/
+git commit -m "feat(ops/logredact): slog.Handler redacting attrs by key/dotted-path"
+```
+
+---
+
+### Task 4: `ops/supervisor` — `WithContext` addition
+
+**Files:**
+- Modify: `ops/supervisor/options.go` (add `WithContext`; add `parent` to `contextConfig`)
+- Modify: `ops/supervisor/context.go` (`NewContext` resolves parent, default `context.Background()`)
+- Test: `ops/supervisor/context_withcontext_test.go`
+
+**Interfaces:**
+- Consumes: existing `ContextOption`, `contextConfig`, `NewContext`, `WithForceQuit`.
+- Produces: `func WithContext(parent context.Context) ContextOption` — roots the signal context at `parent`; default remains `context.Background()`.
+
+- [ ] **Step 1: Read the current code**
+
+Read `ops/supervisor/context.go` and `ops/supervisor/options.go` to confirm `contextConfig`'s definition site and the exact current `NewContext` body before modifying.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `ops/supervisor/context_withcontext_test.go`:
+
+```go
+package supervisor_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/ops/supervisor"
+)
+
+func TestWithContextParentCancels(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	ctx, stop := supervisor.NewContext(supervisor.WithContext(parent))
+	defer stop()
+	select {
+	case <-ctx.Done():
+		t.Fatal("ctx cancelled before parent")
+	default:
+	}
+	cancelParent()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("ctx not cancelled after parent cancel")
+	}
+}
+
+func TestWithContextParentCancelsForceQuit(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	ctx, stop := supervisor.NewContext(supervisor.WithContext(parent), supervisor.WithForceQuit())
+	defer stop()
+	cancelParent()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("force-quit ctx not cancelled after parent cancel")
+	}
+}
+
+func TestNewContextDefaultsToBackground(t *testing.T) {
+	ctx, stop := supervisor.NewContext()
+	defer stop()
+	select {
+	case <-ctx.Done():
+		t.Fatal("default context should not be cancelled")
+	default:
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./ops/supervisor/ -run WithContext`
+Expected: FAIL — undefined `supervisor.WithContext`.
+
+- [ ] **Step 4: Write the implementation**
+
+In `ops/supervisor/options.go` add the `parent` field to `contextConfig` and the option (spec §5a):
+
+```go
+// WithContext roots the signal context at parent instead of context.Background,
+// so cancelling parent triggers the same graceful shutdown a signal would.
+// bootstrap uses it to thread main's context; tests use it to shut down without
+// sending real signals. The zero/default parent remains context.Background.
+func WithContext(parent context.Context) ContextOption {
+	return func(c *contextConfig) { c.parent = parent }
+}
+```
+
+In `ops/supervisor/context.go` replace `NewContext` with the parent-resolving version from spec §5b (resolve `parent := cfg.parent; if parent == nil { parent = context.Background() }`, use `parent` in both the `signal.NotifyContext` branch and the `context.WithCancel` force-quit branch, and add `case <-parent.Done(): return` to the first `select` of the force-quit goroutine).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./ops/supervisor/`
+Expected: PASS (new tests plus all existing supervisor tests still green).
+
+- [ ] **Step 6: Format**
+
+Run: `just fmt ./ops/supervisor/...`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ops/supervisor/
+git commit -m "feat(ops/supervisor): WithContext to root the signal context at a parent"
+```
+
+---
+
+### Task 5: `ops/bootstrap` (integrator — depends on Tasks 1–4)
+
+**Files:**
+- Create: `ops/bootstrap/bootstrap.go`
+- Create: `ops/bootstrap/doc.go`
+- Test: `ops/bootstrap/bootstrap_test.go`
+
+**Interfaces:**
+- Consumes: `buildinfo.Info`/`buildinfo.Read`; `automaxprocs.Set`; `logredact.New`/`WithKeys`; `supervisor.NewContext`/`WithContext`/`WithForceQuit`/`ContextOption`; `logger.New`/`WithConfig`/`Config`; `config.LoadEnv[T]`/`config.Load[T]`/`config.Option`.
+- Produces:
+  - `type Func func(ctx context.Context, log *slog.Logger) error`
+  - `type ConfigFunc[T any] func(ctx context.Context, log *slog.Logger, cfg T) error`
+  - `func Run(ctx context.Context, name string, fn Func, opts ...Option) int`
+  - `func RunWithConfig[T any](ctx context.Context, name string, fn ConfigFunc[T], opts ...Option) int`
+  - Options: `WithLogger(*slog.Logger)`, `WithBuildInfo(buildinfo.Info)`, `WithRedactKeys(...string)`, `WithAutoMaxProcs(bool)`, `WithForceQuit()`, `WithConfigDir(string)`, `WithConfigOptions(...config.Option)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/bootstrap/bootstrap_test.go`:
+
+```go
+package bootstrap_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/ops/bootstrap"
+	"github.com/dmitrymomot/forge/ops/buildinfo"
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+type testConfig struct {
+	Port int    `env:"TEST_PORT"`
+	Name string `env:"TEST_NAME"`
+}
+
+func TestRunCleanExit(t *testing.T) {
+	code := bootstrap.Run(context.Background(), "svc",
+		func(ctx context.Context, log *slog.Logger) error { return nil },
+		bootstrap.WithLogger(logger.NewNope()), bootstrap.WithAutoMaxProcs(false))
+	if code != 0 {
+		t.Errorf("exit = %d, want 0", code)
+	}
+}
+
+func TestRunErrorExitLogs(t *testing.T) {
+	var buf bytes.Buffer
+	code := bootstrap.Run(context.Background(), "svc",
+		func(ctx context.Context, l *slog.Logger) error { return errors.New("boom") },
+		bootstrap.WithLogger(slog.New(slog.NewJSONHandler(&buf, nil))),
+		bootstrap.WithAutoMaxProcs(false))
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(buf.String(), "boom") {
+		t.Errorf("error not logged: %s", buf.String())
+	}
+}
+
+func TestRunContextCancelIsCleanShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan int, 1)
+	go func() {
+		done <- bootstrap.Run(ctx, "svc",
+			func(runCtx context.Context, l *slog.Logger) error {
+				<-runCtx.Done()
+				return runCtx.Err()
+			},
+			bootstrap.WithLogger(logger.NewNope()), bootstrap.WithAutoMaxProcs(false))
+	}()
+	cancel() // supervisor.WithContext threads this like a SIGTERM
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Errorf("exit = %d, want 0 (context.Canceled is clean)", code)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
+func TestRunWithRedactKeys(t *testing.T) {
+	var buf bytes.Buffer
+	bootstrap.Run(context.Background(), "svc",
+		func(ctx context.Context, l *slog.Logger) error {
+			l.Info("login", "password", "hunter2")
+			return nil
+		},
+		bootstrap.WithLogger(slog.New(slog.NewJSONHandler(&buf, nil))),
+		bootstrap.WithRedactKeys("password"), bootstrap.WithAutoMaxProcs(false))
+	if strings.Contains(buf.String(), "hunter2") {
+		t.Errorf("password not redacted: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "[REDACTED]") {
+		t.Errorf("expected [REDACTED]: %s", buf.String())
+	}
+}
+
+func TestRunWithBuildInfoLogs(t *testing.T) {
+	var buf bytes.Buffer
+	bootstrap.Run(context.Background(), "svc",
+		func(ctx context.Context, l *slog.Logger) error { return nil },
+		bootstrap.WithLogger(slog.New(slog.NewJSONHandler(&buf, nil))),
+		bootstrap.WithBuildInfo(buildinfo.Info{Version: "9.9.9"}),
+		bootstrap.WithAutoMaxProcs(false))
+	if !strings.Contains(buf.String(), "9.9.9") {
+		t.Errorf("build info not logged: %s", buf.String())
+	}
+}
+
+func TestRunWithConfigLoadsAndPasses(t *testing.T) {
+	t.Setenv("TEST_PORT", "8080")
+	t.Setenv("TEST_NAME", "svc")
+	var got testConfig
+	code := bootstrap.RunWithConfig(context.Background(), "svc",
+		func(ctx context.Context, l *slog.Logger, cfg testConfig) error {
+			got = cfg
+			return nil
+		},
+		bootstrap.WithLogger(logger.NewNope()), bootstrap.WithAutoMaxProcs(false))
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if got.Port != 8080 || got.Name != "svc" {
+		t.Errorf("config = %+v, want {8080 svc}", got)
+	}
+}
+
+func TestRunWithConfigLoadFailureSkipsFn(t *testing.T) {
+	t.Setenv("TEST_PORT", "not-a-number") // typeconv int parse fails
+	called := false
+	code := bootstrap.RunWithConfig(context.Background(), "svc",
+		func(ctx context.Context, l *slog.Logger, cfg testConfig) error {
+			called = true
+			return nil
+		},
+		bootstrap.WithLogger(logger.NewNope()), bootstrap.WithAutoMaxProcs(false))
+	if code != 1 {
+		t.Errorf("exit = %d, want 1 on config load failure", code)
+	}
+	if called {
+		t.Error("fn must not be called when config load fails")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./ops/bootstrap/`
+Expected: FAIL — undefined `bootstrap.Run` / `RunWithConfig`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/bootstrap/bootstrap.go` from **spec §4a** verbatim (`Func`, `ConfigFunc[T]`, `options`, all seven `With*` options, `Run`, `RunWithConfig[T]`, the shared `run`, `buildLogger`, `loadConfig[T]`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./ops/bootstrap/`
+Expected: PASS. If `TestRunWithConfigLoadsAndPasses` fails on env mapping, confirm `config.LoadEnv[T]` reads `env:"..."` tags (it should, via `structfields`); adjust only the test's tag names to match `config`'s convention if needed — do not weaken the assertion.
+
+- [ ] **Step 5: Write doc.go**
+
+Create `ops/bootstrap/doc.go`: package comment + the canonical `main()` `Example` using `RunWithConfig[AppConfig]` (config load → `supervisor.Run` inside the callback, with `defer db.Close()`), per spec §4b. This `Example` is illustrative (no `// Output:` — it references app-specific helpers), so name it `Example` and keep it compile-only by guarding with a `func Example() { ... }` that never runs external I/O, or write it as a doc comment code block if compilation of app helpers is impractical. Prefer a compiling `Example_main` that calls `bootstrap.Run` with a trivial body.
+
+- [ ] **Step 6: Format**
+
+Run: `just fmt ./ops/bootstrap/...`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ops/bootstrap/
+git commit -m "feat(ops/bootstrap): thin runtime bootstrap with Run and generic RunWithConfig"
+```
+
+---
+
+### Task 6: Bundle finish — lint + docs sync
+
+**Files:**
+- Modify: `docs/packages.md` (post-merge doc sync)
+
+- [ ] **Step 1: Lint the whole tree**
+
+Run: `just lint`
+Expected: clean. Fix anything reported (common: `betteralign` struct field order — reorder fields; `modernize` — apply suggested rewrites).
+
+- [ ] **Step 2: Run the full bundle test suite once more**
+
+Run: `go test ./ops/...`
+Expected: PASS across `buildinfo`, `automaxprocs`, `logredact`, `supervisor`, `bootstrap`.
+
+- [ ] **Step 3: Update `docs/packages.md`**
+
+Move `buildinfo`, `automaxprocs`, `logredact`, `bootstrap` from `ops/` **planned** to **shipped** (note `bootstrap` replaces the `appmain` roadmap name); drop them from the Wave-1 build-order line; record the `supervisor.WithContext` addition. (Per spec "Post-merge doc sync".)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/packages.md
+git commit -m "docs(packages): mark ops runtime-bootstrap bundle shipped"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 `buildinfo` → Task 1 ✓ (Read/String/LogValue/Handler + ldflags).
+- §2 `automaxprocs` → Task 2 ✓ (Set, options incl. `WithCgroupRoot`, v1/v2 CPU+memory, env-skip, fail-open).
+- §3 `logredact` → Task 3 ✓ (keys/paths/replacement, WithAttrs+WithGroup, no level knob).
+- §4 `bootstrap` → Task 5 ✓ (`Run`, `RunWithConfig[T]`, all options, exit codes, redaction, buildinfo, config load+failure, ctx-cancel).
+- §5 `supervisor.WithContext` → Task 4 ✓.
+- doc.go per package → each task's Step 5 ✓.
+- Post-merge `docs/packages.md` sync → Task 6 ✓.
+
+**Placeholder scan:** implementation bodies are referenced to exact spec sections (authoritative verbatim source), test code is complete inline, commands are exact. No `TBD`/`add error handling`/`similar to Task N`.
+
+**Type consistency:** option names, `Func`/`ConfigFunc[T]`, `Run`/`RunWithConfig`, `Set`/`WithCgroupRoot`, `New`/`WithKeys`/`WithPaths`/`WithReplacement`, `WithContext` are used identically in the interfaces, tests, and spec references throughout.

--- a/docs/superpowers/specs/2026-07-07-ops-runtime-bootstrap-bundle-design.md
+++ b/docs/superpowers/specs/2026-07-07-ops-runtime-bootstrap-bundle-design.md
@@ -1,0 +1,965 @@
+# Ops Runtime-Bootstrap Bundle — Design Spec
+
+> Date: 2026-07-07 · Status: approved, ready for implementation plan · Ships as one PR.
+> Wave 1 (ops glue). Four new `ops/` packages: `buildinfo`, `automaxprocs`,
+> `logredact`, `bootstrap`; plus one shipped-package addition
+> (`supervisor.WithContext`). Built leaves-first; `bootstrap` composes the rest.
+
+A focused "app runtime bootstrap + log safety" slice. `buildinfo` gives the
+process an identity, `automaxprocs` right-sizes the runtime to its cgroup,
+`logredact` is a redaction safety-net for logs, and `bootstrap` wires all three
+— plus generic config autoload and supervisor's signal context — into a
+one-line `main()`. Complete, compilable reference implementations for every
+symbol — no sketches. Black-box tests only; options pattern (never builders);
+`errors.Is` sentinels where errors exist; minimal deps.
+
+## Locked decisions (from brainstorming)
+
+1. **`bootstrap` is THIN.** Its callback wraps the *whole* app body, so the
+   consumer calls `supervisor.Run` itself and uses plain `defer` for cleanup.
+   This supersedes two earlier shapes (`[]Service` return, and `[]Option`+
+   `Teardown` accumulator): because setup and run share one function scope, Go's
+   own `defer` handles teardown (partial-init *and* post-drain), so no framework
+   cleanup primitive is needed. `bootstrap` owns only the runtime edges: logger →
+   automaxprocs → buildinfo log → config load → signal ctx → exit code. It does
+   **not** own the service lifecycle — that stays in `supervisor`.
+2. **`bootstrap` delegates the signal context to `supervisor.NewContext`**, via a
+   new `supervisor.WithContext(parent)` option that threads the caller's `ctx`
+   (so a black-box test cancels `ctx` to trigger graceful shutdown — no real
+   signals). This *reverses* an earlier "decouple from supervisor" decision that
+   only duplicated `NewContext`'s signal + force-quit logic. `bootstrap` imports
+   `supervisor` — normal for the top-level integrator — leaving one owner of
+   signal handling.
+3. **`bootstrap` builds the logger from `LOG_*` env first** (`WithLogger`
+   overrides), wrapping it in `logredact` when `WithRedactKeys` is set — *before*
+   loading app config, so a config-load failure can be logged.
+4. **`bootstrap` autoloads typed app config, generically.** `Run` carries no
+   config; `RunWithConfig[T]` loads a `T` (via `config.LoadEnv[T]` by default, or
+   `config.Load[T](dir)` under `WithConfigDir`) and passes it to the callback.
+   `T` is inferred from the callback signature. bootstrap's env-logger and the
+   app's `T` are independent env reads (harmless); embed `logger.Config` in `T`
+   or use `WithLogger` if `T` should drive logging.
+5. **`buildinfo` precedence: ldflags win, `ReadBuildInfo` fills gaps.** Explicit
+   `-X` link-time values are authoritative; `runtime/debug.ReadBuildInfo`
+   supplies VCS revision/time/dirty (from `go build` stamping) and the module
+   version (from `go install pkg@version`) when ldflags are absent. Value type,
+   not a Service or env-`Config` package.
+6. **`automaxprocs` is fail-open and env-respecting.** Any cgroup read/parse
+   failure — or running outside a container — is a *logged no-op*, never a
+   startup error. An explicit `GOMAXPROCS`/`GOMEMLIMIT` env var wins (that leg is
+   skipped). Local `/sys/fs/cgroup` parser, **no uber dependency**. Sets both
+   GOMAXPROCS *and* GOMEMLIMIT (uber's lib does only the former).
+7. **`logredact` correctly implements the `slog.Handler` contract.** It redacts
+   attrs baked in via `WithAttrs` (not only record attrs) and tracks the group
+   prefix through `WithGroup` so dotted-path matches work at any nesting depth.
+
+## Resolved knobs
+
+- **`logredact` has no level knob.** A redaction safety-net must be
+  unconditional; a level-based bypass leaks secrets in exactly the ERROR logs
+  that get shipped (or the DEBUG logs that carry raw bodies). Redaction runs on
+  every record. "No redaction in dev" is a wiring choice (don't install the
+  handler), not a handler option — re-add a level bypass only on a measured
+  throughput need.
+- **`automaxprocs` GOMEMLIMIT headroom = 0.9** — the containerized-Go
+  convention: a soft GC target below the cgroup hard limit, reserving 10% for
+  stacks/non-heap/off-heap. Overridable via `WithMemoryHeadroom`.
+
+## Design invariants
+
+**No global mutable state — one sanctioned exception.**
+- No `init()`, no singletons, no registries. `logredact`'s handler,
+  `automaxprocs`'s config, and `bootstrap`'s options are all explicitly
+  constructed and injected.
+- **Exception:** `buildinfo` has three package-level `string` vars
+  (`version`, `commit`, `buildTime`). This is unavoidable — `-X` ldflags can
+  *only* target package-level string vars. They are written once at link time,
+  never mutated at runtime, and read solely by `Read()`. Documented as the
+  ldflags contract.
+
+**Every feature works on zero-config defaults.**
+- `buildinfo.Read()` — no args; degrades to `ReadBuildInfo`-only, then to
+  `"dev"`/empty fields, with no ldflags.
+- `automaxprocs.Set(log)` — no options; 0.9 headroom, min 1 proc, both legs on.
+- `logredact.New(next, logredact.WithKeys("password"))` — one option to be
+  useful; `[REDACTED]` replacement, redact-all-levels by default.
+- `bootstrap.Run(ctx, "api", fn)` / `bootstrap.RunWithConfig(ctx, "api", fn)` —
+  no options; env logger, automaxprocs on, env config, no buildinfo log, no
+  redaction.
+
+**bootstrap imports:** `ops/logger`, `ops/config`, `ops/buildinfo`,
+`ops/automaxprocs`, `ops/logredact`, `ops/supervisor` + stdlib. It sits at the
+top of the ops dependency DAG — nothing imports it.
+
+---
+
+## Component 1 — `ops/buildinfo`
+
+Value type; free `Read` constructor; `slog.LogValuer` + `fmt.Stringer` +
+`http.Handler`. Stdlib only (`runtime`, `runtime/debug`, `log/slog`,
+`net/http`, `encoding/json`).
+
+### 1a. `buildinfo.go` — complete
+
+```go
+package buildinfo
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime"
+	"runtime/debug"
+	"strings"
+)
+
+// Link-time overrides. Set with, e.g.:
+//
+//	go build -ldflags "\
+//	  -X github.com/dmitrymomot/forge/ops/buildinfo.version=$(git describe --tags --always) \
+//	  -X github.com/dmitrymomot/forge/ops/buildinfo.commit=$(git rev-parse --short HEAD) \
+//	  -X github.com/dmitrymomot/forge/ops/buildinfo.buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+//
+// They are the ONLY package-level vars, are written once by the linker, never
+// mutated at runtime, and are read solely by Read.
+var (
+	version   string
+	commit    string
+	buildTime string
+)
+
+// Info is a snapshot of the binary's build identity. The zero value is valid;
+// unknown fields are empty (Version reads "dev" via String/LogValue).
+type Info struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildTime string `json:"build_time"`
+	GoVersion string `json:"go_version"`
+	Dirty     bool   `json:"dirty"`
+}
+
+// Read merges link-time ldflags (authoritative when set) over
+// runtime/debug.ReadBuildInfo: VCS revision/time/modified from `go build`
+// stamping, and the module version from `go install pkg@version`. With neither
+// source, fields stay empty and String/LogValue substitute "dev".
+func Read() Info {
+	i := Info{Version: version, Commit: commit, BuildTime: buildTime, GoVersion: runtime.Version()}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		if i.Version == "" && bi.Main.Version != "" {
+			i.Version = bi.Main.Version
+		}
+		for _, s := range bi.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				if i.Commit == "" {
+					i.Commit = s.Value
+				}
+			case "vcs.time":
+				if i.BuildTime == "" {
+					i.BuildTime = s.Value
+				}
+			case "vcs.modified":
+				if s.Value == "true" {
+					i.Dirty = true
+				}
+			}
+		}
+	}
+	return i
+}
+
+func (i Info) versionOrDev() string {
+	if i.Version == "" {
+		return "dev"
+	}
+	return i.Version
+}
+
+func (i Info) shortCommit() string {
+	if len(i.Commit) > 12 {
+		return i.Commit[:12]
+	}
+	return i.Commit
+}
+
+// String is a single-line summary: "1.2.3 (abc1234def0 2026-07-07T12:00:00Z, dirty)".
+func (i Info) String() string {
+	var b strings.Builder
+	b.WriteString(i.versionOrDev())
+	var parens []string
+	if c := i.shortCommit(); c != "" {
+		parens = append(parens, c)
+	}
+	if i.BuildTime != "" {
+		parens = append(parens, i.BuildTime)
+	}
+	if len(parens) > 0 {
+		fmt.Fprintf(&b, " (%s", strings.Join(parens, " "))
+		if i.Dirty {
+			b.WriteString(", dirty")
+		}
+		b.WriteByte(')')
+	} else if i.Dirty {
+		b.WriteString(" (dirty)")
+	}
+	return b.String()
+}
+
+// LogValue renders build identity as a grouped slog attribute, so
+// log.Info("starting", slog.Any("build", info)) nests version/commit/… .
+func (i Info) LogValue() slog.Value {
+	attrs := []slog.Attr{slog.String("version", i.versionOrDev())}
+	if c := i.shortCommit(); c != "" {
+		attrs = append(attrs, slog.String("commit", c))
+	}
+	if i.BuildTime != "" {
+		attrs = append(attrs, slog.String("build_time", i.BuildTime))
+	}
+	if i.GoVersion != "" {
+		attrs = append(attrs, slog.String("go", i.GoVersion))
+	}
+	if i.Dirty {
+		attrs = append(attrs, slog.Bool("dirty", true))
+	}
+	return slog.GroupValue(attrs...)
+}
+
+// Handler serves the Info as JSON. Mount at /version behind an auth guard if the
+// commit is sensitive.
+func (i Info) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(i)
+	})
+}
+```
+
+### 1b. `doc.go` — package comment + runnable `Example` printing `Read().String()`.
+
+---
+
+## Component 2 — `ops/automaxprocs`
+
+Free `Set` func returning an `undo`. Fail-open, env-respecting, stdlib-only
+`/sys/fs/cgroup` parser (cgroup v2 primary, v1 fallback). No error return — a
+failure is a logged no-op, because a maxprocs read must never break startup.
+
+### 2a. `automaxprocs.go` — complete
+
+```go
+package automaxprocs
+
+import (
+	"log/slog"
+	"os"
+	"runtime"
+	"runtime/debug"
+)
+
+type config struct {
+	memHeadroom float64
+	minProcs    int
+	setCPU      bool
+	setMemory   bool
+	cgroupRoot  string
+}
+
+// Option configures Set.
+type Option func(*config)
+
+// WithMemoryHeadroom sets the fraction of the cgroup memory limit used for
+// GOMEMLIMIT (default 0.9); the remainder covers stacks, the runtime, and OS
+// overhead. Values outside (0,1] are ignored.
+func WithMemoryHeadroom(f float64) Option {
+	return func(c *config) {
+		if f > 0 && f <= 1 {
+			c.memHeadroom = f
+		}
+	}
+}
+
+// WithMinProcs floors GOMAXPROCS (default 1); a computed quota below it is
+// raised to it. Non-positive ignored.
+func WithMinProcs(n int) Option {
+	return func(c *config) {
+		if n > 0 {
+			c.minProcs = n
+		}
+	}
+}
+
+// WithCPU toggles the GOMAXPROCS leg (default true).
+func WithCPU(on bool) Option { return func(c *config) { c.setCPU = on } }
+
+// WithMemory toggles the GOMEMLIMIT leg (default true).
+func WithMemory(on bool) Option { return func(c *config) { c.setMemory = on } }
+
+// WithCgroupRoot overrides the cgroup mount point (default "/sys/fs/cgroup").
+// Its purpose is twofold: real systems that mount the cgroup hierarchy
+// elsewhere, and black-box tests, which point it at a temp dir of fixture
+// files. An empty dir is ignored.
+func WithCgroupRoot(dir string) Option {
+	return func(c *config) {
+		if dir != "" {
+			c.cgroupRoot = dir
+		}
+	}
+}
+
+// Set tunes GOMAXPROCS and GOMEMLIMIT from the process's cgroup CPU and memory
+// limits, logging every decision at Info (and no-ops at Debug). It is
+// fail-open: a missing/unparbleable cgroup, or a non-Linux host, leaves the
+// runtime defaults untouched with a logged no-op. An explicit GOMAXPROCS or
+// GOMEMLIMIT environment variable is honored — that leg is skipped so the
+// operator's choice wins. The returned undo restores the prior process values
+// (for tests or staged shutdown) and is safe to call once.
+func Set(log *slog.Logger, opts ...Option) (undo func()) {
+	c := config{memHeadroom: 0.9, minProcs: 1, setCPU: true, setMemory: true, cgroupRoot: "/sys/fs/cgroup"}
+	for _, o := range opts {
+		o(&c)
+	}
+
+	prevProcs := runtime.GOMAXPROCS(0)
+	prevMem := debug.SetMemoryLimit(-1) // negative reads without setting
+	undo = func() {
+		runtime.GOMAXPROCS(prevProcs)
+		debug.SetMemoryLimit(prevMem)
+	}
+
+	if c.setCPU {
+		applyCPU(log, c)
+	}
+	if c.setMemory {
+		applyMemory(log, c)
+	}
+	return undo
+}
+
+func applyCPU(log *slog.Logger, c config) {
+	if v, ok := os.LookupEnv("GOMAXPROCS"); ok && v != "" {
+		log.Debug("automaxprocs: GOMAXPROCS set in env, leaving as-is", slog.String("value", v))
+		return
+	}
+	quota, ok := cpuQuota(c.cgroupRoot)
+	if !ok {
+		log.Debug("automaxprocs: no cgroup CPU quota, leaving GOMAXPROCS",
+			slog.Int("gomaxprocs", runtime.GOMAXPROCS(0)))
+		return
+	}
+	procs := int(quota) // floor
+	if procs < c.minProcs {
+		procs = c.minProcs
+	}
+	runtime.GOMAXPROCS(procs)
+	log.Info("automaxprocs: set GOMAXPROCS from cgroup CPU quota",
+		slog.Int("gomaxprocs", procs), slog.Float64("quota", quota))
+}
+
+func applyMemory(log *slog.Logger, c config) {
+	if v, ok := os.LookupEnv("GOMEMLIMIT"); ok && v != "" {
+		log.Debug("automaxprocs: GOMEMLIMIT set in env, leaving as-is", slog.String("value", v))
+		return
+	}
+	limit, ok := memoryLimit(c.cgroupRoot)
+	if !ok {
+		log.Debug("automaxprocs: no cgroup memory limit, leaving GOMEMLIMIT")
+		return
+	}
+	target := int64(float64(limit) * c.memHeadroom)
+	if target <= 0 {
+		return
+	}
+	debug.SetMemoryLimit(target)
+	log.Info("automaxprocs: set GOMEMLIMIT from cgroup memory limit",
+		slog.Int64("gomemlimit_bytes", target),
+		slog.Int64("cgroup_limit_bytes", limit),
+		slog.Float64("headroom", c.memHeadroom))
+}
+```
+
+### 2b. `cgroup.go` — complete (v2 primary, v1 fallback)
+
+```go
+package automaxprocs
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// unlimited treats cgroup v1's PAGE_COUNTER_MAX-ish sentinels as "no limit".
+const unlimited = int64(1) << 62
+
+// cpuQuota returns cores = quota/period from the cgroup under root, or ok=false
+// when unlimited or unreadable. cgroup v2 "cpu.max" is "<quota> <period>" or
+// "max <period>"; v1 splits across cpu.cfs_quota_us / cpu.cfs_period_us. The
+// file reads stay thin so the pure parser (parseCPUMax) carries the logic;
+// full-path coverage rides Set(WithCgroupRoot(tmp)) against fixture files.
+func cpuQuota(root string) (cores float64, ok bool) {
+	if b, err := os.ReadFile(filepath.Join(root, "cpu.max")); err == nil { // v2
+		return parseCPUMax(string(b))
+	}
+	q, e1 := readInt(filepath.Join(root, "cpu", "cpu.cfs_quota_us")) // v1
+	p, e2 := readInt(filepath.Join(root, "cpu", "cpu.cfs_period_us"))
+	if e1 == nil && e2 == nil && q > 0 && p > 0 {
+		return float64(q) / float64(p), true
+	}
+	return 0, false
+}
+
+// parseCPUMax parses a v2 "cpu.max" line into cores. Pure, hence tested directly.
+func parseCPUMax(s string) (cores float64, ok bool) {
+	f := strings.Fields(strings.TrimSpace(s))
+	if len(f) != 2 || f[0] == "max" {
+		return 0, false
+	}
+	q, e1 := strconv.ParseFloat(f[0], 64)
+	p, e2 := strconv.ParseFloat(f[1], 64)
+	if e1 == nil && e2 == nil && q > 0 && p > 0 {
+		return q / p, true
+	}
+	return 0, false
+}
+
+// memoryLimit returns the cgroup memory limit in bytes, or ok=false when
+// unlimited or unreadable. v2 "memory.max" is a number or "max"; v1 is
+// memory.limit_in_bytes with a huge sentinel meaning unlimited.
+func memoryLimit(root string) (bytes int64, ok bool) {
+	if b, err := os.ReadFile(filepath.Join(root, "memory.max")); err == nil { // v2
+		return parseMemMax(string(b))
+	}
+	if n, err := readInt(filepath.Join(root, "memory", "memory.limit_in_bytes")); err == nil { // v1
+		return validMem(n)
+	}
+	return 0, false
+}
+
+// parseMemMax parses a v2 "memory.max" value ("max" or a byte count). Pure.
+func parseMemMax(s string) (bytes int64, ok bool) {
+	s = strings.TrimSpace(s)
+	if s == "max" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return validMem(n)
+}
+
+// validMem accepts a positive, non-sentinel byte count.
+func validMem(n int64) (int64, bool) {
+	if n > 0 && n < unlimited {
+		return n, true
+	}
+	return 0, false
+}
+
+func readInt(path string) (int64, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+}
+```
+
+### 2c. `doc.go` — package comment noting the cgroup root default
+(`/sys/fs/cgroup`, overridable via `WithCgroupRoot`), the containerized-use
+assumption, and the fail-open contract.
+
+---
+
+## Component 3 — `ops/logredact`
+
+An `slog.Handler` middleware. Stdlib only (`log/slog`, `context`). The subtlety
+is honoring the handler contract: redact at both `Handle` and `WithAttrs`, and
+carry the group prefix through `WithGroup` for dotted-path matches.
+
+### 3a. `logredact.go` — complete
+
+```go
+package logredact
+
+import (
+	"context"
+	"log/slog"
+)
+
+// DefaultReplacement is substituted for a redacted attribute value.
+const DefaultReplacement = "[REDACTED]"
+
+type config struct {
+	keys        map[string]struct{}
+	paths       map[string]struct{}
+	replacement string
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithKeys redacts any attribute whose leaf key matches, at any nesting depth.
+func WithKeys(keys ...string) Option {
+	return func(c *config) {
+		for _, k := range keys {
+			c.keys[k] = struct{}{}
+		}
+	}
+}
+
+// WithPaths redacts an attribute by its dotted group path, e.g. "user.ssn"
+// matches key "ssn" inside group "user" but not a top-level "ssn".
+func WithPaths(paths ...string) Option {
+	return func(c *config) {
+		for _, p := range paths {
+			c.paths[p] = struct{}{}
+		}
+	}
+}
+
+// WithReplacement overrides the "[REDACTED]" placeholder.
+func WithReplacement(s string) Option { return func(c *config) { c.replacement = s } }
+
+// handler wraps next, redacting matching attribute values before they reach it.
+type handler struct {
+	next  slog.Handler
+	cfg   *config
+	group string // dotted prefix of currently-open groups; "" at root
+}
+
+// New wraps next so attribute values matching WithKeys / WithPaths are replaced
+// before reaching next. It redacts record attrs (Handle), attrs baked in via
+// WithAttrs, and nested group values, tracking the group prefix across
+// WithGroup so dotted paths resolve at any depth.
+func New(next slog.Handler, opts ...Option) slog.Handler {
+	c := &config{
+		keys:        make(map[string]struct{}),
+		paths:       make(map[string]struct{}),
+		replacement: DefaultReplacement,
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return &handler{next: next, cfg: c}
+}
+
+func (h *handler) Enabled(ctx context.Context, l slog.Level) bool {
+	return h.next.Enabled(ctx, l)
+}
+
+func (h *handler) Handle(ctx context.Context, r slog.Record) error {
+	out := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+	r.Attrs(func(a slog.Attr) bool {
+		out.AddAttrs(h.redact(h.group, a))
+		return true
+	})
+	return h.next.Handle(ctx, out)
+}
+
+func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	red := make([]slog.Attr, len(attrs))
+	for i, a := range attrs {
+		red[i] = h.redact(h.group, a) // attrs are baked now — redact eagerly
+	}
+	return &handler{next: h.next.WithAttrs(red), cfg: h.cfg, group: h.group}
+}
+
+func (h *handler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &handler{next: h.next.WithGroup(name), cfg: h.cfg, group: joinPath(h.group, name)}
+}
+
+// redact replaces a's value when it matches by key or dotted path; group-valued
+// attrs are recursed into. LogValuer values are resolved first so their shape
+// is concrete for matching.
+func (h *handler) redact(prefix string, a slog.Attr) slog.Attr {
+	a.Value = a.Value.Resolve()
+	if a.Value.Kind() == slog.KindGroup {
+		sub := a.Value.Group()
+		gp := joinPath(prefix, a.Key)
+		red := make([]slog.Attr, len(sub))
+		for i, s := range sub {
+			red[i] = h.redact(gp, s)
+		}
+		return slog.Attr{Key: a.Key, Value: slog.GroupValue(red...)}
+	}
+	if h.matches(prefix, a.Key) {
+		return slog.String(a.Key, h.cfg.replacement)
+	}
+	return a
+}
+
+func (h *handler) matches(prefix, key string) bool {
+	if _, ok := h.cfg.keys[key]; ok {
+		return true
+	}
+	if len(h.cfg.paths) > 0 {
+		if _, ok := h.cfg.paths[joinPath(prefix, key)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func joinPath(prefix, name string) string {
+	if prefix == "" {
+		return name
+	}
+	return prefix + "." + name
+}
+```
+
+### 3b. `doc.go` — package comment + `Example` wrapping a `slog.NewJSONHandler`
+and showing a `password` attr emitted as `[REDACTED]`, including one under a
+`WithGroup`.
+
+---
+
+## Component 4 — `ops/bootstrap`
+
+The thin integrator. Two entry points share one bootstrap sequence: `Run`
+(config-less) and `RunWithConfig[T]` (generic config autoload). Imports the
+three siblings + `logger` + `config` + `supervisor`.
+
+### 4a. `bootstrap.go` — complete
+
+```go
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/dmitrymomot/forge/ops/automaxprocs"
+	"github.com/dmitrymomot/forge/ops/buildinfo"
+	"github.com/dmitrymomot/forge/ops/config"
+	"github.com/dmitrymomot/forge/ops/logger"
+	"github.com/dmitrymomot/forge/ops/logredact"
+	"github.com/dmitrymomot/forge/ops/supervisor"
+)
+
+// Func is a config-less application body. It receives a context cancelled on
+// SIGINT/SIGTERM (or when the ctx passed to Run is cancelled) and the configured
+// logger, wires the app, and typically ends by returning supervisor.Run(ctx,…).
+// A nil or context.Canceled result is a clean stop; any other error makes Run
+// return exit code 1. Use plain defer inside fn for resource teardown — it runs
+// after fn returns (i.e. after supervisor.Run drains), and on any early error.
+type Func func(ctx context.Context, log *slog.Logger) error
+
+// ConfigFunc is an application body that also receives a loaded, typed config.
+// T is inferred from the function literal at the call site.
+type ConfigFunc[T any] func(ctx context.Context, log *slog.Logger, cfg T) error
+
+type options struct {
+	logger      *slog.Logger
+	build       *buildinfo.Info
+	redactKeys  []string
+	autoMaxProc bool
+	forceQuit   bool
+	configDir   string
+	configOpts  []config.Option
+}
+
+// Option configures Run and RunWithConfig.
+type Option func(*options)
+
+// WithLogger supplies a prebuilt logger instead of building one from LOG_* env.
+// WithRedactKeys still wraps it.
+func WithLogger(l *slog.Logger) Option { return func(o *options) { o.logger = l } }
+
+// WithBuildInfo logs the build identity once at startup and is otherwise inert.
+func WithBuildInfo(b buildinfo.Info) Option { return func(o *options) { o.build = &b } }
+
+// WithRedactKeys wraps the logger in logredact, redacting these attribute keys.
+func WithRedactKeys(keys ...string) Option { return func(o *options) { o.redactKeys = keys } }
+
+// WithAutoMaxProcs toggles the automaxprocs step (default on).
+func WithAutoMaxProcs(on bool) Option { return func(o *options) { o.autoMaxProc = on } }
+
+// WithForceQuit makes a second SIGINT/SIGTERM force os.Exit(130) while the first
+// drains gracefully — an escape hatch for a hung shutdown. Forwarded to
+// supervisor.NewContext.
+func WithForceQuit() Option { return func(o *options) { o.forceQuit = true } }
+
+// WithConfigDir switches RunWithConfig from env-only loading to the layered
+// YAML+env loader rooted at dir (config.Load). Ignored by Run.
+func WithConfigDir(dir string) Option { return func(o *options) { o.configDir = dir } }
+
+// WithConfigOptions forwards options to the underlying config loader (dotenv,
+// profile, lookup). Ignored by Run.
+func WithConfigOptions(opts ...config.Option) Option {
+	return func(o *options) { o.configOpts = opts }
+}
+
+// Run bootstraps the process runtime and executes fn (no app config), returning
+// a process exit code to pass to os.Exit. In order it: builds the logger from
+// LOG_* env (or WithLogger), wrapping it in logredact when WithRedactKeys is set;
+// tunes GOMAXPROCS/GOMEMLIMIT via automaxprocs unless WithAutoMaxProcs(false);
+// logs build info if WithBuildInfo; derives a SIGINT/SIGTERM-aware context from
+// ctx via supervisor.NewContext; then calls fn. bootstrap owns the runtime edges
+// only — fn owns the service lifecycle (supervisor.Run) and defer-based cleanup.
+func Run(ctx context.Context, name string, fn Func, opts ...Option) int {
+	return run(ctx, name, opts, func(runCtx context.Context, log *slog.Logger, _ options) error {
+		return fn(runCtx, log)
+	})
+}
+
+// RunWithConfig is Run plus generic config autoload: it loads a T (env-only via
+// config.LoadEnv by default, or the layered YAML+env loader under WithConfigDir)
+// and passes it to fn. A load failure is logged and yields exit code 1 without
+// calling fn. T is inferred from fn.
+func RunWithConfig[T any](ctx context.Context, name string, fn ConfigFunc[T], opts ...Option) int {
+	return run(ctx, name, opts, func(runCtx context.Context, log *slog.Logger, o options) error {
+		cfg, err := loadConfig[T](o)
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+		return fn(runCtx, log, cfg)
+	})
+}
+
+// run holds the shared bootstrap sequence; body wraps the caller's fn (with or
+// without config) and receives the resolved options.
+func run(ctx context.Context, name string, opts []Option, body func(context.Context, *slog.Logger, options) error) int {
+	o := options{autoMaxProc: true}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	log, err := buildLogger(o)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bootstrap: logger init: %v\n", err)
+		return 1
+	}
+	log = log.With(slog.String("app", name))
+
+	if o.autoMaxProc {
+		undo := automaxprocs.Set(log)
+		defer undo()
+	}
+	if o.build != nil {
+		log.Info("starting", slog.Any("build", *o.build))
+	}
+
+	ctxOpts := []supervisor.ContextOption{supervisor.WithContext(ctx)}
+	if o.forceQuit {
+		ctxOpts = append(ctxOpts, supervisor.WithForceQuit())
+	}
+	runCtx, stop := supervisor.NewContext(ctxOpts...)
+	defer stop()
+
+	if err := body(runCtx, log, o); err != nil && !errors.Is(err, context.Canceled) {
+		log.Error("exit", slog.Any("err", err))
+		return 1
+	}
+	log.Info("stopped")
+	return 0
+}
+
+func buildLogger(o options) (*slog.Logger, error) {
+	base := o.logger
+	if base == nil {
+		cfg, err := config.LoadEnv[logger.Config]()
+		if err != nil {
+			return nil, err
+		}
+		base, err = logger.New(logger.WithConfig(cfg))
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(o.redactKeys) > 0 {
+		return slog.New(logredact.New(base.Handler(), logredact.WithKeys(o.redactKeys...))), nil
+	}
+	return base, nil
+}
+
+func loadConfig[T any](o options) (T, error) {
+	if o.configDir != "" {
+		return config.Load[T](o.configDir, o.configOpts...)
+	}
+	return config.LoadEnv[T](o.configOpts...)
+}
+```
+
+### 4b. `doc.go` — package comment + the canonical `RunWithConfig[AppConfig]`
+`main()` example (config load → `supervisor.Run` inside the callback, with
+`defer db.Close()`).
+
+---
+
+## Component 5 — `ops/supervisor` (shipped-package addition)
+
+`bootstrap` reuses supervisor's signal handling instead of duplicating it. The
+only gap: `NewContext` hardcodes `context.Background()`, so it can't thread a
+caller's context (needed so a black-box test cancels `ctx` to shut down without
+real signals). One additive option closes it.
+
+### 5a. `options.go` — new `WithContext` ContextOption
+
+```go
+// WithContext roots the signal context at parent instead of context.Background,
+// so cancelling parent triggers the same graceful shutdown a signal would.
+// bootstrap uses it to thread main's context; tests use it to shut down without
+// sending real signals. The zero/default parent remains context.Background.
+func WithContext(parent context.Context) ContextOption {
+	return func(c *contextConfig) { c.parent = parent }
+}
+```
+
+`contextConfig` gains a `parent context.Context` field.
+
+### 5b. `context.go` — `NewContext` resolves the parent (both branches)
+
+```go
+func NewContext(opts ...ContextOption) (context.Context, context.CancelFunc) {
+	var cfg contextConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	parent := cfg.parent
+	if parent == nil {
+		parent = context.Background()
+	}
+	if !cfg.forceQuit {
+		return signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	ch := make(chan os.Signal, 2)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+	stopped := make(chan struct{})
+	go func() {
+		select {
+		case <-ch:
+			cancel()
+		case <-parent.Done(): // parent cancelled: nothing to force, just stop watching
+			return
+		case <-stopped:
+			return
+		}
+		select {
+		case <-ch:
+			os.Exit(forceQuitCode)
+		case <-stopped:
+		}
+	}()
+	var stopOnce sync.Once
+	stop := func() {
+		stopOnce.Do(func() {
+			signal.Stop(ch)
+			close(stopped)
+		})
+		cancel()
+	}
+	return ctx, stop
+}
+```
+
+Backward-compatible: existing `NewContext()` / `NewContext(WithForceQuit())`
+callers are unaffected (parent defaults to `context.Background()`).
+
+---
+
+## Testing plan (black-box, `_test` packages)
+
+**buildinfo** (`buildinfo_test`):
+- `Read()` with all ldflags empty → non-empty `GoVersion`, `Version` renders
+  "dev" via `String`/`LogValue`; JSON round-trips.
+- `String()` formats version/short-commit/time/dirty combinations (table).
+- `LogValue()` emitted through a `slog` JSON handler nests under a `build` group;
+  `dirty` omitted when false.
+- `Handler()` responds `200` + `application/json` decodable back into `Info`.
+- (ldflags injection isn't black-box-testable without a build step — covered by
+  a `//go:build` -tagged example or a Makefile check, noted as out-of-unit.)
+
+**automaxprocs** (`automaxprocs_test`):
+- Full path black-box via `Set(log, WithCgroupRoot(tmp))` against fixture files
+  written into a temp dir (`t.Setenv` clears `GOMAXPROCS`/`GOMEMLIMIT` first):
+  v2 `cpu.max` "300000 100000" → GOMAXPROCS 3; "150000 100000" → 1 (`int(1.5)`
+  floors, then min 1); "max 100000" → untouched; v1 quota/period layout;
+  memory `max`/number/huge-sentinel → GOMEMLIMIT set at ×headroom or untouched.
+  Assert via `runtime.GOMAXPROCS(0)` / `debug.SetMemoryLimit(-1)`, then `undo()`
+  restores originals. `WithMinProcs` floor and `WithMemoryHeadroom` scaling
+  covered the same way; a leg whose env var is present is skipped; an
+  unreadable/garbage root → no-op, no panic.
+- `Set` outside a container → no-op, `undo` restores the original GOMAXPROCS.
+- `GOMAXPROCS`/`GOMEMLIMIT` env present → that leg skipped (assert value
+  unchanged via a captured logger `Recorder`).
+- `WithMinProcs` floor applied; `WithMemoryHeadroom` scales the target.
+- fail-open: unreadable/garbage cgroup files → no panic, runtime defaults intact.
+
+**logredact** (`logredact_test`) — the correctness-critical suite:
+- `WithKeys` redacts a top-level `password`; a same-named key nested in a
+  `WithGroup("user")` group; and a key inside a `slog.Group(...)` value.
+- `WithPaths("user.ssn")` redacts only the nested `ssn`, leaving a top-level
+  `ssn` intact.
+- Attrs added via `logger.With(...)` (**WithAttrs path**) are redacted — the
+  regression that a naive Handle-only implementation misses.
+- `WithReplacement` custom placeholder; non-matching attrs pass through byte-for-
+  byte; `LogValuer` values resolved before matching.
+- Redaction is unconditional at every level (no bypass knob); `Enabled`
+  delegates to next.
+
+**bootstrap** (`bootstrap_test`):
+- `Run` with a `fn` returning `nil` → exit `0`; returning an error → exit `1`
+  and the error logged (assert via `WithLogger` + `logger.Recorder`).
+- `fn` returning `context.Canceled` → exit `0` (clean stop).
+- Cancelling the `ctx` passed to `Run` cancels the `runCtx` seen by `fn` — the
+  graceful-shutdown-without-signals hook, now via `supervisor.WithContext`.
+- `RunWithConfig[T]`: a `T` populated from env is passed to `fn` (`T` inferred
+  from the literal); `WithConfigDir` loads via the YAML+env loader; a load
+  failure → exit `1`, logged, and `fn` is never called.
+- `WithRedactKeys` → an attr logged by `fn` via the injected logger is redacted.
+- `WithBuildInfo` logs a `starting` record with a `build` group.
+- `WithAutoMaxProcs(false)` → GOMAXPROCS untouched.
+
+**supervisor** (`supervisor_test`, addition):
+- `WithContext(parent)`: cancelling `parent` cancels the returned context in
+  both plain and `WithForceQuit` modes; with no option the context still roots
+  at `context.Background` (existing behavior unchanged).
+
+## File inventory
+
+```
+ops/buildinfo/buildinfo.go     Info, Read, String, LogValue, Handler; ldflags vars
+ops/buildinfo/doc.go           package doc + Example
+ops/automaxprocs/automaxprocs.go  config/options (+WithCgroupRoot), Set, applyCPU, applyMemory
+ops/automaxprocs/cgroup.go        cpuQuota(root), memoryLimit(root); pure parseCPUMax/parseMemMax/validMem; readInt
+ops/automaxprocs/doc.go           package doc
+ops/logredact/logredact.go     config/options, handler (Enabled/Handle/WithAttrs/WithGroup), redact
+ops/logredact/doc.go           package doc + Example
+ops/bootstrap/bootstrap.go     Func, ConfigFunc[T], options, Run, RunWithConfig[T], run, buildLogger, loadConfig
+ops/bootstrap/doc.go           package doc + canonical RunWithConfig main() Example
+ops/supervisor/options.go      +WithContext(parent) ContextOption; contextConfig.parent field
+ops/supervisor/context.go      NewContext resolves parent (default context.Background)
+```
+
+## Non-goals (this PR)
+
+- No `cli` / `diag` / `metrics` / `featureflag` — the rest of the ops-glue wave,
+  deliberately deferred; `bootstrap` is the single-entrypoint (serve) path, not a
+  command tree.
+- No DI container or service registry in `bootstrap`; config loading delegates to
+  `ops/config` (bootstrap adds no config framework of its own).
+- `bootstrap` doesn't load `.env` implicitly — pass `config.WithDotenv(…)` via
+  `WithConfigOptions`.
+- No per-process cgroup-path discovery from `/proc/self/cgroup` — reads the
+  cgroup root (the containerized case). Refinement is a later, demand-driven fix.
+- `logredact` does not partial-mask (e.g. show last 4) — whole-value replacement
+  only; `crypto/redact` covers values you own.
+
+## Post-merge doc sync
+
+Move `buildinfo`, `automaxprocs`, `logredact`, `bootstrap` from `ops/`
+**planned** to **shipped** in `docs/packages.md` (note `bootstrap` replaces the
+`appmain` roadmap name); drop them from the Wave-1 build-order line. Record the
+`supervisor.WithContext` addition.

--- a/ops/automaxprocs/automaxprocs.go
+++ b/ops/automaxprocs/automaxprocs.go
@@ -97,10 +97,7 @@ func applyCPU(log *slog.Logger, c config) {
 			slog.Int("gomaxprocs", runtime.GOMAXPROCS(0)))
 		return
 	}
-	procs := int(quota) // floor
-	if procs < c.minProcs {
-		procs = c.minProcs
-	}
+	procs := max(int(quota), c.minProcs) // floor at minProcs
 	runtime.GOMAXPROCS(procs)
 	log.Info("automaxprocs: set GOMAXPROCS from cgroup CPU quota",
 		slog.Int("gomaxprocs", procs), slog.Float64("quota", quota))

--- a/ops/automaxprocs/automaxprocs.go
+++ b/ops/automaxprocs/automaxprocs.go
@@ -59,7 +59,7 @@ func WithCgroupRoot(dir string) Option {
 
 // Set tunes GOMAXPROCS and GOMEMLIMIT from the process's cgroup CPU and memory
 // limits, logging every decision at Info (and no-ops at Debug). It is
-// fail-open: a missing/unparbleable cgroup, or a non-Linux host, leaves the
+// fail-open: a missing/unparseable cgroup, or a non-Linux host, leaves the
 // runtime defaults untouched with a logged no-op. An explicit GOMAXPROCS or
 // GOMEMLIMIT environment variable is honored — that leg is skipped so the
 // operator's choice wins. The returned undo restores the prior process values

--- a/ops/automaxprocs/automaxprocs.go
+++ b/ops/automaxprocs/automaxprocs.go
@@ -1,0 +1,128 @@
+package automaxprocs
+
+import (
+	"log/slog"
+	"os"
+	"runtime"
+	"runtime/debug"
+)
+
+type config struct {
+	cgroupRoot  string
+	memHeadroom float64
+	minProcs    int
+	setCPU      bool
+	setMemory   bool
+}
+
+// Option configures Set.
+type Option func(*config)
+
+// WithMemoryHeadroom sets the fraction of the cgroup memory limit used for
+// GOMEMLIMIT (default 0.9); the remainder covers stacks, the runtime, and OS
+// overhead. Values outside (0,1] are ignored.
+func WithMemoryHeadroom(f float64) Option {
+	return func(c *config) {
+		if f > 0 && f <= 1 {
+			c.memHeadroom = f
+		}
+	}
+}
+
+// WithMinProcs floors GOMAXPROCS (default 1); a computed quota below it is
+// raised to it. Non-positive ignored.
+func WithMinProcs(n int) Option {
+	return func(c *config) {
+		if n > 0 {
+			c.minProcs = n
+		}
+	}
+}
+
+// WithCPU toggles the GOMAXPROCS leg (default true).
+func WithCPU(on bool) Option { return func(c *config) { c.setCPU = on } }
+
+// WithMemory toggles the GOMEMLIMIT leg (default true).
+func WithMemory(on bool) Option { return func(c *config) { c.setMemory = on } }
+
+// WithCgroupRoot overrides the cgroup mount point (default "/sys/fs/cgroup").
+// Its purpose is twofold: real systems that mount the cgroup hierarchy
+// elsewhere, and black-box tests, which point it at a temp dir of fixture
+// files. An empty dir is ignored.
+func WithCgroupRoot(dir string) Option {
+	return func(c *config) {
+		if dir != "" {
+			c.cgroupRoot = dir
+		}
+	}
+}
+
+// Set tunes GOMAXPROCS and GOMEMLIMIT from the process's cgroup CPU and memory
+// limits, logging every decision at Info (and no-ops at Debug). It is
+// fail-open: a missing/unparbleable cgroup, or a non-Linux host, leaves the
+// runtime defaults untouched with a logged no-op. An explicit GOMAXPROCS or
+// GOMEMLIMIT environment variable is honored — that leg is skipped so the
+// operator's choice wins. The returned undo restores the prior process values
+// (for tests or staged shutdown) and is safe to call once.
+func Set(log *slog.Logger, opts ...Option) (undo func()) {
+	c := config{memHeadroom: 0.9, minProcs: 1, setCPU: true, setMemory: true, cgroupRoot: "/sys/fs/cgroup"}
+	for _, o := range opts {
+		o(&c)
+	}
+
+	prevProcs := runtime.GOMAXPROCS(0)
+	prevMem := debug.SetMemoryLimit(-1) // negative reads without setting
+	undo = func() {
+		runtime.GOMAXPROCS(prevProcs)
+		debug.SetMemoryLimit(prevMem)
+	}
+
+	if c.setCPU {
+		applyCPU(log, c)
+	}
+	if c.setMemory {
+		applyMemory(log, c)
+	}
+	return undo
+}
+
+func applyCPU(log *slog.Logger, c config) {
+	if v, ok := os.LookupEnv("GOMAXPROCS"); ok && v != "" {
+		log.Debug("automaxprocs: GOMAXPROCS set in env, leaving as-is", slog.String("value", v))
+		return
+	}
+	quota, ok := cpuQuota(c.cgroupRoot)
+	if !ok {
+		log.Debug("automaxprocs: no cgroup CPU quota, leaving GOMAXPROCS",
+			slog.Int("gomaxprocs", runtime.GOMAXPROCS(0)))
+		return
+	}
+	procs := int(quota) // floor
+	if procs < c.minProcs {
+		procs = c.minProcs
+	}
+	runtime.GOMAXPROCS(procs)
+	log.Info("automaxprocs: set GOMAXPROCS from cgroup CPU quota",
+		slog.Int("gomaxprocs", procs), slog.Float64("quota", quota))
+}
+
+func applyMemory(log *slog.Logger, c config) {
+	if v, ok := os.LookupEnv("GOMEMLIMIT"); ok && v != "" {
+		log.Debug("automaxprocs: GOMEMLIMIT set in env, leaving as-is", slog.String("value", v))
+		return
+	}
+	limit, ok := memoryLimit(c.cgroupRoot)
+	if !ok {
+		log.Debug("automaxprocs: no cgroup memory limit, leaving GOMEMLIMIT")
+		return
+	}
+	target := int64(float64(limit) * c.memHeadroom)
+	if target <= 0 {
+		return
+	}
+	debug.SetMemoryLimit(target)
+	log.Info("automaxprocs: set GOMEMLIMIT from cgroup memory limit",
+		slog.Int64("gomemlimit_bytes", target),
+		slog.Int64("cgroup_limit_bytes", limit),
+		slog.Float64("headroom", c.memHeadroom))
+}

--- a/ops/automaxprocs/automaxprocs_test.go
+++ b/ops/automaxprocs/automaxprocs_test.go
@@ -137,6 +137,19 @@ func TestSetEnvPresentSkipsCPU(t *testing.T) {
 	}
 }
 
+func TestSetEnvPresentSkipsMemory(t *testing.T) {
+	t.Setenv("GOMAXPROCS", "")
+	t.Setenv("GOMEMLIMIT", "500MiB") // runtime read env at startup; Set must not override
+	prev := debug.SetMemoryLimit(-1)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "", "1000000000")),
+		automaxprocs.WithCPU(false))
+	defer undo()
+	if got := debug.SetMemoryLimit(-1); got != prev {
+		t.Errorf("env present must skip memory leg; GOMEMLIMIT = %d, want %d", got, prev)
+	}
+}
+
 func TestSetMissingRootIsNoOp(t *testing.T) {
 	clearRuntimeEnv(t)
 	prevP, prevM := runtime.GOMAXPROCS(0), debug.SetMemoryLimit(-1)

--- a/ops/automaxprocs/automaxprocs_test.go
+++ b/ops/automaxprocs/automaxprocs_test.go
@@ -83,8 +83,12 @@ func TestSetV1CPUQuota(t *testing.T) {
 	if err := os.MkdirAll(cpuDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	os.WriteFile(filepath.Join(cpuDir, "cpu.cfs_quota_us"), []byte("400000"), 0o644)
-	os.WriteFile(filepath.Join(cpuDir, "cpu.cfs_period_us"), []byte("100000"), 0o644)
+	if err := os.WriteFile(filepath.Join(cpuDir, "cpu.cfs_quota_us"), []byte("400000"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cpuDir, "cpu.cfs_period_us"), []byte("100000"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	undo := automaxprocs.Set(nopLogger(), automaxprocs.WithCgroupRoot(root), automaxprocs.WithMemory(false))
 	defer undo()
 	if got := runtime.GOMAXPROCS(0); got != 4 {

--- a/ops/automaxprocs/automaxprocs_test.go
+++ b/ops/automaxprocs/automaxprocs_test.go
@@ -1,0 +1,145 @@
+package automaxprocs_test
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/automaxprocs"
+)
+
+func nopLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// clearRuntimeEnv blanks GOMAXPROCS/GOMEMLIMIT for the test; Set treats "" as
+// unset. t.Setenv restores originals on cleanup.
+func clearRuntimeEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("GOMAXPROCS", "")
+	t.Setenv("GOMEMLIMIT", "")
+}
+
+func writeV2(t *testing.T, cpuMax, memMax string) string {
+	t.Helper()
+	root := t.TempDir()
+	if cpuMax != "" {
+		if err := os.WriteFile(filepath.Join(root, "cpu.max"), []byte(cpuMax), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if memMax != "" {
+		if err := os.WriteFile(filepath.Join(root, "memory.max"), []byte(memMax), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestSetV2CPUQuota(t *testing.T) {
+	clearRuntimeEnv(t)
+	prev := runtime.GOMAXPROCS(0)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "300000 100000", "")),
+		automaxprocs.WithMemory(false))
+	if got := runtime.GOMAXPROCS(0); got != 3 {
+		t.Errorf("GOMAXPROCS = %d, want 3", got)
+	}
+	undo()
+	if got := runtime.GOMAXPROCS(0); got != prev {
+		t.Errorf("undo left GOMAXPROCS = %d, want %d", got, prev)
+	}
+}
+
+func TestSetV2CPUFloorsToMinOne(t *testing.T) {
+	clearRuntimeEnv(t)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "150000 100000", "")), // 1.5 -> floor 1
+		automaxprocs.WithMemory(false))
+	defer undo()
+	if got := runtime.GOMAXPROCS(0); got != 1 {
+		t.Errorf("GOMAXPROCS = %d, want 1", got)
+	}
+}
+
+func TestSetV2CPUUnlimitedLeavesDefault(t *testing.T) {
+	clearRuntimeEnv(t)
+	prev := runtime.GOMAXPROCS(0)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "max 100000", "")),
+		automaxprocs.WithMemory(false))
+	defer undo()
+	if got := runtime.GOMAXPROCS(0); got != prev {
+		t.Errorf("GOMAXPROCS = %d, want unchanged %d", got, prev)
+	}
+}
+
+func TestSetV1CPUQuota(t *testing.T) {
+	clearRuntimeEnv(t)
+	root := t.TempDir()
+	cpuDir := filepath.Join(root, "cpu")
+	if err := os.MkdirAll(cpuDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(cpuDir, "cpu.cfs_quota_us"), []byte("400000"), 0o644)
+	os.WriteFile(filepath.Join(cpuDir, "cpu.cfs_period_us"), []byte("100000"), 0o644)
+	undo := automaxprocs.Set(nopLogger(), automaxprocs.WithCgroupRoot(root), automaxprocs.WithMemory(false))
+	defer undo()
+	if got := runtime.GOMAXPROCS(0); got != 4 {
+		t.Errorf("v1 GOMAXPROCS = %d, want 4", got)
+	}
+}
+
+func TestSetV2MemoryHeadroom(t *testing.T) {
+	clearRuntimeEnv(t)
+	prev := debug.SetMemoryLimit(-1)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "", "1000000000")),
+		automaxprocs.WithCPU(false),
+		automaxprocs.WithMemoryHeadroom(0.9))
+	if got := debug.SetMemoryLimit(-1); got != 900000000 {
+		t.Errorf("GOMEMLIMIT = %d, want 900000000", got)
+	}
+	undo()
+	if got := debug.SetMemoryLimit(-1); got != prev {
+		t.Errorf("undo left GOMEMLIMIT = %d, want %d", got, prev)
+	}
+}
+
+func TestSetV2MemoryUnlimited(t *testing.T) {
+	clearRuntimeEnv(t)
+	prev := debug.SetMemoryLimit(-1)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "", "max")),
+		automaxprocs.WithCPU(false))
+	defer undo()
+	if got := debug.SetMemoryLimit(-1); got != prev {
+		t.Errorf("GOMEMLIMIT = %d, want unchanged %d", got, prev)
+	}
+}
+
+func TestSetEnvPresentSkipsCPU(t *testing.T) {
+	t.Setenv("GOMAXPROCS", "7") // runtime read env at startup; Set must not override
+	t.Setenv("GOMEMLIMIT", "")
+	prev := runtime.GOMAXPROCS(0)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(writeV2(t, "300000 100000", "")),
+		automaxprocs.WithMemory(false))
+	defer undo()
+	if got := runtime.GOMAXPROCS(0); got != prev {
+		t.Errorf("env present must skip CPU leg; GOMAXPROCS = %d, want %d", got, prev)
+	}
+}
+
+func TestSetMissingRootIsNoOp(t *testing.T) {
+	clearRuntimeEnv(t)
+	prevP, prevM := runtime.GOMAXPROCS(0), debug.SetMemoryLimit(-1)
+	undo := automaxprocs.Set(nopLogger(),
+		automaxprocs.WithCgroupRoot(filepath.Join(t.TempDir(), "nonexistent")))
+	defer undo()
+	if runtime.GOMAXPROCS(0) != prevP || debug.SetMemoryLimit(-1) != prevM {
+		t.Error("missing cgroup root should be a no-op")
+	}
+}

--- a/ops/automaxprocs/cgroup.go
+++ b/ops/automaxprocs/cgroup.go
@@ -1,0 +1,84 @@
+package automaxprocs
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// unlimited treats cgroup v1's PAGE_COUNTER_MAX-ish sentinels as "no limit".
+const unlimited = int64(1) << 62
+
+// cpuQuota returns cores = quota/period from the cgroup under root, or ok=false
+// when unlimited or unreadable. cgroup v2 "cpu.max" is "<quota> <period>" or
+// "max <period>"; v1 splits across cpu.cfs_quota_us / cpu.cfs_period_us. The
+// file reads stay thin so the pure parser (parseCPUMax) carries the logic;
+// full-path coverage rides Set(WithCgroupRoot(tmp)) against fixture files.
+func cpuQuota(root string) (cores float64, ok bool) {
+	if b, err := os.ReadFile(filepath.Join(root, "cpu.max")); err == nil { // v2
+		return parseCPUMax(string(b))
+	}
+	q, e1 := readInt(filepath.Join(root, "cpu", "cpu.cfs_quota_us")) // v1
+	p, e2 := readInt(filepath.Join(root, "cpu", "cpu.cfs_period_us"))
+	if e1 == nil && e2 == nil && q > 0 && p > 0 {
+		return float64(q) / float64(p), true
+	}
+	return 0, false
+}
+
+// parseCPUMax parses a v2 "cpu.max" line into cores. Pure, hence tested directly.
+func parseCPUMax(s string) (cores float64, ok bool) {
+	f := strings.Fields(strings.TrimSpace(s))
+	if len(f) != 2 || f[0] == "max" {
+		return 0, false
+	}
+	q, e1 := strconv.ParseFloat(f[0], 64)
+	p, e2 := strconv.ParseFloat(f[1], 64)
+	if e1 == nil && e2 == nil && q > 0 && p > 0 {
+		return q / p, true
+	}
+	return 0, false
+}
+
+// memoryLimit returns the cgroup memory limit in bytes, or ok=false when
+// unlimited or unreadable. v2 "memory.max" is a number or "max"; v1 is
+// memory.limit_in_bytes with a huge sentinel meaning unlimited.
+func memoryLimit(root string) (bytes int64, ok bool) {
+	if b, err := os.ReadFile(filepath.Join(root, "memory.max")); err == nil { // v2
+		return parseMemMax(string(b))
+	}
+	if n, err := readInt(filepath.Join(root, "memory", "memory.limit_in_bytes")); err == nil { // v1
+		return validMem(n)
+	}
+	return 0, false
+}
+
+// parseMemMax parses a v2 "memory.max" value ("max" or a byte count). Pure.
+func parseMemMax(s string) (bytes int64, ok bool) {
+	s = strings.TrimSpace(s)
+	if s == "max" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return validMem(n)
+}
+
+// validMem accepts a positive, non-sentinel byte count.
+func validMem(n int64) (int64, bool) {
+	if n > 0 && n < unlimited {
+		return n, true
+	}
+	return 0, false
+}
+
+func readInt(path string) (int64, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+}

--- a/ops/automaxprocs/doc.go
+++ b/ops/automaxprocs/doc.go
@@ -1,0 +1,15 @@
+// Package automaxprocs right-sizes the Go runtime to its cgroup CPU and
+// memory limits: GOMAXPROCS from the cgroup CPU quota, GOMEMLIMIT from the
+// cgroup memory limit (scaled by a headroom fraction, default 0.9).
+//
+// It assumes a containerized host: the default cgroup root is
+// "/sys/fs/cgroup" (cgroup v2, with a v1 fallback), overridable via
+// WithCgroupRoot for non-standard mounts or tests. Outside a container, or
+// wherever the cgroup files are missing or unparseable, the corresponding leg
+// is simply left alone.
+//
+// Set is fail-open: any read or parse failure — or an explicit GOMAXPROCS /
+// GOMEMLIMIT environment variable, which always wins — is a logged no-op,
+// never a startup error. A maxprocs adjustment must never be the reason a
+// process fails to start.
+package automaxprocs

--- a/ops/bootstrap/bootstrap.go
+++ b/ops/bootstrap/bootstrap.go
@@ -18,9 +18,10 @@ import (
 // Func is a config-less application body. It receives a context cancelled on
 // SIGINT/SIGTERM (or when the ctx passed to Run is cancelled) and the configured
 // logger, wires the app, and typically ends by returning supervisor.Run(ctx,…).
-// A nil or context.Canceled result is a clean stop; any other error makes Run
-// return exit code 1. Use plain defer inside fn for resource teardown — it runs
-// after fn returns (i.e. after supervisor.Run drains), and on any early error.
+// A nil result, or a context.Canceled / context.DeadlineExceeded error from a
+// cancelled or timed-out parent context, is a clean stop; any other error makes
+// Run return exit code 1. Use plain defer inside fn for resource teardown — it
+// runs after fn returns (i.e. after supervisor.Run drains), and on any early error.
 type Func func(ctx context.Context, log *slog.Logger) error
 
 // ConfigFunc is an application body that also receives a loaded, typed config.
@@ -125,7 +126,8 @@ func run(ctx context.Context, name string, opts []Option, body func(context.Cont
 	runCtx, stop := supervisor.NewContext(ctxOpts...)
 	defer stop()
 
-	if err := body(runCtx, log, o); err != nil && !errors.Is(err, context.Canceled) {
+	if err := body(runCtx, log, o); err != nil &&
+		!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		log.Error("exit", slog.Any("err", err))
 		return 1
 	}

--- a/ops/bootstrap/bootstrap.go
+++ b/ops/bootstrap/bootstrap.go
@@ -1,0 +1,159 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/dmitrymomot/forge/ops/automaxprocs"
+	"github.com/dmitrymomot/forge/ops/buildinfo"
+	"github.com/dmitrymomot/forge/ops/config"
+	"github.com/dmitrymomot/forge/ops/logger"
+	"github.com/dmitrymomot/forge/ops/logredact"
+	"github.com/dmitrymomot/forge/ops/supervisor"
+)
+
+// Func is a config-less application body. It receives a context cancelled on
+// SIGINT/SIGTERM (or when the ctx passed to Run is cancelled) and the configured
+// logger, wires the app, and typically ends by returning supervisor.Run(ctx,…).
+// A nil or context.Canceled result is a clean stop; any other error makes Run
+// return exit code 1. Use plain defer inside fn for resource teardown — it runs
+// after fn returns (i.e. after supervisor.Run drains), and on any early error.
+type Func func(ctx context.Context, log *slog.Logger) error
+
+// ConfigFunc is an application body that also receives a loaded, typed config.
+// T is inferred from the function literal at the call site.
+type ConfigFunc[T any] func(ctx context.Context, log *slog.Logger, cfg T) error
+
+type options struct {
+	logger      *slog.Logger
+	build       *buildinfo.Info
+	configDir   string
+	redactKeys  []string
+	configOpts  []config.Option
+	autoMaxProc bool
+	forceQuit   bool
+}
+
+// Option configures Run and RunWithConfig.
+type Option func(*options)
+
+// WithLogger supplies a prebuilt logger instead of building one from LOG_* env.
+// WithRedactKeys still wraps it.
+func WithLogger(l *slog.Logger) Option { return func(o *options) { o.logger = l } }
+
+// WithBuildInfo logs the build identity once at startup and is otherwise inert.
+func WithBuildInfo(b buildinfo.Info) Option { return func(o *options) { o.build = &b } }
+
+// WithRedactKeys wraps the logger in logredact, redacting these attribute keys.
+func WithRedactKeys(keys ...string) Option { return func(o *options) { o.redactKeys = keys } }
+
+// WithAutoMaxProcs toggles the automaxprocs step (default on).
+func WithAutoMaxProcs(on bool) Option { return func(o *options) { o.autoMaxProc = on } }
+
+// WithForceQuit makes a second SIGINT/SIGTERM force os.Exit(130) while the first
+// drains gracefully — an escape hatch for a hung shutdown. Forwarded to
+// supervisor.NewContext.
+func WithForceQuit() Option { return func(o *options) { o.forceQuit = true } }
+
+// WithConfigDir switches RunWithConfig from env-only loading to the layered
+// YAML+env loader rooted at dir (config.Load). Ignored by Run.
+func WithConfigDir(dir string) Option { return func(o *options) { o.configDir = dir } }
+
+// WithConfigOptions forwards options to the underlying config loader (dotenv,
+// profile, lookup). Ignored by Run.
+func WithConfigOptions(opts ...config.Option) Option {
+	return func(o *options) { o.configOpts = opts }
+}
+
+// Run bootstraps the process runtime and executes fn (no app config), returning
+// a process exit code to pass to os.Exit. In order it: builds the logger from
+// LOG_* env (or WithLogger), wrapping it in logredact when WithRedactKeys is set;
+// tunes GOMAXPROCS/GOMEMLIMIT via automaxprocs unless WithAutoMaxProcs(false);
+// logs build info if WithBuildInfo; derives a SIGINT/SIGTERM-aware context from
+// ctx via supervisor.NewContext; then calls fn. bootstrap owns the runtime edges
+// only — fn owns the service lifecycle (supervisor.Run) and defer-based cleanup.
+func Run(ctx context.Context, name string, fn Func, opts ...Option) int {
+	return run(ctx, name, opts, func(runCtx context.Context, log *slog.Logger, _ options) error {
+		return fn(runCtx, log)
+	})
+}
+
+// RunWithConfig is Run plus generic config autoload: it loads a T (env-only via
+// config.LoadEnv by default, or the layered YAML+env loader under WithConfigDir)
+// and passes it to fn. A load failure is logged and yields exit code 1 without
+// calling fn. T is inferred from fn.
+func RunWithConfig[T any](ctx context.Context, name string, fn ConfigFunc[T], opts ...Option) int {
+	return run(ctx, name, opts, func(runCtx context.Context, log *slog.Logger, o options) error {
+		cfg, err := loadConfig[T](o)
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+		return fn(runCtx, log, cfg)
+	})
+}
+
+// run holds the shared bootstrap sequence; body wraps the caller's fn (with or
+// without config) and receives the resolved options.
+func run(ctx context.Context, name string, opts []Option, body func(context.Context, *slog.Logger, options) error) int {
+	o := options{autoMaxProc: true}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	log, err := buildLogger(o)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bootstrap: logger init: %v\n", err)
+		return 1
+	}
+	log = log.With(slog.String("app", name))
+
+	if o.autoMaxProc {
+		undo := automaxprocs.Set(log)
+		defer undo()
+	}
+	if o.build != nil {
+		log.Info("starting", slog.Any("build", *o.build))
+	}
+
+	ctxOpts := []supervisor.ContextOption{supervisor.WithContext(ctx)}
+	if o.forceQuit {
+		ctxOpts = append(ctxOpts, supervisor.WithForceQuit())
+	}
+	runCtx, stop := supervisor.NewContext(ctxOpts...)
+	defer stop()
+
+	if err := body(runCtx, log, o); err != nil && !errors.Is(err, context.Canceled) {
+		log.Error("exit", slog.Any("err", err))
+		return 1
+	}
+	log.Info("stopped")
+	return 0
+}
+
+func buildLogger(o options) (*slog.Logger, error) {
+	base := o.logger
+	if base == nil {
+		cfg, err := config.LoadEnv[logger.Config]()
+		if err != nil {
+			return nil, err
+		}
+		base, err = logger.New(logger.WithConfig(cfg))
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(o.redactKeys) > 0 {
+		return slog.New(logredact.New(base.Handler(), logredact.WithKeys(o.redactKeys...))), nil
+	}
+	return base, nil
+}
+
+func loadConfig[T any](o options) (T, error) {
+	if o.configDir != "" {
+		return config.Load[T](o.configDir, o.configOpts...)
+	}
+	return config.LoadEnv[T](o.configOpts...)
+}

--- a/ops/bootstrap/bootstrap_test.go
+++ b/ops/bootstrap/bootstrap_test.go
@@ -64,6 +64,28 @@ func TestRunContextCancelIsCleanShutdown(t *testing.T) {
 	}
 }
 
+func TestRunContextDeadlineExceededIsCleanShutdown(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	done := make(chan int, 1)
+	go func() {
+		done <- bootstrap.Run(ctx, "svc",
+			func(runCtx context.Context, l *slog.Logger) error {
+				<-runCtx.Done()
+				return runCtx.Err()
+			},
+			bootstrap.WithLogger(logger.NewNope()), bootstrap.WithAutoMaxProcs(false))
+	}()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Errorf("exit = %d, want 0 (context.DeadlineExceeded is clean)", code)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after parent deadline expired")
+	}
+}
+
 func TestRunWithRedactKeys(t *testing.T) {
 	var buf bytes.Buffer
 	bootstrap.Run(context.Background(), "svc",

--- a/ops/bootstrap/bootstrap_test.go
+++ b/ops/bootstrap/bootstrap_test.go
@@ -1,0 +1,129 @@
+package bootstrap_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/ops/bootstrap"
+	"github.com/dmitrymomot/forge/ops/buildinfo"
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+type testConfig struct {
+	Port int    `env:"TEST_PORT"`
+	Name string `env:"TEST_NAME"`
+}
+
+func TestRunCleanExit(t *testing.T) {
+	code := bootstrap.Run(context.Background(), "svc",
+		func(ctx context.Context, log *slog.Logger) error { return nil },
+		bootstrap.WithLogger(logger.NewNope()), bootstrap.WithAutoMaxProcs(false))
+	if code != 0 {
+		t.Errorf("exit = %d, want 0", code)
+	}
+}
+
+func TestRunErrorExitLogs(t *testing.T) {
+	var buf bytes.Buffer
+	code := bootstrap.Run(context.Background(), "svc",
+		func(ctx context.Context, l *slog.Logger) error { return errors.New("boom") },
+		bootstrap.WithLogger(slog.New(slog.NewJSONHandler(&buf, nil))),
+		bootstrap.WithAutoMaxProcs(false))
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(buf.String(), "boom") {
+		t.Errorf("error not logged: %s", buf.String())
+	}
+}
+
+func TestRunContextCancelIsCleanShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan int, 1)
+	go func() {
+		done <- bootstrap.Run(ctx, "svc",
+			func(runCtx context.Context, l *slog.Logger) error {
+				<-runCtx.Done()
+				return runCtx.Err()
+			},
+			bootstrap.WithLogger(logger.NewNope()), bootstrap.WithAutoMaxProcs(false))
+	}()
+	cancel() // supervisor.WithContext threads this like a SIGTERM
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Errorf("exit = %d, want 0 (context.Canceled is clean)", code)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
+func TestRunWithRedactKeys(t *testing.T) {
+	var buf bytes.Buffer
+	bootstrap.Run(context.Background(), "svc",
+		func(ctx context.Context, l *slog.Logger) error {
+			l.Info("login", "password", "hunter2")
+			return nil
+		},
+		bootstrap.WithLogger(slog.New(slog.NewJSONHandler(&buf, nil))),
+		bootstrap.WithRedactKeys("password"), bootstrap.WithAutoMaxProcs(false))
+	if strings.Contains(buf.String(), "hunter2") {
+		t.Errorf("password not redacted: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "[REDACTED]") {
+		t.Errorf("expected [REDACTED]: %s", buf.String())
+	}
+}
+
+func TestRunWithBuildInfoLogs(t *testing.T) {
+	var buf bytes.Buffer
+	bootstrap.Run(context.Background(), "svc",
+		func(ctx context.Context, l *slog.Logger) error { return nil },
+		bootstrap.WithLogger(slog.New(slog.NewJSONHandler(&buf, nil))),
+		bootstrap.WithBuildInfo(buildinfo.Info{Version: "9.9.9"}),
+		bootstrap.WithAutoMaxProcs(false))
+	if !strings.Contains(buf.String(), "9.9.9") {
+		t.Errorf("build info not logged: %s", buf.String())
+	}
+}
+
+func TestRunWithConfigLoadsAndPasses(t *testing.T) {
+	t.Setenv("TEST_PORT", "8080")
+	t.Setenv("TEST_NAME", "svc")
+	var got testConfig
+	code := bootstrap.RunWithConfig(context.Background(), "svc",
+		func(ctx context.Context, l *slog.Logger, cfg testConfig) error {
+			got = cfg
+			return nil
+		},
+		bootstrap.WithLogger(logger.NewNope()), bootstrap.WithAutoMaxProcs(false))
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if got.Port != 8080 || got.Name != "svc" {
+		t.Errorf("config = %+v, want {8080 svc}", got)
+	}
+}
+
+func TestRunWithConfigLoadFailureSkipsFn(t *testing.T) {
+	t.Setenv("TEST_PORT", "not-a-number") // typeconv int parse fails
+	called := false
+	code := bootstrap.RunWithConfig(context.Background(), "svc",
+		func(ctx context.Context, l *slog.Logger, cfg testConfig) error {
+			called = true
+			return nil
+		},
+		bootstrap.WithLogger(logger.NewNope()), bootstrap.WithAutoMaxProcs(false))
+	if code != 1 {
+		t.Errorf("exit = %d, want 1 on config load failure", code)
+	}
+	if called {
+		t.Error("fn must not be called when config load fails")
+	}
+}

--- a/ops/bootstrap/doc.go
+++ b/ops/bootstrap/doc.go
@@ -1,0 +1,53 @@
+// Package bootstrap is the thin runtime integrator for a forge process's
+// main(). It wires together the sibling ops packages — logger, automaxprocs,
+// buildinfo, logredact, config, and supervisor — into a one-line entry point,
+// so a typical main() reduces to:
+//
+//	func main() {
+//		os.Exit(bootstrap.Run(context.Background(), "svc", run))
+//	}
+//
+// bootstrap owns only the runtime edges, in order: build the logger from
+// LOG_* env (or an injected *slog.Logger via WithLogger), wrap it in
+// logredact when WithRedactKeys is set, tune GOMAXPROCS/GOMEMLIMIT via
+// automaxprocs (unless WithAutoMaxProcs(false)), log build info when
+// WithBuildInfo is set, derive a SIGINT/SIGTERM-aware context via
+// supervisor.NewContext, then call the caller's function body.
+//
+// It does NOT own the service lifecycle: the callback (Func or ConfigFunc[T])
+// wraps the whole app body, so the caller invokes supervisor.Run itself and
+// uses plain defer for cleanup — teardown runs after the callback returns,
+// whether that's after a graceful drain or an early setup error. A nil
+// result, or an error satisfying errors.Is(err, context.Canceled), is a
+// clean stop (exit code 0); any other error logs and exits 1.
+//
+// RunWithConfig[T] additionally autoloads a typed application config before
+// invoking the callback: config.LoadEnv[T] by default, or the layered
+// YAML+env loader (config.Load[T]) when WithConfigDir is set. T is inferred
+// from the callback's signature. A load failure is logged and yields exit
+// code 1 without calling the callback. A fuller shape, wiring a database and
+// an HTTP server behind supervisor.Run, looks like:
+//
+//	/*
+//	type AppConfig struct {
+//		HTTP httpserver.Config
+//		DB   dbConfig
+//	}
+//
+//	func main() {
+//		os.Exit(bootstrap.RunWithConfig(context.Background(), "svc",
+//			func(ctx context.Context, log *slog.Logger, cfg AppConfig) error {
+//				db, err := openDB(cfg.DB)
+//				if err != nil {
+//					return err
+//				}
+//				defer db.Close()
+//
+//				srv := newServer(db, cfg.HTTP)
+//				return supervisor.Run(ctx, log, srv)
+//			},
+//			bootstrap.WithBuildInfo(buildinfo.Read()),
+//		))
+//	}
+//	*/
+package bootstrap

--- a/ops/bootstrap/doc.go
+++ b/ops/bootstrap/doc.go
@@ -18,7 +18,8 @@
 // wraps the whole app body, so the caller invokes supervisor.Run itself and
 // uses plain defer for cleanup — teardown runs after the callback returns,
 // whether that's after a graceful drain or an early setup error. A nil
-// result, or an error satisfying errors.Is(err, context.Canceled), is a
+// result, or an error satisfying errors.Is against context.Canceled or
+// context.DeadlineExceeded (a cancelled or timed-out parent context), is a
 // clean stop (exit code 0); any other error logs and exits 1.
 //
 // RunWithConfig[T] additionally autoloads a typed application config before

--- a/ops/bootstrap/example_test.go
+++ b/ops/bootstrap/example_test.go
@@ -1,0 +1,29 @@
+package bootstrap_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/dmitrymomot/forge/ops/bootstrap"
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+// Example_main shows the canonical shape of a bootstrap-driven main(): the
+// callback owns the whole app body (wiring, supervisor.Run, defer-based
+// cleanup) while bootstrap owns only the runtime edges. This example has no
+// "Output:" comment, so `go test` compiles it but does not execute it.
+func Example_main() {
+	os.Exit(bootstrap.Run(context.Background(), "svc",
+		func(ctx context.Context, log *slog.Logger) error {
+			// Wire the app, then hand off to supervisor.Run, e.g.:
+			//
+			//	return supervisor.Run(ctx, log, srv1, srv2)
+			//
+			// defer any resource cleanup here — it runs after the callback
+			// returns, whether that's a clean drain or an early error.
+			return nil
+		},
+		bootstrap.WithLogger(logger.NewNope()),
+	))
+}

--- a/ops/buildinfo/buildinfo.go
+++ b/ops/buildinfo/buildinfo.go
@@ -1,0 +1,131 @@
+package buildinfo
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime"
+	"runtime/debug"
+	"strings"
+)
+
+// Link-time overrides. Set with, e.g.:
+//
+//	go build -ldflags "\
+//	  -X github.com/dmitrymomot/forge/ops/buildinfo.version=$(git describe --tags --always) \
+//	  -X github.com/dmitrymomot/forge/ops/buildinfo.commit=$(git rev-parse --short HEAD) \
+//	  -X github.com/dmitrymomot/forge/ops/buildinfo.buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+//
+// They are the ONLY package-level vars, are written once by the linker, never
+// mutated at runtime, and are read solely by Read.
+var (
+	version   string
+	commit    string
+	buildTime string
+)
+
+// Info is a snapshot of the binary's build identity. The zero value is valid;
+// unknown fields are empty (Version reads "dev" via String/LogValue).
+type Info struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildTime string `json:"build_time"`
+	GoVersion string `json:"go_version"`
+	Dirty     bool   `json:"dirty"`
+}
+
+// Read merges link-time ldflags (authoritative when set) over
+// runtime/debug.ReadBuildInfo: VCS revision/time/modified from `go build`
+// stamping, and the module version from `go install pkg@version`. With neither
+// source, fields stay empty and String/LogValue substitute "dev".
+func Read() Info {
+	i := Info{Version: version, Commit: commit, BuildTime: buildTime, GoVersion: runtime.Version()}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		if i.Version == "" && bi.Main.Version != "" {
+			i.Version = bi.Main.Version
+		}
+		for _, s := range bi.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				if i.Commit == "" {
+					i.Commit = s.Value
+				}
+			case "vcs.time":
+				if i.BuildTime == "" {
+					i.BuildTime = s.Value
+				}
+			case "vcs.modified":
+				if s.Value == "true" {
+					i.Dirty = true
+				}
+			}
+		}
+	}
+	return i
+}
+
+func (i Info) versionOrDev() string {
+	if i.Version == "" {
+		return "dev"
+	}
+	return i.Version
+}
+
+func (i Info) shortCommit() string {
+	if len(i.Commit) > 12 {
+		return i.Commit[:12]
+	}
+	return i.Commit
+}
+
+// String is a single-line summary: "1.2.3 (abc1234def0 2026-07-07T12:00:00Z, dirty)".
+func (i Info) String() string {
+	var b strings.Builder
+	b.WriteString(i.versionOrDev())
+	var parens []string
+	if c := i.shortCommit(); c != "" {
+		parens = append(parens, c)
+	}
+	if i.BuildTime != "" {
+		parens = append(parens, i.BuildTime)
+	}
+	if len(parens) > 0 {
+		fmt.Fprintf(&b, " (%s", strings.Join(parens, " "))
+		if i.Dirty {
+			b.WriteString(", dirty")
+		}
+		b.WriteByte(')')
+	} else if i.Dirty {
+		b.WriteString(" (dirty)")
+	}
+	return b.String()
+}
+
+// LogValue renders build identity as a grouped slog attribute, so
+// log.Info("starting", slog.Any("build", info)) nests version/commit/… .
+func (i Info) LogValue() slog.Value {
+	attrs := []slog.Attr{slog.String("version", i.versionOrDev())}
+	if c := i.shortCommit(); c != "" {
+		attrs = append(attrs, slog.String("commit", c))
+	}
+	if i.BuildTime != "" {
+		attrs = append(attrs, slog.String("build_time", i.BuildTime))
+	}
+	if i.GoVersion != "" {
+		attrs = append(attrs, slog.String("go", i.GoVersion))
+	}
+	if i.Dirty {
+		attrs = append(attrs, slog.Bool("dirty", true))
+	}
+	return slog.GroupValue(attrs...)
+}
+
+// Handler serves the Info as JSON. Mount at /version behind an auth guard if the
+// commit is sensitive.
+func (i Info) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(i)
+	})
+}

--- a/ops/buildinfo/buildinfo_test.go
+++ b/ops/buildinfo/buildinfo_test.go
@@ -1,0 +1,89 @@
+package buildinfo_test
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/buildinfo"
+)
+
+func TestReadPopulatesGoVersion(t *testing.T) {
+	if buildinfo.Read().GoVersion == "" {
+		t.Fatal("Read().GoVersion must be populated from runtime.Version()")
+	}
+}
+
+func TestInfoString(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   buildinfo.Info
+		want string
+	}{
+		{"empty renders dev", buildinfo.Info{}, "dev"},
+		{"version only", buildinfo.Info{Version: "1.2.3"}, "1.2.3"},
+		{"version commit time", buildinfo.Info{Version: "1.2.3", Commit: "abcdef1234567890", BuildTime: "2026-07-07T12:00:00Z"}, "1.2.3 (abcdef123456 2026-07-07T12:00:00Z)"},
+		{"short commit kept whole", buildinfo.Info{Version: "1.2.3", Commit: "abc1234"}, "1.2.3 (abc1234)"},
+		{"dirty flag", buildinfo.Info{Version: "1.2.3", Commit: "abc1234", Dirty: true}, "1.2.3 (abc1234, dirty)"},
+		{"dev dirty no meta", buildinfo.Info{Dirty: true}, "dev (dirty)"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.in.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInfoLogValueGroups(t *testing.T) {
+	var buf strings.Builder
+	slog.New(slog.NewJSONHandler(&buf, nil)).
+		Info("msg", slog.Any("build", buildinfo.Info{Version: "1.2.3", Commit: "abc1234def", GoVersion: "go1.26", Dirty: true}))
+
+	var rec map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &rec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	grp, ok := rec["build"].(map[string]any)
+	if !ok {
+		t.Fatalf("build attr is not a group: %T", rec["build"])
+	}
+	if grp["version"] != "1.2.3" {
+		t.Errorf("version = %v", grp["version"])
+	}
+	if grp["dirty"] != true {
+		t.Errorf("dirty = %v", grp["dirty"])
+	}
+}
+
+func TestInfoLogValueOmitsDirtyWhenFalse(t *testing.T) {
+	var buf strings.Builder
+	slog.New(slog.NewJSONHandler(&buf, nil)).
+		Info("msg", slog.Any("build", buildinfo.Info{Version: "1.2.3"}))
+	if strings.Contains(buf.String(), "dirty") {
+		t.Errorf("dirty should be omitted when false: %s", buf.String())
+	}
+}
+
+func TestInfoHandlerServesJSON(t *testing.T) {
+	rr := httptest.NewRecorder()
+	buildinfo.Info{Version: "1.2.3", Commit: "abc"}.Handler().
+		ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/version", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q", ct)
+	}
+	var got buildinfo.Info
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Version != "1.2.3" || got.Commit != "abc" {
+		t.Errorf("decoded = %+v", got)
+	}
+}

--- a/ops/buildinfo/doc.go
+++ b/ops/buildinfo/doc.go
@@ -1,0 +1,18 @@
+// Package buildinfo gives a binary its build identity: version, commit,
+// build time, Go toolchain version, and a dirty-worktree flag.
+//
+// Read merges link-time ldflags (authoritative when set via `-X`) over
+// runtime/debug.ReadBuildInfo, which supplies the VCS revision/time/dirty
+// bit stamped by `go build` and the module version recorded by
+// `go install pkg@version`. With neither source, fields stay empty and
+// String/LogValue substitute "dev":
+//
+//	go build -ldflags "\
+//	  -X github.com/dmitrymomot/forge/ops/buildinfo.version=$(git describe --tags --always) \
+//	  -X github.com/dmitrymomot/forge/ops/buildinfo.commit=$(git rev-parse --short HEAD) \
+//	  -X github.com/dmitrymomot/forge/ops/buildinfo.buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+//
+// Info is a plain value type: it satisfies fmt.Stringer for a one-line
+// summary, slog.LogValuer for a grouped log attribute, and it can serve
+// itself as a JSON http.Handler (e.g. mounted at /version).
+package buildinfo

--- a/ops/buildinfo/example_test.go
+++ b/ops/buildinfo/example_test.go
@@ -1,0 +1,18 @@
+package buildinfo_test
+
+import (
+	"fmt"
+
+	"github.com/dmitrymomot/forge/ops/buildinfo"
+)
+
+// Example demonstrates the "version (commit build_time)" shape produced by
+// String. Read().String() is not asserted here — its output varies with the
+// build environment — so this uses a constructed Info for a deterministic
+// Output.
+func Example() {
+	info := buildinfo.Info{Version: "1.2.3", Commit: "abc1234"}
+	fmt.Println(info.String())
+	// Output:
+	// 1.2.3 (abc1234)
+}

--- a/ops/logredact/doc.go
+++ b/ops/logredact/doc.go
@@ -1,0 +1,15 @@
+// Package logredact is an slog.Handler middleware that redacts attribute
+// values before they reach a downstream handler.
+//
+// Attributes are matched either by leaf key (WithKeys), which matches at any
+// nesting depth, or by dotted group path (WithPaths), which matches only the
+// exact group prefix. Matching values are replaced with DefaultReplacement
+// ("[REDACTED]") or a custom string set via WithReplacement.
+//
+// Redaction is unconditional: there is no level knob, and it applies equally
+// to attributes passed to a log call, attributes baked in via
+// slog.Logger.With (which routes through Handler.WithAttrs), and attributes
+// nested inside slog.Group values. The group prefix is tracked across
+// slog.Logger.WithGroup so dotted-path matches resolve correctly regardless
+// of nesting depth.
+package logredact

--- a/ops/logredact/example_test.go
+++ b/ops/logredact/example_test.go
@@ -1,0 +1,28 @@
+package logredact_test
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/dmitrymomot/forge/ops/logredact"
+)
+
+func Example() {
+	opts := &slog.HandlerOptions{
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey && len(groups) == 0 {
+				return slog.Attr{}
+			}
+			return a
+		},
+	}
+	h := logredact.New(slog.NewJSONHandler(os.Stdout, opts), logredact.WithKeys("password"))
+	log := slog.New(h)
+
+	log.Info("login", "password", "hunter2")
+	log.WithGroup("auth").Info("login", "password", "hunter2")
+
+	// Output:
+	// {"level":"INFO","msg":"login","password":"[REDACTED]"}
+	// {"level":"INFO","msg":"login","auth":{"password":"[REDACTED]"}}
+}

--- a/ops/logredact/logredact.go
+++ b/ops/logredact/logredact.go
@@ -1,0 +1,130 @@
+package logredact
+
+import (
+	"context"
+	"log/slog"
+)
+
+// DefaultReplacement is substituted for a redacted attribute value.
+const DefaultReplacement = "[REDACTED]"
+
+type config struct {
+	keys        map[string]struct{}
+	paths       map[string]struct{}
+	replacement string
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithKeys redacts any attribute whose leaf key matches, at any nesting depth.
+func WithKeys(keys ...string) Option {
+	return func(c *config) {
+		for _, k := range keys {
+			c.keys[k] = struct{}{}
+		}
+	}
+}
+
+// WithPaths redacts an attribute by its dotted group path, e.g. "user.ssn"
+// matches key "ssn" inside group "user" but not a top-level "ssn".
+func WithPaths(paths ...string) Option {
+	return func(c *config) {
+		for _, p := range paths {
+			c.paths[p] = struct{}{}
+		}
+	}
+}
+
+// WithReplacement overrides the "[REDACTED]" placeholder.
+func WithReplacement(s string) Option { return func(c *config) { c.replacement = s } }
+
+// handler wraps next, redacting matching attribute values before they reach it.
+type handler struct {
+	next  slog.Handler
+	cfg   *config
+	group string // dotted prefix of currently-open groups; "" at root
+}
+
+// New wraps next so attribute values matching WithKeys / WithPaths are replaced
+// before reaching next. It redacts record attrs (Handle), attrs baked in via
+// WithAttrs, and nested group values, tracking the group prefix across
+// WithGroup so dotted paths resolve at any depth.
+func New(next slog.Handler, opts ...Option) slog.Handler {
+	c := &config{
+		keys:        make(map[string]struct{}),
+		paths:       make(map[string]struct{}),
+		replacement: DefaultReplacement,
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return &handler{next: next, cfg: c}
+}
+
+func (h *handler) Enabled(ctx context.Context, l slog.Level) bool {
+	return h.next.Enabled(ctx, l)
+}
+
+func (h *handler) Handle(ctx context.Context, r slog.Record) error {
+	out := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+	r.Attrs(func(a slog.Attr) bool {
+		out.AddAttrs(h.redact(h.group, a))
+		return true
+	})
+	return h.next.Handle(ctx, out)
+}
+
+func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	red := make([]slog.Attr, len(attrs))
+	for i, a := range attrs {
+		red[i] = h.redact(h.group, a) // attrs are baked now — redact eagerly
+	}
+	return &handler{next: h.next.WithAttrs(red), cfg: h.cfg, group: h.group}
+}
+
+func (h *handler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &handler{next: h.next.WithGroup(name), cfg: h.cfg, group: joinPath(h.group, name)}
+}
+
+// redact replaces a's value when it matches by key or dotted path; group-valued
+// attrs are recursed into. LogValuer values are resolved first so their shape
+// is concrete for matching.
+func (h *handler) redact(prefix string, a slog.Attr) slog.Attr {
+	a.Value = a.Value.Resolve()
+	if a.Value.Kind() == slog.KindGroup {
+		sub := a.Value.Group()
+		gp := joinPath(prefix, a.Key)
+		red := make([]slog.Attr, len(sub))
+		for i, s := range sub {
+			red[i] = h.redact(gp, s)
+		}
+		return slog.Attr{Key: a.Key, Value: slog.GroupValue(red...)}
+	}
+	if h.matches(prefix, a.Key) {
+		return slog.String(a.Key, h.cfg.replacement)
+	}
+	return a
+}
+
+func (h *handler) matches(prefix, key string) bool {
+	if _, ok := h.cfg.keys[key]; ok {
+		return true
+	}
+	if len(h.cfg.paths) > 0 {
+		if _, ok := h.cfg.paths[joinPath(prefix, key)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func joinPath(prefix, name string) string {
+	if prefix == "" {
+		return name
+	}
+	return prefix + "." + name
+}

--- a/ops/logredact/logredact.go
+++ b/ops/logredact/logredact.go
@@ -27,7 +27,9 @@ func WithKeys(keys ...string) Option {
 }
 
 // WithPaths redacts an attribute by its dotted group path, e.g. "user.ssn"
-// matches key "ssn" inside group "user" but not a top-level "ssn".
+// matches key "ssn" inside group "user" but not a top-level "ssn". Paths are
+// resolved relative to the root of this handler — any slog.WithGroup already
+// applied to the handler that New wraps is not part of the matched path.
 func WithPaths(paths ...string) Option {
 	return func(c *config) {
 		for _, p := range paths {

--- a/ops/logredact/logredact_test.go
+++ b/ops/logredact/logredact_test.go
@@ -1,0 +1,110 @@
+package logredact_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/logredact"
+)
+
+func newLog(buf *bytes.Buffer, opts ...logredact.Option) *slog.Logger {
+	return slog.New(logredact.New(slog.NewJSONHandler(buf, nil), opts...))
+}
+
+func decode(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("unmarshal %q: %v", buf.String(), err)
+	}
+	return m
+}
+
+func TestRedactTopLevelKey(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, logredact.WithKeys("password")).Info("login", "password", "hunter2", "user", "alice")
+	m := decode(t, &buf)
+	if m["password"] != "[REDACTED]" {
+		t.Errorf("password = %v, want [REDACTED]", m["password"])
+	}
+	if m["user"] != "alice" {
+		t.Errorf("user = %v, want alice (untouched)", m["user"])
+	}
+}
+
+func TestRedactKeyInsideGroupValue(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, logredact.WithKeys("password")).
+		Info("m", slog.Group("creds", slog.String("password", "hunter2"), slog.String("kind", "basic")))
+	creds := decode(t, &buf)["creds"].(map[string]any)
+	if creds["password"] != "[REDACTED]" {
+		t.Errorf("creds.password = %v", creds["password"])
+	}
+	if creds["kind"] != "basic" {
+		t.Errorf("creds.kind = %v", creds["kind"])
+	}
+}
+
+func TestRedactKeyUnderWithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, logredact.WithKeys("password")).WithGroup("auth").Info("m", "password", "hunter2")
+	auth := decode(t, &buf)["auth"].(map[string]any)
+	if auth["password"] != "[REDACTED]" {
+		t.Errorf("auth.password = %v", auth["password"])
+	}
+}
+
+func TestRedactByDottedPath(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, logredact.WithPaths("user.ssn")).Info("m",
+		slog.Group("user", slog.String("ssn", "123-45-6789"), slog.String("name", "alice")),
+		slog.String("ssn", "top"))
+	m := decode(t, &buf)
+	if user := m["user"].(map[string]any); user["ssn"] != "[REDACTED]" {
+		t.Errorf("user.ssn = %v, want redacted", user["ssn"])
+	}
+	if m["ssn"] != "top" {
+		t.Errorf("top-level ssn = %v, want untouched", m["ssn"])
+	}
+}
+
+func TestRedactWithAttrsBakedIn(t *testing.T) {
+	var buf bytes.Buffer
+	// With(...) routes through WithAttrs, not Handle's record attrs — the
+	// regression a naive Handle-only redactor misses.
+	newLog(&buf, logredact.WithKeys("token")).With("token", "secret-abc").Info("m")
+	if decode(t, &buf)["token"] != "[REDACTED]" {
+		t.Errorf("WithAttrs-baked token not redacted: %s", buf.String())
+	}
+}
+
+func TestCustomReplacement(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, logredact.WithKeys("password"), logredact.WithReplacement("***")).Info("m", "password", "x")
+	if got := decode(t, &buf)["password"]; got != "***" {
+		t.Errorf("replacement = %v, want ***", got)
+	}
+}
+
+func TestNonMatchingPassThrough(t *testing.T) {
+	var buf bytes.Buffer
+	newLog(&buf, logredact.WithKeys("password")).Info("m", "count", 42, "name", "alice")
+	m := decode(t, &buf)
+	if m["count"] != float64(42) || m["name"] != "alice" {
+		t.Errorf("non-matching attrs altered: %+v", m)
+	}
+}
+
+func TestEnabledDelegates(t *testing.T) {
+	var buf bytes.Buffer
+	h := logredact.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	if h.Enabled(context.Background(), slog.LevelInfo) {
+		t.Error("Enabled(Info) should be false (delegates to Warn-level next)")
+	}
+	if !h.Enabled(context.Background(), slog.LevelError) {
+		t.Error("Enabled(Error) should be true")
+	}
+}

--- a/ops/logredact/logredact_test.go
+++ b/ops/logredact/logredact_test.go
@@ -71,6 +71,28 @@ func TestRedactByDottedPath(t *testing.T) {
 	}
 }
 
+func TestRedactByDottedPathTwoLevels(t *testing.T) {
+	var buf bytes.Buffer
+	// Two levels of nesting exercise joinPath/group-prefix accumulation at depth:
+	// only a.b.token matches, not a same-named token one level up or at the root.
+	newLog(&buf, logredact.WithPaths("a.b.token")).Info("m",
+		slog.Group("a",
+			slog.String("token", "shallow"),
+			slog.Group("b", slog.String("token", "deep"), slog.String("kind", "basic"))),
+		slog.String("token", "top"))
+	m := decode(t, &buf)
+	a := m["a"].(map[string]any)
+	if b := a["b"].(map[string]any); b["token"] != "[REDACTED]" {
+		t.Errorf("a.b.token = %v, want redacted", b["token"])
+	}
+	if a["token"] != "shallow" {
+		t.Errorf("a.token = %v, want untouched", a["token"])
+	}
+	if m["token"] != "top" {
+		t.Errorf("top-level token = %v, want untouched", m["token"])
+	}
+}
+
 func TestRedactWithAttrsBakedIn(t *testing.T) {
 	var buf bytes.Buffer
 	// With(...) routes through WithAttrs, not Handle's record attrs — the

--- a/ops/supervisor/context.go
+++ b/ops/supervisor/context.go
@@ -22,11 +22,15 @@ func NewContext(opts ...ContextOption) (context.Context, context.CancelFunc) {
 	for _, o := range opts {
 		o(&cfg)
 	}
+	parent := cfg.parent
+	if parent == nil {
+		parent = context.Background()
+	}
 	if !cfg.forceQuit {
-		return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		return signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(parent)
 	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 	stopped := make(chan struct{})
@@ -34,6 +38,8 @@ func NewContext(opts ...ContextOption) (context.Context, context.CancelFunc) {
 		select {
 		case <-ch:
 			cancel()
+		case <-parent.Done(): // parent cancelled: nothing to force, just stop watching
+			return
 		case <-stopped:
 			return
 		}

--- a/ops/supervisor/context.go
+++ b/ops/supervisor/context.go
@@ -38,8 +38,10 @@ func NewContext(opts ...ContextOption) (context.Context, context.CancelFunc) {
 		select {
 		case <-ch:
 			cancel()
-		case <-parent.Done(): // parent cancelled: nothing to force, just stop watching
-			return
+		case <-parent.Done():
+			// Parent cancelled: the graceful drain is already underway (ctx derives
+			// from parent). Keep watching for an impatient second signal so the
+			// force-quit escape hatch stays armed for parent-initiated shutdowns.
 		case <-stopped:
 			return
 		}

--- a/ops/supervisor/context_test.go
+++ b/ops/supervisor/context_test.go
@@ -65,3 +65,27 @@ func TestNewContext_ForceQuit_SecondSignalExits(t *testing.T) {
 	require.ErrorAs(t, err, &ee)
 	assert.Equal(t, 130, ee.ExitCode())
 }
+
+// TestNewContext_ForceQuit_ParentCancelThenSignalExits is a regression test for
+// the force-quit escape hatch staying armed after a parent-initiated (not
+// signal-initiated) cancellation. Before the fix, the watcher goroutine
+// returned as soon as parent.Done() fired, so a subsequent impatient signal
+// was never observed and the process would not force-exit.
+func TestNewContext_ForceQuit_ParentCancelThenSignalExits(t *testing.T) {
+	if os.Getenv("FORGE_FORCEQUIT_PARENT_CHILD") == "1" {
+		parent, cancelParent := context.WithCancel(context.Background())
+		_, stop := supervisor.NewContext(supervisor.WithContext(parent), supervisor.WithForceQuit())
+		defer stop()
+		cancelParent()
+		time.Sleep(100 * time.Millisecond)
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		time.Sleep(2 * time.Second) // parent expects exit(130) before this returns
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestNewContext_ForceQuit_ParentCancelThenSignalExits")
+	cmd.Env = append(os.Environ(), "FORGE_FORCEQUIT_PARENT_CHILD=1")
+	err := cmd.Run()
+	var ee *exec.ExitError
+	require.ErrorAs(t, err, &ee)
+	assert.Equal(t, 130, ee.ExitCode())
+}

--- a/ops/supervisor/context_withcontext_test.go
+++ b/ops/supervisor/context_withcontext_test.go
@@ -1,0 +1,48 @@
+package supervisor_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/ops/supervisor"
+)
+
+func TestWithContextParentCancels(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	ctx, stop := supervisor.NewContext(supervisor.WithContext(parent))
+	defer stop()
+	select {
+	case <-ctx.Done():
+		t.Fatal("ctx cancelled before parent")
+	default:
+	}
+	cancelParent()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("ctx not cancelled after parent cancel")
+	}
+}
+
+func TestWithContextParentCancelsForceQuit(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	ctx, stop := supervisor.NewContext(supervisor.WithContext(parent), supervisor.WithForceQuit())
+	defer stop()
+	cancelParent()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("force-quit ctx not cancelled after parent cancel")
+	}
+}
+
+func TestNewContextDefaultsToBackground(t *testing.T) {
+	ctx, stop := supervisor.NewContext()
+	defer stop()
+	select {
+	case <-ctx.Done():
+		t.Fatal("default context should not be cancelled")
+	default:
+	}
+}

--- a/ops/supervisor/options.go
+++ b/ops/supervisor/options.go
@@ -108,6 +108,7 @@ func WithRecover(enabled bool) Option {
 type ContextOption func(*contextConfig)
 
 type contextConfig struct {
+	parent    context.Context
 	forceQuit bool
 }
 
@@ -117,4 +118,12 @@ type contextConfig struct {
 // bypasses deferred cleanup by design.
 func WithForceQuit() ContextOption {
 	return func(c *contextConfig) { c.forceQuit = true }
+}
+
+// WithContext roots the signal context at parent instead of context.Background,
+// so cancelling parent triggers the same graceful shutdown a signal would.
+// bootstrap uses it to thread main's context; tests use it to shut down without
+// sending real signals. The zero/default parent remains context.Background.
+func WithContext(parent context.Context) ContextOption {
+	return func(c *contextConfig) { c.parent = parent }
 }


### PR DESCRIPTION
## Ops runtime-bootstrap bundle

Ships four `ops/` packages plus one shipped-package addition, giving a forge app a one-line `main()` with runtime tuning, build identity, log redaction, and generic config autoload. Built leaves-first; `bootstrap` composes the rest. Design spec and plan are the first commit.

### Packages

- **`ops/buildinfo`** — build-identity value type merging ldflags over `runtime/debug.ReadBuildInfo` (version/commit/build-time/dirty). Implements `fmt.Stringer`, `slog.LogValuer`, and an `http.Handler` serving `/version` JSON.
- **`ops/automaxprocs`** — sets `GOMAXPROCS`/`GOMEMLIMIT` from cgroup CPU/memory quotas at startup via a local stdlib parser (v2 primary, v1 fallback, **no uber dep**). Fail-open (a missing/unparseable cgroup or non-container host is a logged no-op, never a startup error), env-respecting (explicit `GOMAXPROCS`/`GOMEMLIMIT` wins), returns an `undo`.
- **`ops/logredact`** — `slog.Handler` middleware redacting attribute values by leaf key (`WithKeys`) or dotted group path (`WithPaths`). Unconditional (no level knob), correctly honors the handler contract: redacts `WithAttrs`-baked attrs and tracks the `WithGroup` prefix so dotted paths resolve at any depth.
- **`ops/bootstrap`** — thin integrator (replaces the planned `appmain` name). `Run` / generic `RunWithConfig[T]` wire logger → automaxprocs → build-info log → config autoload → signal context → exit code. The callback owns `supervisor.Run` and `defer`-based cleanup; bootstrap owns only the runtime edges. Not a DI container.
- **`ops/supervisor`** — additive `WithContext(parent)` so `NewContext` can root its signal context at a caller's context (default remains `context.Background()`); backward compatible.

### Notes

- Black-box tests only; options pattern throughout; stdlib-only leaves.
- A clean exit (code 0) covers `nil`, `context.Canceled`, and `context.DeadlineExceeded` (a cancelled or timed-out parent context); any other error is exit 1.
- The force-quit escape hatch stays armed after a parent-initiated drain (subprocess-tested via real `os.Exit(130)`).
- `just lint` clean; `go test ./ops/...` green.
- `docs/packages.md` updated: the four packages moved to shipped, `appmain` retired, build-order line updated.
