### PR TITLE
feat(jwt): full JWT sign/verify with pinned alg allowlist + JWKS

### DIFF
--- a/auth/jwt/alg.go
+++ b/auth/jwt/alg.go
@@ -1,0 +1,168 @@
+package jwt
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/asn1"
+	"fmt"
+	"math/big"
+)
+
+// Alg identifies a JWS signing algorithm. The set is closed: forge never
+// negotiates algorithms and offers no registration hook.
+type Alg string
+
+const (
+	HS256 Alg = "HS256"
+	RS256 Alg = "RS256"
+	ES256 Alg = "ES256"
+	EdDSA Alg = "EdDSA"
+)
+
+// Key is a verification key bound to exactly one algorithm. Key holds
+// *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey, or a []byte secret
+// for HS256.
+type Key struct {
+	Key crypto.PublicKey
+	KID string
+	Alg Alg
+}
+
+const minHS256KeyLen = 32
+
+// algForPrivate infers the pinned alg for a parsed PKCS#8 private key.
+func algForPrivate(key any) (Alg, error) {
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		if k.N.BitLen() < 2048 {
+			return "", fmt.Errorf("%w: RSA key must be at least 2048 bits", ErrBadKey)
+		}
+		return RS256, nil
+	case *ecdsa.PrivateKey:
+		if k.Curve != elliptic.P256() {
+			return "", fmt.Errorf("%w: ECDSA key must use P-256", ErrBadKey)
+		}
+		return ES256, nil
+	case ed25519.PrivateKey:
+		return EdDSA, nil
+	default:
+		return "", fmt.Errorf("%w: unsupported key type %T", ErrBadKey, key)
+	}
+}
+
+// checkSignerAlg validates that a caller-supplied crypto.Signer matches its
+// declared alg.
+func checkSignerAlg(alg Alg, pub crypto.PublicKey) error {
+	switch alg {
+	case HS256:
+		return fmt.Errorf("%w: HS256 needs a secret, use WithHS256Keyset", ErrBadKey)
+	case RS256:
+		if k, ok := pub.(*rsa.PublicKey); !ok || k.N.BitLen() < 2048 {
+			return fmt.Errorf("%w: RS256 requires an RSA key of at least 2048 bits", ErrBadKey)
+		}
+	case ES256:
+		if k, ok := pub.(*ecdsa.PublicKey); !ok || k.Curve != elliptic.P256() {
+			return fmt.Errorf("%w: ES256 requires an ECDSA P-256 key", ErrBadKey)
+		}
+	case EdDSA:
+		if _, ok := pub.(ed25519.PublicKey); !ok {
+			return fmt.Errorf("%w: EdDSA requires an Ed25519 key", ErrBadKey)
+		}
+	default:
+		return fmt.Errorf("%w: unsupported alg %q", ErrBadKey, alg)
+	}
+	return nil
+}
+
+// checkVerifyKey validates a verification Key's alg/key-type binding.
+func checkVerifyKey(k Key) error {
+	if k.Alg == HS256 {
+		secret, ok := k.Key.([]byte)
+		if !ok || len(secret) < minHS256KeyLen {
+			return fmt.Errorf("%w: HS256 key must be a []byte secret of at least %d bytes", ErrBadKey, minHS256KeyLen)
+		}
+		return nil
+	}
+	return checkSignerAlg(k.Alg, k.Key)
+}
+
+// signBytes signs the JWS signing input. Exactly one of signer/secret is set.
+func signBytes(alg Alg, signer crypto.Signer, secret, input []byte) ([]byte, error) {
+	switch alg {
+	case HS256:
+		m := hmac.New(sha256.New, secret)
+		m.Write(input)
+		return m.Sum(nil), nil
+	case RS256:
+		d := sha256.Sum256(input)
+		return signer.Sign(rand.Reader, d[:], crypto.SHA256)
+	case ES256:
+		d := sha256.Sum256(input)
+		der, err := signer.Sign(rand.Reader, d[:], crypto.SHA256)
+		if err != nil {
+			return nil, err
+		}
+		return derToRawES256(der)
+	case EdDSA:
+		return signer.Sign(rand.Reader, input, crypto.Hash(0))
+	default:
+		return nil, fmt.Errorf("%w: unsupported alg %q", ErrBadKey, alg)
+	}
+}
+
+// verifyBytes reports whether sig is a valid signature over input for k.
+func verifyBytes(k Key, input, sig []byte) bool {
+	switch k.Alg {
+	case HS256:
+		secret, ok := k.Key.([]byte)
+		if !ok {
+			return false
+		}
+		m := hmac.New(sha256.New, secret)
+		m.Write(input)
+		return hmac.Equal(sig, m.Sum(nil))
+	case RS256:
+		pub, ok := k.Key.(*rsa.PublicKey)
+		if !ok {
+			return false
+		}
+		d := sha256.Sum256(input)
+		return rsa.VerifyPKCS1v15(pub, crypto.SHA256, d[:], sig) == nil
+	case ES256:
+		pub, ok := k.Key.(*ecdsa.PublicKey)
+		if !ok || len(sig) != 64 {
+			return false
+		}
+		d := sha256.Sum256(input)
+		r := new(big.Int).SetBytes(sig[:32])
+		s := new(big.Int).SetBytes(sig[32:])
+		return ecdsa.Verify(pub, d[:], r, s)
+	case EdDSA:
+		pub, ok := k.Key.(ed25519.PublicKey)
+		if !ok {
+			return false
+		}
+		return ed25519.Verify(pub, input, sig)
+	default:
+		return false
+	}
+}
+
+// derToRawES256 converts an ASN.1 DER ECDSA signature (what crypto.Signer
+// returns) to the raw fixed-width R||S form JWS requires.
+func derToRawES256(der []byte) ([]byte, error) {
+	var sig struct{ R, S *big.Int }
+	if _, err := asn1.Unmarshal(der, &sig); err != nil {
+		return nil, fmt.Errorf("jwt: ES256 signature encoding: %w", err)
+	}
+	out := make([]byte, 64)
+	sig.R.FillBytes(out[:32])
+	sig.S.FillBytes(out[32:])
+	return out, nil
+}

--- a/auth/jwt/alg.go
+++ b/auth/jwt/alg.go
@@ -36,12 +36,18 @@ type Key struct {
 
 const minHS256KeyLen = 32
 
+// maxRSABits caps accepted RSA modulus size. Keys are parsed from remote
+// JWKS endpoints (parseJWK), and an oversized modulus makes every Verify on
+// that kid an expensive modexp — a CPU-exhaustion vector. 8192 bits admits
+// every realistic key (2048/3072/4096/8192) while rejecting absurd sizes.
+const maxRSABits = 8192
+
 // algForPrivate infers the pinned alg for a parsed PKCS#8 private key.
 func algForPrivate(key any) (Alg, error) {
 	switch k := key.(type) {
 	case *rsa.PrivateKey:
-		if k.N.BitLen() < 2048 {
-			return "", fmt.Errorf("%w: RSA key must be at least 2048 bits", ErrBadKey)
+		if k.N.BitLen() < 2048 || k.N.BitLen() > maxRSABits {
+			return "", fmt.Errorf("%w: RSA key must be 2048–%d bits", ErrBadKey, maxRSABits)
 		}
 		return RS256, nil
 	case *ecdsa.PrivateKey:
@@ -63,8 +69,9 @@ func checkSignerAlg(alg Alg, pub crypto.PublicKey) error {
 	case HS256:
 		return fmt.Errorf("%w: HS256 needs a secret, use WithHS256Keyset", ErrBadKey)
 	case RS256:
-		if k, ok := pub.(*rsa.PublicKey); !ok || k.N.BitLen() < 2048 {
-			return fmt.Errorf("%w: RS256 requires an RSA key of at least 2048 bits", ErrBadKey)
+		k, ok := pub.(*rsa.PublicKey)
+		if !ok || k.N.BitLen() < 2048 || k.N.BitLen() > maxRSABits {
+			return fmt.Errorf("%w: RS256 requires an RSA key of 2048–%d bits", ErrBadKey, maxRSABits)
 		}
 	case ES256:
 		if k, ok := pub.(*ecdsa.PublicKey); !ok || k.Curve != elliptic.P256() {

--- a/auth/jwt/bench_test.go
+++ b/auth/jwt/bench_test.go
@@ -1,0 +1,120 @@
+package jwt_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+func benchKeysetHS(b *testing.B) *keyset.Keyset {
+	b.Helper()
+	ks, err := keyset.New(keyset.WithPrimary(1, []byte("0123456789abcdef0123456789abcdef")))
+	if err != nil {
+		b.Fatalf("keyset: %v", err)
+	}
+	return ks
+}
+
+func benchKeysetEd(b *testing.B) *keyset.Keyset {
+	b.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		b.Fatalf("ed25519: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		b.Fatalf("pkcs8: %v", err)
+	}
+	ks, err := keyset.New(keyset.WithPrimary(1, der))
+	if err != nil {
+		b.Fatalf("keyset: %v", err)
+	}
+	return ks
+}
+
+func benchClaims() jwt.Claims {
+	return jwt.Claims{
+		Issuer:    "https://api.example.com",
+		Subject:   "user-1",
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+}
+
+func BenchmarkSignHS256(b *testing.B) {
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(benchKeysetHS(b)))
+	if err != nil {
+		b.Fatalf("NewSigner: %v", err)
+	}
+	c := benchClaims()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := s.Sign(c); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyHS256(b *testing.B) {
+	ks := benchKeysetHS(b)
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(ks))
+	if err != nil {
+		b.Fatalf("NewSigner: %v", err)
+	}
+	v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(ks))
+	if err != nil {
+		b.Fatalf("NewVerifier: %v", err)
+	}
+	tok, err := s.Sign(benchClaims())
+	if err != nil {
+		b.Fatalf("Sign: %v", err)
+	}
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := jwt.Verify[jwt.Claims](ctx, v, tok); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSignEdDSA(b *testing.B) {
+	s, err := jwt.NewSigner(jwt.WithKeyset(benchKeysetEd(b)))
+	if err != nil {
+		b.Fatalf("NewSigner: %v", err)
+	}
+	c := benchClaims()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := s.Sign(c); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyEdDSA(b *testing.B) {
+	ks := benchKeysetEd(b)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		b.Fatalf("NewSigner: %v", err)
+	}
+	v, err := jwt.NewVerifier(jwt.WithVerifyKeyset(ks))
+	if err != nil {
+		b.Fatalf("NewVerifier: %v", err)
+	}
+	tok, err := s.Sign(benchClaims())
+	if err != nil {
+		b.Fatalf("Sign: %v", err)
+	}
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := jwt.Verify[jwt.Claims](ctx, v, tok); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/auth/jwt/claims.go
+++ b/auth/jwt/claims.go
@@ -1,0 +1,84 @@
+package jwt
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+	"time"
+)
+
+// Audience is the RFC 7519 "aud" claim. It unmarshals from either a JSON
+// string or an array of strings and marshals to a bare string when it
+// holds exactly one value.
+type Audience []string
+
+// Contains reports whether v is one of the audience values.
+func (a Audience) Contains(v string) bool {
+	return slices.Contains(a, v)
+}
+
+func (a Audience) MarshalJSON() ([]byte, error) {
+	if len(a) == 1 {
+		return json.Marshal(a[0])
+	}
+	return json.Marshal([]string(a))
+}
+
+func (a *Audience) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		*a = Audience{s}
+		return nil
+	}
+	var ss []string
+	if err := json.Unmarshal(b, &ss); err != nil {
+		return err
+	}
+	*a = Audience(ss)
+	return nil
+}
+
+// NumericDate is an RFC 7519 NumericDate: unix seconds as a JSON number.
+// Fractional seconds are accepted on input and truncated.
+type NumericDate struct {
+	time.Time
+}
+
+// NewNumericDate returns t truncated to whole seconds.
+func NewNumericDate(t time.Time) *NumericDate {
+	return &NumericDate{Time: t.Truncate(time.Second)}
+}
+
+func (d NumericDate) MarshalJSON() ([]byte, error) {
+	return strconv.AppendInt(nil, d.Unix(), 10), nil
+}
+
+func (d *NumericDate) UnmarshalJSON(b []byte) error {
+	f, err := strconv.ParseFloat(string(b), 64)
+	if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+		return fmt.Errorf("jwt: invalid NumericDate %q", b)
+	}
+	d.Time = time.Unix(int64(f), 0)
+	return nil
+}
+
+// Claims holds the RFC 7519 registered claims. Consumers embed it:
+//
+//	type AccessClaims struct {
+//	    jwt.Claims
+//	    TenantID string `json:"tid"`
+//	}
+type Claims struct {
+	ExpiresAt *NumericDate `json:"exp,omitempty"`
+	NotBefore *NumericDate `json:"nbf,omitempty"`
+	IssuedAt  *NumericDate `json:"iat,omitempty"`
+	Issuer    string       `json:"iss,omitempty"`
+	Subject   string       `json:"sub,omitempty"`
+	ID        string       `json:"jti,omitempty"`
+	Audience  Audience     `json:"aud,omitempty"`
+}

--- a/auth/jwt/claims_policy_test.go
+++ b/auth/jwt/claims_policy_test.go
@@ -1,0 +1,193 @@
+package jwt_test
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// RFC 7515 Appendix A.1 golden vector (HS256, no kid header).
+// If ONLY this test fails while round-trip tests pass, re-copy these two
+// constants from the RFC text before debugging the implementation.
+const (
+	rfc7515A1Token = "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	rfc7515A1Key   = "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
+)
+
+func TestRFC7515A1GoldenVector(t *testing.T) {
+	t.Parallel()
+	secret, err := base64.RawURLEncoding.DecodeString(rfc7515A1Key)
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	// exp is 1300819380 (2011) — pin the clock before it.
+	v, err := jwt.NewVerifier(
+		jwt.WithKeys(jwt.Key{KID: "a1", Alg: jwt.HS256, Key: secret}),
+		jwt.WithClock(clock.NewMock(time.Unix(1300819000, 0))),
+		jwt.WithIssuer("joe"),
+	)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	type rootClaims struct {
+		jwt.Claims
+		IsRoot bool `json:"http://example.com/is_root"`
+	}
+	got, err := jwt.Verify[rootClaims](t.Context(), v, rfc7515A1Token)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got.Issuer != "joe" || !got.IsRoot || got.ExpiresAt.Unix() != 1300819380 {
+		t.Fatalf("claims %+v", got)
+	}
+}
+
+func policyVerifier(t *testing.T, now time.Time, opts ...jwt.VerifierOption) *jwt.Verifier {
+	t.Helper()
+	base := []jwt.VerifierOption{
+		jwt.WithVerifyHS256Keyset(hsKeyset(t)),
+		jwt.WithClock(clock.NewMock(now)),
+	}
+	v, err := jwt.NewVerifier(append(base, opts...)...)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	return v
+}
+
+func signClaims(t *testing.T, c any) string {
+	t.Helper()
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(c)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	return tok
+}
+
+func TestExpiryPolicy(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_700_000_000, 0)
+	exp := jwt.NewNumericDate(now.Add(-time.Minute))
+	expired := signClaims(t, jwt.Claims{ExpiresAt: exp})
+
+	t.Run("expired rejected", func(t *testing.T) {
+		t.Parallel()
+		v := policyVerifier(t, now)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, expired); !errors.Is(err, jwt.ErrExpired) {
+			t.Fatalf("got %v, want ErrExpired", err)
+		}
+	})
+
+	t.Run("within default 30s leeway accepted", func(t *testing.T) {
+		t.Parallel()
+		tok := signClaims(t, jwt.Claims{ExpiresAt: jwt.NewNumericDate(now.Add(-29 * time.Second))})
+		v := policyVerifier(t, now)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+			t.Fatalf("leeway not applied: %v", err)
+		}
+	})
+
+	t.Run("exactly exp+leeway rejected", func(t *testing.T) {
+		t.Parallel()
+		tok := signClaims(t, jwt.Claims{ExpiresAt: jwt.NewNumericDate(now.Add(-30 * time.Second))})
+		v := policyVerifier(t, now)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrExpired) {
+			t.Fatalf("got %v, want ErrExpired at boundary", err)
+		}
+	})
+
+	t.Run("custom leeway", func(t *testing.T) {
+		t.Parallel()
+		v := policyVerifier(t, now, jwt.WithLeeway(2*time.Minute))
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, expired); err != nil {
+			t.Fatalf("2m leeway should accept 1m-expired: %v", err)
+		}
+	})
+
+	t.Run("missing exp rejected by default", func(t *testing.T) {
+		t.Parallel()
+		tok := signClaims(t, jwt.Claims{Subject: "user-1"})
+		v := policyVerifier(t, now)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrExpired) {
+			t.Fatalf("got %v, want ErrExpired for missing exp", err)
+		}
+	})
+
+	t.Run("missing exp allowed with WithoutExpiry", func(t *testing.T) {
+		t.Parallel()
+		tok := signClaims(t, jwt.Claims{Subject: "user-1"})
+		v := policyVerifier(t, now, jwt.WithoutExpiry())
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+			t.Fatalf("WithoutExpiry: %v", err)
+		}
+	})
+}
+
+func TestNotBeforePolicy(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_700_000_000, 0)
+	future := jwt.NewNumericDate(now.Add(time.Hour))
+	exp := jwt.NewNumericDate(now.Add(2 * time.Hour))
+
+	t.Run("future nbf rejected", func(t *testing.T) {
+		t.Parallel()
+		tok := signClaims(t, jwt.Claims{NotBefore: future, ExpiresAt: exp})
+		v := policyVerifier(t, now)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrNotYetValid) {
+			t.Fatalf("got %v, want ErrNotYetValid", err)
+		}
+	})
+
+	t.Run("nbf within leeway accepted", func(t *testing.T) {
+		t.Parallel()
+		tok := signClaims(t, jwt.Claims{NotBefore: jwt.NewNumericDate(now.Add(29 * time.Second)), ExpiresAt: exp})
+		v := policyVerifier(t, now)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+			t.Fatalf("nbf leeway: %v", err)
+		}
+	})
+}
+
+func TestIssuerAudiencePolicy(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_700_000_000, 0)
+	claims := jwt.Claims{
+		Issuer:    "https://api.example.com",
+		Audience:  jwt.Audience{"my-app", "other"},
+		ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+	}
+	tok := signClaims(t, claims)
+
+	cases := map[string]struct {
+		opts []jwt.VerifierOption
+		want error
+	}{
+		"iss match":       {[]jwt.VerifierOption{jwt.WithIssuer("https://api.example.com")}, nil},
+		"iss mismatch":    {[]jwt.VerifierOption{jwt.WithIssuer("https://evil.example.com")}, jwt.ErrIssuerMismatch},
+		"aud contains":    {[]jwt.VerifierOption{jwt.WithAudience("my-app")}, nil},
+		"aud missing":     {[]jwt.VerifierOption{jwt.WithAudience("mobile")}, jwt.ErrAudienceMismatch},
+		"no policy":       {nil, nil},
+		"both mismatched": {[]jwt.VerifierOption{jwt.WithIssuer("x"), jwt.WithAudience("y")}, jwt.ErrIssuerMismatch},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			v := policyVerifier(t, now, tc.opts...)
+			_, err := jwt.Verify[jwt.Claims](t.Context(), v, tok)
+			if tc.want == nil && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.want != nil && !errors.Is(err, tc.want) {
+				t.Fatalf("got %v, want %v", err, tc.want)
+			}
+		})
+	}
+}

--- a/auth/jwt/claims_test.go
+++ b/auth/jwt/claims_test.go
@@ -1,0 +1,154 @@
+package jwt_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+)
+
+func TestAudienceJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unmarshal string", func(t *testing.T) {
+		t.Parallel()
+		var a jwt.Audience
+		if err := json.Unmarshal([]byte(`"api"`), &a); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(a) != 1 || a[0] != "api" {
+			t.Fatalf("got %v, want [api]", a)
+		}
+	})
+
+	t.Run("unmarshal array", func(t *testing.T) {
+		t.Parallel()
+		var a jwt.Audience
+		if err := json.Unmarshal([]byte(`["api","web"]`), &a); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(a) != 2 || a[0] != "api" || a[1] != "web" {
+			t.Fatalf("got %v, want [api web]", a)
+		}
+	})
+
+	t.Run("unmarshal rejects number", func(t *testing.T) {
+		t.Parallel()
+		var a jwt.Audience
+		if err := json.Unmarshal([]byte(`42`), &a); err == nil {
+			t.Fatal("want error for non-string aud")
+		}
+	})
+
+	t.Run("marshal single as string", func(t *testing.T) {
+		t.Parallel()
+		b, err := json.Marshal(jwt.Audience{"api"})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if string(b) != `"api"` {
+			t.Fatalf("got %s, want %q", b, `"api"`)
+		}
+	})
+
+	t.Run("marshal multiple as array", func(t *testing.T) {
+		t.Parallel()
+		b, err := json.Marshal(jwt.Audience{"api", "web"})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if string(b) != `["api","web"]` {
+			t.Fatalf("got %s, want array", b)
+		}
+	})
+
+	t.Run("contains", func(t *testing.T) {
+		t.Parallel()
+		a := jwt.Audience{"api", "web"}
+		if !a.Contains("web") || a.Contains("mobile") {
+			t.Fatalf("Contains misbehaves: %v", a)
+		}
+	})
+}
+
+func TestNumericDateJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("round trip unix seconds", func(t *testing.T) {
+		t.Parallel()
+		d := jwt.NewNumericDate(time.Unix(1300819380, 0))
+		b, err := json.Marshal(d)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if string(b) != "1300819380" {
+			t.Fatalf("got %s, want 1300819380", b)
+		}
+		var back jwt.NumericDate
+		if err := json.Unmarshal(b, &back); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if !back.Equal(time.Unix(1300819380, 0)) {
+			t.Fatalf("got %v", back.Time)
+		}
+	})
+
+	t.Run("fractional seconds truncate", func(t *testing.T) {
+		t.Parallel()
+		var d jwt.NumericDate
+		if err := json.Unmarshal([]byte("1300819380.75"), &d); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if d.Unix() != 1300819380 {
+			t.Fatalf("got %d, want 1300819380", d.Unix())
+		}
+	})
+
+	t.Run("rejects non-numbers", func(t *testing.T) {
+		t.Parallel()
+		for _, in := range []string{`"soon"`, `null`, `{}`, `NaN`} {
+			var d jwt.NumericDate
+			if err := json.Unmarshal([]byte(in), &d); err == nil {
+				t.Fatalf("want error for %s", in)
+			}
+		}
+	})
+}
+
+func TestClaimsEmbedding(t *testing.T) {
+	t.Parallel()
+	type access struct {
+		jwt.Claims
+		TenantID string `json:"tid"`
+	}
+	in := access{
+		Claims: jwt.Claims{
+			Issuer:    "https://api.example.com",
+			Subject:   "user-1",
+			Audience:  jwt.Audience{"my-app"},
+			ExpiresAt: jwt.NewNumericDate(time.Unix(1300819380, 0)),
+			ID:        "jti-1",
+		},
+		TenantID: "t-42",
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out access
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Issuer != in.Issuer || out.TenantID != "t-42" || !out.Audience.Contains("my-app") {
+		t.Fatalf("round trip mismatch: %+v", out)
+	}
+	// omitempty: zero claims marshal to {} — no null exp/nbf noise.
+	empty, err := json.Marshal(jwt.Claims{})
+	if err != nil {
+		t.Fatalf("marshal empty: %v", err)
+	}
+	if string(empty) != "{}" {
+		t.Fatalf("empty claims marshal to %s, want {}", empty)
+	}
+}

--- a/auth/jwt/doc.go
+++ b/auth/jwt/doc.go
@@ -1,0 +1,60 @@
+// Package jwt signs and verifies JSON Web Tokens with a pinned algorithm
+// allowlist — HS256, RS256, ES256, EdDSA — that is never negotiated. Every
+// key is bound to exactly one algorithm at construction and the token's
+// alg header must match the resolved key's algorithm, which structurally
+// rules out alg:none, algorithm-swap, and HMAC/public-key confusion
+// attacks. There is no JWE and no algorithm registry.
+//
+// Signing and verifying are split: a Signer issues tokens with its primary
+// key and publishes its asymmetric public keys over an RFC 7517 JWKS
+// handler; a Verifier checks tokens from static keys, a keyset, or a
+// remote JWKS URL with in-memory caching, TTL refresh, and unknown-kid
+// refetch behind a cooldown. Key rotation rides crypto/keyset: the primary
+// version signs, retired versions keep verifying, and the keyset version
+// is the kid.
+//
+// Claims are typed: embed Claims in a consumer struct and Verify returns
+// it decoded, with exp/nbf/iss/aud already enforced (30s default leeway;
+// missing exp is rejected unless WithoutExpiry is set). Sign marshals
+// exactly the claims it is given — nothing is auto-filled.
+//
+// # Usage
+//
+// Simple shared-secret API (HS256 over one env-loaded keyset):
+//
+//	ks, _ := keyset.New(keyset.WithBase64Keys(os.Getenv("JWT_KEYS")))
+//	signer, _ := jwt.NewSigner(jwt.WithHS256Keyset(ks))
+//	verifier, _ := jwt.NewVerifier(
+//		jwt.WithVerifyHS256Keyset(ks),
+//		jwt.WithIssuer("https://api.example.com"),
+//	)
+//
+//	type AccessClaims struct {
+//		jwt.Claims
+//		TenantID string `json:"tid"`
+//	}
+//
+//	token, _ := signer.Sign(AccessClaims{
+//		Claims: jwt.Claims{
+//			Issuer:    "https://api.example.com",
+//			Subject:   userID,
+//			ExpiresAt: jwt.NewNumericDate(time.Now().Add(15 * time.Minute)),
+//		},
+//		TenantID: tenantID,
+//	})
+//
+//	claims, err := jwt.Verify[AccessClaims](ctx, verifier, token)
+//
+// Asymmetric issuing with a JWKS endpoint for external verifiers:
+//
+//	signer, _ := jwt.NewSigner(jwt.WithKeyset(ks)) // PKCS#8 DER material
+//	mux.Handle("/.well-known/jwks.json", signer.JWKS(jwt.WithCacheControl(5*time.Minute)))
+//
+// Verifying a third party's tokens from their JWKS:
+//
+//	verifier, _ := jwt.NewVerifier(
+//		jwt.WithJWKSURL("https://issuer.example.com/.well-known/jwks.json"),
+//		jwt.WithIssuer("https://issuer.example.com"),
+//		jwt.WithAudience("my-client-id"),
+//	)
+package jwt

--- a/auth/jwt/errors.go
+++ b/auth/jwt/errors.go
@@ -1,0 +1,24 @@
+package jwt
+
+import "errors"
+
+var (
+	// ErrMalformed reports a token that is not a structurally valid compact JWS.
+	ErrMalformed = errors.New("jwt: malformed token")
+	// ErrSignature reports a signature that does not verify, including alg/key mismatches.
+	ErrSignature = errors.New("jwt: signature mismatch")
+	// ErrExpired reports a token past its exp claim, or missing exp when expiry is required.
+	ErrExpired = errors.New("jwt: token expired")
+	// ErrNotYetValid reports a token whose nbf claim is in the future.
+	ErrNotYetValid = errors.New("jwt: token not yet valid")
+	// ErrIssuerMismatch reports an iss claim that differs from the configured issuer.
+	ErrIssuerMismatch = errors.New("jwt: issuer mismatch")
+	// ErrAudienceMismatch reports an aud claim missing the configured audience.
+	ErrAudienceMismatch = errors.New("jwt: audience mismatch")
+	// ErrUnknownKey reports a kid that resolves to no known key.
+	ErrUnknownKey = errors.New("jwt: unknown key")
+	// ErrNoKeys reports key resolution over an empty key set.
+	ErrNoKeys = errors.New("jwt: no keys available")
+	// ErrBadKey reports invalid key material or configuration at construction.
+	ErrBadKey = errors.New("jwt: invalid key material")
+)

--- a/auth/jwt/jwks.go
+++ b/auth/jwt/jwks.go
@@ -4,12 +4,20 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/resilience/singleflight"
 )
 
 // jwk is the wire form of a single RFC 7517 key.
@@ -91,9 +99,177 @@ func (s *Signer) JWKS(opts ...ServeOption) http.Handler {
 	})
 }
 
-// jwksCache is implemented in Task 6 (JWKS fetch).
-type jwksCache struct{}
+// maxJWKSBody bounds the JWKS response size (DoS guard).
+const maxJWKSBody = 1 << 20
+
+// jwksCache is an in-memory JWK set with lazy fetch, TTL refresh, and
+// unknown-kid refetch behind a cooldown. Failed refreshes serve the stale
+// set; only a cold cache surfaces the fetch error.
+type jwksCache struct {
+	fetchedAt time.Time
+	clk       clock.Clock
+
+	client *http.Client
+	keys   map[string]Key
+	url    string
+
+	group singleflight.Group[struct{}]
+
+	refresh      time.Duration
+	cooldown     time.Duration
+	fetchTimeout time.Duration
+
+	mu      sync.RWMutex
+	fetched bool
+}
 
 func (c *jwksCache) get(ctx context.Context, kid string) (Key, error) {
-	return Key{}, ErrUnknownKey
+	c.mu.RLock()
+	k, ok := c.keys[kid]
+	fetched, fetchedAt := c.fetched, c.fetchedAt
+	c.mu.RUnlock()
+
+	now := c.clk.Now()
+	fresh := fetched && now.Sub(fetchedAt) < c.refresh
+	if ok && fresh {
+		return k, nil
+	}
+	needFetch := !fetched || !fresh || (!ok && now.Sub(fetchedAt) >= c.cooldown)
+	if needFetch {
+		_, _, err := c.group.Do(ctx, "fetch", func(ctx context.Context) (struct{}, error) {
+			keys, err := c.fetchSet(ctx)
+			if err != nil {
+				return struct{}{}, err
+			}
+			c.mu.Lock()
+			c.keys, c.fetchedAt, c.fetched = keys, c.clk.Now(), true
+			c.mu.Unlock()
+			return struct{}{}, nil
+		})
+		if err != nil && !fetched {
+			return Key{}, fmt.Errorf("%w: jwks fetch: %w", ErrNoKeys, err)
+		}
+		// A failed refresh with a warm cache falls through to the stale set.
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if len(c.keys) == 0 {
+		return Key{}, fmt.Errorf("%w: jwks set is empty", ErrNoKeys)
+	}
+	if k, ok := c.keys[kid]; ok {
+		return k, nil
+	}
+	return Key{}, fmt.Errorf("%w: kid %q", ErrUnknownKey, kid)
+}
+
+func (c *jwksCache) fetchSet(ctx context.Context) (map[string]Key, error) {
+	// Fetches are deduplicated via singleflight, which runs this closure under
+	// context.WithoutCancel — stripping the caller's deadline. Bound the shared
+	// fetch here so a stalled JWKS endpoint cannot wedge every waiting Verify.
+	if c.fetchTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.fetchTimeout)
+		defer cancel()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	//nolint:nilaway // resp is non-nil whenever err is nil, per http.Client.Do's contract
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("jwks endpoint returned status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxJWKSBody))
+	if err != nil {
+		return nil, err
+	}
+	var set jwkSet
+	if err := json.Unmarshal(body, &set); err != nil {
+		return nil, fmt.Errorf("jwks body: %w", err)
+	}
+	keys := make(map[string]Key, len(set.Keys))
+	for _, j := range set.Keys {
+		k, ok := parseJWK(j)
+		if !ok {
+			continue
+		}
+		keys[k.KID] = k
+	}
+	return keys, nil
+}
+
+// parseJWK converts a wire JWK into a verification Key. Unusable entries
+// (wrong use/key_ops, unknown kty/crv, missing kid, undecodable material)
+// report ok=false and are skipped, not fatal.
+func parseJWK(j jwk) (Key, bool) {
+	if j.Kid == "" {
+		return Key{}, false // key resolution is kid-based; kid-less keys are unusable
+	}
+	if j.Use != "" && j.Use != "sig" {
+		return Key{}, false
+	}
+	if len(j.KeyOps) > 0 && !slices.Contains(j.KeyOps, "verify") {
+		return Key{}, false
+	}
+	enc := base64.RawURLEncoding
+	switch j.Kty {
+	case "RSA":
+		if j.Alg != "" && j.Alg != string(RS256) {
+			return Key{}, false
+		}
+		nb, err := enc.DecodeString(j.N)
+		if err != nil {
+			return Key{}, false
+		}
+		eb, err := enc.DecodeString(j.E)
+		if err != nil || len(eb) == 0 || len(eb) > 4 {
+			return Key{}, false
+		}
+		e := 0
+		for _, b := range eb {
+			e = e<<8 | int(b)
+		}
+		pub := &rsa.PublicKey{N: new(big.Int).SetBytes(nb), E: e}
+		k := Key{KID: j.Kid, Alg: RS256, Key: pub}
+		return k, checkVerifyKey(k) == nil
+	case "EC":
+		if j.Crv != "P-256" || (j.Alg != "" && j.Alg != string(ES256)) {
+			return Key{}, false
+		}
+		xb, err := enc.DecodeString(j.X)
+		if err != nil || len(xb) != 32 {
+			return Key{}, false
+		}
+		yb, err := enc.DecodeString(j.Y)
+		if err != nil || len(yb) != 32 {
+			return Key{}, false
+		}
+		// SEC1 uncompressed point 0x04 || X(32) || Y(32); ParseUncompressedPublicKey validates on-curve + not-infinity.
+		data := make([]byte, 1+len(xb)+len(yb))
+		data[0] = 0x04
+		copy(data[1:], xb)
+		copy(data[1+len(xb):], yb)
+		pub, err := ecdsa.ParseUncompressedPublicKey(elliptic.P256(), data)
+		if err != nil {
+			return Key{}, false
+		}
+		return Key{KID: j.Kid, Alg: ES256, Key: pub}, true
+	case "OKP":
+		if j.Crv != "Ed25519" || (j.Alg != "" && j.Alg != string(EdDSA)) {
+			return Key{}, false
+		}
+		xb, err := enc.DecodeString(j.X)
+		if err != nil || len(xb) != ed25519.PublicKeySize {
+			return Key{}, false
+		}
+		return Key{KID: j.Kid, Alg: EdDSA, Key: ed25519.PublicKey(xb)}, true
+	default:
+		return Key{}, false
+	}
 }

--- a/auth/jwt/jwks.go
+++ b/auth/jwt/jwks.go
@@ -1,0 +1,91 @@
+package jwt
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+)
+
+// jwk is the wire form of a single RFC 7517 key.
+type jwk struct {
+	Kty    string   `json:"kty"`
+	Kid    string   `json:"kid,omitempty"`
+	Alg    string   `json:"alg,omitempty"`
+	Use    string   `json:"use,omitempty"`
+	N      string   `json:"n,omitempty"`
+	E      string   `json:"e,omitempty"`
+	Crv    string   `json:"crv,omitempty"`
+	X      string   `json:"x,omitempty"`
+	Y      string   `json:"y,omitempty"`
+	KeyOps []string `json:"key_ops,omitempty"`
+}
+
+type jwkSet struct {
+	Keys []jwk `json:"keys"`
+}
+
+// publicJWK renders an asymmetric verification key as a JWK. HS256 and
+// unknown key types report ok=false.
+func publicJWK(k Key) (jwk, bool) {
+	enc := base64.RawURLEncoding
+	out := jwk{Kid: k.KID, Alg: string(k.Alg), Use: "sig"}
+	switch pub := k.Key.(type) {
+	case *rsa.PublicKey:
+		out.Kty = "RSA"
+		out.N = enc.EncodeToString(pub.N.Bytes())
+		out.E = enc.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	case *ecdsa.PublicKey:
+		// pub.Bytes() is the SEC1 uncompressed point 0x04 || X(32) || Y(32); slice out the two P-256 coordinates.
+		b, err := pub.Bytes()
+		if err != nil || len(b) != 65 {
+			return jwk{}, false
+		}
+		out.Kty, out.Crv = "EC", "P-256"
+		out.X = enc.EncodeToString(b[1:33])
+		out.Y = enc.EncodeToString(b[33:65])
+	case ed25519.PublicKey:
+		out.Kty, out.Crv = "OKP", "Ed25519"
+		out.X = enc.EncodeToString(pub)
+	default:
+		return jwk{}, false
+	}
+	return out, true
+}
+
+// JWKS returns an http.Handler serving the signer's asymmetric public keys
+// as an RFC 7517 JWK set. HS256 keys are never published; an HS256-only
+// signer serves an empty set. The body is rendered once at handler
+// construction — signer keys do not change after NewSigner.
+func (s *Signer) JWKS(opts ...ServeOption) http.Handler {
+	var cfg serveConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	set := jwkSet{Keys: []jwk{}}
+	for _, k := range s.PublicKeys() {
+		if j, ok := publicJWK(k); ok {
+			set.Keys = append(set.Keys, j)
+		}
+	}
+	body, err := json.Marshal(set)
+	if err != nil {
+		// Key material was validated at NewSigner; this is unreachable.
+		panic(fmt.Sprintf("jwt: marshal jwks: %v", err))
+	}
+	cacheControl := ""
+	if cfg.maxAge > 0 {
+		cacheControl = fmt.Sprintf("public, max-age=%d", int(cfg.maxAge.Seconds()))
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if cacheControl != "" {
+			w.Header().Set("Cache-Control", cacheControl)
+		}
+		_, _ = w.Write(body)
+	})
+}

--- a/auth/jwt/jwks.go
+++ b/auth/jwt/jwks.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
@@ -88,4 +89,11 @@ func (s *Signer) JWKS(opts ...ServeOption) http.Handler {
 		}
 		_, _ = w.Write(body)
 	})
+}
+
+// jwksCache is implemented in Task 6 (JWKS fetch).
+type jwksCache struct{}
+
+func (c *jwksCache) get(ctx context.Context, kid string) (Key, error) {
+	return Key{}, ErrUnknownKey
 }

--- a/auth/jwt/jwks_fetch_test.go
+++ b/auth/jwt/jwks_fetch_test.go
@@ -1,11 +1,15 @@
 package jwt_test
 
 import (
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -13,6 +17,7 @@ import (
 
 	"github.com/dmitrymomot/forge/auth/jwt"
 	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/crypto/keyset"
 )
 
 // jwksServer serves the JWKS of the given signer and counts fetches.
@@ -340,4 +345,114 @@ func TestJWKSFetchTimeoutBounded(t *testing.T) {
 // clock 2h past the refresh TTL and the token must still be unexpired.
 func freshClaims(now time.Time) jwt.Claims {
 	return jwt.Claims{Subject: "user-1", ExpiresAt: jwt.NewNumericDate(now.Add(48 * time.Hour))}
+}
+
+// TestVerifierCombinedKeySources proves the four verifier key sources merge
+// coherently into one Verifier: WithKeys, WithVerifyHS256Keyset,
+// WithVerifyKeyset, and WithJWKSURL each resolve their own signer's token
+// through their own path, provided their kids are disjoint.
+func TestVerifierCombinedKeySources(t *testing.T) {
+	t.Parallel()
+
+	// Source A: WithKeys — an explicit Ed25519 signer, kid "kid-a".
+	_, privA, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519: %v", err)
+	}
+	sA, err := jwt.NewSigner(jwt.WithSignerKey("kid-a", jwt.EdDSA, privA))
+	if err != nil {
+		t.Fatalf("NewSigner sA: %v", err)
+	}
+
+	// Source B: WithVerifyHS256Keyset — HS256 keyset version 5, kid "5".
+	hsKS, err := keyset.New(keyset.WithPrimary(5, []byte("0123456789abcdef0123456789abcdef")))
+	if err != nil {
+		t.Fatalf("keyset hsKS: %v", err)
+	}
+	sB, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKS))
+	if err != nil {
+		t.Fatalf("NewSigner sB: %v", err)
+	}
+
+	// Source C: WithVerifyKeyset — EC keyset version 7, kid "7".
+	ecPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa ecPriv: %v", err)
+	}
+	ecKS, err := keyset.New(keyset.WithPrimary(7, pkcs8(t, ecPriv)))
+	if err != nil {
+		t.Fatalf("keyset ecKS: %v", err)
+	}
+	sC, err := jwt.NewSigner(jwt.WithKeyset(ecKS))
+	if err != nil {
+		t.Fatalf("NewSigner sC: %v", err)
+	}
+
+	// Source D: WithJWKSURL — an ES256 signer served over JWKS, kid "kid-d".
+	ecPrivD, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa ecPrivD: %v", err)
+	}
+	sD, err := jwt.NewSigner(jwt.WithSignerKey("kid-d", jwt.ES256, ecPrivD))
+	if err != nil {
+		t.Fatalf("NewSigner sD: %v", err)
+	}
+	js := newJWKSServer(t, sD)
+
+	v, err := jwt.NewVerifier(
+		jwt.WithKeys(sA.PublicKeys()...),
+		jwt.WithVerifyHS256Keyset(hsKS),
+		jwt.WithVerifyKeyset(ecKS),
+		jwt.WithJWKSURL(js.URL),
+	)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+
+	for name, s := range map[string]*jwt.Signer{"A-WithKeys": sA, "B-HS256Keyset": sB, "C-Keyset": sC, "D-JWKS": sD} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			tok, err := s.Sign(testClaims())
+			if err != nil {
+				t.Fatalf("Sign: %v", err)
+			}
+			got, err := jwt.Verify[jwt.Claims](t.Context(), v, tok)
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if got.Subject != "user-1" {
+				t.Fatalf("claims %+v, want Subject user-1", got)
+			}
+		})
+	}
+}
+
+// TestVerifyNoKidWithJWKSSourceRejected guards resolveKey's no-kid rule:
+// the sole-static-key fallback fires only when the verifier holds exactly
+// one static key AND has no JWKS source (v.jwks == nil). Here the verifier
+// has zero static keys and a JWKS source, so a kid-less header must be
+// rejected outright rather than silently trying a key or triggering a
+// try-all-keys scan.
+func TestVerifyNoKidWithJWKSSourceRejected(t *testing.T) {
+	t.Parallel()
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	js := newJWKSServer(t, s) // serves exactly one key
+
+	v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+
+	enc := base64.RawURLEncoding
+	header := `{"alg":"EdDSA"}` // no kid
+	payload := `{"exp":` + strconv.FormatInt(time.Now().Add(24*time.Hour).Unix(), 10) + `}`
+	tok := enc.EncodeToString([]byte(header)) + "." + enc.EncodeToString([]byte(payload)) + "." + enc.EncodeToString([]byte("sig"))
+
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrUnknownKey) {
+		t.Fatalf("got %v, want ErrUnknownKey", err)
+	}
 }

--- a/auth/jwt/jwks_fetch_test.go
+++ b/auth/jwt/jwks_fetch_test.go
@@ -1,0 +1,343 @@
+package jwt_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// jwksServer serves the JWKS of the given signer and counts fetches.
+type jwksServer struct {
+	*httptest.Server
+	hits atomic.Int64
+	mu   sync.Mutex
+	h    http.Handler
+	fail bool
+}
+
+func newJWKSServer(t *testing.T, s *jwt.Signer) *jwksServer {
+	t.Helper()
+	js := &jwksServer{h: s.JWKS()}
+	js.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		js.hits.Add(1)
+		js.mu.Lock()
+		fail, h := js.fail, js.h
+		js.mu.Unlock()
+		if fail {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		h.ServeHTTP(w, r)
+	}))
+	t.Cleanup(js.Close)
+	return js
+}
+
+func (js *jwksServer) swap(h http.Handler) { js.mu.Lock(); js.h = h; js.mu.Unlock() }
+func (js *jwksServer) setFail(f bool)      { js.mu.Lock(); js.fail = f; js.mu.Unlock() }
+
+func TestJWKSFetchVerify(t *testing.T) {
+	t.Parallel()
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	js := newJWKSServer(t, s)
+	v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if js.hits.Load() != 0 {
+		t.Fatal("fetch happened before first Verify (must be lazy)")
+	}
+	got, err := jwt.Verify[jwt.Claims](t.Context(), v, tok)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got.Subject != "user-1" {
+		t.Fatalf("claims %+v", got)
+	}
+	// Second verify is served from cache.
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+		t.Fatalf("cached Verify: %v", err)
+	}
+	if hits := js.hits.Load(); hits != 1 {
+		t.Fatalf("got %d fetches, want 1 (cache miss only on first Verify)", hits)
+	}
+}
+
+func TestJWKSRotationPickupAndCooldown(t *testing.T) {
+	t.Parallel()
+	ks1, _ := edKeyset(t)
+	s1, err := jwt.NewSigner(jwt.WithKeyset(ks1))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	js := newJWKSServer(t, s1)
+	mock := clock.NewMock(time.Unix(1_700_000_000, 0))
+	v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL), jwt.WithClock(mock))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	tok1, err := s1.Sign(freshClaims(mock.Now()))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok1); err != nil {
+		t.Fatalf("initial Verify: %v", err)
+	}
+
+	// Rotate: new signer under kid "2" (WithSignerKey to control the kid).
+	_, priv2, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519: %v", err)
+	}
+	s2, err := jwt.NewSigner(jwt.WithSignerKey("2", jwt.EdDSA, priv2))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	js.swap(s2.JWKS())
+	tok2, err := s2.Sign(freshClaims(mock.Now()))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	// Within the cooldown (default 1m) the unknown kid must NOT refetch.
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok2); !errors.Is(err, jwt.ErrUnknownKey) {
+		t.Fatalf("got %v, want ErrUnknownKey inside cooldown", err)
+	}
+	if hits := js.hits.Load(); hits != 1 {
+		t.Fatalf("refetched inside cooldown: %d hits", hits)
+	}
+
+	// Past the cooldown the unknown kid triggers a refetch and verifies.
+	mock.Advance(2 * time.Minute)
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok2); err != nil {
+		t.Fatalf("rotation pickup: %v", err)
+	}
+	if hits := js.hits.Load(); hits != 2 {
+		t.Fatalf("got %d hits, want 2", hits)
+	}
+}
+
+func TestJWKSStaleIfErrorAndColdError(t *testing.T) {
+	t.Parallel()
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+
+	t.Run("cold cache surfaces fetch error", func(t *testing.T) {
+		t.Parallel()
+		js := newJWKSServer(t, s)
+		js.setFail(true)
+		v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok, err := s.Sign(testClaims())
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrNoKeys) {
+			t.Fatalf("got %v, want ErrNoKeys on cold fetch failure", err)
+		}
+	})
+
+	t.Run("stale keys served when refresh fails", func(t *testing.T) {
+		t.Parallel()
+		js := newJWKSServer(t, s)
+		mock := clock.NewMock(time.Unix(1_700_000_000, 0))
+		v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL), jwt.WithClock(mock))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok, err := s.Sign(freshClaims(mock.Now()))
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+			t.Fatalf("warm up: %v", err)
+		}
+		js.setFail(true)
+		mock.Advance(2 * time.Hour) // past the 1h refresh TTL
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+			t.Fatalf("stale-if-error not honored: %v", err)
+		}
+	})
+}
+
+func TestJWKSConcurrentVerifySingleFetch(t *testing.T) {
+	t.Parallel()
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	js := newJWKSServer(t, s)
+	v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+				t.Errorf("concurrent Verify: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+	if hits := js.hits.Load(); hits != 1 {
+		t.Fatalf("got %d fetches for 50 concurrent verifies, want 1", hits)
+	}
+}
+
+func TestJWKSSkipsUnusableKeys(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// enc-use key, unknown kty, and kid-less key must all be skipped -> empty set.
+		_, _ = w.Write([]byte(`{"keys":[
+			{"kty":"RSA","kid":"enc","use":"enc","n":"AQAB","e":"AQAB"},
+			{"kty":"WEIRD","kid":"w"},
+			{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}
+		]}`))
+	}))
+	t.Cleanup(srv.Close)
+	v, err := jwt.NewVerifier(jwt.WithJWKSURL(srv.URL))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrNoKeys) {
+		t.Fatalf("got %v, want ErrNoKeys when all JWKS entries are unusable", err)
+	}
+}
+
+// TestJWKSFetchVerifyRSAAndEC proves the RSA and EC fetch -> parseJWK ->
+// verify round-trips work end to end, including the modern
+// ecdsa.ParseUncompressedPublicKey-based EC branch of parseJWK.
+func TestJWKSFetchVerifyRSAAndEC(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RSA", func(t *testing.T) {
+		t.Parallel()
+		ks, _ := rsaKeyset(t)
+		s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		js := newJWKSServer(t, s)
+		v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok, err := s.Sign(testClaims())
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		got, err := jwt.Verify[jwt.Claims](t.Context(), v, tok)
+		if err != nil {
+			t.Fatalf("Verify: %v", err)
+		}
+		if got.Subject != "user-1" {
+			t.Fatalf("claims %+v", got)
+		}
+	})
+
+	t.Run("EC", func(t *testing.T) {
+		t.Parallel()
+		ks, _ := ecKeyset(t)
+		s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		js := newJWKSServer(t, s)
+		v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok, err := s.Sign(testClaims())
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		got, err := jwt.Verify[jwt.Claims](t.Context(), v, tok)
+		if err != nil {
+			t.Fatalf("Verify: %v", err)
+		}
+		if got.Subject != "user-1" {
+			t.Fatalf("claims %+v", got)
+		}
+	})
+}
+
+// TestJWKSFetchTimeoutBounded proves a stalled JWKS endpoint cannot wedge
+// Verify forever: singleflight runs the fetch under context.WithoutCancel,
+// stripping the caller's deadline, so WithFetchTimeout must bound the fetch
+// on its own.
+func TestJWKSFetchTimeoutBounded(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	v, err := jwt.NewVerifier(jwt.WithJWKSURL(srv.URL, jwt.WithFetchTimeout(200*time.Millisecond)))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+
+	start := time.Now()
+	_, err = jwt.Verify[jwt.Claims](t.Context(), v, tok)
+	elapsed := time.Since(start)
+	if !errors.Is(err, jwt.ErrNoKeys) {
+		t.Fatalf("got %v, want ErrNoKeys on timed-out fetch", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("Verify took %s, want well under 2s (fetch timeout not bounding the block)", elapsed)
+	}
+}
+
+// freshClaims uses a 48h exp: the stale-if-error test advances the mock
+// clock 2h past the refresh TTL and the token must still be unexpired.
+func freshClaims(now time.Time) jwt.Claims {
+	return jwt.Claims{Subject: "user-1", ExpiresAt: jwt.NewNumericDate(now.Add(48 * time.Hour))}
+}

--- a/auth/jwt/jwks_fetch_test.go
+++ b/auth/jwt/jwks_fetch_test.go
@@ -1,6 +1,7 @@
 package jwt_test
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
@@ -244,6 +245,44 @@ func TestJWKSSkipsUnusableKeys(t *testing.T) {
 	}
 	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrNoKeys) {
 		t.Fatalf("got %v, want ErrNoKeys when all JWKS entries are unusable", err)
+	}
+}
+
+// TestJWKSSkipsOversizedRSAKey is the actual threat path the maxRSABits cap
+// guards: a JWKS endpoint (untrusted, possibly third-party) that serves an
+// oversized RSA modulus must have that key skipped by parseJWK, not admitted
+// into the usable set. Without the cap, every Verify resolving to that kid
+// would pay an expensive modexp — a cheap, repeatable CPU-exhaustion vector.
+func TestJWKSSkipsOversizedRSAKey(t *testing.T) {
+	t.Parallel()
+
+	// 1100 bytes -> ~8800-bit modulus, over maxRSABits (8192).
+	n := base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0xff}, 1100))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"big","n":"` + n + `","e":"AQAB"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	v, err := jwt.NewVerifier(jwt.WithJWKSURL(srv.URL))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	// The oversized key is skipped, leaving the JWKS set empty, so even an
+	// unrelated valid token resolves to no usable keys.
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrNoKeys) {
+		t.Fatalf("got %v, want ErrNoKeys (oversized RSA key must be skipped, not admitted)", err)
 	}
 }
 

--- a/auth/jwt/jwks_serve_test.go
+++ b/auth/jwt/jwks_serve_test.go
@@ -1,0 +1,188 @@
+package jwt_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+)
+
+type jwksDoc struct {
+	Keys []map[string]any `json:"keys"`
+}
+
+func fetchJWKS(t *testing.T, s *jwt.Signer, opts ...jwt.ServeOption) (*httptest.ResponseRecorder, jwksDoc) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.JWKS(opts...).ServeHTTP(rec, httptest.NewRequest("GET", "/.well-known/jwks.json", nil))
+	var doc jwksDoc
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("jwks body %s: %v", rec.Body.Bytes(), err)
+	}
+	return rec, doc
+}
+
+func TestPublicKeysExcludesHS256(t *testing.T) {
+	t.Parallel()
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	if keys := s.PublicKeys(); len(keys) != 0 {
+		t.Fatalf("HS256 secrets leaked via PublicKeys: %v", keys)
+	}
+}
+
+func TestPublicKeysEdDSA(t *testing.T) {
+	t.Parallel()
+	ks, priv := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	keys := s.PublicKeys()
+	if len(keys) != 1 || keys[0].KID != "1" || keys[0].Alg != jwt.EdDSA {
+		t.Fatalf("got %+v", keys)
+	}
+	pub, ok := keys[0].Key.(ed25519.PublicKey)
+	if !ok || !pub.Equal(priv.Public().(ed25519.PublicKey)) {
+		t.Fatalf("wrong public key: %T", keys[0].Key)
+	}
+}
+
+func TestJWKSServeEdDSA(t *testing.T) {
+	t.Parallel()
+	ks, priv := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	rec, doc := fetchJWKS(t, s)
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content type %q", ct)
+	}
+	if len(doc.Keys) != 1 {
+		t.Fatalf("got %d keys", len(doc.Keys))
+	}
+	k := doc.Keys[0]
+	if k["kty"] != "OKP" || k["crv"] != "Ed25519" || k["kid"] != "1" || k["alg"] != "EdDSA" || k["use"] != "sig" {
+		t.Fatalf("jwk %v", k)
+	}
+	x, err := base64.RawURLEncoding.DecodeString(k["x"].(string))
+	if err != nil || !ed25519.PublicKey(x).Equal(priv.Public().(ed25519.PublicKey)) {
+		t.Fatalf("x mismatch: %v", err)
+	}
+}
+
+func TestJWKSServeAllKtys(t *testing.T) {
+	t.Parallel()
+	for name, mk := range map[string]func(*testing.T) *jwt.Signer{
+		"RSA": func(t *testing.T) *jwt.Signer {
+			ks, _ := rsaKeyset(t)
+			s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+			if err != nil {
+				t.Fatalf("NewSigner: %v", err)
+			}
+			return s
+		},
+		"EC": func(t *testing.T) *jwt.Signer {
+			ks, _ := ecKeyset(t)
+			s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+			if err != nil {
+				t.Fatalf("NewSigner: %v", err)
+			}
+			return s
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			s := mk(t)
+			_, doc := fetchJWKS(t, s)
+			if len(doc.Keys) != 1 || doc.Keys[0]["kty"] != name {
+				t.Fatalf("got %v, want kty %s", doc.Keys, name)
+			}
+			if name == "EC" && doc.Keys[0]["crv"] != "P-256" {
+				t.Fatalf("crv %v", doc.Keys[0]["crv"])
+			}
+
+			switch name {
+			case "RSA":
+				nb, err := base64.RawURLEncoding.DecodeString(doc.Keys[0]["n"].(string))
+				if err != nil {
+					t.Fatalf("decode n: %v", err)
+				}
+				eb, err := base64.RawURLEncoding.DecodeString(doc.Keys[0]["e"].(string))
+				if err != nil {
+					t.Fatalf("decode e: %v", err)
+				}
+				e := 0
+				for _, b := range eb {
+					e = e<<8 | int(b)
+				}
+				got := &rsa.PublicKey{N: new(big.Int).SetBytes(nb), E: e}
+				want, ok := s.PublicKeys()[0].Key.(*rsa.PublicKey)
+				if !ok || !got.Equal(want) {
+					t.Fatalf("RSA public key mismatch: got %+v, want %+v", got, want)
+				}
+			case "EC":
+				xb, err := base64.RawURLEncoding.DecodeString(doc.Keys[0]["x"].(string))
+				if err != nil || len(xb) != 32 {
+					t.Fatalf("decode x: len=%d err=%v", len(xb), err)
+				}
+				yb, err := base64.RawURLEncoding.DecodeString(doc.Keys[0]["y"].(string))
+				if err != nil || len(yb) != 32 {
+					t.Fatalf("decode y: len=%d err=%v", len(yb), err)
+				}
+				data := append([]byte{0x04}, append(xb, yb...)...)
+				got, err := ecdsa.ParseUncompressedPublicKey(elliptic.P256(), data)
+				if err != nil {
+					t.Fatalf("ParseUncompressedPublicKey: %v", err)
+				}
+				want, ok := s.PublicKeys()[0].Key.(*ecdsa.PublicKey)
+				if !ok || !got.Equal(want) {
+					t.Fatalf("EC public key mismatch: got %+v, want %+v", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestJWKSServeHS256Empty(t *testing.T) {
+	t.Parallel()
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	rec, doc := fetchJWKS(t, s)
+	if len(doc.Keys) != 0 {
+		t.Fatalf("HS256 keys served: %v", doc.Keys)
+	}
+	if rec.Body.String() != `{"keys":[]}` {
+		t.Fatalf("body %q, want {\"keys\":[]}", rec.Body.String())
+	}
+}
+
+func TestJWKSServeCacheControl(t *testing.T) {
+	t.Parallel()
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	rec, _ := fetchJWKS(t, s, jwt.WithCacheControl(5*time.Minute))
+	if cc := rec.Header().Get("Cache-Control"); cc != "public, max-age=300" {
+		t.Fatalf("Cache-Control %q", cc)
+	}
+	rec, _ = fetchJWKS(t, s)
+	if cc := rec.Header().Get("Cache-Control"); cc != "" {
+		t.Fatalf("unexpected Cache-Control %q", cc)
+	}
+}

--- a/auth/jwt/options.go
+++ b/auth/jwt/options.go
@@ -130,13 +130,19 @@ func WithKeys(keys ...Key) VerifierOption {
 
 // WithVerifyKeyset derives verification keys from the public halves of an
 // asymmetric keyset (PKCS#8 DER private-key material). All versions —
-// primary and retired — verify.
+// primary and retired — verify. Key sources are combinable, but their kids
+// must be disjoint: since the kid is the keyset version as a decimal
+// string, combining keysets (or a keyset with explicit keys) that share a
+// version number makes NewVerifier fail with ErrBadKey (duplicate kid).
 func WithVerifyKeyset(ks *keyset.Keyset) VerifierOption {
 	return func(c *verifierConfig) { c.keysets = append(c.keysets, ks) }
 }
 
 // WithVerifyHS256Keyset adds every version of an HS256 secret keyset as a
-// verification key.
+// verification key. Key sources are combinable, but their kids must be
+// disjoint: since the kid is the keyset version as a decimal string,
+// combining keysets (or a keyset with explicit keys) that share a version
+// number makes NewVerifier fail with ErrBadKey (duplicate kid).
 func WithVerifyHS256Keyset(ks *keyset.Keyset) VerifierOption {
 	return func(c *verifierConfig) { c.hsKeysets = append(c.hsKeysets, ks) }
 }

--- a/auth/jwt/options.go
+++ b/auth/jwt/options.go
@@ -102,3 +102,25 @@ func WithVerifyHS256Keyset(ks *keyset.Keyset) VerifierOption {
 func WithClock(clk clock.Clock) VerifierOption {
 	return func(c *verifierConfig) { c.clk = clk }
 }
+
+// WithIssuer requires the iss claim to equal iss exactly.
+func WithIssuer(iss string) VerifierOption {
+	return func(c *verifierConfig) { c.iss = iss }
+}
+
+// WithAudience requires the aud claim to contain aud.
+func WithAudience(aud string) VerifierOption {
+	return func(c *verifierConfig) { c.aud = aud }
+}
+
+// WithLeeway sets the clock-skew tolerance applied to exp and nbf.
+// Default 30s.
+func WithLeeway(d time.Duration) VerifierOption {
+	return func(c *verifierConfig) { c.leeway = d }
+}
+
+// WithoutExpiry accepts tokens with no exp claim. By default a missing
+// exp is rejected as ErrExpired.
+func WithoutExpiry() VerifierOption {
+	return func(c *verifierConfig) { c.requireExp = false }
+}

--- a/auth/jwt/options.go
+++ b/auth/jwt/options.go
@@ -2,8 +2,10 @@ package jwt
 
 import (
 	"crypto"
+	"net/http"
 	"time"
 
+	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/crypto/keyset"
 )
 
@@ -53,4 +55,50 @@ type serveConfig struct {
 // JWKS responses. Without it no cache header is written.
 func WithCacheControl(maxAge time.Duration) ServeOption {
 	return func(c *serveConfig) { c.maxAge = maxAge }
+}
+
+// VerifierOption configures NewVerifier.
+type VerifierOption func(*verifierConfig)
+
+type verifierConfig struct {
+	clk        clock.Clock
+	jwksURL    string
+	iss        string
+	aud        string
+	keys       []Key
+	keysets    []*keyset.Keyset // asymmetric PKCS#8 material
+	hsKeysets  []*keyset.Keyset // raw HS256 secrets
+	jwksCfg    jwksConfig
+	leeway     time.Duration
+	requireExp bool
+}
+
+// jwksConfig is a placeholder for JWKS fetch settings, wired up in Task 6.
+type jwksConfig struct {
+	client   *http.Client
+	refresh  time.Duration
+	cooldown time.Duration
+}
+
+// WithKeys adds explicit verification keys (e.g. from Signer.PublicKeys).
+func WithKeys(keys ...Key) VerifierOption {
+	return func(c *verifierConfig) { c.keys = append(c.keys, keys...) }
+}
+
+// WithVerifyKeyset derives verification keys from the public halves of an
+// asymmetric keyset (PKCS#8 DER private-key material). All versions —
+// primary and retired — verify.
+func WithVerifyKeyset(ks *keyset.Keyset) VerifierOption {
+	return func(c *verifierConfig) { c.keysets = append(c.keysets, ks) }
+}
+
+// WithVerifyHS256Keyset adds every version of an HS256 secret keyset as a
+// verification key.
+func WithVerifyHS256Keyset(ks *keyset.Keyset) VerifierOption {
+	return func(c *verifierConfig) { c.hsKeysets = append(c.hsKeysets, ks) }
+}
+
+// WithClock overrides the time source used for exp/nbf checks (tests).
+func WithClock(clk clock.Clock) VerifierOption {
+	return func(c *verifierConfig) { c.clk = clk }
 }

--- a/auth/jwt/options.go
+++ b/auth/jwt/options.go
@@ -1,0 +1,42 @@
+package jwt
+
+import (
+	"crypto"
+
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+// SignerOption configures NewSigner.
+type SignerOption func(*signerConfig)
+
+type signerConfig struct {
+	ks     *keyset.Keyset
+	hs     *keyset.Keyset
+	direct *directKey
+}
+
+type directKey struct {
+	key crypto.Signer
+	kid string
+	alg Alg
+}
+
+// WithKeyset loads asymmetric signing keys from ks. Key material must be
+// PKCS#8 DER private keys; the alg is inferred per key: RSA (>=2048 bits)
+// -> RS256, ECDSA P-256 -> ES256, Ed25519 -> EdDSA. The keyset primary
+// signs; retired versions stay published via PublicKeys and JWKS.
+func WithKeyset(ks *keyset.Keyset) SignerOption {
+	return func(c *signerConfig) { c.ks = ks }
+}
+
+// WithHS256Keyset loads HMAC secrets from ks. Each version's material is
+// the raw secret and must be at least 32 bytes.
+func WithHS256Keyset(ks *keyset.Keyset) SignerOption {
+	return func(c *signerConfig) { c.hs = ks }
+}
+
+// WithSignerKey supplies a single caller-owned signing key (HSM/KMS-backed
+// crypto.Signer). HS256 is not accepted here — use WithHS256Keyset.
+func WithSignerKey(kid string, alg Alg, key crypto.Signer) SignerOption {
+	return func(c *signerConfig) { c.direct = &directKey{kid: kid, alg: alg, key: key} }
+}

--- a/auth/jwt/options.go
+++ b/auth/jwt/options.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"crypto"
+	"time"
 
 	"github.com/dmitrymomot/forge/crypto/keyset"
 )
@@ -39,4 +40,17 @@ func WithHS256Keyset(ks *keyset.Keyset) SignerOption {
 // crypto.Signer). HS256 is not accepted here — use WithHS256Keyset.
 func WithSignerKey(kid string, alg Alg, key crypto.Signer) SignerOption {
 	return func(c *signerConfig) { c.direct = &directKey{kid: kid, alg: alg, key: key} }
+}
+
+// ServeOption configures the Signer.JWKS handler.
+type ServeOption func(*serveConfig)
+
+type serveConfig struct {
+	maxAge time.Duration
+}
+
+// WithCacheControl sets a "Cache-Control: public, max-age=..." header on
+// JWKS responses. Without it no cache header is written.
+func WithCacheControl(maxAge time.Duration) ServeOption {
+	return func(c *serveConfig) { c.maxAge = maxAge }
 }

--- a/auth/jwt/options.go
+++ b/auth/jwt/options.go
@@ -73,11 +73,54 @@ type verifierConfig struct {
 	requireExp bool
 }
 
-// jwksConfig is a placeholder for JWKS fetch settings, wired up in Task 6.
+// jwksConfig holds JWKS fetch settings configured via JWKSOption.
 type jwksConfig struct {
-	client   *http.Client
-	refresh  time.Duration
-	cooldown time.Duration
+	client       *http.Client
+	refresh      time.Duration
+	cooldown     time.Duration
+	fetchTimeout time.Duration
+}
+
+// JWKSOption configures JWKS fetching for WithJWKSURL.
+type JWKSOption func(*jwksConfig)
+
+// WithJWKSURL adds a remote RFC 7517 JWK set as a verification key source.
+// Fetching is lazy: the first Verify triggers it. Keys are cached in
+// memory, refreshed when the refresh interval elapses, and refetched on an
+// unknown kid no more often than the cooldown.
+func WithJWKSURL(url string, opts ...JWKSOption) VerifierOption {
+	return func(c *verifierConfig) {
+		c.jwksURL = url
+		for _, o := range opts {
+			o(&c.jwksCfg)
+		}
+	}
+}
+
+// WithHTTPClient sets the HTTP client used to fetch the JWK set.
+// Default: httpclient.New().
+func WithHTTPClient(client *http.Client) JWKSOption {
+	return func(c *jwksConfig) { c.client = client }
+}
+
+// WithRefreshInterval sets how long a fetched JWK set stays fresh.
+// Default 1h.
+func WithRefreshInterval(d time.Duration) JWKSOption {
+	return func(c *jwksConfig) { c.refresh = d }
+}
+
+// WithRefreshCooldown sets the minimum gap between unknown-kid refetches.
+// Default 1m.
+func WithRefreshCooldown(d time.Duration) JWKSOption {
+	return func(c *jwksConfig) { c.cooldown = d }
+}
+
+// WithFetchTimeout bounds each JWKS HTTP fetch. Because fetches are
+// deduplicated (the caller's context deadline does not propagate to the
+// shared fetch), this is the ceiling on how long a Verify can block on a
+// stalled JWKS endpoint. Default 30s.
+func WithFetchTimeout(d time.Duration) JWKSOption {
+	return func(c *jwksConfig) { c.fetchTimeout = d }
 }
 
 // WithKeys adds explicit verification keys (e.g. from Signer.PublicKeys).

--- a/auth/jwt/signer.go
+++ b/auth/jwt/signer.go
@@ -101,6 +101,21 @@ func newSignerFromKeyset(ks *keyset.Keyset, build func(int, []byte) (signingKey,
 	return s, nil
 }
 
+// PublicKeys returns the verification halves of the signer's asymmetric
+// keys (primary first, then retired) for direct in-process wiring via
+// NewVerifier(WithKeys(...)). HS256 secrets are never included — wire the
+// HS256 keyset into the verifier with WithVerifyHS256Keyset instead.
+func (s *Signer) PublicKeys() []Key {
+	keys := make([]Key, 0, len(s.all))
+	for _, k := range s.all {
+		if k.alg == HS256 {
+			continue
+		}
+		keys = append(keys, Key{KID: k.kid, Alg: k.alg, Key: k.signer.Public()})
+	}
+	return keys
+}
+
 // Sign marshals claims with encoding/json and returns the signed compact
 // JWT. It signs exactly what it is given — no claims are auto-filled. The
 // header carries alg, kid, and typ "JWT".

--- a/auth/jwt/signer.go
+++ b/auth/jwt/signer.go
@@ -1,0 +1,127 @@
+package jwt
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+type signingKey struct {
+	kid    string
+	alg    Alg
+	signer crypto.Signer // nil for HS256
+	secret []byte        // HS256 only
+}
+
+// Signer issues compact JWTs signed with its primary key. Construct with
+// exactly one key source: WithKeyset, WithHS256Keyset, or WithSignerKey.
+type Signer struct {
+	primary signingKey
+	all     []signingKey // primary first, then retired versions
+}
+
+// NewSigner builds a Signer from exactly one key-source option.
+func NewSigner(opts ...SignerOption) (*Signer, error) {
+	var cfg signerConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	sources := 0
+	if cfg.ks != nil {
+		sources++
+	}
+	if cfg.hs != nil {
+		sources++
+	}
+	if cfg.direct != nil {
+		sources++
+	}
+	if sources != 1 {
+		return nil, fmt.Errorf("%w: exactly one key source required", ErrBadKey)
+	}
+	switch {
+	case cfg.direct != nil:
+		d := cfg.direct
+		if d.kid == "" || d.key == nil {
+			return nil, fmt.Errorf("%w: WithSignerKey requires a kid and a key", ErrBadKey)
+		}
+		if err := checkSignerAlg(d.alg, d.key.Public()); err != nil {
+			return nil, err
+		}
+		k := signingKey{kid: d.kid, alg: d.alg, signer: d.key}
+		return &Signer{primary: k, all: []signingKey{k}}, nil
+	case cfg.hs != nil:
+		return newSignerFromKeyset(cfg.hs, hsSigningKey)
+	default:
+		return newSignerFromKeyset(cfg.ks, asymmetricSigningKey)
+	}
+}
+
+func hsSigningKey(version int, material []byte) (signingKey, error) {
+	if len(material) < minHS256KeyLen {
+		return signingKey{}, fmt.Errorf("%w: HS256 key version %d shorter than %d bytes", ErrBadKey, version, minHS256KeyLen)
+	}
+	return signingKey{kid: strconv.Itoa(version), alg: HS256, secret: material}, nil
+}
+
+func asymmetricSigningKey(version int, material []byte) (signingKey, error) {
+	parsed, err := x509.ParsePKCS8PrivateKey(material)
+	if err != nil {
+		return signingKey{}, fmt.Errorf("%w: key version %d is not PKCS#8 DER: %v", ErrBadKey, version, err)
+	}
+	alg, err := algForPrivate(parsed)
+	if err != nil {
+		return signingKey{}, fmt.Errorf("key version %d: %w", version, err)
+	}
+	return signingKey{kid: strconv.Itoa(version), alg: alg, signer: parsed.(crypto.Signer)}, nil
+}
+
+func newSignerFromKeyset(ks *keyset.Keyset, build func(int, []byte) (signingKey, error)) (*Signer, error) {
+	primaryVersion, primaryMaterial := ks.Primary()
+	primary, err := build(primaryVersion, primaryMaterial)
+	if err != nil {
+		return nil, err
+	}
+	s := &Signer{primary: primary, all: []signingKey{primary}}
+	for version, material := range ks.All() {
+		if version == primaryVersion {
+			continue
+		}
+		k, err := build(version, material)
+		if err != nil {
+			return nil, err
+		}
+		s.all = append(s.all, k)
+	}
+	return s, nil
+}
+
+// Sign marshals claims with encoding/json and returns the signed compact
+// JWT. It signs exactly what it is given — no claims are auto-filled. The
+// header carries alg, kid, and typ "JWT".
+func (s *Signer) Sign(claims any) (string, error) {
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("jwt: marshal claims: %w", err)
+	}
+	header, err := json.Marshal(map[string]string{
+		"alg": string(s.primary.alg),
+		"kid": s.primary.kid,
+		"typ": "JWT",
+	})
+	if err != nil {
+		return "", fmt.Errorf("jwt: marshal header: %w", err)
+	}
+	enc := base64.RawURLEncoding
+	input := enc.EncodeToString(header) + "." + enc.EncodeToString(payload)
+	sig, err := signBytes(s.primary.alg, s.primary.signer, s.primary.secret, []byte(input))
+	if err != nil {
+		return "", fmt.Errorf("jwt: sign: %w", err)
+	}
+	return input + "." + enc.EncodeToString(sig), nil
+}

--- a/auth/jwt/signer_test.go
+++ b/auth/jwt/signer_test.go
@@ -313,6 +313,27 @@ func TestSignRS256(t *testing.T) {
 	}
 }
 
+// TestRSAKeyTooLargeRejected guards the upper bound added alongside the
+// existing >=2048-bit floor: an oversized modulus makes every Verify on that
+// key an expensive modexp (CPU-exhaustion via a malicious JWKS), so
+// checkVerifyKey must reject it at construction, not just tiny keys.
+func TestRSAKeyTooLargeRejected(t *testing.T) {
+	t.Parallel()
+
+	hugeN := new(big.Int).Lsh(big.NewInt(1), 9000) // 9001-bit modulus, > maxRSABits
+	k := jwt.Key{KID: "1", Alg: jwt.RS256, Key: &rsa.PublicKey{N: hugeN, E: 65537}}
+	if _, err := jwt.NewVerifier(jwt.WithKeys(k)); !errors.Is(err, jwt.ErrBadKey) {
+		t.Fatalf("got %v, want ErrBadKey for a 9001-bit RSA modulus", err)
+	}
+
+	// Boundary: exactly 8192 bits must still be accepted.
+	okN := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 8192), big.NewInt(1))
+	okKey := jwt.Key{KID: "2", Alg: jwt.RS256, Key: &rsa.PublicKey{N: okN, E: 65537}}
+	if _, err := jwt.NewVerifier(jwt.WithKeys(okKey)); err != nil {
+		t.Fatalf("NewVerifier: %v, want no error for an exactly-8192-bit RSA modulus", err)
+	}
+}
+
 func TestSignRejectsUnmarshalableClaims(t *testing.T) {
 	t.Parallel()
 	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))

--- a/auth/jwt/signer_test.go
+++ b/auth/jwt/signer_test.go
@@ -1,0 +1,325 @@
+package jwt_test
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+// --- helpers shared by later test files ---
+
+func hsKeyset(t *testing.T) *keyset.Keyset {
+	t.Helper()
+	ks, err := keyset.New(
+		keyset.WithPrimary(2, []byte("0123456789abcdef0123456789abcdef")),
+		keyset.WithRetired(1, []byte("fedcba9876543210fedcba9876543210")),
+	)
+	if err != nil {
+		t.Fatalf("keyset: %v", err)
+	}
+	return ks
+}
+
+func pkcs8(t *testing.T, key any) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("pkcs8: %v", err)
+	}
+	return der
+}
+
+func edKeyset(t *testing.T) (*keyset.Keyset, ed25519.PrivateKey) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519: %v", err)
+	}
+	ks, err := keyset.New(keyset.WithPrimary(1, pkcs8(t, priv)))
+	if err != nil {
+		t.Fatalf("keyset: %v", err)
+	}
+	return ks, priv
+}
+
+func ecKeyset(t *testing.T) (*keyset.Keyset, *ecdsa.PrivateKey) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa: %v", err)
+	}
+	ks, err := keyset.New(keyset.WithPrimary(1, pkcs8(t, priv)))
+	if err != nil {
+		t.Fatalf("keyset: %v", err)
+	}
+	return ks, priv
+}
+
+func rsaKeyset(t *testing.T) (*keyset.Keyset, *rsa.PrivateKey) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa: %v", err)
+	}
+	ks, err := keyset.New(keyset.WithPrimary(1, pkcs8(t, priv)))
+	if err != nil {
+		t.Fatalf("keyset: %v", err)
+	}
+	return ks, priv
+}
+
+// splitToken decodes the three segments of a compact JWS.
+func splitToken(t *testing.T, tok string) (header map[string]any, payload, sig []byte, signingInput string) {
+	t.Helper()
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token has %d parts, want 3: %s", len(parts), tok)
+	}
+	hb, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("header b64: %v", err)
+	}
+	if err := json.Unmarshal(hb, &header); err != nil {
+		t.Fatalf("header json: %v", err)
+	}
+	payload, err = base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("payload b64: %v", err)
+	}
+	sig, err = base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("sig b64: %v", err)
+	}
+	return header, payload, sig, parts[0] + "." + parts[1]
+}
+
+func testClaims() jwt.Claims {
+	return jwt.Claims{
+		Issuer:    "https://api.example.com",
+		Subject:   "user-1",
+		Audience:  jwt.Audience{"my-app"},
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+}
+
+// --- construction ---
+
+func TestNewSignerKeySources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no key source", func(t *testing.T) {
+		t.Parallel()
+		if _, err := jwt.NewSigner(); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("two key sources", func(t *testing.T) {
+		t.Parallel()
+		ks, _ := edKeyset(t)
+		_, err := jwt.NewSigner(jwt.WithKeyset(ks), jwt.WithHS256Keyset(hsKeyset(t)))
+		if !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("HS256 secret too short", func(t *testing.T) {
+		t.Parallel()
+		ks, err := keyset.New(keyset.WithPrimary(1, []byte("short")))
+		if err != nil {
+			t.Fatalf("keyset: %v", err)
+		}
+		if _, err := jwt.NewSigner(jwt.WithHS256Keyset(ks)); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("asymmetric keyset rejects raw bytes", func(t *testing.T) {
+		t.Parallel()
+		ks, err := keyset.New(keyset.WithPrimary(1, []byte("0123456789abcdef0123456789abcdef")))
+		if err != nil {
+			t.Fatalf("keyset: %v", err)
+		}
+		if _, err := jwt.NewSigner(jwt.WithKeyset(ks)); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("RSA under 2048 bits rejected", func(t *testing.T) {
+		t.Parallel()
+		priv, err := rsa.GenerateKey(rand.Reader, 1024)
+		if err != nil {
+			t.Fatalf("rsa: %v", err)
+		}
+		ks, err := keyset.New(keyset.WithPrimary(1, pkcs8(t, priv)))
+		if err != nil {
+			t.Fatalf("keyset: %v", err)
+		}
+		if _, err := jwt.NewSigner(jwt.WithKeyset(ks)); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("non-P256 curve rejected", func(t *testing.T) {
+		t.Parallel()
+		priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		if err != nil {
+			t.Fatalf("ecdsa: %v", err)
+		}
+		ks, err := keyset.New(keyset.WithPrimary(1, pkcs8(t, priv)))
+		if err != nil {
+			t.Fatalf("keyset: %v", err)
+		}
+		if _, err := jwt.NewSigner(jwt.WithKeyset(ks)); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("WithSignerKey rejects HS256", func(t *testing.T) {
+		t.Parallel()
+		_, priv, _ := ed25519.GenerateKey(rand.Reader)
+		_, err := jwt.NewSigner(jwt.WithSignerKey("k1", jwt.HS256, priv))
+		if !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("WithSignerKey rejects alg/key mismatch", func(t *testing.T) {
+		t.Parallel()
+		_, priv, _ := ed25519.GenerateKey(rand.Reader)
+		_, err := jwt.NewSigner(jwt.WithSignerKey("k1", jwt.RS256, priv))
+		if !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("WithSignerKey requires kid", func(t *testing.T) {
+		t.Parallel()
+		_, priv, _ := ed25519.GenerateKey(rand.Reader)
+		_, err := jwt.NewSigner(jwt.WithSignerKey("", jwt.EdDSA, priv))
+		if !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+}
+
+// --- signing, cross-checked with stdlib crypto ---
+
+func TestSignHS256(t *testing.T) {
+	t.Parallel()
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	header, payload, sig, input := splitToken(t, tok)
+	if header["alg"] != "HS256" || header["typ"] != "JWT" || header["kid"] != "2" {
+		t.Fatalf("header %v: want alg=HS256 typ=JWT kid=2 (primary keyset version)", header)
+	}
+	var c jwt.Claims
+	if err := json.Unmarshal(payload, &c); err != nil || c.Subject != "user-1" {
+		t.Fatalf("payload %s: %v", payload, err)
+	}
+	m := hmac.New(sha256.New, []byte("0123456789abcdef0123456789abcdef"))
+	m.Write([]byte(input))
+	if !hmac.Equal(sig, m.Sum(nil)) {
+		t.Fatal("HMAC does not verify with stdlib crypto")
+	}
+}
+
+func TestSignEdDSA(t *testing.T) {
+	t.Parallel()
+	ks, priv := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	header, _, sig, input := splitToken(t, tok)
+	if header["alg"] != "EdDSA" || header["kid"] != "1" {
+		t.Fatalf("header %v", header)
+	}
+	if !ed25519.Verify(priv.Public().(ed25519.PublicKey), []byte(input), sig) {
+		t.Fatal("Ed25519 signature does not verify with stdlib crypto")
+	}
+}
+
+func TestSignES256RawSignature(t *testing.T) {
+	t.Parallel()
+	ks, priv := ecKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	header, _, sig, input := splitToken(t, tok)
+	if header["alg"] != "ES256" {
+		t.Fatalf("header %v", header)
+	}
+	if len(sig) != 64 {
+		t.Fatalf("ES256 signature is %d bytes, want raw R||S 64", len(sig))
+	}
+	d := sha256.Sum256([]byte(input))
+	r := new(big.Int).SetBytes(sig[:32])
+	ss := new(big.Int).SetBytes(sig[32:])
+	if !ecdsa.Verify(&priv.PublicKey, d[:], r, ss) {
+		t.Fatal("ECDSA signature does not verify with stdlib crypto")
+	}
+}
+
+func TestSignRS256(t *testing.T) {
+	t.Parallel()
+	ks, priv := rsaKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	header, _, sig, input := splitToken(t, tok)
+	if header["alg"] != "RS256" {
+		t.Fatalf("header %v", header)
+	}
+	d := sha256.Sum256([]byte(input))
+	if err := rsa.VerifyPKCS1v15(&priv.PublicKey, crypto.SHA256, d[:], sig); err != nil {
+		t.Fatalf("RSA signature does not verify with stdlib crypto: %v", err)
+	}
+}
+
+func TestSignRejectsUnmarshalableClaims(t *testing.T) {
+	t.Parallel()
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	if _, err := s.Sign(func() {}); err == nil {
+		t.Fatal("want error for unmarshalable claims")
+	}
+}

--- a/auth/jwt/verifier.go
+++ b/auth/jwt/verifier.go
@@ -1,0 +1,214 @@
+package jwt
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+// maxTokenLen bounds Verify input before any decoding (DoS guard).
+const maxTokenLen = 64 << 10
+
+const defaultLeeway = 30 * time.Second
+
+// Verifier checks compact JWTs against a fixed key set and claim policy.
+// Key sources are combinable; policy is fixed at construction.
+type Verifier struct {
+	clk        clock.Clock
+	static     map[string]Key
+	jwks       *jwksCache // nil unless WithJWKSURL
+	iss        string
+	aud        string
+	leeway     time.Duration
+	requireExp bool
+}
+
+// NewVerifier builds a Verifier from at least one key source.
+func NewVerifier(opts ...VerifierOption) (*Verifier, error) {
+	cfg := verifierConfig{
+		leeway:     defaultLeeway,
+		requireExp: true,
+		clk:        clock.System(),
+		jwksCfg:    jwksConfig{refresh: time.Hour, cooldown: time.Minute},
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	keys := cfg.keys
+	for _, ks := range cfg.keysets {
+		expanded, err := verifyKeysFromKeyset(ks)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, expanded...)
+	}
+	for _, ks := range cfg.hsKeysets {
+		for version, material := range ks.All() {
+			keys = append(keys, Key{KID: strconv.Itoa(version), Alg: HS256, Key: material})
+		}
+	}
+	static := make(map[string]Key, len(keys))
+	for _, k := range keys {
+		if err := checkVerifyKey(k); err != nil {
+			return nil, err
+		}
+		if _, dup := static[k.KID]; dup {
+			return nil, fmt.Errorf("%w: duplicate kid %q", ErrBadKey, k.KID)
+		}
+		static[k.KID] = k
+	}
+	if len(static) == 0 && cfg.jwksURL == "" {
+		return nil, fmt.Errorf("%w: at least one key source required", ErrBadKey)
+	}
+	v := &Verifier{
+		static:     static,
+		iss:        cfg.iss,
+		aud:        cfg.aud,
+		leeway:     cfg.leeway,
+		requireExp: cfg.requireExp,
+		clk:        cfg.clk,
+	}
+	// Task 6 wires cfg.jwksURL into v.jwks here.
+	return v, nil
+}
+
+func verifyKeysFromKeyset(ks *keyset.Keyset) ([]Key, error) {
+	var keys []Key
+	for version, material := range ks.All() {
+		parsed, err := x509.ParsePKCS8PrivateKey(material)
+		if err != nil {
+			return nil, fmt.Errorf("%w: key version %d is not PKCS#8 DER: %v", ErrBadKey, version, err)
+		}
+		alg, err := algForPrivate(parsed)
+		if err != nil {
+			return nil, fmt.Errorf("key version %d: %w", version, err)
+		}
+		keys = append(keys, Key{KID: strconv.Itoa(version), Alg: alg, Key: parsed.(crypto.Signer).Public()})
+	}
+	return keys, nil
+}
+
+// Verify checks token against v's keys and claim policy and unmarshals the
+// payload into T. T should embed Claims. It is a package-level function
+// because Go methods cannot take type parameters.
+func Verify[T any](ctx context.Context, v *Verifier, token string) (*T, error) {
+	_, payload, err := v.verify(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	out := new(T)
+	if err := json.Unmarshal(payload, out); err != nil {
+		return nil, fmt.Errorf("%w: claims: %v", ErrMalformed, err)
+	}
+	return out, nil
+}
+
+// verify runs parse -> key resolution -> signature -> registered claims and
+// returns the validated registered claims plus the raw payload.
+func (v *Verifier) verify(ctx context.Context, token string) (*Claims, []byte, error) {
+	if len(token) > maxTokenLen {
+		return nil, nil, fmt.Errorf("%w: token exceeds %d bytes", ErrMalformed, maxTokenLen)
+	}
+	h64, rest, ok := strings.Cut(token, ".")
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: want 3 segments", ErrMalformed)
+	}
+	p64, s64, ok := strings.Cut(rest, ".")
+	if !ok || strings.Contains(s64, ".") {
+		return nil, nil, fmt.Errorf("%w: want 3 segments", ErrMalformed)
+	}
+	enc := base64.RawURLEncoding.Strict()
+	headerBytes, err := enc.DecodeString(h64)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: header encoding", ErrMalformed)
+	}
+	var header struct {
+		Alg string `json:"alg"`
+		Kid string `json:"kid"`
+		Typ string `json:"typ"`
+	}
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return nil, nil, fmt.Errorf("%w: header is not a JSON object", ErrMalformed)
+	}
+	if header.Typ != "" && !strings.EqualFold(header.Typ, "JWT") {
+		return nil, nil, fmt.Errorf("%w: unexpected typ %q", ErrMalformed, header.Typ)
+	}
+	key, err := v.resolveKey(ctx, header.Kid)
+	if err != nil {
+		return nil, nil, err
+	}
+	if header.Alg != string(key.Alg) {
+		return nil, nil, fmt.Errorf("%w: token alg %q does not match key alg %q", ErrSignature, header.Alg, key.Alg)
+	}
+	sig, err := enc.DecodeString(s64)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: signature encoding", ErrMalformed)
+	}
+	if !verifyBytes(key, []byte(h64+"."+p64), sig) {
+		return nil, nil, ErrSignature
+	}
+	payload, err := enc.DecodeString(p64)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: payload encoding", ErrMalformed)
+	}
+	var claims Claims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, nil, fmt.Errorf("%w: payload is not a JSON object", ErrMalformed)
+	}
+	if err := v.checkClaims(&claims); err != nil {
+		return nil, nil, err
+	}
+	return &claims, payload, nil
+}
+
+func (v *Verifier) checkClaims(c *Claims) error {
+	now := v.clk.Now()
+	switch {
+	case c.ExpiresAt == nil:
+		if v.requireExp {
+			return fmt.Errorf("%w: exp claim missing", ErrExpired)
+		}
+	case !now.Before(c.ExpiresAt.Add(v.leeway)):
+		return ErrExpired
+	}
+	if c.NotBefore != nil && now.Before(c.NotBefore.Add(-v.leeway)) {
+		return ErrNotYetValid
+	}
+	if v.iss != "" && c.Issuer != v.iss {
+		return ErrIssuerMismatch
+	}
+	if v.aud != "" && !c.Audience.Contains(v.aud) {
+		return ErrAudienceMismatch
+	}
+	return nil
+}
+
+// resolveKey maps a token's kid to a verification key. Without a kid the
+// sole static key is used iff the verifier holds exactly one key and no
+// JWKS source; there is no try-all-keys fallback.
+func (v *Verifier) resolveKey(ctx context.Context, kid string) (Key, error) {
+	if kid == "" {
+		if v.jwks == nil && len(v.static) == 1 {
+			for _, k := range v.static {
+				return k, nil
+			}
+		}
+		return Key{}, fmt.Errorf("%w: no kid and no single-key fallback", ErrUnknownKey)
+	}
+	if k, ok := v.static[kid]; ok {
+		return k, nil
+	}
+	if v.jwks != nil {
+		return v.jwks.get(ctx, kid)
+	}
+	return Key{}, fmt.Errorf("%w: kid %q", ErrUnknownKey, kid)
+}

--- a/auth/jwt/verifier.go
+++ b/auth/jwt/verifier.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/crypto/keyset"
+	"github.com/dmitrymomot/forge/web/httpclient"
 )
 
 // maxTokenLen bounds Verify input before any decoding (DoS guard).
@@ -38,7 +39,7 @@ func NewVerifier(opts ...VerifierOption) (*Verifier, error) {
 		leeway:     defaultLeeway,
 		requireExp: true,
 		clk:        clock.System(),
-		jwksCfg:    jwksConfig{refresh: time.Hour, cooldown: time.Minute},
+		jwksCfg:    jwksConfig{refresh: time.Hour, cooldown: time.Minute, fetchTimeout: 30 * time.Second},
 	}
 	for _, o := range opts {
 		o(&cfg)
@@ -77,7 +78,20 @@ func NewVerifier(opts ...VerifierOption) (*Verifier, error) {
 		requireExp: cfg.requireExp,
 		clk:        cfg.clk,
 	}
-	// Task 6 wires cfg.jwksURL into v.jwks here.
+	if cfg.jwksURL != "" {
+		client := cfg.jwksCfg.client
+		if client == nil {
+			client = httpclient.New()
+		}
+		v.jwks = &jwksCache{
+			url:          cfg.jwksURL,
+			client:       client,
+			refresh:      cfg.jwksCfg.refresh,
+			cooldown:     cfg.jwksCfg.cooldown,
+			fetchTimeout: cfg.jwksCfg.fetchTimeout,
+			clk:          cfg.clk,
+		}
+	}
 	return v, nil
 }
 

--- a/auth/jwt/verifier_test.go
+++ b/auth/jwt/verifier_test.go
@@ -1,0 +1,385 @@
+package jwt_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+type accessClaims struct {
+	jwt.Claims
+	TenantID string `json:"tid"`
+}
+
+// hsToken hand-crafts an HS256 token so tests control every header field.
+func hsToken(t *testing.T, secret []byte, headerJSON, payloadJSON string) string {
+	t.Helper()
+	enc := base64.RawURLEncoding
+	input := enc.EncodeToString([]byte(headerJSON)) + "." + enc.EncodeToString([]byte(payloadJSON))
+	m := hmac.New(sha256.New, secret)
+	m.Write([]byte(input))
+	return input + "." + enc.EncodeToString(m.Sum(nil))
+}
+
+func TestNewVerifierConstruction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("requires a key source", func(t *testing.T) {
+		t.Parallel()
+		if _, err := jwt.NewVerifier(); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("duplicate kid rejected", func(t *testing.T) {
+		t.Parallel()
+		ks, _ := edKeyset(t)
+		s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		k := s.PublicKeys()[0]
+		if _, err := jwt.NewVerifier(jwt.WithKeys(k, k)); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("short HS256 key in WithKeys rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwt.NewVerifier(jwt.WithKeys(jwt.Key{KID: "1", Alg: jwt.HS256, Key: []byte("short")}))
+		if !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("alg/key type mismatch rejected", func(t *testing.T) {
+		t.Parallel()
+		ks, _ := edKeyset(t)
+		s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		k := s.PublicKeys()[0]
+		k.Alg = jwt.RS256 // Ed25519 key claiming RS256
+		if _, err := jwt.NewVerifier(jwt.WithKeys(k)); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+}
+
+func TestRoundTripAllAlgs(t *testing.T) {
+	t.Parallel()
+	cases := map[string]func(*testing.T) (*jwt.Signer, *jwt.Verifier){
+		"HS256": func(t *testing.T) (*jwt.Signer, *jwt.Verifier) {
+			ks := hsKeyset(t)
+			s, err := jwt.NewSigner(jwt.WithHS256Keyset(ks))
+			if err != nil {
+				t.Fatalf("NewSigner: %v", err)
+			}
+			v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(ks))
+			if err != nil {
+				t.Fatalf("NewVerifier: %v", err)
+			}
+			return s, v
+		},
+		"EdDSA": func(t *testing.T) (*jwt.Signer, *jwt.Verifier) {
+			ks, _ := edKeyset(t)
+			return signerVerifierPair(t, ks)
+		},
+		"ES256": func(t *testing.T) (*jwt.Signer, *jwt.Verifier) {
+			ks, _ := ecKeyset(t)
+			return signerVerifierPair(t, ks)
+		},
+		"RS256": func(t *testing.T) (*jwt.Signer, *jwt.Verifier) {
+			ks, _ := rsaKeyset(t)
+			return signerVerifierPair(t, ks)
+		},
+	}
+	for name, mk := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			s, v := mk(t)
+			in := accessClaims{Claims: testClaims(), TenantID: "t-42"}
+			tok, err := s.Sign(in)
+			if err != nil {
+				t.Fatalf("Sign: %v", err)
+			}
+			out, err := jwt.Verify[accessClaims](t.Context(), v, tok)
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if out.Subject != "user-1" || out.TenantID != "t-42" {
+				t.Fatalf("claims %+v", out)
+			}
+		})
+	}
+}
+
+func signerVerifierPair(t *testing.T, ks *keyset.Keyset) (*jwt.Signer, *jwt.Verifier) {
+	t.Helper()
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	v, err := jwt.NewVerifier(jwt.WithKeys(s.PublicKeys()...))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	return s, v
+}
+
+// Retired keyset versions must keep verifying (rotation).
+func TestVerifyRetiredKeysetVersion(t *testing.T) {
+	t.Parallel()
+	oldKS, err := keyset.New(keyset.WithPrimary(1, []byte("fedcba9876543210fedcba9876543210")))
+	if err != nil {
+		t.Fatalf("keyset: %v", err)
+	}
+	oldSigner, err := jwt.NewSigner(jwt.WithHS256Keyset(oldKS))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := oldSigner.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	// hsKeyset has primary 2 and retired 1 (same material as oldKS's primary).
+	v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+		t.Fatalf("retired version does not verify: %v", err)
+	}
+}
+
+// WithVerifyKeyset derives verification (public) keys for every version in
+// an asymmetric keyset. This exercises both the primary version (kid "2")
+// and a retired version (kid "1") to prove the retired public half was
+// derived correctly, not just the primary.
+func TestVerifyWithVerifyKeyset(t *testing.T) {
+	t.Parallel()
+
+	priv1, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa priv1: %v", err)
+	}
+	priv2, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa priv2: %v", err)
+	}
+
+	ks, err := keyset.New(
+		keyset.WithPrimary(2, pkcs8(t, priv2)),
+		keyset.WithRetired(1, pkcs8(t, priv1)),
+	)
+	if err != nil {
+		t.Fatalf("keyset: %v", err)
+	}
+
+	v, err := jwt.NewVerifier(jwt.WithVerifyKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+
+	t.Run("primary version", func(t *testing.T) {
+		t.Parallel()
+		s2, err := jwt.NewSigner(jwt.WithKeyset(ks))
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		tok, err := s2.Sign(testClaims())
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		out, err := jwt.Verify[jwt.Claims](t.Context(), v, tok)
+		if err != nil {
+			t.Fatalf("Verify primary: %v", err)
+		}
+		if out.Subject != "user-1" {
+			t.Fatalf("claims %+v, want Subject user-1", out)
+		}
+	})
+
+	t.Run("retired version", func(t *testing.T) {
+		t.Parallel()
+		s1, err := jwt.NewSigner(jwt.WithSignerKey("1", jwt.ES256, priv1))
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		tok, err := s1.Sign(testClaims())
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		out, err := jwt.Verify[jwt.Claims](t.Context(), v, tok)
+		if err != nil {
+			t.Fatalf("Verify retired: %v", err)
+		}
+		if out.Subject != "user-1" {
+			t.Fatalf("claims %+v, want Subject user-1", out)
+		}
+	})
+}
+
+func TestVerifyMalformed(t *testing.T) {
+	t.Parallel()
+	v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	good, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	parts := strings.Split(good, ".")
+	cases := map[string]string{
+		"empty":              "",
+		"garbage":            "not-a-token",
+		"two segments":       parts[0] + "." + parts[1],
+		"four segments":      good + ".extra",
+		"padded base64":      parts[0] + "==." + parts[1] + "." + parts[2],
+		"standard base64":    strings.ReplaceAll(good, "_", "/") + "+",
+		"non-object header":  hsToken(t, []byte("0123456789abcdef0123456789abcdef"), `"HS256"`, `{}`),
+		"non-object payload": hsToken(t, []byte("0123456789abcdef0123456789abcdef"), `{"alg":"HS256","kid":"2"}`, `[1,2]`),
+		"bad typ":            hsToken(t, []byte("0123456789abcdef0123456789abcdef"), `{"alg":"HS256","kid":"2","typ":"JWE"}`, `{}`),
+		"oversized":          good + strings.Repeat("a", 64<<10),
+	}
+	for name, tok := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrMalformed) {
+				t.Fatalf("got %v, want ErrMalformed", err)
+			}
+		})
+	}
+}
+
+func TestVerifyKeyResolution(t *testing.T) {
+	t.Parallel()
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	exp := time.Now().Add(time.Hour).Unix()
+	payload := `{"exp":` + itoa(exp) + `}`
+
+	t.Run("unknown kid", func(t *testing.T) {
+		t.Parallel()
+		v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(hsKeyset(t)))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok := hsToken(t, secret, `{"alg":"HS256","kid":"99"}`, payload)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrUnknownKey) {
+			t.Fatalf("got %v, want ErrUnknownKey", err)
+		}
+	})
+
+	t.Run("no kid with single key uses it", func(t *testing.T) {
+		t.Parallel()
+		v, err := jwt.NewVerifier(jwt.WithKeys(jwt.Key{KID: "only", Alg: jwt.HS256, Key: secret}))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok := hsToken(t, secret, `{"alg":"HS256"}`, payload)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+			t.Fatalf("single-key rule failed: %v", err)
+		}
+	})
+
+	t.Run("no kid with multiple keys rejected", func(t *testing.T) {
+		t.Parallel()
+		v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(hsKeyset(t))) // 2 versions
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok := hsToken(t, secret, `{"alg":"HS256"}`, payload)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrUnknownKey) {
+			t.Fatalf("got %v, want ErrUnknownKey", err)
+		}
+	})
+}
+
+func TestVerifyAlgAttacks(t *testing.T) {
+	t.Parallel()
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	exp := time.Now().Add(time.Hour).Unix()
+	payload := `{"exp":` + itoa(exp) + `}`
+
+	t.Run("alg none", func(t *testing.T) {
+		t.Parallel()
+		v, err := jwt.NewVerifier(jwt.WithKeys(jwt.Key{KID: "only", Alg: jwt.HS256, Key: secret}))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		enc := base64.RawURLEncoding
+		tok := enc.EncodeToString([]byte(`{"alg":"none"}`)) + "." + enc.EncodeToString([]byte(payload)) + "."
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrSignature) && !errors.Is(err, jwt.ErrMalformed) {
+			t.Fatalf("got %v, want ErrSignature or ErrMalformed", err)
+		}
+	})
+
+	t.Run("HS256 signed with the public key bytes (confusion)", func(t *testing.T) {
+		t.Parallel()
+		ks, priv := ecKeyset(t)
+		s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		v, err := jwt.NewVerifier(jwt.WithKeys(s.PublicKeys()...))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		// Attacker HMACs with the DER of the public key and claims HS256 for kid "1".
+		pubDER, err := ecdsaPublicDER(&priv.PublicKey)
+		if err != nil {
+			t.Fatalf("marshal public: %v", err)
+		}
+		tok := hsToken(t, pubDER, `{"alg":"HS256","kid":"1"}`, payload)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrSignature) {
+			t.Fatalf("confusion attack not rejected: %v", err)
+		}
+	})
+
+	t.Run("tampered payload", func(t *testing.T) {
+		t.Parallel()
+		s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(hsKeyset(t)))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok, err := s.Sign(testClaims())
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		parts := strings.Split(tok, ".")
+		forged := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"admin","exp":` + itoa(exp) + `}`))
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, parts[0]+"."+forged+"."+parts[2]); !errors.Is(err, jwt.ErrSignature) {
+			t.Fatalf("got %v, want ErrSignature", err)
+		}
+	})
+}
+
+func itoa(n int64) string {
+	return strconv.FormatInt(n, 10)
+}
+
+func ecdsaPublicDER(pub *ecdsa.PublicKey) ([]byte, error) {
+	return x509.MarshalPKIXPublicKey(pub)
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -311,16 +311,6 @@ WWW-Authenticate — gates pprof/metrics/staging/admin), and
 
 ---
 
-**auth/jwt**
-
-Full JWT: sign and verify with a pinned alg allowlist (RS256/ES256/EdDSA —
-never negotiated), exp/nbf/aud/iss checks, JWKS serve + fetch with kid
-cache/rotation, key rotation via `crypto/keyset`. No JWE. Consumed by
-`oauthserver` (issuing), `oauthclient` (id_token verify), `guard` (bearer
-verify), and inter-service auth.
-
----
-
 **auth/lockout**
 
 Login/OTP failure counting with exponential delay and lockout windows over

--- a/docs/superpowers/plans/2026-07-10-auth-jwt.md
+++ b/docs/superpowers/plans/2026-07-10-auth-jwt.md
@@ -1,0 +1,2978 @@
+# auth/jwt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Full JWT for forge — sign/verify with pinned alg allowlist (HS256/RS256/ES256/EdDSA), registered-claim checks, JWKS serve + fetch with kid cache/rotation, key rotation via `crypto/keyset`.
+
+**Architecture:** Split `Signer`/`Verifier` types per the approved spec
+(`docs/superpowers/specs/2026-07-10-auth-jwt-design.md`). Every key is bound
+to exactly one alg at construction; the token's `alg` header is matched
+against the resolved key's alg, never negotiated. Typed claims via a
+package-level generic `Verify[T]`. JWKS fetch is an in-memory cache with
+TTL refresh + unknown-kid cooldown over `resilience/singleflight`.
+
+**Tech Stack:** Go stdlib crypto only + forge `crypto/keyset`,
+`core/clock`, `resilience/singleflight`, `web/httpclient` (default JWKS
+client). No external JWT libs.
+
+## Global Constraints
+
+- Read the spec first: `docs/superpowers/specs/2026-07-10-auth-jwt-design.md`.
+- Black-box tests only: all tests in `package jwt_test`.
+- Error sentinels are single-line, `errors.Is`-matchable, prefixed `jwt: `.
+- Run `just fmt ./auth/jwt/...` after changing files (package-path form — the single-file form trips a spurious betteralign error).
+- Tests run with race detection: `go test -race ./auth/jwt/...` (or `just test ./auth/jwt/...`).
+- `just lint` must pass at the end (Task 7); fix everything it reports.
+- Go 1.26: use `new(expr)` where a pointer to a value is needed; the modernize linter enforces it.
+- NEVER add Claude/AI attribution lines to commits.
+- Public methods never return unexported types.
+- No auto-magic: `Sign` signs exactly the claims given (no auto `iat`).
+
+## File Structure
+
+```
+auth/jwt/
+  doc.go        # package doc + runnable usage examples (Task 7)
+  errors.go     # sentinels (Task 2)
+  claims.go     # Claims, Audience, NumericDate (Task 1)
+  alg.go        # Alg, Key, sign/verify primitives, key-type inference (Task 2)
+  signer.go     # Signer, NewSigner, Sign, PublicKeys (Tasks 2–3)
+  verifier.go   # Verifier, NewVerifier, Verify[T], resolveKey (Tasks 4–5)
+  jwks.go       # JWKS serve handler + fetch cache (Tasks 3, 6)
+  options.go    # SignerOption/VerifierOption/JWKSOption/ServeOption (Tasks 2–6)
+  claims_test.go, signer_test.go, jwks_serve_test.go,
+  verifier_test.go, claims_policy_test.go, jwks_fetch_test.go,
+  bench_test.go # all package jwt_test
+```
+
+---
+
+### Task 1: Claims types (`claims.go`)
+
+**Files:**
+- Create: `auth/jwt/claims.go`
+- Test: `auth/jwt/claims_test.go`
+
+**Interfaces:**
+- Consumes: stdlib only.
+- Produces: `type Claims struct{ Issuer, Subject string; Audience Audience; ExpiresAt, NotBefore, IssuedAt *NumericDate; ID string }`, `type Audience []string` with `Contains(string) bool`, `type NumericDate struct{ time.Time }` with `NewNumericDate(time.Time) *NumericDate`. Later tasks unmarshal token payloads into `Claims` and consumers embed it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// auth/jwt/claims_test.go
+package jwt_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+)
+
+func TestAudienceJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unmarshal string", func(t *testing.T) {
+		t.Parallel()
+		var a jwt.Audience
+		if err := json.Unmarshal([]byte(`"api"`), &a); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(a) != 1 || a[0] != "api" {
+			t.Fatalf("got %v, want [api]", a)
+		}
+	})
+
+	t.Run("unmarshal array", func(t *testing.T) {
+		t.Parallel()
+		var a jwt.Audience
+		if err := json.Unmarshal([]byte(`["api","web"]`), &a); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(a) != 2 || a[0] != "api" || a[1] != "web" {
+			t.Fatalf("got %v, want [api web]", a)
+		}
+	})
+
+	t.Run("unmarshal rejects number", func(t *testing.T) {
+		t.Parallel()
+		var a jwt.Audience
+		if err := json.Unmarshal([]byte(`42`), &a); err == nil {
+			t.Fatal("want error for non-string aud")
+		}
+	})
+
+	t.Run("marshal single as string", func(t *testing.T) {
+		t.Parallel()
+		b, err := json.Marshal(jwt.Audience{"api"})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if string(b) != `"api"` {
+			t.Fatalf("got %s, want %q", b, `"api"`)
+		}
+	})
+
+	t.Run("marshal multiple as array", func(t *testing.T) {
+		t.Parallel()
+		b, err := json.Marshal(jwt.Audience{"api", "web"})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if string(b) != `["api","web"]` {
+			t.Fatalf("got %s, want array", b)
+		}
+	})
+
+	t.Run("contains", func(t *testing.T) {
+		t.Parallel()
+		a := jwt.Audience{"api", "web"}
+		if !a.Contains("web") || a.Contains("mobile") {
+			t.Fatalf("Contains misbehaves: %v", a)
+		}
+	})
+}
+
+func TestNumericDateJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("round trip unix seconds", func(t *testing.T) {
+		t.Parallel()
+		d := jwt.NewNumericDate(time.Unix(1300819380, 0))
+		b, err := json.Marshal(d)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if string(b) != "1300819380" {
+			t.Fatalf("got %s, want 1300819380", b)
+		}
+		var back jwt.NumericDate
+		if err := json.Unmarshal(b, &back); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if !back.Equal(time.Unix(1300819380, 0)) {
+			t.Fatalf("got %v", back.Time)
+		}
+	})
+
+	t.Run("fractional seconds truncate", func(t *testing.T) {
+		t.Parallel()
+		var d jwt.NumericDate
+		if err := json.Unmarshal([]byte("1300819380.75"), &d); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if d.Unix() != 1300819380 {
+			t.Fatalf("got %d, want 1300819380", d.Unix())
+		}
+	})
+
+	t.Run("rejects non-numbers", func(t *testing.T) {
+		t.Parallel()
+		for _, in := range []string{`"soon"`, `null`, `{}`, `NaN`} {
+			var d jwt.NumericDate
+			if err := json.Unmarshal([]byte(in), &d); err == nil {
+				t.Fatalf("want error for %s", in)
+			}
+		}
+	})
+}
+
+func TestClaimsEmbedding(t *testing.T) {
+	t.Parallel()
+	type access struct {
+		jwt.Claims
+		TenantID string `json:"tid"`
+	}
+	in := access{
+		Claims: jwt.Claims{
+			Issuer:    "https://api.example.com",
+			Subject:   "user-1",
+			Audience:  jwt.Audience{"my-app"},
+			ExpiresAt: jwt.NewNumericDate(time.Unix(1300819380, 0)),
+			ID:        "jti-1",
+		},
+		TenantID: "t-42",
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out access
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Issuer != in.Issuer || out.TenantID != "t-42" || !out.Audience.Contains("my-app") {
+		t.Fatalf("round trip mismatch: %+v", out)
+	}
+	// omitempty: zero claims marshal to {} — no null exp/nbf noise.
+	empty, err := json.Marshal(jwt.Claims{})
+	if err != nil {
+		t.Fatalf("marshal empty: %v", err)
+	}
+	if string(empty) != "{}" {
+		t.Fatalf("empty claims marshal to %s, want {}", empty)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -race ./auth/jwt/...`
+Expected: FAIL — package does not exist / undefined: jwt.Audience
+
+- [ ] **Step 3: Implement `claims.go`**
+
+```go
+// auth/jwt/claims.go
+package jwt
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+	"time"
+)
+
+// Audience is the RFC 7519 "aud" claim. It unmarshals from either a JSON
+// string or an array of strings and marshals to a bare string when it
+// holds exactly one value.
+type Audience []string
+
+// Contains reports whether v is one of the audience values.
+func (a Audience) Contains(v string) bool {
+	return slices.Contains(a, v)
+}
+
+func (a Audience) MarshalJSON() ([]byte, error) {
+	if len(a) == 1 {
+		return json.Marshal(a[0])
+	}
+	return json.Marshal([]string(a))
+}
+
+func (a *Audience) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		*a = Audience{s}
+		return nil
+	}
+	var ss []string
+	if err := json.Unmarshal(b, &ss); err != nil {
+		return err
+	}
+	*a = Audience(ss)
+	return nil
+}
+
+// NumericDate is an RFC 7519 NumericDate: unix seconds as a JSON number.
+// Fractional seconds are accepted on input and truncated.
+type NumericDate struct {
+	time.Time
+}
+
+// NewNumericDate returns t truncated to whole seconds.
+func NewNumericDate(t time.Time) *NumericDate {
+	return &NumericDate{Time: t.Truncate(time.Second)}
+}
+
+func (d NumericDate) MarshalJSON() ([]byte, error) {
+	return strconv.AppendInt(nil, d.Unix(), 10), nil
+}
+
+func (d *NumericDate) UnmarshalJSON(b []byte) error {
+	f, err := strconv.ParseFloat(string(b), 64)
+	if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+		return fmt.Errorf("jwt: invalid NumericDate %q", b)
+	}
+	d.Time = time.Unix(int64(f), 0)
+	return nil
+}
+
+// Claims holds the RFC 7519 registered claims. Consumers embed it:
+//
+//	type AccessClaims struct {
+//	    jwt.Claims
+//	    TenantID string `json:"tid"`
+//	}
+type Claims struct {
+	Issuer    string       `json:"iss,omitempty"`
+	Subject   string       `json:"sub,omitempty"`
+	Audience  Audience     `json:"aud,omitempty"`
+	ExpiresAt *NumericDate `json:"exp,omitempty"`
+	NotBefore *NumericDate `json:"nbf,omitempty"`
+	IssuedAt  *NumericDate `json:"iat,omitempty"`
+	ID        string       `json:"jti,omitempty"`
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -race ./auth/jwt/...`
+Expected: PASS
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/jwt/...
+git add auth/jwt
+git commit -m "feat(jwt): registered claims, Audience, NumericDate"
+```
+
+---
+
+### Task 2: Errors, alg primitives, Signer construction + Sign
+
+**Files:**
+- Create: `auth/jwt/errors.go`, `auth/jwt/alg.go`, `auth/jwt/signer.go`, `auth/jwt/options.go`
+- Test: `auth/jwt/signer_test.go`
+
+**Interfaces:**
+- Consumes: `keyset.New/WithPrimary/WithRetired/Primary/All`, Task 1 types.
+- Produces:
+  - Sentinels: `ErrMalformed, ErrSignature, ErrExpired, ErrNotYetValid, ErrIssuerMismatch, ErrAudienceMismatch, ErrUnknownKey, ErrNoKeys, ErrBadKey`.
+  - `type Alg string`; consts `HS256, RS256, ES256, EdDSA`.
+  - `type Key struct{ KID string; Alg Alg; Key crypto.PublicKey }`.
+  - `func NewSigner(opts ...SignerOption) (*Signer, error)`; options `WithKeyset(*keyset.Keyset)`, `WithHS256Keyset(*keyset.Keyset)`, `WithSignerKey(kid string, alg Alg, key crypto.Signer)`.
+  - `func (s *Signer) Sign(claims any) (string, error)`.
+  - Unexported helpers used by Tasks 4–6: `verifyBytes(k Key, input, sig []byte) bool`, `algForPrivate(key any) (Alg, error)`, `checkVerifyKey(k Key) error`, `minHS256KeyLen = 32`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// auth/jwt/signer_test.go
+package jwt_test
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+// --- helpers shared by later test files ---
+
+func hsKeyset(t *testing.T) *keyset.Keyset {
+	t.Helper()
+	ks, err := keyset.New(
+		keyset.WithPrimary(2, []byte("0123456789abcdef0123456789abcdef")),
+		keyset.WithRetired(1, []byte("fedcba9876543210fedcba9876543210")),
+	)
+	if err != nil {
+		t.Fatalf("keyset: %v", err)
+	}
+	return ks
+}
+
+func pkcs8(t *testing.T, key any) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("pkcs8: %v", err)
+	}
+	return der
+}
+
+func edKeyset(t *testing.T) (*keyset.Keyset, ed25519.PrivateKey) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519: %v", err)
+	}
+	ks, err := keyset.New(keyset.WithPrimary(1, pkcs8(t, priv)))
+	if err != nil {
+		t.Fatalf("keyset: %v", err)
+	}
+	return ks, priv
+}
+
+func ecKeyset(t *testing.T) (*keyset.Keyset, *ecdsa.PrivateKey) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa: %v", err)
+	}
+	ks, err := keyset.New(keyset.WithPrimary(1, pkcs8(t, priv)))
+	if err != nil {
+		t.Fatalf("keyset: %v", err)
+	}
+	return ks, priv
+}
+
+func rsaKeyset(t *testing.T) (*keyset.Keyset, *rsa.PrivateKey) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa: %v", err)
+	}
+	ks, err := keyset.New(keyset.WithPrimary(1, pkcs8(t, priv)))
+	if err != nil {
+		t.Fatalf("keyset: %v", err)
+	}
+	return ks, priv
+}
+
+// splitToken decodes the three segments of a compact JWS.
+func splitToken(t *testing.T, tok string) (header map[string]any, payload, sig []byte, signingInput string) {
+	t.Helper()
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token has %d parts, want 3: %s", len(parts), tok)
+	}
+	hb, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("header b64: %v", err)
+	}
+	if err := json.Unmarshal(hb, &header); err != nil {
+		t.Fatalf("header json: %v", err)
+	}
+	payload, err = base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("payload b64: %v", err)
+	}
+	sig, err = base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("sig b64: %v", err)
+	}
+	return header, payload, sig, parts[0] + "." + parts[1]
+}
+
+func testClaims() jwt.Claims {
+	return jwt.Claims{
+		Issuer:    "https://api.example.com",
+		Subject:   "user-1",
+		Audience:  jwt.Audience{"my-app"},
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+}
+
+// --- construction ---
+
+func TestNewSignerKeySources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no key source", func(t *testing.T) {
+		t.Parallel()
+		if _, err := jwt.NewSigner(); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("two key sources", func(t *testing.T) {
+		t.Parallel()
+		ks, _ := edKeyset(t)
+		_, err := jwt.NewSigner(jwt.WithKeyset(ks), jwt.WithHS256Keyset(hsKeyset(t)))
+		if !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("HS256 secret too short", func(t *testing.T) {
+		t.Parallel()
+		ks, err := keyset.New(keyset.WithPrimary(1, []byte("short")))
+		if err != nil {
+			t.Fatalf("keyset: %v", err)
+		}
+		if _, err := jwt.NewSigner(jwt.WithHS256Keyset(ks)); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("asymmetric keyset rejects raw bytes", func(t *testing.T) {
+		t.Parallel()
+		ks, err := keyset.New(keyset.WithPrimary(1, []byte("0123456789abcdef0123456789abcdef")))
+		if err != nil {
+			t.Fatalf("keyset: %v", err)
+		}
+		if _, err := jwt.NewSigner(jwt.WithKeyset(ks)); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("RSA under 2048 bits rejected", func(t *testing.T) {
+		t.Parallel()
+		priv, err := rsa.GenerateKey(rand.Reader, 1024)
+		if err != nil {
+			t.Fatalf("rsa: %v", err)
+		}
+		ks, err := keyset.New(keyset.WithPrimary(1, pkcs8(t, priv)))
+		if err != nil {
+			t.Fatalf("keyset: %v", err)
+		}
+		if _, err := jwt.NewSigner(jwt.WithKeyset(ks)); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("non-P256 curve rejected", func(t *testing.T) {
+		t.Parallel()
+		priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		if err != nil {
+			t.Fatalf("ecdsa: %v", err)
+		}
+		ks, err := keyset.New(keyset.WithPrimary(1, pkcs8(t, priv)))
+		if err != nil {
+			t.Fatalf("keyset: %v", err)
+		}
+		if _, err := jwt.NewSigner(jwt.WithKeyset(ks)); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("WithSignerKey rejects HS256", func(t *testing.T) {
+		t.Parallel()
+		_, priv, _ := ed25519.GenerateKey(rand.Reader)
+		_, err := jwt.NewSigner(jwt.WithSignerKey("k1", jwt.HS256, priv))
+		if !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("WithSignerKey rejects alg/key mismatch", func(t *testing.T) {
+		t.Parallel()
+		_, priv, _ := ed25519.GenerateKey(rand.Reader)
+		_, err := jwt.NewSigner(jwt.WithSignerKey("k1", jwt.RS256, priv))
+		if !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("WithSignerKey requires kid", func(t *testing.T) {
+		t.Parallel()
+		_, priv, _ := ed25519.GenerateKey(rand.Reader)
+		_, err := jwt.NewSigner(jwt.WithSignerKey("", jwt.EdDSA, priv))
+		if !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+}
+
+// --- signing, cross-checked with stdlib crypto ---
+
+func TestSignHS256(t *testing.T) {
+	t.Parallel()
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	header, payload, sig, input := splitToken(t, tok)
+	if header["alg"] != "HS256" || header["typ"] != "JWT" || header["kid"] != "2" {
+		t.Fatalf("header %v: want alg=HS256 typ=JWT kid=2 (primary keyset version)", header)
+	}
+	var c jwt.Claims
+	if err := json.Unmarshal(payload, &c); err != nil || c.Subject != "user-1" {
+		t.Fatalf("payload %s: %v", payload, err)
+	}
+	m := hmac.New(sha256.New, []byte("0123456789abcdef0123456789abcdef"))
+	m.Write([]byte(input))
+	if !hmac.Equal(sig, m.Sum(nil)) {
+		t.Fatal("HMAC does not verify with stdlib crypto")
+	}
+}
+
+func TestSignEdDSA(t *testing.T) {
+	t.Parallel()
+	ks, priv := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	header, _, sig, input := splitToken(t, tok)
+	if header["alg"] != "EdDSA" || header["kid"] != "1" {
+		t.Fatalf("header %v", header)
+	}
+	if !ed25519.Verify(priv.Public().(ed25519.PublicKey), []byte(input), sig) {
+		t.Fatal("Ed25519 signature does not verify with stdlib crypto")
+	}
+}
+
+func TestSignES256RawSignature(t *testing.T) {
+	t.Parallel()
+	ks, priv := ecKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	header, _, sig, input := splitToken(t, tok)
+	if header["alg"] != "ES256" {
+		t.Fatalf("header %v", header)
+	}
+	if len(sig) != 64 {
+		t.Fatalf("ES256 signature is %d bytes, want raw R||S 64", len(sig))
+	}
+	d := sha256.Sum256([]byte(input))
+	r := new(big.Int).SetBytes(sig[:32])
+	ss := new(big.Int).SetBytes(sig[32:])
+	if !ecdsa.Verify(&priv.PublicKey, d[:], r, ss) {
+		t.Fatal("ECDSA signature does not verify with stdlib crypto")
+	}
+}
+
+func TestSignRS256(t *testing.T) {
+	t.Parallel()
+	ks, priv := rsaKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	header, _, sig, input := splitToken(t, tok)
+	if header["alg"] != "RS256" {
+		t.Fatalf("header %v", header)
+	}
+	d := sha256.Sum256([]byte(input))
+	if err := rsa.VerifyPKCS1v15(&priv.PublicKey, crypto.SHA256, d[:], sig); err != nil {
+		t.Fatalf("RSA signature does not verify with stdlib crypto: %v", err)
+	}
+}
+
+func TestSignRejectsUnmarshalableClaims(t *testing.T) {
+	t.Parallel()
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	if _, err := s.Sign(func() {}); err == nil {
+		t.Fatal("want error for unmarshalable claims")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -race ./auth/jwt/...`
+Expected: FAIL — undefined: jwt.NewSigner, jwt.ErrBadKey, ...
+
+- [ ] **Step 3: Implement `errors.go`**
+
+```go
+// auth/jwt/errors.go
+package jwt
+
+import "errors"
+
+var (
+	// ErrMalformed reports a token that is not a structurally valid compact JWS.
+	ErrMalformed = errors.New("jwt: malformed token")
+	// ErrSignature reports a signature that does not verify, including alg/key mismatches.
+	ErrSignature = errors.New("jwt: signature mismatch")
+	// ErrExpired reports a token past its exp claim, or missing exp when expiry is required.
+	ErrExpired = errors.New("jwt: token expired")
+	// ErrNotYetValid reports a token whose nbf claim is in the future.
+	ErrNotYetValid = errors.New("jwt: token not yet valid")
+	// ErrIssuerMismatch reports an iss claim that differs from the configured issuer.
+	ErrIssuerMismatch = errors.New("jwt: issuer mismatch")
+	// ErrAudienceMismatch reports an aud claim missing the configured audience.
+	ErrAudienceMismatch = errors.New("jwt: audience mismatch")
+	// ErrUnknownKey reports a kid that resolves to no known key.
+	ErrUnknownKey = errors.New("jwt: unknown key")
+	// ErrNoKeys reports key resolution over an empty key set.
+	ErrNoKeys = errors.New("jwt: no keys available")
+	// ErrBadKey reports invalid key material or configuration at construction.
+	ErrBadKey = errors.New("jwt: invalid key material")
+)
+```
+
+- [ ] **Step 4: Implement `alg.go`**
+
+```go
+// auth/jwt/alg.go
+package jwt
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/asn1"
+	"fmt"
+	"math/big"
+)
+
+// Alg identifies a JWS signing algorithm. The set is closed: forge never
+// negotiates algorithms and offers no registration hook.
+type Alg string
+
+const (
+	HS256 Alg = "HS256"
+	RS256 Alg = "RS256"
+	ES256 Alg = "ES256"
+	EdDSA Alg = "EdDSA"
+)
+
+// Key is a verification key bound to exactly one algorithm. Key holds
+// *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey, or a []byte secret
+// for HS256.
+type Key struct {
+	KID string
+	Alg Alg
+	Key crypto.PublicKey
+}
+
+const minHS256KeyLen = 32
+
+// algForPrivate infers the pinned alg for a parsed PKCS#8 private key.
+func algForPrivate(key any) (Alg, error) {
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		if k.N.BitLen() < 2048 {
+			return "", fmt.Errorf("%w: RSA key must be at least 2048 bits", ErrBadKey)
+		}
+		return RS256, nil
+	case *ecdsa.PrivateKey:
+		if k.Curve != elliptic.P256() {
+			return "", fmt.Errorf("%w: ECDSA key must use P-256", ErrBadKey)
+		}
+		return ES256, nil
+	case ed25519.PrivateKey:
+		return EdDSA, nil
+	default:
+		return "", fmt.Errorf("%w: unsupported key type %T", ErrBadKey, key)
+	}
+}
+
+// checkSignerAlg validates that a caller-supplied crypto.Signer matches its
+// declared alg.
+func checkSignerAlg(alg Alg, pub crypto.PublicKey) error {
+	switch alg {
+	case HS256:
+		return fmt.Errorf("%w: HS256 needs a secret, use WithHS256Keyset", ErrBadKey)
+	case RS256:
+		if k, ok := pub.(*rsa.PublicKey); !ok || k.N.BitLen() < 2048 {
+			return fmt.Errorf("%w: RS256 requires an RSA key of at least 2048 bits", ErrBadKey)
+		}
+	case ES256:
+		if k, ok := pub.(*ecdsa.PublicKey); !ok || k.Curve != elliptic.P256() {
+			return fmt.Errorf("%w: ES256 requires an ECDSA P-256 key", ErrBadKey)
+		}
+	case EdDSA:
+		if _, ok := pub.(ed25519.PublicKey); !ok {
+			return fmt.Errorf("%w: EdDSA requires an Ed25519 key", ErrBadKey)
+		}
+	default:
+		return fmt.Errorf("%w: unsupported alg %q", ErrBadKey, alg)
+	}
+	return nil
+}
+
+// checkVerifyKey validates a verification Key's alg/key-type binding.
+func checkVerifyKey(k Key) error {
+	if k.Alg == HS256 {
+		secret, ok := k.Key.([]byte)
+		if !ok || len(secret) < minHS256KeyLen {
+			return fmt.Errorf("%w: HS256 key must be a []byte secret of at least %d bytes", ErrBadKey, minHS256KeyLen)
+		}
+		return nil
+	}
+	return checkSignerAlg(k.Alg, k.Key)
+}
+
+// signBytes signs the JWS signing input. Exactly one of signer/secret is set.
+func signBytes(alg Alg, signer crypto.Signer, secret, input []byte) ([]byte, error) {
+	switch alg {
+	case HS256:
+		m := hmac.New(sha256.New, secret)
+		m.Write(input)
+		return m.Sum(nil), nil
+	case RS256:
+		d := sha256.Sum256(input)
+		return signer.Sign(rand.Reader, d[:], crypto.SHA256)
+	case ES256:
+		d := sha256.Sum256(input)
+		der, err := signer.Sign(rand.Reader, d[:], crypto.SHA256)
+		if err != nil {
+			return nil, err
+		}
+		return derToRawES256(der)
+	case EdDSA:
+		return signer.Sign(rand.Reader, input, crypto.Hash(0))
+	default:
+		return nil, fmt.Errorf("%w: unsupported alg %q", ErrBadKey, alg)
+	}
+}
+
+// verifyBytes reports whether sig is a valid signature over input for k.
+func verifyBytes(k Key, input, sig []byte) bool {
+	switch k.Alg {
+	case HS256:
+		secret, ok := k.Key.([]byte)
+		if !ok {
+			return false
+		}
+		m := hmac.New(sha256.New, secret)
+		m.Write(input)
+		return hmac.Equal(sig, m.Sum(nil))
+	case RS256:
+		pub, ok := k.Key.(*rsa.PublicKey)
+		if !ok {
+			return false
+		}
+		d := sha256.Sum256(input)
+		return rsa.VerifyPKCS1v15(pub, crypto.SHA256, d[:], sig) == nil
+	case ES256:
+		pub, ok := k.Key.(*ecdsa.PublicKey)
+		if !ok || len(sig) != 64 {
+			return false
+		}
+		d := sha256.Sum256(input)
+		r := new(big.Int).SetBytes(sig[:32])
+		s := new(big.Int).SetBytes(sig[32:])
+		return ecdsa.Verify(pub, d[:], r, s)
+	case EdDSA:
+		pub, ok := k.Key.(ed25519.PublicKey)
+		if !ok {
+			return false
+		}
+		return ed25519.Verify(pub, input, sig)
+	default:
+		return false
+	}
+}
+
+// derToRawES256 converts an ASN.1 DER ECDSA signature (what crypto.Signer
+// returns) to the raw fixed-width R||S form JWS requires.
+func derToRawES256(der []byte) ([]byte, error) {
+	var sig struct{ R, S *big.Int }
+	if _, err := asn1.Unmarshal(der, &sig); err != nil {
+		return nil, fmt.Errorf("jwt: ES256 signature encoding: %w", err)
+	}
+	out := make([]byte, 64)
+	sig.R.FillBytes(out[:32])
+	sig.S.FillBytes(out[32:])
+	return out, nil
+}
+```
+
+- [ ] **Step 5: Implement `options.go` (signer part)**
+
+```go
+// auth/jwt/options.go
+package jwt
+
+import (
+	"crypto"
+
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+// SignerOption configures NewSigner.
+type SignerOption func(*signerConfig)
+
+type signerConfig struct {
+	ks     *keyset.Keyset
+	hs     *keyset.Keyset
+	direct *directKey
+}
+
+type directKey struct {
+	kid string
+	alg Alg
+	key crypto.Signer
+}
+
+// WithKeyset loads asymmetric signing keys from ks. Key material must be
+// PKCS#8 DER private keys; the alg is inferred per key: RSA (>=2048 bits)
+// -> RS256, ECDSA P-256 -> ES256, Ed25519 -> EdDSA. The keyset primary
+// signs; retired versions stay published via PublicKeys and JWKS.
+func WithKeyset(ks *keyset.Keyset) SignerOption {
+	return func(c *signerConfig) { c.ks = ks }
+}
+
+// WithHS256Keyset loads HMAC secrets from ks. Each version's material is
+// the raw secret and must be at least 32 bytes.
+func WithHS256Keyset(ks *keyset.Keyset) SignerOption {
+	return func(c *signerConfig) { c.hs = ks }
+}
+
+// WithSignerKey supplies a single caller-owned signing key (HSM/KMS-backed
+// crypto.Signer). HS256 is not accepted here — use WithHS256Keyset.
+func WithSignerKey(kid string, alg Alg, key crypto.Signer) SignerOption {
+	return func(c *signerConfig) { c.direct = &directKey{kid: kid, alg: alg, key: key} }
+}
+```
+
+- [ ] **Step 6: Implement `signer.go`**
+
+```go
+// auth/jwt/signer.go
+package jwt
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+type signingKey struct {
+	kid    string
+	alg    Alg
+	signer crypto.Signer // nil for HS256
+	secret []byte        // HS256 only
+}
+
+// Signer issues compact JWTs signed with its primary key. Construct with
+// exactly one key source: WithKeyset, WithHS256Keyset, or WithSignerKey.
+type Signer struct {
+	primary signingKey
+	all     []signingKey // primary first, then retired versions
+}
+
+// NewSigner builds a Signer from exactly one key-source option.
+func NewSigner(opts ...SignerOption) (*Signer, error) {
+	var cfg signerConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	sources := 0
+	if cfg.ks != nil {
+		sources++
+	}
+	if cfg.hs != nil {
+		sources++
+	}
+	if cfg.direct != nil {
+		sources++
+	}
+	if sources != 1 {
+		return nil, fmt.Errorf("%w: exactly one key source required", ErrBadKey)
+	}
+	switch {
+	case cfg.direct != nil:
+		d := cfg.direct
+		if d.kid == "" || d.key == nil {
+			return nil, fmt.Errorf("%w: WithSignerKey requires a kid and a key", ErrBadKey)
+		}
+		if err := checkSignerAlg(d.alg, d.key.Public()); err != nil {
+			return nil, err
+		}
+		k := signingKey{kid: d.kid, alg: d.alg, signer: d.key}
+		return &Signer{primary: k, all: []signingKey{k}}, nil
+	case cfg.hs != nil:
+		return newSignerFromKeyset(cfg.hs, hsSigningKey)
+	default:
+		return newSignerFromKeyset(cfg.ks, asymmetricSigningKey)
+	}
+}
+
+func hsSigningKey(version int, material []byte) (signingKey, error) {
+	if len(material) < minHS256KeyLen {
+		return signingKey{}, fmt.Errorf("%w: HS256 key version %d shorter than %d bytes", ErrBadKey, version, minHS256KeyLen)
+	}
+	return signingKey{kid: strconv.Itoa(version), alg: HS256, secret: material}, nil
+}
+
+func asymmetricSigningKey(version int, material []byte) (signingKey, error) {
+	parsed, err := x509.ParsePKCS8PrivateKey(material)
+	if err != nil {
+		return signingKey{}, fmt.Errorf("%w: key version %d is not PKCS#8 DER: %v", ErrBadKey, version, err)
+	}
+	alg, err := algForPrivate(parsed)
+	if err != nil {
+		return signingKey{}, fmt.Errorf("key version %d: %w", version, err)
+	}
+	return signingKey{kid: strconv.Itoa(version), alg: alg, signer: parsed.(crypto.Signer)}, nil
+}
+
+func newSignerFromKeyset(ks *keyset.Keyset, build func(int, []byte) (signingKey, error)) (*Signer, error) {
+	primaryVersion, primaryMaterial := ks.Primary()
+	primary, err := build(primaryVersion, primaryMaterial)
+	if err != nil {
+		return nil, err
+	}
+	s := &Signer{primary: primary, all: []signingKey{primary}}
+	for version, material := range ks.All() {
+		if version == primaryVersion {
+			continue
+		}
+		k, err := build(version, material)
+		if err != nil {
+			return nil, err
+		}
+		s.all = append(s.all, k)
+	}
+	return s, nil
+}
+
+// Sign marshals claims with encoding/json and returns the signed compact
+// JWT. It signs exactly what it is given — no claims are auto-filled. The
+// header carries alg, kid, and typ "JWT".
+func (s *Signer) Sign(claims any) (string, error) {
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("jwt: marshal claims: %w", err)
+	}
+	header, err := json.Marshal(map[string]string{
+		"alg": string(s.primary.alg),
+		"kid": s.primary.kid,
+		"typ": "JWT",
+	})
+	if err != nil {
+		return "", fmt.Errorf("jwt: marshal header: %w", err)
+	}
+	enc := base64.RawURLEncoding
+	input := enc.EncodeToString(header) + "." + enc.EncodeToString(payload)
+	sig, err := signBytes(s.primary.alg, s.primary.signer, s.primary.secret, []byte(input))
+	if err != nil {
+		return "", fmt.Errorf("jwt: sign: %w", err)
+	}
+	return input + "." + enc.EncodeToString(sig), nil
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `go test -race ./auth/jwt/...`
+Expected: PASS
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+just fmt ./auth/jwt/...
+git add auth/jwt
+git commit -m "feat(jwt): signer with pinned alg allowlist over keyset"
+```
+
+---
+
+### Task 3: PublicKeys + JWKS serve handler
+
+**Files:**
+- Modify: `auth/jwt/signer.go` (add `PublicKeys`), `auth/jwt/options.go` (add `ServeOption`)
+- Create: `auth/jwt/jwks.go` (serve half)
+- Test: `auth/jwt/jwks_serve_test.go`
+
+**Interfaces:**
+- Consumes: `Signer.all`, `Key`, alg helpers from Task 2.
+- Produces: `func (s *Signer) PublicKeys() []Key` (asymmetric keys only — HS256 excluded, same rule as JWKS), `func (s *Signer) JWKS(opts ...ServeOption) http.Handler`, `func WithCacheControl(maxAge time.Duration) ServeOption`. Unexported for Task 6: `type jwk struct{...}`, `type jwkSet struct{ Keys []jwk }`, `func parseJWK(j jwk) (Key, bool)` (Task 6 implements parseJWK; this task defines jwk/jwkSet and `publicJWK(k Key) (jwk, bool)`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// auth/jwt/jwks_serve_test.go
+package jwt_test
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+)
+
+type jwksDoc struct {
+	Keys []map[string]any `json:"keys"`
+}
+
+func fetchJWKS(t *testing.T, s *jwt.Signer, opts ...jwt.ServeOption) (*httptest.ResponseRecorder, jwksDoc) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.JWKS(opts...).ServeHTTP(rec, httptest.NewRequest("GET", "/.well-known/jwks.json", nil))
+	var doc jwksDoc
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("jwks body %s: %v", rec.Body.Bytes(), err)
+	}
+	return rec, doc
+}
+
+func TestPublicKeysExcludesHS256(t *testing.T) {
+	t.Parallel()
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	if keys := s.PublicKeys(); len(keys) != 0 {
+		t.Fatalf("HS256 secrets leaked via PublicKeys: %v", keys)
+	}
+}
+
+func TestPublicKeysEdDSA(t *testing.T) {
+	t.Parallel()
+	ks, priv := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	keys := s.PublicKeys()
+	if len(keys) != 1 || keys[0].KID != "1" || keys[0].Alg != jwt.EdDSA {
+		t.Fatalf("got %+v", keys)
+	}
+	pub, ok := keys[0].Key.(ed25519.PublicKey)
+	if !ok || !pub.Equal(priv.Public().(ed25519.PublicKey)) {
+		t.Fatalf("wrong public key: %T", keys[0].Key)
+	}
+}
+
+func TestJWKSServeEdDSA(t *testing.T) {
+	t.Parallel()
+	ks, priv := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	rec, doc := fetchJWKS(t, s)
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content type %q", ct)
+	}
+	if len(doc.Keys) != 1 {
+		t.Fatalf("got %d keys", len(doc.Keys))
+	}
+	k := doc.Keys[0]
+	if k["kty"] != "OKP" || k["crv"] != "Ed25519" || k["kid"] != "1" || k["alg"] != "EdDSA" || k["use"] != "sig" {
+		t.Fatalf("jwk %v", k)
+	}
+	x, err := base64.RawURLEncoding.DecodeString(k["x"].(string))
+	if err != nil || !ed25519.PublicKey(x).Equal(priv.Public().(ed25519.PublicKey)) {
+		t.Fatalf("x mismatch: %v", err)
+	}
+}
+
+func TestJWKSServeAllKtys(t *testing.T) {
+	t.Parallel()
+	for name, mk := range map[string]func(*testing.T) *jwt.Signer{
+		"RSA": func(t *testing.T) *jwt.Signer {
+			ks, _ := rsaKeyset(t)
+			s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+			if err != nil {
+				t.Fatalf("NewSigner: %v", err)
+			}
+			return s
+		},
+		"EC": func(t *testing.T) *jwt.Signer {
+			ks, _ := ecKeyset(t)
+			s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+			if err != nil {
+				t.Fatalf("NewSigner: %v", err)
+			}
+			return s
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, doc := fetchJWKS(t, mk(t))
+			if len(doc.Keys) != 1 || doc.Keys[0]["kty"] != name {
+				t.Fatalf("got %v, want kty %s", doc.Keys, name)
+			}
+			if name == "EC" && doc.Keys[0]["crv"] != "P-256" {
+				t.Fatalf("crv %v", doc.Keys[0]["crv"])
+			}
+		})
+	}
+}
+
+func TestJWKSServeHS256Empty(t *testing.T) {
+	t.Parallel()
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	rec, doc := fetchJWKS(t, s)
+	if len(doc.Keys) != 0 {
+		t.Fatalf("HS256 keys served: %v", doc.Keys)
+	}
+	if rec.Body.String() != `{"keys":[]}` {
+		t.Fatalf("body %q, want {\"keys\":[]}", rec.Body.String())
+	}
+}
+
+func TestJWKSServeCacheControl(t *testing.T) {
+	t.Parallel()
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	rec, _ := fetchJWKS(t, s, jwt.WithCacheControl(5*time.Minute))
+	if cc := rec.Header().Get("Cache-Control"); cc != "public, max-age=300" {
+		t.Fatalf("Cache-Control %q", cc)
+	}
+	rec, _ = fetchJWKS(t, s)
+	if cc := rec.Header().Get("Cache-Control"); cc != "" {
+		t.Fatalf("unexpected Cache-Control %q", cc)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -race ./auth/jwt/...`
+Expected: FAIL — undefined: PublicKeys / JWKS / ServeOption
+
+- [ ] **Step 3: Add `PublicKeys` to `signer.go`**
+
+```go
+// PublicKeys returns the verification halves of the signer's asymmetric
+// keys (primary first, then retired) for direct in-process wiring via
+// NewVerifier(WithKeys(...)). HS256 secrets are never included — wire the
+// HS256 keyset into the verifier with WithVerifyHS256Keyset instead.
+func (s *Signer) PublicKeys() []Key {
+	keys := make([]Key, 0, len(s.all))
+	for _, k := range s.all {
+		if k.alg == HS256 {
+			continue
+		}
+		keys = append(keys, Key{KID: k.kid, Alg: k.alg, Key: k.signer.Public()})
+	}
+	return keys
+}
+```
+
+- [ ] **Step 4: Add `ServeOption` to `options.go`**
+
+```go
+// ServeOption configures the Signer.JWKS handler.
+type ServeOption func(*serveConfig)
+
+type serveConfig struct {
+	maxAge time.Duration
+}
+
+// WithCacheControl sets a "Cache-Control: public, max-age=..." header on
+// JWKS responses. Without it no cache header is written.
+func WithCacheControl(maxAge time.Duration) ServeOption {
+	return func(c *serveConfig) { c.maxAge = maxAge }
+}
+```
+
+(Add `"time"` to options.go imports.)
+
+- [ ] **Step 5: Implement the serve half of `jwks.go`**
+
+```go
+// auth/jwt/jwks.go
+package jwt
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+)
+
+// jwk is the wire form of a single RFC 7517 key.
+type jwk struct {
+	Kty    string   `json:"kty"`
+	Kid    string   `json:"kid,omitempty"`
+	Alg    string   `json:"alg,omitempty"`
+	Use    string   `json:"use,omitempty"`
+	KeyOps []string `json:"key_ops,omitempty"`
+	N      string   `json:"n,omitempty"`
+	E      string   `json:"e,omitempty"`
+	Crv    string   `json:"crv,omitempty"`
+	X      string   `json:"x,omitempty"`
+	Y      string   `json:"y,omitempty"`
+}
+
+type jwkSet struct {
+	Keys []jwk `json:"keys"`
+}
+
+// publicJWK renders an asymmetric verification key as a JWK. HS256 and
+// unknown key types report ok=false.
+func publicJWK(k Key) (jwk, bool) {
+	enc := base64.RawURLEncoding
+	out := jwk{Kid: k.KID, Alg: string(k.Alg), Use: "sig"}
+	switch pub := k.Key.(type) {
+	case *rsa.PublicKey:
+		out.Kty = "RSA"
+		out.N = enc.EncodeToString(pub.N.Bytes())
+		out.E = enc.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	case *ecdsa.PublicKey:
+		x := make([]byte, 32)
+		y := make([]byte, 32)
+		pub.X.FillBytes(x)
+		pub.Y.FillBytes(y)
+		out.Kty, out.Crv = "EC", "P-256"
+		out.X = enc.EncodeToString(x)
+		out.Y = enc.EncodeToString(y)
+	case ed25519.PublicKey:
+		out.Kty, out.Crv = "OKP", "Ed25519"
+		out.X = enc.EncodeToString(pub)
+	default:
+		return jwk{}, false
+	}
+	return out, true
+}
+
+// JWKS returns an http.Handler serving the signer's asymmetric public keys
+// as an RFC 7517 JWK set. HS256 keys are never published; an HS256-only
+// signer serves an empty set. The body is rendered once at handler
+// construction — signer keys do not change after NewSigner.
+func (s *Signer) JWKS(opts ...ServeOption) http.Handler {
+	var cfg serveConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	set := jwkSet{Keys: []jwk{}}
+	for _, k := range s.PublicKeys() {
+		if j, ok := publicJWK(k); ok {
+			set.Keys = append(set.Keys, j)
+		}
+	}
+	body, err := json.Marshal(set)
+	if err != nil {
+		// Key material was validated at NewSigner; this is unreachable.
+		panic(fmt.Sprintf("jwt: marshal jwks: %v", err))
+	}
+	cacheControl := ""
+	if cfg.maxAge > 0 {
+		cacheControl = fmt.Sprintf("public, max-age=%d", int(cfg.maxAge.Seconds()))
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if cacheControl != "" {
+			w.Header().Set("Cache-Control", cacheControl)
+		}
+		_, _ = w.Write(body)
+	})
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test -race ./auth/jwt/...`
+Expected: PASS
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+just fmt ./auth/jwt/...
+git add auth/jwt
+git commit -m "feat(jwt): PublicKeys and RFC 7517 JWKS serve handler"
+```
+
+---
+
+### Task 4: Verifier core — parsing, key resolution, signature, Verify[T]
+
+**Files:**
+- Create: `auth/jwt/verifier.go`
+- Modify: `auth/jwt/options.go` (verifier options)
+- Test: `auth/jwt/verifier_test.go`
+
+**Interfaces:**
+- Consumes: `verifyBytes`, `checkVerifyKey`, `algForPrivate`, `Claims`, sentinels; `clock.Clock`/`clock.System`; `keyset`.
+- Produces:
+  - `func NewVerifier(opts ...VerifierOption) (*Verifier, error)`
+  - Options this task implements: `WithKeys(keys ...Key)`, `WithVerifyKeyset(ks *keyset.Keyset)`, `WithVerifyHS256Keyset(ks *keyset.Keyset)`, `WithClock(c clock.Clock)`.
+  - `func Verify[T any](ctx context.Context, v *Verifier, token string) (*T, error)`
+  - Unexported, used by Task 5/6: `(*Verifier).verify(ctx, token) (*Claims, []byte, error)`, `(*Verifier).resolveKey(ctx, kid) (Key, error)`; struct fields `iss, aud string`, `leeway time.Duration`, `requireExp bool`, `clk clock.Clock`, `jwks *jwksCache` (nil until Task 6).
+  - Claim checks (exp/nbf with default 30s leeway) are implemented HERE so tokens verify realistically; Task 5 adds the policy options and boundary tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// auth/jwt/verifier_test.go
+package jwt_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+type accessClaims struct {
+	jwt.Claims
+	TenantID string `json:"tid"`
+}
+
+// hsToken hand-crafts an HS256 token so tests control every header field.
+func hsToken(t *testing.T, secret []byte, headerJSON, payloadJSON string) string {
+	t.Helper()
+	enc := base64.RawURLEncoding
+	input := enc.EncodeToString([]byte(headerJSON)) + "." + enc.EncodeToString([]byte(payloadJSON))
+	m := hmac.New(sha256.New, secret)
+	m.Write([]byte(input))
+	return input + "." + enc.EncodeToString(m.Sum(nil))
+}
+
+func TestNewVerifierConstruction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("requires a key source", func(t *testing.T) {
+		t.Parallel()
+		if _, err := jwt.NewVerifier(); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("duplicate kid rejected", func(t *testing.T) {
+		t.Parallel()
+		ks, _ := edKeyset(t)
+		s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		k := s.PublicKeys()[0]
+		if _, err := jwt.NewVerifier(jwt.WithKeys(k, k)); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("short HS256 key in WithKeys rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwt.NewVerifier(jwt.WithKeys(jwt.Key{KID: "1", Alg: jwt.HS256, Key: []byte("short")}))
+		if !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+
+	t.Run("alg/key type mismatch rejected", func(t *testing.T) {
+		t.Parallel()
+		ks, _ := edKeyset(t)
+		s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		k := s.PublicKeys()[0]
+		k.Alg = jwt.RS256 // Ed25519 key claiming RS256
+		if _, err := jwt.NewVerifier(jwt.WithKeys(k)); !errors.Is(err, jwt.ErrBadKey) {
+			t.Fatalf("got %v, want ErrBadKey", err)
+		}
+	})
+}
+
+func TestRoundTripAllAlgs(t *testing.T) {
+	t.Parallel()
+	cases := map[string]func(*testing.T) (*jwt.Signer, *jwt.Verifier){
+		"HS256": func(t *testing.T) (*jwt.Signer, *jwt.Verifier) {
+			ks := hsKeyset(t)
+			s, err := jwt.NewSigner(jwt.WithHS256Keyset(ks))
+			if err != nil {
+				t.Fatalf("NewSigner: %v", err)
+			}
+			v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(ks))
+			if err != nil {
+				t.Fatalf("NewVerifier: %v", err)
+			}
+			return s, v
+		},
+		"EdDSA": func(t *testing.T) (*jwt.Signer, *jwt.Verifier) {
+			ks, _ := edKeyset(t)
+			return signerVerifierPair(t, ks)
+		},
+		"ES256": func(t *testing.T) (*jwt.Signer, *jwt.Verifier) {
+			ks, _ := ecKeyset(t)
+			return signerVerifierPair(t, ks)
+		},
+		"RS256": func(t *testing.T) (*jwt.Signer, *jwt.Verifier) {
+			ks, _ := rsaKeyset(t)
+			return signerVerifierPair(t, ks)
+		},
+	}
+	for name, mk := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			s, v := mk(t)
+			in := accessClaims{Claims: testClaims(), TenantID: "t-42"}
+			tok, err := s.Sign(in)
+			if err != nil {
+				t.Fatalf("Sign: %v", err)
+			}
+			out, err := jwt.Verify[accessClaims](t.Context(), v, tok)
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if out.Subject != "user-1" || out.TenantID != "t-42" {
+				t.Fatalf("claims %+v", out)
+			}
+		})
+	}
+}
+
+func signerVerifierPair(t *testing.T, ks *keyset.Keyset) (*jwt.Signer, *jwt.Verifier) {
+	t.Helper()
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	v, err := jwt.NewVerifier(jwt.WithKeys(s.PublicKeys()...))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	return s, v
+}
+
+// Retired keyset versions must keep verifying (rotation).
+func TestVerifyRetiredKeysetVersion(t *testing.T) {
+	t.Parallel()
+	oldKS, err := keyset.New(keyset.WithPrimary(1, []byte("fedcba9876543210fedcba9876543210")))
+	if err != nil {
+		t.Fatalf("keyset: %v", err)
+	}
+	oldSigner, err := jwt.NewSigner(jwt.WithHS256Keyset(oldKS))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := oldSigner.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	// hsKeyset has primary 2 and retired 1 (same material as oldKS's primary).
+	v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+		t.Fatalf("retired version does not verify: %v", err)
+	}
+}
+
+func TestVerifyMalformed(t *testing.T) {
+	t.Parallel()
+	v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	good, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	parts := strings.Split(good, ".")
+	cases := map[string]string{
+		"empty":              "",
+		"garbage":            "not-a-token",
+		"two segments":       parts[0] + "." + parts[1],
+		"four segments":      good + ".extra",
+		"padded base64":      parts[0] + "==." + parts[1] + "." + parts[2],
+		"standard base64":    strings.ReplaceAll(good, "_", "/") + "+",
+		"non-object header":  hsToken(t, []byte("0123456789abcdef0123456789abcdef"), `"HS256"`, `{}`),
+		"non-object payload": hsToken(t, []byte("0123456789abcdef0123456789abcdef"), `{"alg":"HS256","kid":"2"}`, `[1,2]`),
+		"bad typ":            hsToken(t, []byte("0123456789abcdef0123456789abcdef"), `{"alg":"HS256","kid":"2","typ":"JWE"}`, `{}`),
+		"oversized":          good + strings.Repeat("a", 64<<10),
+	}
+	for name, tok := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrMalformed) {
+				t.Fatalf("got %v, want ErrMalformed", err)
+			}
+		})
+	}
+}
+
+func TestVerifyKeyResolution(t *testing.T) {
+	t.Parallel()
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	exp := time.Now().Add(time.Hour).Unix()
+	payload := `{"exp":` + itoa(exp) + `}`
+
+	t.Run("unknown kid", func(t *testing.T) {
+		t.Parallel()
+		v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(hsKeyset(t)))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok := hsToken(t, secret, `{"alg":"HS256","kid":"99"}`, payload)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrUnknownKey) {
+			t.Fatalf("got %v, want ErrUnknownKey", err)
+		}
+	})
+
+	t.Run("no kid with single key uses it", func(t *testing.T) {
+		t.Parallel()
+		v, err := jwt.NewVerifier(jwt.WithKeys(jwt.Key{KID: "only", Alg: jwt.HS256, Key: secret}))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok := hsToken(t, secret, `{"alg":"HS256"}`, payload)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+			t.Fatalf("single-key rule failed: %v", err)
+		}
+	})
+
+	t.Run("no kid with multiple keys rejected", func(t *testing.T) {
+		t.Parallel()
+		v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(hsKeyset(t))) // 2 versions
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok := hsToken(t, secret, `{"alg":"HS256"}`, payload)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrUnknownKey) {
+			t.Fatalf("got %v, want ErrUnknownKey", err)
+		}
+	})
+}
+
+func TestVerifyAlgAttacks(t *testing.T) {
+	t.Parallel()
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	exp := time.Now().Add(time.Hour).Unix()
+	payload := `{"exp":` + itoa(exp) + `}`
+
+	t.Run("alg none", func(t *testing.T) {
+		t.Parallel()
+		v, err := jwt.NewVerifier(jwt.WithKeys(jwt.Key{KID: "only", Alg: jwt.HS256, Key: secret}))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		enc := base64.RawURLEncoding
+		tok := enc.EncodeToString([]byte(`{"alg":"none"}`)) + "." + enc.EncodeToString([]byte(payload)) + "."
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrSignature) && !errors.Is(err, jwt.ErrMalformed) {
+			t.Fatalf("got %v, want ErrSignature or ErrMalformed", err)
+		}
+	})
+
+	t.Run("HS256 signed with the public key bytes (confusion)", func(t *testing.T) {
+		t.Parallel()
+		ks, priv := ecKeyset(t)
+		s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		v, err := jwt.NewVerifier(jwt.WithKeys(s.PublicKeys()...))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		// Attacker HMACs with the DER of the public key and claims HS256 for kid "1".
+		pubDER, err := ecdsaPublicDER(&priv.PublicKey)
+		if err != nil {
+			t.Fatalf("marshal public: %v", err)
+		}
+		tok := hsToken(t, pubDER, `{"alg":"HS256","kid":"1"}`, payload)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrSignature) {
+			t.Fatalf("confusion attack not rejected: %v", err)
+		}
+	})
+
+	t.Run("tampered payload", func(t *testing.T) {
+		t.Parallel()
+		s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(hsKeyset(t)))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok, err := s.Sign(testClaims())
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		parts := strings.Split(tok, ".")
+		forged := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"admin","exp":` + itoa(exp) + `}`))
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, parts[0]+"."+forged+"."+parts[2]); !errors.Is(err, jwt.ErrSignature) {
+			t.Fatalf("got %v, want ErrSignature", err)
+		}
+	})
+}
+
+func itoa(n int64) string {
+	return strconv.FormatInt(n, 10)
+}
+
+func ecdsaPublicDER(pub *ecdsa.PublicKey) ([]byte, error) {
+	return x509.MarshalPKIXPublicKey(pub)
+}
+```
+
+(Add `"crypto/x509"` and `"strconv"` to the import list; `rand` is used by helpers in signer_test.go — remove any unused imports the compiler flags.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -race ./auth/jwt/...`
+Expected: FAIL — undefined: jwt.NewVerifier, jwt.Verify, jwt.WithKeys, ...
+
+- [ ] **Step 3: Add verifier options to `options.go`**
+
+```go
+// VerifierOption configures NewVerifier.
+type VerifierOption func(*verifierConfig)
+
+type verifierConfig struct {
+	keys       []Key
+	keysets    []*keyset.Keyset // asymmetric PKCS#8 material
+	hsKeysets  []*keyset.Keyset // raw HS256 secrets
+	jwksURL    string
+	jwksCfg    jwksConfig
+	iss        string
+	aud        string
+	leeway     time.Duration
+	requireExp bool
+	clk        clock.Clock
+}
+
+// WithKeys adds explicit verification keys (e.g. from Signer.PublicKeys).
+func WithKeys(keys ...Key) VerifierOption {
+	return func(c *verifierConfig) { c.keys = append(c.keys, keys...) }
+}
+
+// WithVerifyKeyset derives verification keys from the public halves of an
+// asymmetric keyset (PKCS#8 DER private-key material). All versions —
+// primary and retired — verify.
+func WithVerifyKeyset(ks *keyset.Keyset) VerifierOption {
+	return func(c *verifierConfig) { c.keysets = append(c.keysets, ks) }
+}
+
+// WithVerifyHS256Keyset adds every version of an HS256 secret keyset as a
+// verification key.
+func WithVerifyHS256Keyset(ks *keyset.Keyset) VerifierOption {
+	return func(c *verifierConfig) { c.hsKeysets = append(c.hsKeysets, ks) }
+}
+
+// WithClock overrides the time source used for exp/nbf checks (tests).
+func WithClock(clk clock.Clock) VerifierOption {
+	return func(c *verifierConfig) { c.clk = clk }
+}
+```
+
+(Import `"time"`, `"github.com/dmitrymomot/forge/core/clock"`; `jwksConfig` is a placeholder until Task 6 — declare it now:)
+
+```go
+type jwksConfig struct {
+	client   *http.Client
+	refresh  time.Duration
+	cooldown time.Duration
+}
+```
+
+(Import `"net/http"`.)
+
+- [ ] **Step 4: Implement `verifier.go`**
+
+```go
+// auth/jwt/verifier.go
+package jwt
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+// maxTokenLen bounds Verify input before any decoding (DoS guard).
+const maxTokenLen = 64 << 10
+
+const defaultLeeway = 30 * time.Second
+
+// Verifier checks compact JWTs against a fixed key set and claim policy.
+// Key sources are combinable; policy is fixed at construction.
+type Verifier struct {
+	static     map[string]Key
+	jwks       *jwksCache // nil unless WithJWKSURL
+	iss        string
+	aud        string
+	leeway     time.Duration
+	requireExp bool
+	clk        clock.Clock
+}
+
+// NewVerifier builds a Verifier from at least one key source.
+func NewVerifier(opts ...VerifierOption) (*Verifier, error) {
+	cfg := verifierConfig{
+		leeway:     defaultLeeway,
+		requireExp: true,
+		clk:        clock.System(),
+		jwksCfg:    jwksConfig{refresh: time.Hour, cooldown: time.Minute},
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	keys := cfg.keys
+	for _, ks := range cfg.keysets {
+		expanded, err := verifyKeysFromKeyset(ks)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, expanded...)
+	}
+	for _, ks := range cfg.hsKeysets {
+		for version, material := range ks.All() {
+			keys = append(keys, Key{KID: strconv.Itoa(version), Alg: HS256, Key: material})
+		}
+	}
+	static := make(map[string]Key, len(keys))
+	for _, k := range keys {
+		if err := checkVerifyKey(k); err != nil {
+			return nil, err
+		}
+		if _, dup := static[k.KID]; dup {
+			return nil, fmt.Errorf("%w: duplicate kid %q", ErrBadKey, k.KID)
+		}
+		static[k.KID] = k
+	}
+	if len(static) == 0 && cfg.jwksURL == "" {
+		return nil, fmt.Errorf("%w: at least one key source required", ErrBadKey)
+	}
+	v := &Verifier{
+		static:     static,
+		iss:        cfg.iss,
+		aud:        cfg.aud,
+		leeway:     cfg.leeway,
+		requireExp: cfg.requireExp,
+		clk:        cfg.clk,
+	}
+	// Task 6 wires cfg.jwksURL into v.jwks here.
+	return v, nil
+}
+
+func verifyKeysFromKeyset(ks *keyset.Keyset) ([]Key, error) {
+	var keys []Key
+	for version, material := range ks.All() {
+		parsed, err := x509.ParsePKCS8PrivateKey(material)
+		if err != nil {
+			return nil, fmt.Errorf("%w: key version %d is not PKCS#8 DER: %v", ErrBadKey, version, err)
+		}
+		alg, err := algForPrivate(parsed)
+		if err != nil {
+			return nil, fmt.Errorf("key version %d: %w", version, err)
+		}
+		keys = append(keys, Key{KID: strconv.Itoa(version), Alg: alg, Key: parsed.(crypto.Signer).Public()})
+	}
+	return keys, nil
+}
+
+// Verify checks token against v's keys and claim policy and unmarshals the
+// payload into T. T should embed Claims. It is a package-level function
+// because Go methods cannot take type parameters.
+func Verify[T any](ctx context.Context, v *Verifier, token string) (*T, error) {
+	_, payload, err := v.verify(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	out := new(T)
+	if err := json.Unmarshal(payload, out); err != nil {
+		return nil, fmt.Errorf("%w: claims: %v", ErrMalformed, err)
+	}
+	return out, nil
+}
+
+// verify runs parse -> key resolution -> signature -> registered claims and
+// returns the validated registered claims plus the raw payload.
+func (v *Verifier) verify(ctx context.Context, token string) (*Claims, []byte, error) {
+	if len(token) > maxTokenLen {
+		return nil, nil, fmt.Errorf("%w: token exceeds %d bytes", ErrMalformed, maxTokenLen)
+	}
+	h64, rest, ok := strings.Cut(token, ".")
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: want 3 segments", ErrMalformed)
+	}
+	p64, s64, ok := strings.Cut(rest, ".")
+	if !ok || strings.Contains(s64, ".") {
+		return nil, nil, fmt.Errorf("%w: want 3 segments", ErrMalformed)
+	}
+	enc := base64.RawURLEncoding.Strict()
+	headerBytes, err := enc.DecodeString(h64)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: header encoding", ErrMalformed)
+	}
+	var header struct {
+		Alg string `json:"alg"`
+		Kid string `json:"kid"`
+		Typ string `json:"typ"`
+	}
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return nil, nil, fmt.Errorf("%w: header is not a JSON object", ErrMalformed)
+	}
+	if header.Typ != "" && !strings.EqualFold(header.Typ, "JWT") {
+		return nil, nil, fmt.Errorf("%w: unexpected typ %q", ErrMalformed, header.Typ)
+	}
+	key, err := v.resolveKey(ctx, header.Kid)
+	if err != nil {
+		return nil, nil, err
+	}
+	if header.Alg != string(key.Alg) {
+		return nil, nil, fmt.Errorf("%w: token alg %q does not match key alg %q", ErrSignature, header.Alg, key.Alg)
+	}
+	sig, err := enc.DecodeString(s64)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: signature encoding", ErrMalformed)
+	}
+	if !verifyBytes(key, []byte(h64+"."+p64), sig) {
+		return nil, nil, ErrSignature
+	}
+	payload, err := enc.DecodeString(p64)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: payload encoding", ErrMalformed)
+	}
+	var claims Claims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, nil, fmt.Errorf("%w: payload is not a JSON object", ErrMalformed)
+	}
+	if err := v.checkClaims(&claims); err != nil {
+		return nil, nil, err
+	}
+	return &claims, payload, nil
+}
+
+func (v *Verifier) checkClaims(c *Claims) error {
+	now := v.clk.Now()
+	switch {
+	case c.ExpiresAt == nil:
+		if v.requireExp {
+			return fmt.Errorf("%w: exp claim missing", ErrExpired)
+		}
+	case !now.Before(c.ExpiresAt.Add(v.leeway)):
+		return ErrExpired
+	}
+	if c.NotBefore != nil && now.Before(c.NotBefore.Add(-v.leeway)) {
+		return ErrNotYetValid
+	}
+	if v.iss != "" && c.Issuer != v.iss {
+		return ErrIssuerMismatch
+	}
+	if v.aud != "" && !c.Audience.Contains(v.aud) {
+		return ErrAudienceMismatch
+	}
+	return nil
+}
+
+// resolveKey maps a token's kid to a verification key. Without a kid the
+// sole static key is used iff the verifier holds exactly one key and no
+// JWKS source; there is no try-all-keys fallback.
+func (v *Verifier) resolveKey(ctx context.Context, kid string) (Key, error) {
+	if kid == "" {
+		if v.jwks == nil && len(v.static) == 1 {
+			for _, k := range v.static {
+				return k, nil
+			}
+		}
+		return Key{}, fmt.Errorf("%w: no kid and no single-key fallback", ErrUnknownKey)
+	}
+	if k, ok := v.static[kid]; ok {
+		return k, nil
+	}
+	if v.jwks != nil {
+		return v.jwks.get(ctx, kid)
+	}
+	return Key{}, fmt.Errorf("%w: kid %q", ErrUnknownKey, kid)
+}
+```
+
+Note: `jwksCache` does not exist yet. Add a minimal stub in `jwks.go` so this task compiles; Task 6 replaces it:
+
+```go
+// jwksCache is implemented in Task 6 (JWKS fetch).
+type jwksCache struct{}
+
+func (c *jwksCache) get(ctx context.Context, kid string) (Key, error) {
+	return Key{}, ErrUnknownKey
+}
+```
+
+(Import `"context"` in jwks.go.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test -race ./auth/jwt/...`
+Expected: PASS
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+just fmt ./auth/jwt/...
+git add auth/jwt
+git commit -m "feat(jwt): verifier with strict parsing, alg binding, typed Verify"
+```
+
+---
+
+### Task 5: Claim policy options + clock + RFC 7515 A.1 golden vector
+
+**Files:**
+- Modify: `auth/jwt/options.go`
+- Test: `auth/jwt/claims_policy_test.go`
+
+**Interfaces:**
+- Consumes: `verifierConfig` fields from Task 4; `clock.NewMock`.
+- Produces: `WithIssuer(iss string)`, `WithAudience(aud string)`, `WithLeeway(d time.Duration)`, `WithoutExpiry()` — all `VerifierOption`. No new types.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// auth/jwt/claims_policy_test.go
+package jwt_test
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// RFC 7515 Appendix A.1 golden vector (HS256, no kid header).
+// If ONLY this test fails while round-trip tests pass, re-copy these two
+// constants from the RFC text before debugging the implementation.
+const (
+	rfc7515A1Token = "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	rfc7515A1Key   = "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
+)
+
+func TestRFC7515A1GoldenVector(t *testing.T) {
+	t.Parallel()
+	secret, err := base64.RawURLEncoding.DecodeString(rfc7515A1Key)
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	// exp is 1300819380 (2011) — pin the clock before it.
+	v, err := jwt.NewVerifier(
+		jwt.WithKeys(jwt.Key{KID: "a1", Alg: jwt.HS256, Key: secret}),
+		jwt.WithClock(clock.NewMock(time.Unix(1300819000, 0))),
+		jwt.WithIssuer("joe"),
+	)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	type rootClaims struct {
+		jwt.Claims
+		IsRoot bool `json:"http://example.com/is_root"`
+	}
+	got, err := jwt.Verify[rootClaims](t.Context(), v, rfc7515A1Token)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got.Issuer != "joe" || !got.IsRoot || got.ExpiresAt.Unix() != 1300819380 {
+		t.Fatalf("claims %+v", got)
+	}
+}
+
+func policyVerifier(t *testing.T, now time.Time, opts ...jwt.VerifierOption) *jwt.Verifier {
+	t.Helper()
+	base := []jwt.VerifierOption{
+		jwt.WithVerifyHS256Keyset(hsKeyset(t)),
+		jwt.WithClock(clock.NewMock(now)),
+	}
+	v, err := jwt.NewVerifier(append(base, opts...)...)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	return v
+}
+
+func signClaims(t *testing.T, c any) string {
+	t.Helper()
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(hsKeyset(t)))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(c)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	return tok
+}
+
+func TestExpiryPolicy(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_700_000_000, 0)
+	exp := jwt.NewNumericDate(now.Add(-time.Minute))
+	expired := signClaims(t, jwt.Claims{ExpiresAt: exp})
+
+	t.Run("expired rejected", func(t *testing.T) {
+		t.Parallel()
+		v := policyVerifier(t, now)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, expired); !errors.Is(err, jwt.ErrExpired) {
+			t.Fatalf("got %v, want ErrExpired", err)
+		}
+	})
+
+	t.Run("within default 30s leeway accepted", func(t *testing.T) {
+		t.Parallel()
+		tok := signClaims(t, jwt.Claims{ExpiresAt: jwt.NewNumericDate(now.Add(-29 * time.Second))})
+		v := policyVerifier(t, now)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+			t.Fatalf("leeway not applied: %v", err)
+		}
+	})
+
+	t.Run("exactly exp+leeway rejected", func(t *testing.T) {
+		t.Parallel()
+		tok := signClaims(t, jwt.Claims{ExpiresAt: jwt.NewNumericDate(now.Add(-30 * time.Second))})
+		v := policyVerifier(t, now)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrExpired) {
+			t.Fatalf("got %v, want ErrExpired at boundary", err)
+		}
+	})
+
+	t.Run("custom leeway", func(t *testing.T) {
+		t.Parallel()
+		v := policyVerifier(t, now, jwt.WithLeeway(2*time.Minute))
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, expired); err != nil {
+			t.Fatalf("2m leeway should accept 1m-expired: %v", err)
+		}
+	})
+
+	t.Run("missing exp rejected by default", func(t *testing.T) {
+		t.Parallel()
+		tok := signClaims(t, jwt.Claims{Subject: "user-1"})
+		v := policyVerifier(t, now)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrExpired) {
+			t.Fatalf("got %v, want ErrExpired for missing exp", err)
+		}
+	})
+
+	t.Run("missing exp allowed with WithoutExpiry", func(t *testing.T) {
+		t.Parallel()
+		tok := signClaims(t, jwt.Claims{Subject: "user-1"})
+		v := policyVerifier(t, now, jwt.WithoutExpiry())
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+			t.Fatalf("WithoutExpiry: %v", err)
+		}
+	})
+}
+
+func TestNotBeforePolicy(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_700_000_000, 0)
+	future := jwt.NewNumericDate(now.Add(time.Hour))
+	exp := jwt.NewNumericDate(now.Add(2 * time.Hour))
+
+	t.Run("future nbf rejected", func(t *testing.T) {
+		t.Parallel()
+		tok := signClaims(t, jwt.Claims{NotBefore: future, ExpiresAt: exp})
+		v := policyVerifier(t, now)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrNotYetValid) {
+			t.Fatalf("got %v, want ErrNotYetValid", err)
+		}
+	})
+
+	t.Run("nbf within leeway accepted", func(t *testing.T) {
+		t.Parallel()
+		tok := signClaims(t, jwt.Claims{NotBefore: jwt.NewNumericDate(now.Add(29 * time.Second)), ExpiresAt: exp})
+		v := policyVerifier(t, now)
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+			t.Fatalf("nbf leeway: %v", err)
+		}
+	})
+}
+
+func TestIssuerAudiencePolicy(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_700_000_000, 0)
+	claims := jwt.Claims{
+		Issuer:    "https://api.example.com",
+		Audience:  jwt.Audience{"my-app", "other"},
+		ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+	}
+	tok := signClaims(t, claims)
+
+	cases := map[string]struct {
+		opts []jwt.VerifierOption
+		want error
+	}{
+		"iss match":       {[]jwt.VerifierOption{jwt.WithIssuer("https://api.example.com")}, nil},
+		"iss mismatch":    {[]jwt.VerifierOption{jwt.WithIssuer("https://evil.example.com")}, jwt.ErrIssuerMismatch},
+		"aud contains":    {[]jwt.VerifierOption{jwt.WithAudience("my-app")}, nil},
+		"aud missing":     {[]jwt.VerifierOption{jwt.WithAudience("mobile")}, jwt.ErrAudienceMismatch},
+		"no policy":       {nil, nil},
+		"both mismatched": {[]jwt.VerifierOption{jwt.WithIssuer("x"), jwt.WithAudience("y")}, jwt.ErrIssuerMismatch},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			v := policyVerifier(t, now, tc.opts...)
+			_, err := jwt.Verify[jwt.Claims](t.Context(), v, tok)
+			if tc.want == nil && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.want != nil && !errors.Is(err, tc.want) {
+				t.Fatalf("got %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -race ./auth/jwt/...`
+Expected: FAIL — undefined: jwt.WithIssuer, jwt.WithLeeway, jwt.WithAudience, jwt.WithoutExpiry
+
+- [ ] **Step 3: Add the policy options to `options.go`**
+
+```go
+// WithIssuer requires the iss claim to equal iss exactly.
+func WithIssuer(iss string) VerifierOption {
+	return func(c *verifierConfig) { c.iss = iss }
+}
+
+// WithAudience requires the aud claim to contain aud.
+func WithAudience(aud string) VerifierOption {
+	return func(c *verifierConfig) { c.aud = aud }
+}
+
+// WithLeeway sets the clock-skew tolerance applied to exp and nbf.
+// Default 30s.
+func WithLeeway(d time.Duration) VerifierOption {
+	return func(c *verifierConfig) { c.leeway = d }
+}
+
+// WithoutExpiry accepts tokens with no exp claim. By default a missing
+// exp is rejected as ErrExpired.
+func WithoutExpiry() VerifierOption {
+	return func(c *verifierConfig) { c.requireExp = false }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -race ./auth/jwt/...`
+Expected: PASS (if ONLY the A.1 golden test fails, re-copy the vector constants from RFC 7515 Appendix A.1 — see the comment in the test)
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/jwt/...
+git add auth/jwt
+git commit -m "feat(jwt): claim policy options, leeway, RFC 7515 A.1 vector"
+```
+
+---
+
+### Task 6: JWKS fetch — cache, TTL, cooldown, stale-if-error
+
+**Files:**
+- Modify: `auth/jwt/jwks.go` (replace stub with real cache + `parseJWK`), `auth/jwt/options.go` (JWKS options), `auth/jwt/verifier.go` (wire `cfg.jwksURL`)
+- Test: `auth/jwt/jwks_fetch_test.go`
+
+**Interfaces:**
+- Consumes: `singleflight.Group[V]`, `httpclient.New`, `clock.Clock`, `jwk`/`jwkSet`/`publicJWK` from Task 3, `checkVerifyKey`.
+- Produces: `WithJWKSURL(url string, opts ...JWKSOption) VerifierOption`; `JWKSOption`s `WithHTTPClient(c *http.Client)`, `WithRefreshInterval(d time.Duration)`, `WithRefreshCooldown(d time.Duration)`. Unexported: real `jwksCache` with `get(ctx, kid) (Key, error)`, `parseJWK(j jwk) (Key, bool)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// auth/jwt/jwks_fetch_test.go
+package jwt_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// jwksServer serves the JWKS of the given signer and counts fetches.
+type jwksServer struct {
+	*httptest.Server
+	hits atomic.Int64
+	mu   sync.Mutex
+	h    http.Handler
+	fail bool
+}
+
+func newJWKSServer(t *testing.T, s *jwt.Signer) *jwksServer {
+	t.Helper()
+	js := &jwksServer{h: s.JWKS()}
+	js.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		js.hits.Add(1)
+		js.mu.Lock()
+		fail, h := js.fail, js.h
+		js.mu.Unlock()
+		if fail {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		h.ServeHTTP(w, r)
+	}))
+	t.Cleanup(js.Close)
+	return js
+}
+
+func (js *jwksServer) swap(h http.Handler) { js.mu.Lock(); js.h = h; js.mu.Unlock() }
+func (js *jwksServer) setFail(f bool)      { js.mu.Lock(); js.fail = f; js.mu.Unlock() }
+
+func TestJWKSFetchVerify(t *testing.T) {
+	t.Parallel()
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	js := newJWKSServer(t, s)
+	v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if js.hits.Load() != 0 {
+		t.Fatal("fetch happened before first Verify (must be lazy)")
+	}
+	got, err := jwt.Verify[jwt.Claims](t.Context(), v, tok)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got.Subject != "user-1" {
+		t.Fatalf("claims %+v", got)
+	}
+	// Second verify is served from cache.
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+		t.Fatalf("cached Verify: %v", err)
+	}
+	if hits := js.hits.Load(); hits != 1 {
+		t.Fatalf("got %d fetches, want 1 (cache miss only on first Verify)", hits)
+	}
+}
+
+func TestJWKSRotationPickupAndCooldown(t *testing.T) {
+	t.Parallel()
+	ks1, _ := edKeyset(t)
+	s1, err := jwt.NewSigner(jwt.WithKeyset(ks1))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	js := newJWKSServer(t, s1)
+	mock := clock.NewMock(time.Unix(1_700_000_000, 0))
+	v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL), jwt.WithClock(mock))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	tok1, err := s1.Sign(freshClaims(mock.Now()))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok1); err != nil {
+		t.Fatalf("initial Verify: %v", err)
+	}
+
+	// Rotate: new signer under kid "2" (WithSignerKey to control the kid).
+	_, priv2, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519: %v", err)
+	}
+	s2, err := jwt.NewSigner(jwt.WithSignerKey("2", jwt.EdDSA, priv2))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	js.swap(s2.JWKS())
+	tok2, err := s2.Sign(freshClaims(mock.Now()))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	// Within the cooldown (default 1m) the unknown kid must NOT refetch.
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok2); !errors.Is(err, jwt.ErrUnknownKey) {
+		t.Fatalf("got %v, want ErrUnknownKey inside cooldown", err)
+	}
+	if hits := js.hits.Load(); hits != 1 {
+		t.Fatalf("refetched inside cooldown: %d hits", hits)
+	}
+
+	// Past the cooldown the unknown kid triggers a refetch and verifies.
+	mock.Advance(2 * time.Minute)
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok2); err != nil {
+		t.Fatalf("rotation pickup: %v", err)
+	}
+	if hits := js.hits.Load(); hits != 2 {
+		t.Fatalf("got %d hits, want 2", hits)
+	}
+}
+
+func TestJWKSStaleIfErrorAndColdError(t *testing.T) {
+	t.Parallel()
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+
+	t.Run("cold cache surfaces fetch error", func(t *testing.T) {
+		t.Parallel()
+		js := newJWKSServer(t, s)
+		js.setFail(true)
+		v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok, err := s.Sign(testClaims())
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrNoKeys) {
+			t.Fatalf("got %v, want ErrNoKeys on cold fetch failure", err)
+		}
+	})
+
+	t.Run("stale keys served when refresh fails", func(t *testing.T) {
+		t.Parallel()
+		js := newJWKSServer(t, s)
+		mock := clock.NewMock(time.Unix(1_700_000_000, 0))
+		v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL), jwt.WithClock(mock))
+		if err != nil {
+			t.Fatalf("NewVerifier: %v", err)
+		}
+		tok, err := s.Sign(freshClaims(mock.Now()))
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+			t.Fatalf("warm up: %v", err)
+		}
+		js.setFail(true)
+		mock.Advance(2 * time.Hour) // past the 1h refresh TTL
+		if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+			t.Fatalf("stale-if-error not honored: %v", err)
+		}
+	})
+}
+
+func TestJWKSConcurrentVerifySingleFetch(t *testing.T) {
+	t.Parallel()
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	js := newJWKSServer(t, s)
+	v, err := jwt.NewVerifier(jwt.WithJWKSURL(js.URL))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); err != nil {
+				t.Errorf("concurrent Verify: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if hits := js.hits.Load(); hits != 1 {
+		t.Fatalf("got %d fetches for 50 concurrent verifies, want 1", hits)
+	}
+}
+
+func TestJWKSSkipsUnusableKeys(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// enc-use key, unknown kty, and kid-less key must all be skipped -> empty set.
+		_, _ = w.Write([]byte(`{"keys":[
+			{"kty":"RSA","kid":"enc","use":"enc","n":"AQAB","e":"AQAB"},
+			{"kty":"WEIRD","kid":"w"},
+			{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}
+		]}`))
+	}))
+	t.Cleanup(srv.Close)
+	v, err := jwt.NewVerifier(jwt.WithJWKSURL(srv.URL))
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	ks, _ := edKeyset(t)
+	s, err := jwt.NewSigner(jwt.WithKeyset(ks))
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	tok, err := s.Sign(testClaims())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if _, err := jwt.Verify[jwt.Claims](t.Context(), v, tok); !errors.Is(err, jwt.ErrNoKeys) {
+		t.Fatalf("got %v, want ErrNoKeys when all JWKS entries are unusable", err)
+	}
+}
+
+// freshClaims uses a 48h exp: the stale-if-error test advances the mock
+// clock 2h past the refresh TTL and the token must still be unexpired.
+func freshClaims(now time.Time) jwt.Claims {
+	return jwt.Claims{Subject: "user-1", ExpiresAt: jwt.NewNumericDate(now.Add(48 * time.Hour))}
+}
+```
+
+(Import `"crypto/ed25519"` and `"crypto/rand"`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -race ./auth/jwt/...`
+Expected: FAIL — undefined: jwt.WithJWKSURL
+
+- [ ] **Step 3: Add JWKS options to `options.go`**
+
+```go
+// JWKSOption configures JWKS fetching for WithJWKSURL.
+type JWKSOption func(*jwksConfig)
+
+// WithJWKSURL adds a remote RFC 7517 JWK set as a verification key source.
+// Fetching is lazy: the first Verify triggers it. Keys are cached in
+// memory, refreshed when the refresh interval elapses, and refetched on an
+// unknown kid no more often than the cooldown.
+func WithJWKSURL(url string, opts ...JWKSOption) VerifierOption {
+	return func(c *verifierConfig) {
+		c.jwksURL = url
+		for _, o := range opts {
+			o(&c.jwksCfg)
+		}
+	}
+}
+
+// WithHTTPClient sets the HTTP client used to fetch the JWK set.
+// Default: httpclient.New().
+func WithHTTPClient(client *http.Client) JWKSOption {
+	return func(c *jwksConfig) { c.client = client }
+}
+
+// WithRefreshInterval sets how long a fetched JWK set stays fresh.
+// Default 1h.
+func WithRefreshInterval(d time.Duration) JWKSOption {
+	return func(c *jwksConfig) { c.refresh = d }
+}
+
+// WithRefreshCooldown sets the minimum gap between unknown-kid refetches.
+// Default 1m.
+func WithRefreshCooldown(d time.Duration) JWKSOption {
+	return func(c *jwksConfig) { c.cooldown = d }
+}
+```
+
+- [ ] **Step 4: Wire the cache into `NewVerifier` (`verifier.go`)**
+
+Replace the `// Task 6 wires cfg.jwksURL into v.jwks here.` comment with:
+
+```go
+	if cfg.jwksURL != "" {
+		client := cfg.jwksCfg.client
+		if client == nil {
+			client = httpclient.New()
+		}
+		v.jwks = &jwksCache{
+			url:      cfg.jwksURL,
+			client:   client,
+			refresh:  cfg.jwksCfg.refresh,
+			cooldown: cfg.jwksCfg.cooldown,
+			clk:      cfg.clk,
+		}
+	}
+```
+
+(Import `"github.com/dmitrymomot/forge/web/httpclient"`.)
+
+- [ ] **Step 5: Replace the `jwksCache` stub in `jwks.go`**
+
+```go
+// maxJWKSBody bounds the JWKS response size (DoS guard).
+const maxJWKSBody = 1 << 20
+
+// jwksCache is an in-memory JWK set with lazy fetch, TTL refresh, and
+// unknown-kid refetch behind a cooldown. Failed refreshes serve the stale
+// set; only a cold cache surfaces the fetch error.
+type jwksCache struct {
+	url      string
+	client   *http.Client
+	refresh  time.Duration
+	cooldown time.Duration
+	clk      clock.Clock
+
+	group singleflight.Group[struct{}]
+
+	mu        sync.RWMutex
+	keys      map[string]Key
+	fetchedAt time.Time
+	fetched   bool
+}
+
+func (c *jwksCache) get(ctx context.Context, kid string) (Key, error) {
+	c.mu.RLock()
+	k, ok := c.keys[kid]
+	fetched, fetchedAt := c.fetched, c.fetchedAt
+	c.mu.RUnlock()
+
+	now := c.clk.Now()
+	fresh := fetched && now.Sub(fetchedAt) < c.refresh
+	if ok && fresh {
+		return k, nil
+	}
+	needFetch := !fetched || !fresh || (!ok && now.Sub(fetchedAt) >= c.cooldown)
+	if needFetch {
+		_, _, err := c.group.Do(ctx, "fetch", func(ctx context.Context) (struct{}, error) {
+			keys, err := c.fetchSet(ctx)
+			if err != nil {
+				return struct{}{}, err
+			}
+			c.mu.Lock()
+			c.keys, c.fetchedAt, c.fetched = keys, c.clk.Now(), true
+			c.mu.Unlock()
+			return struct{}{}, nil
+		})
+		if err != nil && !fetched {
+			return Key{}, fmt.Errorf("%w: jwks fetch: %w", ErrNoKeys, err)
+		}
+		// A failed refresh with a warm cache falls through to the stale set.
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if len(c.keys) == 0 {
+		return Key{}, fmt.Errorf("%w: jwks set is empty", ErrNoKeys)
+	}
+	if k, ok := c.keys[kid]; ok {
+		return k, nil
+	}
+	return Key{}, fmt.Errorf("%w: kid %q", ErrUnknownKey, kid)
+}
+
+func (c *jwksCache) fetchSet(ctx context.Context) (map[string]Key, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("jwt: jwks endpoint returned status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxJWKSBody))
+	if err != nil {
+		return nil, err
+	}
+	var set jwkSet
+	if err := json.Unmarshal(body, &set); err != nil {
+		return nil, fmt.Errorf("jwt: jwks body: %w", err)
+	}
+	keys := make(map[string]Key, len(set.Keys))
+	for _, j := range set.Keys {
+		k, ok := parseJWK(j)
+		if !ok {
+			continue
+		}
+		keys[k.KID] = k
+	}
+	return keys, nil
+}
+
+// parseJWK converts a wire JWK into a verification Key. Unusable entries
+// (wrong use/key_ops, unknown kty/crv, missing kid, undecodable material)
+// report ok=false and are skipped, not fatal.
+func parseJWK(j jwk) (Key, bool) {
+	if j.Kid == "" {
+		return Key{}, false // key resolution is kid-based; kid-less keys are unusable
+	}
+	if j.Use != "" && j.Use != "sig" {
+		return Key{}, false
+	}
+	if len(j.KeyOps) > 0 && !slices.Contains(j.KeyOps, "verify") {
+		return Key{}, false
+	}
+	enc := base64.RawURLEncoding
+	switch j.Kty {
+	case "RSA":
+		if j.Alg != "" && j.Alg != string(RS256) {
+			return Key{}, false
+		}
+		nb, err := enc.DecodeString(j.N)
+		if err != nil {
+			return Key{}, false
+		}
+		eb, err := enc.DecodeString(j.E)
+		if err != nil || len(eb) == 0 || len(eb) > 4 {
+			return Key{}, false
+		}
+		e := 0
+		for _, b := range eb {
+			e = e<<8 | int(b)
+		}
+		pub := &rsa.PublicKey{N: new(big.Int).SetBytes(nb), E: e}
+		k := Key{KID: j.Kid, Alg: RS256, Key: pub}
+		return k, checkVerifyKey(k) == nil
+	case "EC":
+		if j.Crv != "P-256" || (j.Alg != "" && j.Alg != string(ES256)) {
+			return Key{}, false
+		}
+		xb, err := enc.DecodeString(j.X)
+		if err != nil || len(xb) != 32 {
+			return Key{}, false
+		}
+		yb, err := enc.DecodeString(j.Y)
+		if err != nil || len(yb) != 32 {
+			return Key{}, false
+		}
+		pub := &ecdsa.PublicKey{Curve: elliptic.P256(), X: new(big.Int).SetBytes(xb), Y: new(big.Int).SetBytes(yb)}
+		if !pub.Curve.IsOnCurve(pub.X, pub.Y) {
+			return Key{}, false
+		}
+		return Key{KID: j.Kid, Alg: ES256, Key: pub}, true
+	case "OKP":
+		if j.Crv != "Ed25519" || (j.Alg != "" && j.Alg != string(EdDSA)) {
+			return Key{}, false
+		}
+		xb, err := enc.DecodeString(j.X)
+		if err != nil || len(xb) != ed25519.PublicKeySize {
+			return Key{}, false
+		}
+		return Key{KID: j.Kid, Alg: EdDSA, Key: ed25519.PublicKey(xb)}, true
+	default:
+		return Key{}, false
+	}
+}
+```
+
+(Update jwks.go imports: add `"context"`, `"crypto/elliptic"`, `"io"`, `"slices"`, `"sync"`, `"time"`, `"github.com/dmitrymomot/forge/core/clock"`, `"github.com/dmitrymomot/forge/resilience/singleflight"`. Remove the Task 4 stub.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test -race ./auth/jwt/...`
+Expected: PASS
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+just fmt ./auth/jwt/...
+git add auth/jwt
+git commit -m "feat(jwt): JWKS fetch cache with TTL, cooldown, stale-if-error"
+```
+
+---
+
+### Task 7: doc.go, benchmarks, lint
+
+**Files:**
+- Create: `auth/jwt/doc.go`, `auth/jwt/bench_test.go`
+
+**Interfaces:**
+- Consumes: the whole public API. Produces: package documentation; no code.
+
+- [ ] **Step 1: Write `doc.go`**
+
+```go
+// Package jwt signs and verifies JSON Web Tokens with a pinned algorithm
+// allowlist — HS256, RS256, ES256, EdDSA — that is never negotiated. Every
+// key is bound to exactly one algorithm at construction and the token's
+// alg header must match the resolved key's algorithm, which structurally
+// rules out alg:none, algorithm-swap, and HMAC/public-key confusion
+// attacks. There is no JWE and no algorithm registry.
+//
+// Signing and verifying are split: a Signer issues tokens with its primary
+// key and publishes its asymmetric public keys over an RFC 7517 JWKS
+// handler; a Verifier checks tokens from static keys, a keyset, or a
+// remote JWKS URL with in-memory caching, TTL refresh, and unknown-kid
+// refetch behind a cooldown. Key rotation rides crypto/keyset: the primary
+// version signs, retired versions keep verifying, and the keyset version
+// is the kid.
+//
+// Claims are typed: embed Claims in a consumer struct and Verify returns
+// it decoded, with exp/nbf/iss/aud already enforced (30s default leeway;
+// missing exp is rejected unless WithoutExpiry is set). Sign marshals
+// exactly the claims it is given — nothing is auto-filled.
+//
+// # Usage
+//
+// Simple shared-secret API (HS256 over one env-loaded keyset):
+//
+//	ks, _ := keyset.New(keyset.WithBase64Keys(os.Getenv("JWT_KEYS")))
+//	signer, _ := jwt.NewSigner(jwt.WithHS256Keyset(ks))
+//	verifier, _ := jwt.NewVerifier(
+//		jwt.WithVerifyHS256Keyset(ks),
+//		jwt.WithIssuer("https://api.example.com"),
+//	)
+//
+//	type AccessClaims struct {
+//		jwt.Claims
+//		TenantID string `json:"tid"`
+//	}
+//
+//	token, _ := signer.Sign(AccessClaims{
+//		Claims: jwt.Claims{
+//			Issuer:    "https://api.example.com",
+//			Subject:   userID,
+//			ExpiresAt: jwt.NewNumericDate(time.Now().Add(15 * time.Minute)),
+//		},
+//		TenantID: tenantID,
+//	})
+//
+//	claims, err := jwt.Verify[AccessClaims](ctx, verifier, token)
+//
+// Asymmetric issuing with a JWKS endpoint for external verifiers:
+//
+//	signer, _ := jwt.NewSigner(jwt.WithKeyset(ks)) // PKCS#8 DER material
+//	mux.Handle("/.well-known/jwks.json", signer.JWKS(jwt.WithCacheControl(5*time.Minute)))
+//
+// Verifying a third party's tokens from their JWKS:
+//
+//	verifier, _ := jwt.NewVerifier(
+//		jwt.WithJWKSURL("https://issuer.example.com/.well-known/jwks.json"),
+//		jwt.WithIssuer("https://issuer.example.com"),
+//		jwt.WithAudience("my-client-id"),
+//	)
+package jwt
+```
+
+- [ ] **Step 2: Write `bench_test.go`**
+
+```go
+// auth/jwt/bench_test.go
+package jwt_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+func benchKeysetHS(b *testing.B) *keyset.Keyset {
+	b.Helper()
+	ks, err := keyset.New(keyset.WithPrimary(1, []byte("0123456789abcdef0123456789abcdef")))
+	if err != nil {
+		b.Fatalf("keyset: %v", err)
+	}
+	return ks
+}
+
+func benchClaims() jwt.Claims {
+	return jwt.Claims{
+		Issuer:    "https://api.example.com",
+		Subject:   "user-1",
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+}
+
+func BenchmarkSignHS256(b *testing.B) {
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(benchKeysetHS(b)))
+	if err != nil {
+		b.Fatalf("NewSigner: %v", err)
+	}
+	c := benchClaims()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := s.Sign(c); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyHS256(b *testing.B) {
+	ks := benchKeysetHS(b)
+	s, err := jwt.NewSigner(jwt.WithHS256Keyset(ks))
+	if err != nil {
+		b.Fatalf("NewSigner: %v", err)
+	}
+	v, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(ks))
+	if err != nil {
+		b.Fatalf("NewVerifier: %v", err)
+	}
+	tok, err := s.Sign(benchClaims())
+	if err != nil {
+		b.Fatalf("Sign: %v", err)
+	}
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := jwt.Verify[jwt.Claims](ctx, v, tok); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+```
+
+Also add EdDSA variants (`BenchmarkSignEdDSA`, `BenchmarkVerifyEdDSA`) using the same shape with a generated Ed25519 keyset built via `x509.MarshalPKCS8PrivateKey` inside a `b.Helper()` func (mirror `edKeyset` from signer_test.go but taking `*testing.B`).
+
+- [ ] **Step 3: Run the full gate**
+
+```bash
+go test -race ./auth/jwt/...
+just bench ./auth/jwt/...
+just lint
+```
+
+Expected: tests PASS, benchmarks run, lint clean. Fix anything lint reports (modernize/betteralign/nilaway are enabled).
+
+- [ ] **Step 4: Format and commit**
+
+```bash
+just fmt ./auth/jwt/...
+git add auth/jwt
+git commit -m "docs(jwt): package documentation and benchmarks"
+```
+
+- [ ] **Step 5: Remove auth/jwt from the roadmap**
+
+Delete the `**auth/jwt**` entry (heading + paragraph + surrounding `---` separator) from `docs/packages.md` — shipped packages are removed from the catalog; doc.go is now the reference.
+
+```bash
+git add docs/packages.md
+git commit -m "docs: drop shipped auth/jwt from package catalog"
+```

--- a/docs/superpowers/specs/2026-07-10-auth-jwt-design.md
+++ b/docs/superpowers/specs/2026-07-10-auth-jwt-design.md
@@ -1,0 +1,214 @@
+# auth/jwt — Design
+
+Date: 2026-07-10
+Status: approved
+
+## Purpose
+
+Full JWT for forge: sign and verify with a pinned algorithm allowlist
+(HS256/RS256/ES256/EdDSA — never negotiated), registered-claim checks
+(exp/nbf/iss/aud), JWKS serve + fetch with kid cache and rotation, key
+rotation via `crypto/keyset`. No JWE, ever.
+
+Consumers: `auth/oauthserver` (issuing), `auth/oauthclient` (id_token
+verify against provider JWKS), `auth/guard` (bearer verify), inter-service
+auth, and small API apps that want plain HS256 with one secret.
+
+## Decisions (locked during brainstorming)
+
+1. **Key material**: both paths — `FromKeyset`-style options over
+   `crypto/keyset` (env-loadable, versioned) AND a `crypto.Signer` escape
+   hatch for HSM/KMS-backed keys later.
+2. **Scope**: full catalog spec — asymmetric + JWKS both directions.
+3. **HS256 included** for simple shared-secret apps, alongside
+   RS256/ES256/EdDSA. Confusion attacks are closed structurally (see
+   Verification rules).
+4. **Claims**: typed generics. Package exports `Claims` (registered
+   claims); consumers embed it and get their struct back from
+   `Verify[T]`.
+5. **Architecture**: split `Signer` / `Verifier` types (Approach 1) —
+   each side carries only its own config.
+
+## Public API
+
+```go
+package jwt // auth/jwt
+
+type Alg string // "HS256", "RS256", "ES256", "EdDSA" — closed set
+
+// Claims holds the RFC 7519 registered claims. Consumers embed it:
+//
+//	type AccessClaims struct {
+//	    jwt.Claims
+//	    TenantID string `json:"tid"`
+//	}
+type Claims struct {
+    Issuer    string       `json:"iss,omitempty"`
+    Subject   string       `json:"sub,omitempty"`
+    Audience  Audience     `json:"aud,omitempty"`
+    ExpiresAt *NumericDate `json:"exp,omitempty"`
+    NotBefore *NumericDate `json:"nbf,omitempty"`
+    IssuedAt  *NumericDate `json:"iat,omitempty"`
+    ID        string       `json:"jti,omitempty"`
+}
+
+type Audience []string    // JSON: unmarshals string OR []string; marshals string when len==1
+type NumericDate struct{} // wraps time.Time; JSON unix seconds (accepts fractional, truncates)
+
+type Key struct { // a verification key bound to exactly one alg
+    KID string
+    Alg Alg
+    Key crypto.PublicKey // or []byte secret for HS256
+}
+
+// --- Signing side ---
+
+func NewSigner(opts ...SignerOption) (*Signer, error)
+
+// SignerOptions (at least one key source required):
+func WithKeyset(ks *keyset.Keyset) SignerOption      // material = PKCS#8 DER private keys;
+                                                     // alg inferred: RSA→RS256 (key ≥2048 bits),
+                                                     // ECDSA P-256→ES256, Ed25519→EdDSA;
+                                                     // other key types → error at construction
+func WithHS256Keyset(ks *keyset.Keyset) SignerOption // material = raw secrets, ≥32 bytes enforced
+func WithSignerKey(kid string, alg Alg, key crypto.Signer) SignerOption // escape hatch (HSM/KMS)
+
+// A Signer takes EXACTLY ONE key-source option; two or more → construction
+// error. (Verifier sources, by contrast, are combinable.)
+
+func (s *Signer) Sign(claims any) (string, error) // primary key; header {"alg","kid","typ":"JWT"};
+                                                  // signs exactly what it is given — no auto iat
+func (s *Signer) JWKS() http.Handler              // RFC 7517 {"keys":[...]}; public keys only;
+                                                  // HS256 keys never included (HS256-only → empty set)
+func (s *Signer) PublicKeys() []Key               // direct in-process wiring to NewVerifier(WithKeys(...))
+
+// --- Verifying side ---
+
+func NewVerifier(opts ...VerifierOption) (*Verifier, error)
+
+// Key sources (at least one required; combinable):
+func WithKeys(keys ...Key) VerifierOption
+func WithVerifyKeyset(ks *keyset.Keyset) VerifierOption      // PKCS#8 DER; public halves derived; all versions usable
+func WithVerifyHS256Keyset(ks *keyset.Keyset) VerifierOption // raw secrets; all versions usable
+func WithJWKSURL(url string, opts ...JWKSOption) VerifierOption
+
+// Policy:
+func WithIssuer(iss string) VerifierOption      // exact match required when set
+func WithAudience(aud string) VerifierOption    // token aud must contain it when set
+func WithLeeway(d time.Duration) VerifierOption // default 30s; applies to exp and nbf
+func WithoutExpiry() VerifierOption             // opt out of the exp-required default
+func WithClock(c clock.Clock) VerifierOption    // test seam; default clock.System
+
+// JWKS fetch options:
+func WithHTTPClient(c *http.Client) JWKSOption        // default httpclient.New()
+func WithRefreshInterval(d time.Duration) JWKSOption  // default 1h
+func WithRefreshCooldown(d time.Duration) JWKSOption  // default 1m; floor for unknown-kid refetch
+
+func Verify[T any](ctx context.Context, v *Verifier, token string) (*T, error)
+```
+
+`Verify` is package-level because Go methods cannot take type parameters.
+`T` is expected to embed `jwt.Claims`; registered checks are enforced by
+parsing the payload into `Claims` first, then unmarshaling into `T`.
+
+kid convention: keyset-sourced keys use the keyset version formatted as a
+decimal string ("2"); JWKS-sourced and `WithSignerKey` kids are arbitrary
+strings.
+
+## Verification rules
+
+Order: parse → key resolution → signature → registered claims → typed
+unmarshal. First failure wins; nothing later runs.
+
+1. **Strict parsing**: exactly 3 segments; base64url without padding only;
+   header must decode to a JSON object; `typ` accepted iff absent or
+   `"JWT"` (case-insensitive per RFC 7515 §4.1.9).
+2. **Key resolution**: by `kid` header. If the token has no kid and the
+   verifier holds exactly one key, that key is used; no kid + multiple
+   keys → `ErrUnknownKey`. There is NO try-all-keys fallback.
+3. **Alg binding**: the token's `alg` header must equal the resolved
+   key's declared alg. This single rule kills `alg:none`, alg-swap, and
+   HMAC-with-public-key confusion — the attacker controls the header but
+   never the key's binding.
+4. **Signature**: per alg; HMAC comparison via `hmac.Equal`
+   (constant-time). ES256 accepts raw R||S (64 bytes) only — not DER.
+5. **Registered claims** (all against `WithClock`, with leeway):
+   - `exp`: required unless `WithoutExpiry()`; `now < exp + leeway`.
+   - `nbf`: if present, `now >= nbf - leeway`.
+   - `iat`: not validated (informational).
+   - `iss`: exact match if `WithIssuer` set.
+   - `aud`: must contain the `WithAudience` value if set.
+6. **Size guard**: tokens larger than 64 KiB are rejected as
+   `ErrMalformed` before any decoding (DoS bound, mirrors the codec
+   bounds precedent from idempotency).
+
+## JWKS behavior
+
+**Fetch** (`WithJWKSURL`): lazy first fetch on first Verify, deduplicated
+via `resilience/singleflight`; keys cached in-memory. Refresh triggers:
+TTL elapsed (`WithRefreshInterval`, default 1h) or unknown kid seen —
+gated by `WithRefreshCooldown` (default 1m) so rotated issuers are picked
+up promptly but a flood of bogus kids cannot hammer the endpoint.
+Verify's `ctx` bounds the HTTP call. Stale-if-error: a failed refresh
+logs nothing, returns the cached set; only a cold cache surfaces the
+fetch error to Verify. Only keys with supported algs/key types are
+loaded; unknown entries are skipped, not fatal. `use`/`key_ops` fields,
+when present, must permit verification.
+
+**Serve** (`Signer.JWKS()`): `{"keys":[...]}` as `application/json`,
+RSA (`kty:RSA`), EC P-256 (`kty:EC`), Ed25519 (`kty:OKP`) public JWKs
+with `kid` and `alg` set. HS256 keys never appear; an HS256-only signer
+serves `{"keys":[]}` (documented in doc.go). Optional
+`WithCacheControl(maxAge)` on the handler.
+
+## Errors
+
+`errors.go`, single-line, `errors.Is`-matchable sentinels:
+
+- `ErrMalformed` — structure/encoding/size failures
+- `ErrSignature` — signature mismatch
+- `ErrExpired`, `ErrNotYetValid`
+- `ErrIssuerMismatch`, `ErrAudienceMismatch`
+- `ErrUnknownKey` — kid not resolvable (after any permitted refetch)
+- `ErrNoKeys` — key resolution found an empty set at use (e.g. JWKS
+  endpoint returned zero usable keys); a missing key-source option is a
+  construction error, not this sentinel
+- `ErrBadKey` — construction-time key material problems
+
+`guard` will map all Verify errors to 401.
+
+## Package anatomy
+
+`auth/jwt`, single package (stdlib crypto only — nothing to isolate):
+
+- `doc.go` — runnable HS256 quick-start + asymmetric JWKS example
+- `claims.go` — Claims, Audience, NumericDate
+- `signer.go`, `verifier.go`, `jwks.go` (serve + fetch), `options.go`, `errors.go`
+
+Dependencies: stdlib + `crypto/keyset`, `resilience/singleflight`,
+`web/httpclient` (default JWKS client), `core/clock`. Estimated ~800 LOC —
+top of the band; catalog scopes it as "Full JWT".
+
+## Testing (black-box, package `jwt_test`)
+
+- Golden vectors: RFC 7515 A.1 (HS256), A.2 (RS256), A.3 (ES256),
+  RFC 8037 A.4 (EdDSA).
+- Adversarial: `alg:none`, alg-swap, HS256-with-public-key confusion,
+  tampered payload/signature, padding in base64url, >64 KiB token,
+  wrong/missing kid, garbage input, `typ` mismatch.
+- Claim boundaries: exp/nbf at and around leeway edges via `clock.Mock`;
+  aud string-vs-array forms; missing exp with and without
+  `WithoutExpiry`.
+- JWKS: `httptest` server — rotation pickup on unknown kid, cooldown
+  suppression, TTL refresh, stale-if-error, cold-cache error surface,
+  concurrent Verify under `-race`.
+- Round-trip property tests per alg (Sign → Verify, all keyset versions).
+- Benchmarks: HS256 and EdDSA sign/verify with allocation counts.
+
+## Non-goals
+
+- JWE (encryption) — anti-scope, permanent.
+- Alg negotiation or extensible alg registry — the allowlist is closed.
+- JWKS persistence — cache is in-memory only.
+- OAuth2/OIDC flows — those are `auth/oauthclient`/`auth/oauthserver`.
+- Token storage/revocation lists — consumer concern (or future guard/session work).

--- a/docs/superpowers/specs/2026-07-10-auth-jwt-design.md
+++ b/docs/superpowers/specs/2026-07-10-auth-jwt-design.md
@@ -191,8 +191,12 @@ top of the band; catalog scopes it as "Full JWT".
 
 ## Testing (black-box, package `jwt_test`)
 
-- Golden vectors: RFC 7515 A.1 (HS256), A.2 (RS256), A.3 (ES256),
-  RFC 8037 A.4 (EdDSA).
+- Golden vector: RFC 7515 A.1 (HS256) verbatim. RS256/ES256/EdDSA are
+  covered by stdlib-crypto cross-checks in both directions instead —
+  tokens our Signer produces must verify under stdlib `rsa`/`ecdsa`/
+  `ed25519`, and stdlib-signed tokens must pass our Verify. (RFC 8037
+  A.4's payload is not a JSON claims object, so it cannot pass full
+  Verify; long RS256/ES256 vector constants are transcription hazards.)
 - Adversarial: `alg:none`, alg-swap, HS256-with-public-key confusion,
   tampered payload/signature, padding in base64url, >64 KiB token,
   wrong/missing kid, garbage input, `typ` mismatch.


### PR DESCRIPTION
## auth/jwt — full JWT sign/verify

New `auth/jwt` package: sign and verify JSON Web Tokens with a **pinned, non-negotiable algorithm allowlist** (HS256/RS256/ES256/EdDSA), registered-claim checks (exp/nbf/iss/aud), RFC 7517 JWKS serve + fetch with kid cache/rotation, and key rotation over `crypto/keyset`. Stdlib crypto only — no external JWT libs, no JWE.

Implements `docs/superpowers/plans/2026-07-10-auth-jwt.md` against `docs/superpowers/specs/2026-07-10-auth-jwt-design.md`, built task-by-task with a per-task spec+quality review and a final whole-branch review.

### Design highlights
- **Split `Signer` / `Verifier`** — each side carries only its own config. Every key is bound to exactly one alg at construction; the token's `alg` header must equal the resolved key's alg. This single rule structurally kills `alg:none`, algorithm-swap, and HMAC-with-public-key confusion — the attacker controls the header but never the key's binding.
- **Typed claims** — embed `jwt.Claims` in your struct and get it back from the generic `Verify[T]`. Registered checks (exp/nbf/iss/aud, 30s default leeway) run before the typed unmarshal regardless of `T`.
- **JWKS both directions** — `Signer.JWKS()` serves asymmetric public keys (HS256 never published); `WithJWKSURL` fetches a remote set lazily with an in-memory cache, TTL refresh, unknown-kid refetch behind a cooldown, stale-if-error, and singleflight-deduped fetches.
- **No auto-magic** — `Sign` signs exactly the claims it's given (no auto `iat`). Strict base64url; 64 KiB token size guard before any decode.

### Package
`claims.go`, `errors.go`, `alg.go`, `signer.go`, `verifier.go`, `jwks.go` (serve + fetch), `options.go`, `doc.go` + black-box tests (`package jwt_test`) + benchmarks. RFC 7515 A.1 HS256 golden vector; RS256/ES256/EdDSA cross-checked against stdlib crypto both directions; adversarial suite (alg:none, alg-swap, HMAC/pubkey confusion, tamper, padding, >64KiB, wrong/missing kid).

### Notable deviations from the plan's verbatim code (adjudicated in review)
1. **ECDSA JWK uses the modern Go 1.26 API.** The plan's `ecdsa.PublicKey.X/.Y` + `elliptic.Curve.IsOnCurve` are deprecated (staticcheck SA1019) and fail `just lint` — and the plan's own Global Constraint requires lint to pass. Serialize with `pub.Bytes()` (SEC1 uncompressed), parse with `ecdsa.ParseUncompressedPublicKey` (on-curve + not-infinity validated). Byte-identical output; serve↔fetch symmetry proven by round-trip tests for all three key types.
2. **Added `WithFetchTimeout(d) JWKSOption` (default 30s)** — beyond the spec's option list, to fix a **Critical liveness bug** the whole-branch review caught: `singleflight.Do` runs the fetch under `context.WithoutCancel` (which strips the caller's deadline) and `httpclient.New()` sets no timeout, so a JWKS endpoint that accepts then stalls would wedge the singleflight leader — and every waiting/subsequent `Verify` — **forever**. The fetch is now bounded via `context.WithTimeout` in `fetchSet`; `TestJWKSFetchTimeoutBounded` guards it.

### Deferred (non-blocking, all fail safe)
- Warm-cache TTL-refresh against a fast-failing endpoint has no backoff (stale served, concurrent deduped; blast radius now bounded by the fetch timeout).
- `derToRawES256` doesn't reject trailing bytes after the DER SEQUENCE (only ever fed Go's own signer output; verify path uses raw 64-byte R‖S, never DER).
- A literal JSON `null` token header isn't rejected at the "must be object" step (fails safe → `ErrUnknownKey`/`ErrSignature`).

### Verification
- `go build ./...` clean; `go test -race ./auth/jwt/...` green (103 test entries); `go vet` clean.
- `just lint` — **0 issues repo-wide** (golangci-lint / nilaway / betteralign / modernize).
- Benchmarks: HS256 sign 1296 ns/28 allocs, verify 2325 ns/33 allocs; EdDSA sign 16654 ns/23 allocs, verify 35853 ns/27 allocs.
- Removed the shipped `auth/jwt` entry from `docs/packages.md` (doc.go is now the reference).
