### PR TITLE
feat(dnsverify): DNS ownership & routing verification package

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -69,14 +69,6 @@ resolution for customer domains.
 IP → country/region/ASN lookup behind a `Source` seam; CDN-header source
 (CF-IPCountry) built in stdlib-only; `geoip/maxmind` driver.
 
----
-
-**web/dnsverify**
-
-DNS TXT-record domain-ownership verification behind a `net.Resolver` seam:
-custom-domain onboarding (with hostrouter + autocert) and email-sending
-domain checks (SPF/DKIM/return-path) for `comms/email`.
-
 ## view/
 
 ---

--- a/docs/superpowers/plans/2026-07-11-web-dnsverify.md
+++ b/docs/superpowers/plans/2026-07-11-web-dnsverify.md
@@ -1,0 +1,1288 @@
+# web/dnsverify Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `web/dnsverify` — a single-shot, stateless DNS ownership/routing verification package behind a `net.Resolver` seam.
+
+**Architecture:** A `Verifier` (built via `New(...Option)`) does one lookup-and-compare per `Verify(ctx, Challenge)` call over a small `Resolver` interface that `*net.Resolver` satisfies. Batteries-included constructors mint TXT ownership tokens or build CNAME/A/AAAA routing challenges. The package holds no token state — the consumer persists the plain `Challenge`. An in-memory `StaticResolver` (functional-options-configured) is the shipped test double.
+
+**Tech Stack:** Go (stdlib `net`, `net/netip`, `context`, `time`, `strings`, `errors`, `fmt`) + one forge dep, `github.com/dmitrymomot/forge/core/random`, for token minting. No external deps, no driver subpackage.
+
+**Reference spec:** `docs/superpowers/specs/2026-07-11-web-dnsverify-design.md`
+
+## Global Constraints
+
+- **Module path:** `github.com/dmitrymomot/forge`; package import path `github.com/dmitrymomot/forge/web/dnsverify`.
+- **Work only in the current branch; never switch branches.**
+- **Black-box tests only** — test package is `dnsverify_test` (external), reusing the exported `StaticResolver`.
+- **Errors:** single-line, `errors.Is`-matchable sentinels in `errors.go`; wrap with `fmt.Errorf("%w: ...", Sentinel)`.
+- **Env prefix baked into tags:** `DNSVERIFY_` (`DNSVERIFY_TIMEOUT`, `DNSVERIFY_LABEL`, `DNSVERIFY_TOKEN_BYTES`).
+- **`New` convention:** `func New(opts ...Option) (*Verifier, error)` — returns error when `Config.Validate` fails (matches `secheaders`/`timeout`/`compress`).
+- **No builders / mutating setters** — configure via `Option` / `StaticOption` functional options only.
+- **Go 1.26:** use `new(expr)` (no `ptr.To` wrapper) if a pointer to a literal is ever needed; `just lint` runs modernize + betteralign + nilaway.
+- **Formatting/lint:** after file changes run `just fmt ./web/dnsverify/...` (package-path form — single-file form trips a spurious betteralign "undefined"); before finishing run `just lint`.
+- **No Claude attribution** in any commit message.
+- **Constructors are pure** (no error return); `Verify` is the single validation gate.
+
+---
+
+### Task 1: Errors and core value types
+
+**Files:**
+- Create: `web/dnsverify/errors.go`
+- Create: `web/dnsverify/challenge.go` (types only; constructors added in Task 5)
+- Test: `web/dnsverify/challenge_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `ErrLookup`, `ErrInvalidChallenge`, `ErrInvalidConfig error` (package sentinels).
+  - `type RecordType uint8` with `const ( TXT RecordType = iota; CNAME; A; AAAA )` and `func (RecordType) String() string`.
+  - `type Challenge struct { Record RecordType; Host string; Expect []string }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/dnsverify/challenge_test.go`:
+
+```go
+package dnsverify_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/dnsverify"
+)
+
+func TestRecordTypeString(t *testing.T) {
+	cases := map[dnsverify.RecordType]string{
+		dnsverify.TXT:   "TXT",
+		dnsverify.CNAME: "CNAME",
+		dnsverify.A:     "A",
+		dnsverify.AAAA:  "AAAA",
+	}
+	for rt, want := range cases {
+		if got := rt.String(); got != want {
+			t.Errorf("RecordType(%d).String() = %q, want %q", rt, got, want)
+		}
+	}
+	if got := dnsverify.RecordType(99).String(); got != "UNKNOWN" {
+		t.Errorf("unknown RecordType.String() = %q, want UNKNOWN", got)
+	}
+}
+
+func TestChallengeIsPlainValue(t *testing.T) {
+	c := dnsverify.Challenge{
+		Record: dnsverify.TXT,
+		Host:   "_forge-verify.example.com",
+		Expect: []string{"forge-verification=abc"},
+	}
+	if c.Host != "_forge-verify.example.com" || len(c.Expect) != 1 {
+		t.Fatalf("Challenge fields not readable: %+v", c)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./web/dnsverify/...`
+Expected: FAIL — build error, `dnsverify` package/undefined `RecordType`, `Challenge`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `web/dnsverify/errors.go`:
+
+```go
+package dnsverify
+
+import "errors"
+
+var (
+	// ErrLookup wraps a genuine resolver failure (timeout, SERVFAIL, other
+	// temporary DNS error). It is distinct from "the record is not published
+	// yet", which Verify reports as an unverified Result with a nil error.
+	ErrLookup = errors.New("dnsverify: lookup failed")
+
+	// ErrInvalidChallenge marks a malformed Challenge — unknown Record, empty
+	// Host, or empty Expect — rejected before any lookup.
+	ErrInvalidChallenge = errors.New("dnsverify: invalid challenge")
+
+	// ErrInvalidConfig marks a Config that fails Validate at construction.
+	ErrInvalidConfig = errors.New("dnsverify: invalid config")
+)
+```
+
+Create `web/dnsverify/challenge.go`:
+
+```go
+package dnsverify
+
+// RecordType is the DNS record kind a Challenge verifies.
+type RecordType uint8
+
+const (
+	TXT RecordType = iota
+	CNAME
+	A
+	AAAA
+)
+
+// String returns the stable uppercase DNS type token ("TXT", "CNAME", "A",
+// "AAAA"). It is safe as an i18n key fragment and matches the record type a
+// user types into a DNS panel. Unknown values render "UNKNOWN".
+func (t RecordType) String() string {
+	switch t {
+	case TXT:
+		return "TXT"
+	case CNAME:
+		return "CNAME"
+	case A:
+		return "A"
+	case AAAA:
+		return "AAAA"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Challenge describes one DNS record to verify: look up Record at Host and
+// check the observed value(s) against Expect (any match verifies). It is plain
+// and serializable — persist it (e.g. a Postgres row/JSONB) between issuing
+// setup instructions and verifying later.
+type Challenge struct {
+	Record RecordType
+	Host   string
+	Expect []string
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./web/dnsverify/...` then `just test ./web/dnsverify/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/dnsverify/errors.go web/dnsverify/challenge.go web/dnsverify/challenge_test.go
+git commit -m "feat(dnsverify): add error sentinels and core Challenge/RecordType types"
+```
+
+---
+
+### Task 2: Resolver seam and StaticResolver test double
+
+**Files:**
+- Create: `web/dnsverify/resolver.go`
+- Test: `web/dnsverify/resolver_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type Resolver interface { LookupTXT(ctx, host) ([]string, error); LookupCNAME(ctx, host) (string, error); LookupNetIP(ctx, network, host) ([]netip.Addr, error) }`.
+  - `type StaticResolver struct{...}` implementing `Resolver`.
+  - `type StaticOption func(*StaticResolver)`.
+  - `func NewStaticResolver(opts ...StaticOption) *StaticResolver`.
+  - `func WithTXT(host string, values ...string) StaticOption` (repeatable/appends).
+  - `func WithCNAME(host, target string) StaticOption`.
+  - `func WithIP(host string, ips ...netip.Addr) StaticOption`.
+  - `func WithLookupError(host string, err error) StaticOption`.
+  - Unknown hosts return a `*net.DNSError` with `IsNotFound == true`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/dnsverify/resolver_test.go`:
+
+```go
+package dnsverify_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/dnsverify"
+)
+
+func TestStaticResolverTXT(t *testing.T) {
+	r := dnsverify.NewStaticResolver(
+		dnsverify.WithTXT("h.example.com", "a"),
+		dnsverify.WithTXT("h.example.com", "b"), // repeatable → appends
+	)
+	got, err := r.LookupTXT(context.Background(), "h.example.com")
+	if err != nil {
+		t.Fatalf("LookupTXT: %v", err)
+	}
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("LookupTXT = %v, want [a b]", got)
+	}
+}
+
+func TestStaticResolverNotFound(t *testing.T) {
+	r := dnsverify.NewStaticResolver()
+	_, err := r.LookupTXT(context.Background(), "missing.example.com")
+	var d *net.DNSError
+	if !errors.As(err, &d) || !d.IsNotFound {
+		t.Fatalf("want IsNotFound DNSError, got %v", err)
+	}
+}
+
+func TestStaticResolverCNAME(t *testing.T) {
+	r := dnsverify.NewStaticResolver(dnsverify.WithCNAME("app.example.com", "ingress.svc.com."))
+	got, err := r.LookupCNAME(context.Background(), "app.example.com")
+	if err != nil || got != "ingress.svc.com." {
+		t.Fatalf("LookupCNAME = %q, %v", got, err)
+	}
+}
+
+func TestStaticResolverNetIPFamilyFilter(t *testing.T) {
+	r := dnsverify.NewStaticResolver(dnsverify.WithIP("example.com",
+		netip.MustParseAddr("203.0.113.10"),
+		netip.MustParseAddr("2001:db8::1"),
+	))
+	v4, err := r.LookupNetIP(context.Background(), "ip4", "example.com")
+	if err != nil || len(v4) != 1 || !v4[0].Is4() {
+		t.Fatalf("ip4 lookup = %v, %v", v4, err)
+	}
+	v6, err := r.LookupNetIP(context.Background(), "ip6", "example.com")
+	if err != nil || len(v6) != 1 || v6[0].Is4() {
+		t.Fatalf("ip6 lookup = %v, %v", v6, err)
+	}
+}
+
+func TestStaticResolverLookupError(t *testing.T) {
+	sentinel := errors.New("boom")
+	r := dnsverify.NewStaticResolver(
+		dnsverify.WithTXT("h.example.com", "a"),
+		dnsverify.WithLookupError("h.example.com", sentinel),
+	)
+	if _, err := r.LookupTXT(context.Background(), "h.example.com"); !errors.Is(err, sentinel) {
+		t.Fatalf("want sentinel, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./web/dnsverify/...`
+Expected: FAIL — undefined `NewStaticResolver`, `WithTXT`, etc.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `web/dnsverify/resolver.go`:
+
+```go
+package dnsverify
+
+import (
+	"context"
+	"net"
+	"net/netip"
+)
+
+// Resolver is the DNS seam. *net.Resolver satisfies it structurally, so
+// net.DefaultResolver is the zero-config default and a custom *net.Resolver
+// (own dialer/DNS server) drops in unchanged.
+type Resolver interface {
+	LookupTXT(ctx context.Context, host string) ([]string, error)
+	LookupCNAME(ctx context.Context, host string) (string, error)
+	LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error)
+}
+
+// StaticResolver is an in-memory Resolver for tests. Configure it entirely at
+// construction with the With* options; it is immutable afterward and safe to
+// share across goroutines. Unknown hosts resolve as not-found (IsNotFound),
+// which Verify reports as an unverified Result with a nil error.
+type StaticResolver struct {
+	txt   map[string][]string
+	cname map[string]string
+	ips   map[string][]netip.Addr
+	errs  map[string]error
+}
+
+// StaticOption configures a StaticResolver. It is distinct from the Verifier's
+// Option type.
+type StaticOption func(*StaticResolver)
+
+// NewStaticResolver builds an in-memory resolver from the given records.
+func NewStaticResolver(opts ...StaticOption) *StaticResolver {
+	r := &StaticResolver{
+		txt:   map[string][]string{},
+		cname: map[string]string{},
+		ips:   map[string][]netip.Addr{},
+		errs:  map[string]error{},
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
+}
+
+// WithTXT adds TXT values at host. Repeatable — each call appends, modeling
+// multiple TXT records at one host.
+func WithTXT(host string, values ...string) StaticOption {
+	return func(r *StaticResolver) { r.txt[host] = append(r.txt[host], values...) }
+}
+
+// WithCNAME sets the CNAME target at host.
+func WithCNAME(host, target string) StaticOption {
+	return func(r *StaticResolver) { r.cname[host] = target }
+}
+
+// WithIP adds A/AAAA addresses at host; the family is inferred per address at
+// lookup time.
+func WithIP(host string, ips ...netip.Addr) StaticOption {
+	return func(r *StaticResolver) { r.ips[host] = append(r.ips[host], ips...) }
+}
+
+// WithLookupError makes every lookup for host return err — used to exercise
+// the ErrLookup path.
+func WithLookupError(host string, err error) StaticOption {
+	return func(r *StaticResolver) { r.errs[host] = err }
+}
+
+func notFound(host string) error {
+	return &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+}
+
+// LookupTXT implements Resolver.
+func (r *StaticResolver) LookupTXT(_ context.Context, host string) ([]string, error) {
+	if err := r.errs[host]; err != nil {
+		return nil, err
+	}
+	v, ok := r.txt[host]
+	if !ok {
+		return nil, notFound(host)
+	}
+	return v, nil
+}
+
+// LookupCNAME implements Resolver.
+func (r *StaticResolver) LookupCNAME(_ context.Context, host string) (string, error) {
+	if err := r.errs[host]; err != nil {
+		return "", err
+	}
+	v, ok := r.cname[host]
+	if !ok {
+		return "", notFound(host)
+	}
+	return v, nil
+}
+
+// LookupNetIP implements Resolver. network is "ip4", "ip6", or "ip".
+func (r *StaticResolver) LookupNetIP(_ context.Context, network, host string) ([]netip.Addr, error) {
+	if err := r.errs[host]; err != nil {
+		return nil, err
+	}
+	all, ok := r.ips[host]
+	if !ok {
+		return nil, notFound(host)
+	}
+	out := make([]netip.Addr, 0, len(all))
+	for _, ip := range all {
+		switch network {
+		case "ip4":
+			if ip.Is4() {
+				out = append(out, ip)
+			}
+		case "ip6":
+			if !ip.Is4() {
+				out = append(out, ip)
+			}
+		default:
+			out = append(out, ip)
+		}
+	}
+	if len(out) == 0 {
+		return nil, notFound(host)
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./web/dnsverify/...` then `just test ./web/dnsverify/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/dnsverify/resolver.go web/dnsverify/resolver_test.go
+git commit -m "feat(dnsverify): add Resolver seam and in-memory StaticResolver test double"
+```
+
+---
+
+### Task 3: Config, options, and Verifier construction
+
+**Files:**
+- Create: `web/dnsverify/config.go`
+- Create: `web/dnsverify/options.go`
+- Modify: `web/dnsverify/dnsverify.go` (create — `Verifier` + `New` only in this task)
+- Test: `web/dnsverify/config_test.go`
+
+**Interfaces:**
+- Consumes: `Resolver` (Task 2), `ErrInvalidConfig` (Task 1).
+- Produces:
+  - `type Config struct { Timeout time.Duration; Label string; TokenBytes int }` with env tags, `func DefaultConfig() Config`, `func (Config) Validate() error`.
+  - `type Option func(*config)`; `WithConfig`, `WithResolver`, `WithTimeout`, `WithLabel`, `WithTokenBytes`.
+  - `type Verifier struct{...}`; `func New(opts ...Option) (*Verifier, error)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/dnsverify/config_test.go`:
+
+```go
+package dnsverify_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/web/dnsverify"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	c := dnsverify.DefaultConfig()
+	if c.Timeout != 5*time.Second || c.Label != "_forge-verify" || c.TokenBytes != 16 {
+		t.Fatalf("DefaultConfig = %+v", c)
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("DefaultConfig must be valid: %v", err)
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	base := dnsverify.DefaultConfig()
+
+	bad := base
+	bad.Timeout = 0
+	if !errors.Is(bad.Validate(), dnsverify.ErrInvalidConfig) {
+		t.Error("zero Timeout must be invalid")
+	}
+
+	bad = base
+	bad.Label = ""
+	if !errors.Is(bad.Validate(), dnsverify.ErrInvalidConfig) {
+		t.Error("empty Label must be invalid")
+	}
+
+	bad = base
+	bad.TokenBytes = 4
+	if !errors.Is(bad.Validate(), dnsverify.ErrInvalidConfig) {
+		t.Error("TokenBytes < 8 must be invalid")
+	}
+}
+
+func TestNewRejectsInvalidConfig(t *testing.T) {
+	_, err := dnsverify.New(dnsverify.WithTimeout(0))
+	if !errors.Is(err, dnsverify.ErrInvalidConfig) {
+		t.Fatalf("New with zero Timeout: want ErrInvalidConfig, got %v", err)
+	}
+}
+
+func TestNewAppliesOptions(t *testing.T) {
+	v, err := dnsverify.New(
+		dnsverify.WithResolver(dnsverify.NewStaticResolver()),
+		dnsverify.WithLabel("_custom"),
+		dnsverify.WithTokenBytes(24),
+	)
+	if err != nil || v == nil {
+		t.Fatalf("New: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./web/dnsverify/...`
+Expected: FAIL — undefined `DefaultConfig`, `New`, `WithTimeout`, etc.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `web/dnsverify/config.go`:
+
+```go
+package dnsverify
+
+import (
+	"fmt"
+	"time"
+)
+
+// Config is the env-loadable deployment config. The resolver is a code-shaped
+// seam and lives in options (WithResolver), not env.
+type Config struct {
+	Timeout    time.Duration `env:"DNSVERIFY_TIMEOUT"`     // per-lookup deadline
+	Label      string        `env:"DNSVERIFY_LABEL"`       // TXT ownership host prefix
+	TokenBytes int           `env:"DNSVERIFY_TOKEN_BYTES"` // entropy (bytes) of minted tokens
+}
+
+// DefaultConfig returns a 5s per-lookup timeout, the "_forge-verify" TXT label,
+// and 16-byte tokens.
+func DefaultConfig() Config {
+	return Config{
+		Timeout:    5 * time.Second,
+		Label:      "_forge-verify",
+		TokenBytes: 16,
+	}
+}
+
+// Validate rejects a non-positive Timeout, an empty Label, and TokenBytes < 8.
+func (c Config) Validate() error {
+	if c.Timeout <= 0 {
+		return fmt.Errorf("%w: non-positive Timeout", ErrInvalidConfig)
+	}
+	if c.Label == "" {
+		return fmt.Errorf("%w: empty Label", ErrInvalidConfig)
+	}
+	if c.TokenBytes < 8 {
+		return fmt.Errorf("%w: TokenBytes %d (want >= 8)", ErrInvalidConfig, c.TokenBytes)
+	}
+	return nil
+}
+```
+
+Create `web/dnsverify/options.go`:
+
+```go
+package dnsverify
+
+import "time"
+
+type config struct {
+	cfg      Config
+	resolver Resolver
+}
+
+// Option configures a Verifier.
+type Option func(*config)
+
+// WithConfig applies an env-loaded Config. Place it before other options so
+// they can override individual fields.
+func WithConfig(c Config) Option { return func(cf *config) { cf.cfg = c } }
+
+// WithResolver sets the DNS resolver seam (default net.DefaultResolver).
+func WithResolver(r Resolver) Option { return func(cf *config) { cf.resolver = r } }
+
+// WithTimeout sets the per-lookup deadline.
+func WithTimeout(d time.Duration) Option { return func(cf *config) { cf.cfg.Timeout = d } }
+
+// WithLabel sets the TXT ownership host prefix.
+func WithLabel(s string) Option { return func(cf *config) { cf.cfg.Label = s } }
+
+// WithTokenBytes sets the entropy (in bytes) of minted tokens.
+func WithTokenBytes(n int) Option { return func(cf *config) { cf.cfg.TokenBytes = n } }
+```
+
+Create `web/dnsverify/dnsverify.go`:
+
+```go
+package dnsverify
+
+import "net"
+
+// Verifier performs single-shot DNS verification against a Resolver. Build it
+// with New; it is safe for concurrent use.
+type Verifier struct {
+	resolver Resolver
+	cfg      Config
+}
+
+// New builds a Verifier. It applies DefaultConfig, then the options, then
+// returns an error if the resulting Config is invalid. The resolver defaults
+// to net.DefaultResolver.
+func New(opts ...Option) (*Verifier, error) {
+	cf := config{cfg: DefaultConfig()}
+	for _, o := range opts {
+		o(&cf)
+	}
+	if err := cf.cfg.Validate(); err != nil {
+		return nil, err
+	}
+	r := cf.resolver
+	if r == nil {
+		r = net.DefaultResolver
+	}
+	return &Verifier{resolver: r, cfg: cf.cfg}, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./web/dnsverify/...` then `just test ./web/dnsverify/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/dnsverify/config.go web/dnsverify/options.go web/dnsverify/dnsverify.go web/dnsverify/config_test.go
+git commit -m "feat(dnsverify): add Config/Validate, options, and Verifier construction"
+```
+
+---
+
+### Task 4: Verify — per-record match and error taxonomy
+
+**Files:**
+- Modify: `web/dnsverify/dnsverify.go` (add `Result`, `Verify`, helpers)
+- Test: `web/dnsverify/verify_test.go`
+
+**Interfaces:**
+- Consumes: `Verifier`, `Resolver`, `StaticResolver`, `Challenge`, `RecordType`, `ErrLookup`, `ErrInvalidChallenge`.
+- Produces:
+  - `type Result struct { Verified bool; Found []string }`.
+  - `func (v *Verifier) Verify(ctx context.Context, c Challenge) (Result, error)`.
+  - Behavior: TXT/CNAME/A/AAAA match; NXDOMAIN → `Result{}, nil` (pending); temporary DNS error → `ErrLookup`; empty Host/Expect or unknown Record → `ErrInvalidChallenge`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/dnsverify/verify_test.go`:
+
+```go
+package dnsverify_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/dnsverify"
+)
+
+func newVerifier(t *testing.T, r dnsverify.Resolver) *dnsverify.Verifier {
+	t.Helper()
+	v, err := dnsverify.New(dnsverify.WithResolver(r))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return v
+}
+
+func TestVerifyTXT(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver(
+		dnsverify.WithTXT("_forge-verify.example.com", "other=1", "forge-verification=abc"),
+	))
+	c := dnsverify.Challenge{
+		Record: dnsverify.TXT,
+		Host:   "_forge-verify.example.com",
+		Expect: []string{"forge-verification=abc"},
+	}
+	res, err := v.Verify(context.Background(), c)
+	if err != nil || !res.Verified {
+		t.Fatalf("want verified, got %+v err=%v", res, err)
+	}
+}
+
+func TestVerifyTXTMisconfigured(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver(
+		dnsverify.WithTXT("_forge-verify.example.com", "forge-verification=WRONG"),
+	))
+	c := dnsverify.Challenge{
+		Record: dnsverify.TXT,
+		Host:   "_forge-verify.example.com",
+		Expect: []string{"forge-verification=abc"},
+	}
+	res, err := v.Verify(context.Background(), c)
+	if err != nil || res.Verified || len(res.Found) != 1 {
+		t.Fatalf("want misconfigured (found, not verified), got %+v err=%v", res, err)
+	}
+}
+
+func TestVerifyPendingIsNotError(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver()) // nothing published
+	c := dnsverify.Challenge{
+		Record: dnsverify.TXT,
+		Host:   "_forge-verify.example.com",
+		Expect: []string{"forge-verification=abc"},
+	}
+	res, err := v.Verify(context.Background(), c)
+	if err != nil || res.Verified || len(res.Found) != 0 {
+		t.Fatalf("want pending (nil err, empty found), got %+v err=%v", res, err)
+	}
+}
+
+func TestVerifyTemporaryErrorIsErrLookup(t *testing.T) {
+	temp := &net.DNSError{Err: "server misbehaving", Name: "h", IsTemporary: true}
+	v := newVerifier(t, dnsverify.NewStaticResolver(
+		dnsverify.WithTXT("h.example.com", "x"),
+		dnsverify.WithLookupError("h.example.com", temp),
+	))
+	c := dnsverify.Challenge{Record: dnsverify.TXT, Host: "h.example.com", Expect: []string{"y"}}
+	_, err := v.Verify(context.Background(), c)
+	if !errors.Is(err, dnsverify.ErrLookup) {
+		t.Fatalf("want ErrLookup, got %v", err)
+	}
+}
+
+func TestVerifyCNAMENormalizes(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver(
+		dnsverify.WithCNAME("app.example.com", "Ingress.SVC.com."), // mixed case + trailing dot
+	))
+	c := dnsverify.Challenge{
+		Record: dnsverify.CNAME,
+		Host:   "app.example.com",
+		Expect: []string{"ingress.svc.com"},
+	}
+	res, err := v.Verify(context.Background(), c)
+	if err != nil || !res.Verified {
+		t.Fatalf("want verified (normalized), got %+v err=%v", res, err)
+	}
+}
+
+func TestVerifyAIntersects(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver(
+		dnsverify.WithIP("example.com", netip.MustParseAddr("198.51.100.7"), netip.MustParseAddr("203.0.113.10")),
+	))
+	c := dnsverify.Challenge{
+		Record: dnsverify.A,
+		Host:   "example.com",
+		Expect: []string{"203.0.113.10"}, // one of the resolved set
+	}
+	res, err := v.Verify(context.Background(), c)
+	if err != nil || !res.Verified || len(res.Found) != 2 {
+		t.Fatalf("want verified with 2 found, got %+v err=%v", res, err)
+	}
+}
+
+func TestVerifyInvalidChallenge(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver())
+	cases := []dnsverify.Challenge{
+		{Record: dnsverify.TXT, Host: "", Expect: []string{"x"}},          // empty host
+		{Record: dnsverify.TXT, Host: "h", Expect: nil},                   // empty expect
+		{Record: dnsverify.RecordType(99), Host: "h", Expect: []string{"x"}}, // unknown record
+	}
+	for i, c := range cases {
+		if _, err := v.Verify(context.Background(), c); !errors.Is(err, dnsverify.ErrInvalidChallenge) {
+			t.Errorf("case %d: want ErrInvalidChallenge, got %v", i, err)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./web/dnsverify/...`
+Expected: FAIL — undefined `Result`, `(*Verifier).Verify`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `web/dnsverify/dnsverify.go` with (keeps `Verifier`/`New` from Task 3, adds the rest):
+
+```go
+package dnsverify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+)
+
+// Verifier performs single-shot DNS verification against a Resolver. Build it
+// with New; it is safe for concurrent use.
+type Verifier struct {
+	resolver Resolver
+	cfg      Config
+}
+
+// New builds a Verifier. It applies DefaultConfig, then the options, then
+// returns an error if the resulting Config is invalid. The resolver defaults
+// to net.DefaultResolver.
+func New(opts ...Option) (*Verifier, error) {
+	cf := config{cfg: DefaultConfig()}
+	for _, o := range opts {
+		o(&cf)
+	}
+	if err := cf.cfg.Validate(); err != nil {
+		return nil, err
+	}
+	r := cf.resolver
+	if r == nil {
+		r = net.DefaultResolver
+	}
+	return &Verifier{resolver: r, cfg: cf.cfg}, nil
+}
+
+// Result reports the outcome of a Verify call. Verified is whether observed
+// DNS satisfied the Challenge; Found lists the observed values at Host (for
+// display/debug). With a nil error there are three states: verified
+// (Verified), pending (!Verified && len(Found) == 0 — nothing published yet),
+// and misconfigured (!Verified && len(Found) > 0 — published but wrong).
+type Result struct {
+	Verified bool
+	Found    []string
+}
+
+// Verify performs one lookup-and-compare for c. A record that is not published
+// yet (NXDOMAIN / empty) yields an unverified Result with a nil error; a
+// genuine resolver failure returns ErrLookup; a malformed Challenge returns
+// ErrInvalidChallenge. The Verifier's Timeout bounds each lookup and the
+// caller's ctx cancellation is honored.
+func (v *Verifier) Verify(ctx context.Context, c Challenge) (Result, error) {
+	if c.Host == "" || len(c.Expect) == 0 {
+		return Result{}, ErrInvalidChallenge
+	}
+	ctx, cancel := context.WithTimeout(ctx, v.cfg.Timeout)
+	defer cancel()
+
+	switch c.Record {
+	case TXT:
+		return v.verifyTXT(ctx, c)
+	case CNAME:
+		return v.verifyCNAME(ctx, c)
+	case A:
+		return v.verifyIP(ctx, c, "ip4")
+	case AAAA:
+		return v.verifyIP(ctx, c, "ip6")
+	default:
+		return Result{}, ErrInvalidChallenge
+	}
+}
+
+func (v *Verifier) verifyTXT(ctx context.Context, c Challenge) (Result, error) {
+	records, err := v.resolver.LookupTXT(ctx, c.Host)
+	if err != nil {
+		return errResult(err)
+	}
+	for _, rec := range records {
+		for _, want := range c.Expect {
+			if rec == want {
+				return Result{Verified: true, Found: records}, nil
+			}
+		}
+	}
+	return Result{Found: records}, nil
+}
+
+func (v *Verifier) verifyCNAME(ctx context.Context, c Challenge) (Result, error) {
+	cname, err := v.resolver.LookupCNAME(ctx, c.Host)
+	if err != nil {
+		return errResult(err)
+	}
+	got := canonicalHost(cname)
+	// LookupCNAME returns the queried host itself when there is no CNAME.
+	if got == canonicalHost(c.Host) {
+		return Result{}, nil
+	}
+	for _, want := range c.Expect {
+		if got == canonicalHost(want) {
+			return Result{Verified: true, Found: []string{cname}}, nil
+		}
+	}
+	return Result{Found: []string{cname}}, nil
+}
+
+func (v *Verifier) verifyIP(ctx context.Context, c Challenge, network string) (Result, error) {
+	got, err := v.resolver.LookupNetIP(ctx, network, c.Host)
+	if err != nil {
+		return errResult(err)
+	}
+	want := make(map[netip.Addr]struct{}, len(c.Expect))
+	for _, s := range c.Expect {
+		if addr, perr := netip.ParseAddr(s); perr == nil {
+			want[addr.Unmap()] = struct{}{}
+		}
+	}
+	found := make([]string, 0, len(got))
+	verified := false
+	for _, ip := range got {
+		found = append(found, ip.String())
+		if _, ok := want[ip.Unmap()]; ok {
+			verified = true
+		}
+	}
+	if len(found) == 0 {
+		return Result{}, nil // nothing resolved yet → pending
+	}
+	return Result{Verified: verified, Found: found}, nil
+}
+
+// errResult routes a resolver error: "not published yet" (NXDOMAIN) becomes an
+// unverified Result with a nil error; anything else becomes ErrLookup.
+func errResult(err error) (Result, error) {
+	var d *net.DNSError
+	if errors.As(err, &d) && d.IsNotFound {
+		return Result{}, nil
+	}
+	return Result{}, fmt.Errorf("%w: %v", ErrLookup, err)
+}
+
+// canonicalHost lowercases and strips a trailing dot for CNAME comparison.
+func canonicalHost(h string) string {
+	return strings.ToLower(strings.TrimSuffix(h, "."))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./web/dnsverify/...` then `just test ./web/dnsverify/...`
+Expected: PASS (all `verify_test.go` cases plus earlier tasks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/dnsverify/dnsverify.go web/dnsverify/verify_test.go
+git commit -m "feat(dnsverify): implement Verify with per-record match and error taxonomy"
+```
+
+---
+
+### Task 5: Batteries-included Challenge constructors
+
+**Files:**
+- Modify: `web/dnsverify/challenge.go` (add constructors + helper + token-prefix const)
+- Test: `web/dnsverify/constructors_test.go`
+
+**Interfaces:**
+- Consumes: `Verifier` (uses `v.cfg.Label`, `v.cfg.TokenBytes`), `Challenge`, `RecordType`, `github.com/dmitrymomot/forge/core/random`.
+- Produces:
+  - `func (v *Verifier) TXTChallenge(domain string) Challenge` — `Host = Label + "." + domain`, `Expect = ["forge-verification=<token>"]`, token via `random.URLSafe(TokenBytes)`.
+  - `func (v *Verifier) CNAMEChallenge(host, target string) Challenge`.
+  - `func (v *Verifier) AChallenge(host string, ips ...netip.Addr) Challenge`.
+  - `func (v *Verifier) AAAAChallenge(host string, ips ...netip.Addr) Challenge`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/dnsverify/constructors_test.go`:
+
+```go
+package dnsverify_test
+
+import (
+	"context"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/dnsverify"
+)
+
+func TestTXTChallengeShapeAndUniqueness(t *testing.T) {
+	v, err := dnsverify.New(dnsverify.WithResolver(dnsverify.NewStaticResolver()))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c1 := v.TXTChallenge("example.com")
+	c2 := v.TXTChallenge("example.com")
+
+	if c1.Record != dnsverify.TXT {
+		t.Errorf("Record = %v, want TXT", c1.Record)
+	}
+	if c1.Host != "_forge-verify.example.com" {
+		t.Errorf("Host = %q", c1.Host)
+	}
+	if len(c1.Expect) != 1 || !strings.HasPrefix(c1.Expect[0], "forge-verification=") {
+		t.Errorf("Expect = %v, want one forge-verification= value", c1.Expect)
+	}
+	if c1.Expect[0] == c2.Expect[0] {
+		t.Errorf("tokens must be unique across calls: %q", c1.Expect[0])
+	}
+}
+
+func TestTXTChallengeHonorsConfig(t *testing.T) {
+	v, err := dnsverify.New(
+		dnsverify.WithResolver(dnsverify.NewStaticResolver()),
+		dnsverify.WithLabel("_custom"),
+		dnsverify.WithTokenBytes(32),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := v.TXTChallenge("acme.test")
+	if c.Host != "_custom.acme.test" {
+		t.Errorf("Host = %q, want _custom.acme.test", c.Host)
+	}
+	// 32 raw bytes → 43 unpadded base64url chars after the prefix.
+	token := strings.TrimPrefix(c.Expect[0], "forge-verification=")
+	if len(token) != 43 {
+		t.Errorf("token length = %d, want 43 for 32 bytes", len(token))
+	}
+}
+
+func TestRoutingConstructors(t *testing.T) {
+	v, err := dnsverify.New(dnsverify.WithResolver(dnsverify.NewStaticResolver()))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	cn := v.CNAMEChallenge("app.example.com", "ingress.svc.com")
+	if cn.Record != dnsverify.CNAME || cn.Host != "app.example.com" || cn.Expect[0] != "ingress.svc.com" {
+		t.Errorf("CNAMEChallenge = %+v", cn)
+	}
+
+	a := v.AChallenge("example.com", netip.MustParseAddr("203.0.113.10"))
+	if a.Record != dnsverify.A || a.Expect[0] != "203.0.113.10" {
+		t.Errorf("AChallenge = %+v", a)
+	}
+
+	aaaa := v.AAAAChallenge("example.com", netip.MustParseAddr("2001:db8::1"))
+	if aaaa.Record != dnsverify.AAAA || aaaa.Expect[0] != "2001:db8::1" {
+		t.Errorf("AAAAChallenge = %+v", aaaa)
+	}
+}
+
+func TestTXTChallengeRoundTripsThroughVerify(t *testing.T) {
+	v, err := dnsverify.New(dnsverify.WithResolver(dnsverify.NewStaticResolver())) // placeholder, replaced below
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := v.TXTChallenge("example.com")
+
+	// Simulate the user publishing exactly the minted record, then verify.
+	v2, err := dnsverify.New(dnsverify.WithResolver(
+		dnsverify.NewStaticResolver(dnsverify.WithTXT(c.Host, c.Expect[0])),
+	))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := v2.Verify(context.Background(), c)
+	if err != nil || !res.Verified {
+		t.Fatalf("round-trip: want verified, got %+v err=%v", res, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./web/dnsverify/...`
+Expected: FAIL — undefined `(*Verifier).TXTChallenge`, `CNAMEChallenge`, etc.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `web/dnsverify/challenge.go` (add imports `net/netip` and `github.com/dmitrymomot/forge/core/random`):
+
+```go
+// txtValuePrefix namespaces the ownership token inside the TXT value so it
+// never collides with SPF or other TXT records at the same host.
+const txtValuePrefix = "forge-verification="
+
+// TXTChallenge mints a fresh ownership token and returns a TXT Challenge to
+// publish at Label.domain (e.g. "_forge-verify.example.com"). Persist the
+// returned Challenge; verify it later with Verify. The token comes from
+// random.URLSafe (unpadded base64url — safe in a TXT value).
+func (v *Verifier) TXTChallenge(domain string) Challenge {
+	token := random.URLSafe(v.cfg.TokenBytes)
+	return Challenge{
+		Record: TXT,
+		Host:   v.cfg.Label + "." + domain,
+		Expect: []string{txtValuePrefix + token},
+	}
+}
+
+// CNAMEChallenge builds a routing Challenge: host must CNAME to target.
+func (v *Verifier) CNAMEChallenge(host, target string) Challenge {
+	return Challenge{Record: CNAME, Host: host, Expect: []string{target}}
+}
+
+// AChallenge builds a routing Challenge: host must resolve (A) to at least one
+// of ips.
+func (v *Verifier) AChallenge(host string, ips ...netip.Addr) Challenge {
+	return Challenge{Record: A, Host: host, Expect: addrsToStrings(ips)}
+}
+
+// AAAAChallenge builds a routing Challenge: host must resolve (AAAA) to at
+// least one of ips.
+func (v *Verifier) AAAAChallenge(host string, ips ...netip.Addr) Challenge {
+	return Challenge{Record: AAAA, Host: host, Expect: addrsToStrings(ips)}
+}
+
+func addrsToStrings(ips []netip.Addr) []string {
+	out := make([]string, len(ips))
+	for i, ip := range ips {
+		out[i] = ip.String()
+	}
+	return out
+}
+```
+
+The final import block of `web/dnsverify/challenge.go` must be:
+
+```go
+import (
+	"net/netip"
+
+	"github.com/dmitrymomot/forge/core/random"
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./web/dnsverify/...` then `just test ./web/dnsverify/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/dnsverify/challenge.go web/dnsverify/constructors_test.go
+git commit -m "feat(dnsverify): add batteries-included Challenge constructors"
+```
+
+---
+
+### Task 6: Package doc, runnable example, and roadmap cleanup
+
+**Files:**
+- Create: `web/dnsverify/doc.go`
+- Create: `web/dnsverify/example_test.go`
+- Modify: `docs/packages.md` (delete the `web/dnsverify` roadmap entry)
+
+**Interfaces:**
+- Consumes: the full public API.
+- Produces: package documentation + one runnable `Example` (deterministic via `StaticResolver`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/dnsverify/example_test.go`:
+
+```go
+package dnsverify_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/web/dnsverify"
+)
+
+func Example() {
+	// A resolver double stands in for real DNS so the example is deterministic.
+	v, err := dnsverify.New(dnsverify.WithResolver(
+		dnsverify.NewStaticResolver(
+			dnsverify.WithTXT("_forge-verify.example.com", "forge-verification=abc123"),
+		),
+	))
+	if err != nil {
+		panic(err)
+	}
+
+	// In production, mint a token and persist the Challenge (e.g. in Postgres):
+	//   c := v.TXTChallenge("example.com"); save(c)
+	// then reload it later and verify. Here we verify a known record.
+	c := dnsverify.Challenge{
+		Record: dnsverify.TXT,
+		Host:   "_forge-verify.example.com",
+		Expect: []string{"forge-verification=abc123"},
+	}
+	res, err := v.Verify(context.Background(), c)
+	fmt.Println(res.Verified, err)
+	// Output: true <nil>
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./web/dnsverify/...`
+Expected: PASS for existing tests; the `Example` runs and its `// Output:` matches. (If the package doc is missing, the build still succeeds — the doc.go in Step 3 adds the package comment the linter expects.)
+
+Note: this Example uses only already-implemented API, so it passes immediately — its purpose is to lock the doc example as a compiled, output-checked test.
+
+- [ ] **Step 3: Write the package doc**
+
+Create `web/dnsverify/doc.go`:
+
+```go
+// Package dnsverify performs single-shot DNS ownership and routing
+// verification behind a small Resolver seam that *net.Resolver satisfies.
+//
+// Two intents share one mechanic — look up a record at a host, compare the
+// observed value(s) against expected:
+//
+//   - Ownership token: TXTChallenge mints a random token; the domain owner
+//     publishes a TXT record; Verify confirms the token is present.
+//   - Routing target: CNAMEChallenge / AChallenge / AAAAChallenge check that a
+//     domain points at your ingress (for custom-domain onboarding with
+//     hostrouter + autocert).
+//
+// The package is stateless: TXTChallenge returns a plain, serializable
+// Challenge that you persist (e.g. a Postgres row) between showing setup
+// instructions and verifying later — nothing needs to survive a restart on
+// this side. Verify is single-shot; the caller owns polling cadence (a
+// scheduler/jobqueue re-checking a pending domain).
+//
+// A nil error from Verify has three states: verified (Result.Verified),
+// pending (!Verified && len(Found) == 0 — not published yet), and
+// misconfigured (!Verified && len(Found) > 0 — published but wrong). A genuine
+// resolver failure returns ErrLookup, distinct from "not published yet".
+//
+//	v, err := dnsverify.New()
+//	if err != nil { /* invalid config */ }
+//
+//	// Issue an ownership challenge and show the record to the user.
+//	c := v.TXTChallenge("example.com")
+//	// persist c (c.Host, c.Record, c.Expect) tied to the tenant/domain
+//
+//	// Later, after the user says they added it:
+//	res, err := v.Verify(ctx, c)
+//	switch {
+//	case err != nil:                 // errors.Is(err, dnsverify.ErrLookup)
+//	case res.Verified:               // done
+//	case len(res.Found) == 0:        // pending — ask them to wait for DNS
+//	default:                         // misconfigured — show res.Found
+//	}
+//
+// Consumers render setup instructions from the structured Challenge fields via
+// their own i18n layer; dnsverify emits no user-facing prose. The exported
+// StaticResolver is an in-memory test double for exercising these flows
+// without real DNS.
+package dnsverify
+```
+
+- [ ] **Step 4: Verify build, tests, and lint**
+
+Run: `just fmt ./web/dnsverify/...` then `just test ./web/dnsverify/...`
+Expected: PASS, including the `Example` output check.
+
+Then update `docs/packages.md`: delete the `web/dnsverify` entry (the heading `**web/dnsverify**` and its description paragraph plus the trailing `---` separator), since the roadmap lists only unbuilt packages.
+
+Run: `just lint`
+Expected: clean (go vet, build, golangci-lint incl. modernize/betteralign/nilaway all green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/dnsverify/doc.go web/dnsverify/example_test.go docs/packages.md
+git commit -m "docs(dnsverify): add package doc, runnable example, and drop roadmap entry"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+| Spec item | Task |
+|---|---|
+| `New(...Option) (*Verifier, error)`, erroring on invalid config | 3 |
+| `Config` (Timeout/Label/TokenBytes) + env tags + DefaultConfig + Validate | 3 |
+| Options: WithResolver/WithConfig/WithTimeout/WithLabel/WithTokenBytes | 3 |
+| `Verify(ctx, Challenge) (Result, error)` single-shot + per-lookup timeout | 4 |
+| `Challenge{Record,Host,Expect}` plain/serializable | 1 |
+| `RecordType` + stable `String()` | 1 |
+| `Result{Verified,Found}` + three no-error states | 4 |
+| Resolver seam (`*net.Resolver` satisfies) | 2 |
+| `StaticResolver` via functional options, immutable | 2 |
+| TXT exact match / CNAME normalize / A-AAAA intersection | 4 |
+| Error taxonomy: pending vs ErrLookup vs ErrInvalidChallenge | 4 |
+| `ErrInvalidConfig` sentinel | 1, 3 |
+| Batteries constructors (pure), token via random.URLSafe | 5 |
+| i18n-friendly structured fields, no prose | 1 (fields), 6 (doc) |
+| doc.go runnable example | 6 |
+| Delete packages.md roadmap entry | 6 |
+| Black-box tests only | all test files use `dnsverify_test` |
+| CNAME chain caveat (steer to A/AAAA) | documented in spec + doc.go recommends A/AAAA; no code beyond terminal-name match |
+
+No gaps.
+
+**2. Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to". Every code step shows complete code. The word "placeholder" in Task 5's round-trip test is a real comment on a throwaway verifier that the test immediately replaces — not a plan placeholder; the code is complete.
+
+**3. Type consistency:** `Verifier`, `Config`, `config`, `Option`, `StaticOption`, `Resolver`, `StaticResolver`, `Challenge`, `RecordType`, `Result` names are identical across tasks. `Verify`/`TXTChallenge`/`CNAMEChallenge`/`AChallenge`/`AAAAChallenge`/`NewStaticResolver`/`WithTXT`/`WithCNAME`/`WithIP`/`WithLookupError` used consistently. `errResult`/`canonicalHost`/`addrsToStrings`/`notFound`/`txtValuePrefix` helpers each defined once. `random.URLSafe` signature matches `core/random`. `*net.Resolver` satisfies the three-method `Resolver` interface (all exist in stdlib since Go 1.18).
+
+Note for the implementer: Task 4 **replaces** the whole `dnsverify.go` from Task 3 (the file is shown in full, carrying `Verifier`/`New` forward) — do not append and duplicate `New`.

--- a/docs/superpowers/specs/2026-07-11-web-dnsverify-design.md
+++ b/docs/superpowers/specs/2026-07-11-web-dnsverify-design.md
@@ -57,8 +57,8 @@ func (Config) Validate() error
 // The verify core — single-shot, one lookup-and-compare.
 func (v *Verifier) Verify(ctx context.Context, c Challenge) (Result, error)
 
-// Batteries-included challenge constructors.
-func (v *Verifier) TXTChallenge(domain string) (Challenge, error)   // mints token
+// Batteries-included challenge constructors (pure — Verify is the sole gate).
+func (v *Verifier) TXTChallenge(domain string) Challenge            // mints token
 func (v *Verifier) CNAMEChallenge(host, target string) Challenge
 func (v *Verifier) AChallenge(host string, ips ...netip.Addr) Challenge
 func (v *Verifier) AAAAChallenge(host string, ips ...netip.Addr) Challenge
@@ -97,13 +97,15 @@ type Result struct {
 
 ### Challenge construction (structured, i18n-friendly)
 
-- `TXTChallenge(domain)` mints a token via `random`, sets
-  `Host = Label + "." + domain`, `Expect = ["forge-verification=<token>"]`.
-  Returns `(Challenge, error)` — the error path is token-generation failure.
-  The `forge-verification=` prefix namespaces the value so it never collides
-  with SPF / other TXT records at the same host.
-- `CNAMEChallenge` / `AChallenge` / `AAAAChallenge` take consumer-supplied
-  targets; no token, no error.
+- `TXTChallenge(domain)` mints a token via `random.URLSafe(TokenBytes)`
+  (unpadded base64url — TXT-safe), sets `Host = Label + "." + domain`,
+  `Expect = ["forge-verification=<token>"]`. The `forge-verification=` prefix
+  namespaces the value so it never collides with SPF / other TXT records at
+  the same host.
+- All constructors are **pure** (no error): `random` panics only on a broken
+  OS RNG, and `Verify` is the single validation gate (`ErrInvalidChallenge`
+  for empty `Host`/`Expect` or unknown `Record`). This keeps `TXTChallenge`
+  consistent with `CNAMEChallenge`/`AChallenge`/`AAAAChallenge`.
 - Raw `Challenge{...}` literals + `Verify` remain fully supported for advanced
   flows (e.g. a CNAME-in-host ownership token) — the batteries are opt-in.
 - **No user-facing string rendering.** The package renders no prose. Consumers
@@ -191,7 +193,8 @@ look like "DNS is broken":
   `ErrInvalidChallenge` (returned before any lookup).
 
 Sentinels in `errors.go`, single-line, `errors.Is`-matchable: `ErrLookup`,
-`ErrInvalidChallenge`.
+`ErrInvalidChallenge`, and `ErrInvalidConfig` (construction-time
+`Config.Validate` failure — the `secheaders`/`timeout` convention).
 
 The consumer distinguishes four states:
 

--- a/docs/superpowers/specs/2026-07-11-web-dnsverify-design.md
+++ b/docs/superpowers/specs/2026-07-11-web-dnsverify-design.md
@@ -1,0 +1,260 @@
+# web/dnsverify — design
+
+Date: 2026-07-11
+Status: approved for planning
+
+## Purpose
+
+DNS-based domain-ownership and routing verification: prove a tenant controls a
+domain, and confirm a custom domain is pointed at us so TLS/routing works.
+The single mechanic is *look up a record type at a host, compare the observed
+value(s) against expected*. Primary consumers: custom-domain onboarding
+(pairs with `web/hostrouter` + `web/autocert`). Single-shot and stateless —
+the consumer owns token persistence and polling cadence.
+
+## Scope
+
+Two verification **intents**, both DNS-only:
+
+| Intent | Record types | Who supplies the expected value |
+|---|---|---|
+| **Ownership token** | `TXT` | package mints a random token |
+| **Routing target** | `CNAME`, `A`, `AAAA` | consumer supplies the target host / IPs |
+
+Explicitly **out** of v1 (see Non-goals): email deliverability (SPF/DKIM/DMARC),
+HTTP `/.well-known` / meta-tag verification, polling/scheduling, token storage.
+
+## Placement
+
+`web/dnsverify`. Web-boundary concern (custom-domain onboarding, same shelf as
+`hostrouter`/`autocert`). Stdlib-only DNS via the `net` package; one forge dep
+(`random`, for token minting). No driver subpackage — the resolver seam is
+stdlib. When this ships, delete the `web/dnsverify` entry from docs/packages.md.
+
+## API surface
+
+```go
+package dnsverify
+
+// Construction — New(...Option) with env-loadable Config.
+func New(opts ...Option) (*Verifier, error)
+
+type Config struct {
+    Timeout    time.Duration // per-lookup deadline           env:"DNSVERIFY_TIMEOUT"      (default 5s)
+    Label      string        // TXT ownership host prefix      env:"DNSVERIFY_LABEL"        (default "_forge-verify")
+    TokenBytes int           // entropy for minted tokens      env:"DNSVERIFY_TOKEN_BYTES"  (default 16)
+}
+func DefaultConfig() Config
+func (Config) Validate() error
+
+// Options (options.go): type Option func(*config)
+//   WithResolver(Resolver)   // default net.DefaultResolver
+//   WithConfig(Config)
+//   WithTimeout(time.Duration)
+//   WithLabel(string)
+//   WithTokenBytes(int)
+
+// The verify core — single-shot, one lookup-and-compare.
+func (v *Verifier) Verify(ctx context.Context, c Challenge) (Result, error)
+
+// Batteries-included challenge constructors.
+func (v *Verifier) TXTChallenge(domain string) (Challenge, error)   // mints token
+func (v *Verifier) CNAMEChallenge(host, target string) Challenge
+func (v *Verifier) AChallenge(host string, ips ...netip.Addr) Challenge
+func (v *Verifier) AAAAChallenge(host string, ips ...netip.Addr) Challenge
+
+// Core value type — plain, serializable; the consumer persists it (e.g. a
+// Postgres row/JSONB) between "show instructions" and "verify later".
+type Challenge struct {
+    Record RecordType // TXT | CNAME | A | AAAA
+    Host   string     // FQDN to query, e.g. "_forge-verify.example.com"
+    Expect []string   // one-or-more acceptable values (token / target / IPs)
+}
+
+type RecordType uint8
+const ( TXT RecordType = iota; CNAME; A; AAAA )
+func (RecordType) String() string // stable uppercase token: "TXT"/"CNAME"/"A"/"AAAA"
+
+type Result struct {
+    Verified bool     // did observed DNS satisfy the challenge?
+    Found    []string // observed record values at Host (for UI/debug)
+}
+```
+
+### Construction & config
+
+- `WithResolver` defaults to `net.DefaultResolver`. A custom `*net.Resolver`
+  (e.g. with a specific dialer/DNS server) drops in unchanged — it satisfies
+  the `Resolver` interface structurally.
+- `Timeout` is applied per lookup via a context derived from the caller's
+  `ctx` (honors upstream cancellation) — satisfies "every external call has an
+  explicit timeout with a safe default."
+- `Config.Validate`: `Timeout > 0`, `Label` non-empty and a syntactically
+  valid DNS label, `TokenBytes >= 8`. `New` applies `DefaultConfig()` then
+  options and returns `(nil, err)` when the resulting `Config.Validate` fails —
+  the erroring-`New` convention shared by web packages that carry a validatable
+  `Config` (`secheaders`, `timeout`, `compress`, `cors`, `cookie`).
+
+### Challenge construction (structured, i18n-friendly)
+
+- `TXTChallenge(domain)` mints a token via `random`, sets
+  `Host = Label + "." + domain`, `Expect = ["forge-verification=<token>"]`.
+  Returns `(Challenge, error)` — the error path is token-generation failure.
+  The `forge-verification=` prefix namespaces the value so it never collides
+  with SPF / other TXT records at the same host.
+- `CNAMEChallenge` / `AChallenge` / `AAAAChallenge` take consumer-supplied
+  targets; no token, no error.
+- Raw `Challenge{...}` literals + `Verify` remain fully supported for advanced
+  flows (e.g. a CNAME-in-host ownership token) — the batteries are opt-in.
+- **No user-facing string rendering.** The package renders no prose. Consumers
+  feed the structured fields into their own i18n layer, e.g.:
+
+  ```go
+  catalog.T(ctx, "dns_setup."+strings.ToLower(c.Record.String()), i18n.Params{
+      "host":  c.Host,
+      "value": strings.Join(c.Expect, ", "),
+  })
+  ```
+
+  `RecordType.String()` is guaranteed stable (doubles as an i18n key fragment
+  and as the literal record type the user types into their DNS panel).
+
+## Resolver seam
+
+A minimal interface that `*net.Resolver` satisfies structurally:
+
+```go
+type Resolver interface {
+    LookupTXT(ctx context.Context, host string) ([]string, error)
+    LookupCNAME(ctx context.Context, host string) (string, error)
+    LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error)
+}
+```
+
+### Test double — `StaticResolver` (ships with the package)
+
+Map-backed, in-memory, configured entirely at construction via functional
+options (no mutating setters — forge bans builders), immutable afterward so
+it is safe to share across concurrent-lookup tests:
+
+```go
+r := dnsverify.NewStaticResolver(
+    dnsverify.WithTXT("_forge-verify.example.com", "forge-verification=abc123"),
+    dnsverify.WithCNAME("app.example.com", "ingress.ourservice.com."),
+    dnsverify.WithIP("example.com", netip.MustParseAddr("203.0.113.10")),
+    dnsverify.WithLookupError("timeout.example.com", someTempErr),
+)
+
+type StaticOption func(*StaticResolver) // distinct from the Verifier's Option
+func NewStaticResolver(opts ...StaticOption) *StaticResolver
+func WithTXT(host string, values ...string) StaticOption   // repeatable → multiple TXT RRs
+func WithCNAME(host, target string) StaticOption
+func WithIP(host string, ips ...netip.Addr) StaticOption   // A/AAAA inferred from family
+func WithLookupError(host string, err error) StaticOption
+```
+
+Consumers reuse `StaticResolver` to test their own onboarding flows without
+real DNS.
+
+## Match semantics
+
+- **TXT** — exact string match: `Verified` if any observed TXT RR equals any
+  `Expect` entry. Case-sensitive (tokens are). `LookupTXT` already joins the
+  255-char chunks of a single RR, so comparison is against the whole value.
+- **CNAME** — target equality, normalized on both sides (lowercase + strip
+  trailing dot). `LookupCNAME` returns the queried host itself when there is
+  no CNAME, so "no CNAME" reads as not-verified, never a false match.
+  Caveat (stdlib limit): `LookupCNAME` follows the whole chain and returns the
+  **final canonical name**, not the immediate record — so `Expect` must be the
+  terminal target. When our ingress is itself a CNAME (e.g. to an ELB), the
+  robust pointing check is **A/AAAA** (resolve the domain, compare to our
+  anycast IPs), which is chain-agnostic; `doc.go` recommends A/AAAA for apex
+  and for CNAME-fronted ingress. Raw immediate-CNAME inspection would need a
+  non-stdlib DNS library — out of scope.
+- **A / AAAA** — set intersection: `Verified` if the host resolves to **at
+  least one** expected IP. `A` queries `LookupNetIP(ctx, "ip4", host)`, `AAAA`
+  queries `"ip6"`. `Expect` holds canonical IP strings (parsed to
+  `netip.Addr` for comparison so `203.0.113.10` == `203.0.113.010`-style
+  variants compare correctly). `Found` lists observed IPs.
+
+## Error taxonomy
+
+The distinction a polling consumer needs — "user hasn't added it yet" must not
+look like "DNS is broken":
+
+- **Pending** — `NXDOMAIN` / no-such-host / empty record set → **not an
+  error**: `Result{Verified:false, Found:nil}, nil`. Detected via
+  `*net.DNSError.IsNotFound` (and an empty result slice).
+- **Broken DNS** — timeout / SERVFAIL / temporary → wrapped `ErrLookup`.
+  Detected via `*net.DNSError.IsTemporary` / non-NotFound `DNSError`.
+- **Bad input** — unknown `Record`, empty `Host`, empty `Expect` →
+  `ErrInvalidChallenge` (returned before any lookup).
+
+Sentinels in `errors.go`, single-line, `errors.Is`-matchable: `ErrLookup`,
+`ErrInvalidChallenge`.
+
+The consumer distinguishes four states:
+
+| State | Test |
+|---|---|
+| verified | `res.Verified` |
+| pending | `!res.Verified && len(res.Found)==0 && err==nil` |
+| misconfigured | `!res.Verified && len(res.Found)>0` |
+| broken DNS | `errors.Is(err, ErrLookup)` |
+
+## Internals / file layout
+
+```
+web/dnsverify/
+├── doc.go          # package doc + runnable example (mint TXT → persist → reload → verify; CNAME routing check)
+├── config.go       # Config, DefaultConfig, Validate
+├── options.go      # type Option func(*config); With* options
+├── errors.go       # ErrLookup, ErrInvalidChallenge
+├── challenge.go    # RecordType (+String), Challenge, constructors
+├── dnsverify.go    # Verifier, New, Verify + per-record match logic
+└── resolver.go     # Resolver interface + StaticResolver (+ StaticOption, With* fakes)
+```
+
+~400–500 LOC. `Verify` dispatches on `c.Record` to a per-type lookup+compare,
+routes DNS errors through the taxonomy above, and fills `Result`.
+
+## Performance
+
+Not a hot path (onboarding-time, human-driven). Readable-first; per-lookup
+context timeout; clients/resolver created once in `New` and reused. No
+benchmark owed.
+
+## Testing (black-box only, `dnsverify_test`)
+
+- **Per record type**: match / normalization (CNAME trailing-dot + case, IP
+  canonicalization), multi-value `Expect`, multiple TXT RRs at a host.
+- **Result states**: verified / pending / misconfigured for each type.
+- **Error taxonomy**: `NXDOMAIN` → pending (`err==nil`); temporary/SERVFAIL →
+  `ErrLookup`; unknown record / empty host / empty Expect → `ErrInvalidChallenge`.
+- **Constructors**: `TXTChallenge` host = `Label`+domain, value prefix, token
+  uniqueness across calls, `TokenBytes` honored; CNAME/A/AAAA field shapes.
+- **Config**: `DefaultConfig` values; `Validate` rejects non-positive timeout,
+  empty/invalid label, `TokenBytes < 8`.
+- **Context**: caller cancellation is honored; per-lookup timeout fires.
+- **StaticResolver**: options compose (repeatable `WithTXT`), `WithLookupError`
+  surfaces as `ErrLookup`, immutability (shared across goroutines, `-race`).
+- **doc.go example** compiles and runs.
+
+## Non-goals
+
+- **No email deliverability** (SPF/DKIM/DMARC/return-path) — dropped in scoping;
+  a separate package later if needed.
+- **No HTTP `/.well-known` or meta-tag verification** — DNS-only.
+- **No polling / scheduling / `WaitFor`** — single-shot; the consumer's
+  `scheduler`/`jobqueue` owns cadence and expiry.
+- **No token persistence / `Store` seam** — the consumer owns durability
+  (Postgres). `Challenge` is plain and serializable for exactly this.
+- **No user-facing prose** — structured fields for the consumer's i18n.
+- **No live DNS record *creation*** — the package reads DNS; publishing records
+  is the domain owner's action.
+
+## Wrap-up checklist for implementation
+
+- doc.go with runnable usage example.
+- docs/packages.md: delete the `web/dnsverify` roadmap entry.
+- `just fmt ./web/dnsverify/...`, `just lint` green.

--- a/web/dnsverify/challenge.go
+++ b/web/dnsverify/challenge.go
@@ -1,0 +1,39 @@
+package dnsverify
+
+// RecordType is the DNS record kind a Challenge verifies.
+type RecordType uint8
+
+const (
+	TXT RecordType = iota
+	CNAME
+	A
+	AAAA
+)
+
+// String returns the stable uppercase DNS type token ("TXT", "CNAME", "A",
+// "AAAA"). It is safe as an i18n key fragment and matches the record type a
+// user types into a DNS panel. Unknown values render "UNKNOWN".
+func (t RecordType) String() string {
+	switch t {
+	case TXT:
+		return "TXT"
+	case CNAME:
+		return "CNAME"
+	case A:
+		return "A"
+	case AAAA:
+		return "AAAA"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Challenge describes one DNS record to verify: look up Record at Host and
+// check the observed value(s) against Expect (any match verifies). It is plain
+// and serializable — persist it (e.g. a Postgres row/JSONB) between issuing
+// setup instructions and verifying later.
+type Challenge struct {
+	Host   string
+	Expect []string
+	Record RecordType
+}

--- a/web/dnsverify/challenge.go
+++ b/web/dnsverify/challenge.go
@@ -1,5 +1,11 @@
 package dnsverify
 
+import (
+	"net/netip"
+
+	"github.com/dmitrymomot/forge/core/random"
+)
+
 // RecordType is the DNS record kind a Challenge verifies.
 type RecordType uint8
 
@@ -36,4 +42,46 @@ type Challenge struct {
 	Host   string
 	Expect []string
 	Record RecordType
+}
+
+// txtValuePrefix namespaces the ownership token inside the TXT value so it
+// never collides with SPF or other TXT records at the same host.
+const txtValuePrefix = "forge-verification="
+
+// TXTChallenge mints a fresh ownership token and returns a TXT Challenge to
+// publish at Label.domain (e.g. "_forge-verify.example.com"). Persist the
+// returned Challenge; verify it later with Verify. The token comes from
+// random.URLSafe (unpadded base64url — safe in a TXT value).
+func (v *Verifier) TXTChallenge(domain string) Challenge {
+	token := random.URLSafe(v.cfg.TokenBytes)
+	return Challenge{
+		Record: TXT,
+		Host:   v.cfg.Label + "." + domain,
+		Expect: []string{txtValuePrefix + token},
+	}
+}
+
+// CNAMEChallenge builds a routing Challenge: host must CNAME to target.
+func (v *Verifier) CNAMEChallenge(host, target string) Challenge {
+	return Challenge{Record: CNAME, Host: host, Expect: []string{target}}
+}
+
+// AChallenge builds a routing Challenge: host must resolve (A) to at least one
+// of ips.
+func (v *Verifier) AChallenge(host string, ips ...netip.Addr) Challenge {
+	return Challenge{Record: A, Host: host, Expect: addrsToStrings(ips)}
+}
+
+// AAAAChallenge builds a routing Challenge: host must resolve (AAAA) to at
+// least one of ips.
+func (v *Verifier) AAAAChallenge(host string, ips ...netip.Addr) Challenge {
+	return Challenge{Record: AAAA, Host: host, Expect: addrsToStrings(ips)}
+}
+
+func addrsToStrings(ips []netip.Addr) []string {
+	out := make([]string, len(ips))
+	for i, ip := range ips {
+		out[i] = ip.String()
+	}
+	return out
 }

--- a/web/dnsverify/challenge_test.go
+++ b/web/dnsverify/challenge_test.go
@@ -1,0 +1,35 @@
+package dnsverify_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/dnsverify"
+)
+
+func TestRecordTypeString(t *testing.T) {
+	cases := map[dnsverify.RecordType]string{
+		dnsverify.TXT:   "TXT",
+		dnsverify.CNAME: "CNAME",
+		dnsverify.A:     "A",
+		dnsverify.AAAA:  "AAAA",
+	}
+	for rt, want := range cases {
+		if got := rt.String(); got != want {
+			t.Errorf("RecordType(%d).String() = %q, want %q", rt, got, want)
+		}
+	}
+	if got := dnsverify.RecordType(99).String(); got != "UNKNOWN" {
+		t.Errorf("unknown RecordType.String() = %q, want UNKNOWN", got)
+	}
+}
+
+func TestChallengeIsPlainValue(t *testing.T) {
+	c := dnsverify.Challenge{
+		Record: dnsverify.TXT,
+		Host:   "_forge-verify.example.com",
+		Expect: []string{"forge-verification=abc"},
+	}
+	if c.Host != "_forge-verify.example.com" || len(c.Expect) != 1 {
+		t.Fatalf("Challenge fields not readable: %+v", c)
+	}
+}

--- a/web/dnsverify/config.go
+++ b/web/dnsverify/config.go
@@ -45,13 +45,21 @@ func (c Config) Validate() error {
 	return nil
 }
 
+// maxLabelPrefixLen caps the total Label length at the RFC 1035 hostname
+// limit (253 chars); Label is only the prefix of Label + "." + domain, so this
+// is a generous syntactic bound, not the full-name limit.
+const maxLabelPrefixLen = 253
+
 // validLabelPrefix reports whether s is a syntactically valid DNS host prefix:
 // one or more dot-separated labels, each 1-63 ASCII characters of letters,
-// digits, hyphen, or underscore, with no leading or trailing hyphen. Underscore
-// is permitted because service labels (e.g. the default "_forge-verify",
-// "_dmarc", "_acme-challenge") begin with one. The empty string yields a single
-// empty label and is rejected.
+// digits, hyphen, or underscore, with no leading or trailing hyphen, and a
+// total length within maxLabelPrefixLen. Underscore is permitted because
+// service labels (e.g. the default "_forge-verify", "_dmarc", "_acme-challenge")
+// begin with one. The empty string yields a single empty label and is rejected.
 func validLabelPrefix(s string) bool {
+	if len(s) > maxLabelPrefixLen {
+		return false
+	}
 	for label := range strings.SplitSeq(s, ".") {
 		if !validLabel(label) {
 			return false

--- a/web/dnsverify/config.go
+++ b/web/dnsverify/config.go
@@ -1,0 +1,38 @@
+package dnsverify
+
+import (
+	"fmt"
+	"time"
+)
+
+// Config is the env-loadable deployment config. The resolver is a code-shaped
+// seam and lives in options (WithResolver), not env.
+type Config struct {
+	Label      string        `env:"DNSVERIFY_LABEL"`       // TXT ownership host prefix
+	Timeout    time.Duration `env:"DNSVERIFY_TIMEOUT"`     // per-lookup deadline
+	TokenBytes int           `env:"DNSVERIFY_TOKEN_BYTES"` // entropy (bytes) of minted tokens
+}
+
+// DefaultConfig returns a 5s per-lookup timeout, the "_forge-verify" TXT label,
+// and 16-byte tokens.
+func DefaultConfig() Config {
+	return Config{
+		Timeout:    5 * time.Second,
+		Label:      "_forge-verify",
+		TokenBytes: 16,
+	}
+}
+
+// Validate rejects a non-positive Timeout, an empty Label, and TokenBytes < 8.
+func (c Config) Validate() error {
+	if c.Timeout <= 0 {
+		return fmt.Errorf("%w: non-positive Timeout", ErrInvalidConfig)
+	}
+	if c.Label == "" {
+		return fmt.Errorf("%w: empty Label", ErrInvalidConfig)
+	}
+	if c.TokenBytes < 8 {
+		return fmt.Errorf("%w: TokenBytes %d (want >= 8)", ErrInvalidConfig, c.TokenBytes)
+	}
+	return nil
+}

--- a/web/dnsverify/config.go
+++ b/web/dnsverify/config.go
@@ -2,6 +2,7 @@ package dnsverify
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -23,7 +24,11 @@ func DefaultConfig() Config {
 	}
 }
 
-// Validate rejects a non-positive Timeout, an empty Label, and TokenBytes < 8.
+// Validate rejects a non-positive Timeout, a Label that is not a syntactically
+// valid DNS host prefix, and TokenBytes < 8. Label is validated because it is
+// concatenated as Label + "." + domain to form the record host; a malformed
+// Label (spaces, illegal punctuation, stray dots) would otherwise silently
+// yield an unresolvable Host at Verify time.
 func (c Config) Validate() error {
 	if c.Timeout <= 0 {
 		return fmt.Errorf("%w: non-positive Timeout", ErrInvalidConfig)
@@ -31,8 +36,46 @@ func (c Config) Validate() error {
 	if c.Label == "" {
 		return fmt.Errorf("%w: empty Label", ErrInvalidConfig)
 	}
+	if !validLabelPrefix(c.Label) {
+		return fmt.Errorf("%w: Label %q is not a valid DNS label", ErrInvalidConfig, c.Label)
+	}
 	if c.TokenBytes < 8 {
 		return fmt.Errorf("%w: TokenBytes %d (want >= 8)", ErrInvalidConfig, c.TokenBytes)
 	}
 	return nil
+}
+
+// validLabelPrefix reports whether s is a syntactically valid DNS host prefix:
+// one or more dot-separated labels, each 1-63 ASCII characters of letters,
+// digits, hyphen, or underscore, with no leading or trailing hyphen. Underscore
+// is permitted because service labels (e.g. the default "_forge-verify",
+// "_dmarc", "_acme-challenge") begin with one. An empty string is rejected by
+// the caller before this is reached.
+func validLabelPrefix(s string) bool {
+	for label := range strings.SplitSeq(s, ".") {
+		if !validLabel(label) {
+			return false
+		}
+	}
+	return true
+}
+
+func validLabel(label string) bool {
+	if len(label) == 0 || len(label) > 63 {
+		return false
+	}
+	for i := 0; i < len(label); i++ {
+		ch := label[i]
+		switch {
+		case ch >= 'a' && ch <= 'z', ch >= 'A' && ch <= 'Z', ch >= '0' && ch <= '9', ch == '_':
+			// allowed anywhere
+		case ch == '-':
+			if i == 0 || i == len(label)-1 {
+				return false // no leading or trailing hyphen
+			}
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/web/dnsverify/config.go
+++ b/web/dnsverify/config.go
@@ -49,8 +49,8 @@ func (c Config) Validate() error {
 // one or more dot-separated labels, each 1-63 ASCII characters of letters,
 // digits, hyphen, or underscore, with no leading or trailing hyphen. Underscore
 // is permitted because service labels (e.g. the default "_forge-verify",
-// "_dmarc", "_acme-challenge") begin with one. An empty string is rejected by
-// the caller before this is reached.
+// "_dmarc", "_acme-challenge") begin with one. The empty string yields a single
+// empty label and is rejected.
 func validLabelPrefix(s string) bool {
 	for label := range strings.SplitSeq(s, ".") {
 		if !validLabel(label) {

--- a/web/dnsverify/config_test.go
+++ b/web/dnsverify/config_test.go
@@ -2,6 +2,7 @@ package dnsverify_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,6 +38,47 @@ func TestConfigValidate(t *testing.T) {
 	bad.TokenBytes = 4
 	if !errors.Is(bad.Validate(), dnsverify.ErrInvalidConfig) {
 		t.Error("TokenBytes < 8 must be invalid")
+	}
+}
+
+func TestConfigValidateLabelSyntax(t *testing.T) {
+	base := dnsverify.DefaultConfig()
+
+	valid := []string{
+		"_forge-verify", // default, underscore-prefixed service label
+		"_custom",
+		"verify",
+		"a",
+		"_acme-challenge",
+		"_forge-verify.sub", // dotted prefix (each part a valid label)
+	}
+	for _, label := range valid {
+		c := base
+		c.Label = label
+		if err := c.Validate(); err != nil {
+			t.Errorf("Label %q must be valid, got %v", label, err)
+		}
+	}
+
+	invalid := []string{
+		"",                      // empty
+		"_forge verify",         // space
+		"_forge-verify.",        // trailing dot → empty final label
+		".verify",               // leading dot → empty first label
+		"a..b",                  // consecutive dots → empty middle label
+		"-bad",                  // leading hyphen
+		"bad-",                  // trailing hyphen
+		"has_underscore ",       // trailing space
+		"bad!",                  // illegal punctuation
+		"café",                  // non-ASCII
+		strings.Repeat("a", 64), // label longer than 63 chars
+	}
+	for _, label := range invalid {
+		c := base
+		c.Label = label
+		if !errors.Is(c.Validate(), dnsverify.ErrInvalidConfig) {
+			t.Errorf("Label %q must be invalid (ErrInvalidConfig), got %v", label, c.Validate())
+		}
 	}
 }
 

--- a/web/dnsverify/config_test.go
+++ b/web/dnsverify/config_test.go
@@ -72,6 +72,15 @@ func TestConfigValidateLabelSyntax(t *testing.T) {
 		"bad!",                  // illegal punctuation
 		"café",                  // non-ASCII
 		strings.Repeat("a", 64), // label longer than 63 chars
+		// Total prefix longer than 253 chars, built from individually valid
+		// 60-char labels (each within the 1-63 limit).
+		strings.Join([]string{
+			strings.Repeat("a", 60),
+			strings.Repeat("b", 60),
+			strings.Repeat("c", 60),
+			strings.Repeat("d", 60),
+			strings.Repeat("e", 60),
+		}, "."),
 	}
 	for _, label := range invalid {
 		c := base

--- a/web/dnsverify/config_test.go
+++ b/web/dnsverify/config_test.go
@@ -1,0 +1,59 @@
+package dnsverify_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/web/dnsverify"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	c := dnsverify.DefaultConfig()
+	if c.Timeout != 5*time.Second || c.Label != "_forge-verify" || c.TokenBytes != 16 {
+		t.Fatalf("DefaultConfig = %+v", c)
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("DefaultConfig must be valid: %v", err)
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	base := dnsverify.DefaultConfig()
+
+	bad := base
+	bad.Timeout = 0
+	if !errors.Is(bad.Validate(), dnsverify.ErrInvalidConfig) {
+		t.Error("zero Timeout must be invalid")
+	}
+
+	bad = base
+	bad.Label = ""
+	if !errors.Is(bad.Validate(), dnsverify.ErrInvalidConfig) {
+		t.Error("empty Label must be invalid")
+	}
+
+	bad = base
+	bad.TokenBytes = 4
+	if !errors.Is(bad.Validate(), dnsverify.ErrInvalidConfig) {
+		t.Error("TokenBytes < 8 must be invalid")
+	}
+}
+
+func TestNewRejectsInvalidConfig(t *testing.T) {
+	_, err := dnsverify.New(dnsverify.WithTimeout(0))
+	if !errors.Is(err, dnsverify.ErrInvalidConfig) {
+		t.Fatalf("New with zero Timeout: want ErrInvalidConfig, got %v", err)
+	}
+}
+
+func TestNewAppliesOptions(t *testing.T) {
+	v, err := dnsverify.New(
+		dnsverify.WithResolver(dnsverify.NewStaticResolver()),
+		dnsverify.WithLabel("_custom"),
+		dnsverify.WithTokenBytes(24),
+	)
+	if err != nil || v == nil {
+		t.Fatalf("New: %v", err)
+	}
+}

--- a/web/dnsverify/config_test.go
+++ b/web/dnsverify/config_test.go
@@ -76,8 +76,8 @@ func TestConfigValidateLabelSyntax(t *testing.T) {
 	for _, label := range invalid {
 		c := base
 		c.Label = label
-		if !errors.Is(c.Validate(), dnsverify.ErrInvalidConfig) {
-			t.Errorf("Label %q must be invalid (ErrInvalidConfig), got %v", label, c.Validate())
+		if err := c.Validate(); !errors.Is(err, dnsverify.ErrInvalidConfig) {
+			t.Errorf("Label %q must be invalid (ErrInvalidConfig), got %v", label, err)
 		}
 	}
 }

--- a/web/dnsverify/constructors_test.go
+++ b/web/dnsverify/constructors_test.go
@@ -1,0 +1,94 @@
+package dnsverify_test
+
+import (
+	"context"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/dnsverify"
+)
+
+func TestTXTChallengeShapeAndUniqueness(t *testing.T) {
+	v, err := dnsverify.New(dnsverify.WithResolver(dnsverify.NewStaticResolver()))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c1 := v.TXTChallenge("example.com")
+	c2 := v.TXTChallenge("example.com")
+
+	if c1.Record != dnsverify.TXT {
+		t.Errorf("Record = %v, want TXT", c1.Record)
+	}
+	if c1.Host != "_forge-verify.example.com" {
+		t.Errorf("Host = %q", c1.Host)
+	}
+	if len(c1.Expect) != 1 || !strings.HasPrefix(c1.Expect[0], "forge-verification=") {
+		t.Errorf("Expect = %v, want one forge-verification= value", c1.Expect)
+	}
+	if c1.Expect[0] == c2.Expect[0] {
+		t.Errorf("tokens must be unique across calls: %q", c1.Expect[0])
+	}
+}
+
+func TestTXTChallengeHonorsConfig(t *testing.T) {
+	v, err := dnsverify.New(
+		dnsverify.WithResolver(dnsverify.NewStaticResolver()),
+		dnsverify.WithLabel("_custom"),
+		dnsverify.WithTokenBytes(32),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := v.TXTChallenge("acme.test")
+	if c.Host != "_custom.acme.test" {
+		t.Errorf("Host = %q, want _custom.acme.test", c.Host)
+	}
+	// 32 raw bytes → 43 unpadded base64url chars after the prefix.
+	token := strings.TrimPrefix(c.Expect[0], "forge-verification=")
+	if len(token) != 43 {
+		t.Errorf("token length = %d, want 43 for 32 bytes", len(token))
+	}
+}
+
+func TestRoutingConstructors(t *testing.T) {
+	v, err := dnsverify.New(dnsverify.WithResolver(dnsverify.NewStaticResolver()))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	cn := v.CNAMEChallenge("app.example.com", "ingress.svc.com")
+	if cn.Record != dnsverify.CNAME || cn.Host != "app.example.com" || cn.Expect[0] != "ingress.svc.com" {
+		t.Errorf("CNAMEChallenge = %+v", cn)
+	}
+
+	a := v.AChallenge("example.com", netip.MustParseAddr("203.0.113.10"))
+	if a.Record != dnsverify.A || a.Expect[0] != "203.0.113.10" {
+		t.Errorf("AChallenge = %+v", a)
+	}
+
+	aaaa := v.AAAAChallenge("example.com", netip.MustParseAddr("2001:db8::1"))
+	if aaaa.Record != dnsverify.AAAA || aaaa.Expect[0] != "2001:db8::1" {
+		t.Errorf("AAAAChallenge = %+v", aaaa)
+	}
+}
+
+func TestTXTChallengeRoundTripsThroughVerify(t *testing.T) {
+	v, err := dnsverify.New(dnsverify.WithResolver(dnsverify.NewStaticResolver())) // placeholder, replaced below
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := v.TXTChallenge("example.com")
+
+	// Simulate the user publishing exactly the minted record, then verify.
+	v2, err := dnsverify.New(dnsverify.WithResolver(
+		dnsverify.NewStaticResolver(dnsverify.WithTXT(c.Host, c.Expect[0])),
+	))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := v2.Verify(context.Background(), c)
+	if err != nil || !res.Verified {
+		t.Fatalf("round-trip: want verified, got %+v err=%v", res, err)
+	}
+}

--- a/web/dnsverify/dnsverify.go
+++ b/web/dnsverify/dnsverify.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"strings"
 )
 
@@ -76,10 +77,8 @@ func (v *Verifier) verifyTXT(ctx context.Context, c Challenge) (Result, error) {
 		return errResult(err)
 	}
 	for _, rec := range records {
-		for _, want := range c.Expect {
-			if rec == want {
-				return Result{Verified: true, Found: records}, nil
-			}
+		if slices.Contains(c.Expect, rec) {
+			return Result{Verified: true, Found: records}, nil
 		}
 	}
 	return Result{Found: records}, nil
@@ -113,6 +112,7 @@ func (v *Verifier) verifyIP(ctx context.Context, c Challenge, network string) (R
 		if addr, perr := netip.ParseAddr(s); perr == nil {
 			want[addr.Unmap()] = struct{}{}
 		}
+		// Skip unparseable Expect entries — a malformed IP simply cannot match.
 	}
 	found := make([]string, 0, len(got))
 	verified := false

--- a/web/dnsverify/dnsverify.go
+++ b/web/dnsverify/dnsverify.go
@@ -48,8 +48,11 @@ type Result struct {
 // Verify performs one lookup-and-compare for c. A record that is not published
 // yet (NXDOMAIN / empty) yields an unverified Result with a nil error; a
 // genuine resolver failure returns ErrLookup; a malformed Challenge returns
-// ErrInvalidChallenge. The Verifier's Timeout bounds each lookup and the
-// caller's ctx cancellation is honored.
+// ErrInvalidChallenge. A Challenge is malformed if Host or Expect is empty, the
+// Record is unknown, or — for an A/AAAA Challenge — any Expect entry is not an
+// IP of the matching family (an IPv6 literal in an A Challenge, or vice versa).
+// The Verifier's Timeout bounds each lookup and the caller's ctx cancellation
+// is honored.
 func (v *Verifier) Verify(ctx context.Context, c Challenge) (Result, error) {
 	if c.Host == "" || len(c.Expect) == 0 {
 		return Result{}, ErrInvalidChallenge
@@ -103,16 +106,27 @@ func (v *Verifier) verifyCNAME(ctx context.Context, c Challenge) (Result, error)
 }
 
 func (v *Verifier) verifyIP(ctx context.Context, c Challenge, network string) (Result, error) {
+	// Validate the Expect set before touching the network: every entry must be
+	// an IP of the record's family. A wrong-family or unparseable entry can
+	// never match the family-filtered LookupNetIP results, so it is malformed
+	// misuse — fail fast with ErrInvalidChallenge rather than sitting pending
+	// forever. This keeps Verify the single validation gate (constructors stay
+	// pure and non-erroring).
+	want := make(map[netip.Addr]struct{}, len(c.Expect))
+	for _, s := range c.Expect {
+		addr, perr := netip.ParseAddr(s)
+		if perr != nil {
+			return Result{}, fmt.Errorf("%w: Expect %q is not an IP address", ErrInvalidChallenge, s)
+		}
+		addr = addr.Unmap()
+		if (network == "ip4") != addr.Is4() {
+			return Result{}, fmt.Errorf("%w: Expect %q does not match record family %s", ErrInvalidChallenge, s, c.Record)
+		}
+		want[addr] = struct{}{}
+	}
 	got, err := v.resolver.LookupNetIP(ctx, network, c.Host)
 	if err != nil {
 		return errResult(err)
-	}
-	want := make(map[netip.Addr]struct{}, len(c.Expect))
-	for _, s := range c.Expect {
-		if addr, perr := netip.ParseAddr(s); perr == nil {
-			want[addr.Unmap()] = struct{}{}
-		}
-		// Skip unparseable Expect entries — a malformed IP simply cannot match.
 	}
 	found := make([]string, 0, len(got))
 	verified := false

--- a/web/dnsverify/dnsverify.go
+++ b/web/dnsverify/dnsverify.go
@@ -1,0 +1,28 @@
+package dnsverify
+
+import "net"
+
+// Verifier performs single-shot DNS verification against a Resolver. Build it
+// with New; it is safe for concurrent use.
+type Verifier struct {
+	resolver Resolver
+	cfg      Config
+}
+
+// New builds a Verifier. It applies DefaultConfig, then the options, then
+// returns an error if the resulting Config is invalid. The resolver defaults
+// to net.DefaultResolver.
+func New(opts ...Option) (*Verifier, error) {
+	cf := config{cfg: DefaultConfig()}
+	for _, o := range opts {
+		o(&cf)
+	}
+	if err := cf.cfg.Validate(); err != nil {
+		return nil, err
+	}
+	r := cf.resolver
+	if r == nil {
+		r = net.DefaultResolver
+	}
+	return &Verifier{resolver: r, cfg: cf.cfg}, nil
+}

--- a/web/dnsverify/dnsverify.go
+++ b/web/dnsverify/dnsverify.go
@@ -1,6 +1,13 @@
 package dnsverify
 
-import "net"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+)
 
 // Verifier performs single-shot DNS verification against a Resolver. Build it
 // with New; it is safe for concurrent use.
@@ -25,4 +32,113 @@ func New(opts ...Option) (*Verifier, error) {
 		r = net.DefaultResolver
 	}
 	return &Verifier{resolver: r, cfg: cf.cfg}, nil
+}
+
+// Result reports the outcome of a Verify call. Verified is whether observed
+// DNS satisfied the Challenge; Found lists the observed values at Host (for
+// display/debug). With a nil error there are three states: verified
+// (Verified), pending (!Verified && len(Found) == 0 — nothing published yet),
+// and misconfigured (!Verified && len(Found) > 0 — published but wrong).
+type Result struct {
+	Found    []string
+	Verified bool
+}
+
+// Verify performs one lookup-and-compare for c. A record that is not published
+// yet (NXDOMAIN / empty) yields an unverified Result with a nil error; a
+// genuine resolver failure returns ErrLookup; a malformed Challenge returns
+// ErrInvalidChallenge. The Verifier's Timeout bounds each lookup and the
+// caller's ctx cancellation is honored.
+func (v *Verifier) Verify(ctx context.Context, c Challenge) (Result, error) {
+	if c.Host == "" || len(c.Expect) == 0 {
+		return Result{}, ErrInvalidChallenge
+	}
+	ctx, cancel := context.WithTimeout(ctx, v.cfg.Timeout)
+	defer cancel()
+
+	switch c.Record {
+	case TXT:
+		return v.verifyTXT(ctx, c)
+	case CNAME:
+		return v.verifyCNAME(ctx, c)
+	case A:
+		return v.verifyIP(ctx, c, "ip4")
+	case AAAA:
+		return v.verifyIP(ctx, c, "ip6")
+	default:
+		return Result{}, ErrInvalidChallenge
+	}
+}
+
+func (v *Verifier) verifyTXT(ctx context.Context, c Challenge) (Result, error) {
+	records, err := v.resolver.LookupTXT(ctx, c.Host)
+	if err != nil {
+		return errResult(err)
+	}
+	for _, rec := range records {
+		for _, want := range c.Expect {
+			if rec == want {
+				return Result{Verified: true, Found: records}, nil
+			}
+		}
+	}
+	return Result{Found: records}, nil
+}
+
+func (v *Verifier) verifyCNAME(ctx context.Context, c Challenge) (Result, error) {
+	cname, err := v.resolver.LookupCNAME(ctx, c.Host)
+	if err != nil {
+		return errResult(err)
+	}
+	got := canonicalHost(cname)
+	// LookupCNAME returns the queried host itself when there is no CNAME.
+	if got == canonicalHost(c.Host) {
+		return Result{}, nil
+	}
+	for _, want := range c.Expect {
+		if got == canonicalHost(want) {
+			return Result{Verified: true, Found: []string{cname}}, nil
+		}
+	}
+	return Result{Found: []string{cname}}, nil
+}
+
+func (v *Verifier) verifyIP(ctx context.Context, c Challenge, network string) (Result, error) {
+	got, err := v.resolver.LookupNetIP(ctx, network, c.Host)
+	if err != nil {
+		return errResult(err)
+	}
+	want := make(map[netip.Addr]struct{}, len(c.Expect))
+	for _, s := range c.Expect {
+		if addr, perr := netip.ParseAddr(s); perr == nil {
+			want[addr.Unmap()] = struct{}{}
+		}
+	}
+	found := make([]string, 0, len(got))
+	verified := false
+	for _, ip := range got {
+		found = append(found, ip.String())
+		if _, ok := want[ip.Unmap()]; ok {
+			verified = true
+		}
+	}
+	if len(found) == 0 {
+		return Result{}, nil // nothing resolved yet → pending
+	}
+	return Result{Verified: verified, Found: found}, nil
+}
+
+// errResult routes a resolver error: "not published yet" (NXDOMAIN) becomes an
+// unverified Result with a nil error; anything else becomes ErrLookup.
+func errResult(err error) (Result, error) {
+	var d *net.DNSError
+	if errors.As(err, &d) && d.IsNotFound {
+		return Result{}, nil
+	}
+	return Result{}, fmt.Errorf("%w: %v", ErrLookup, err)
+}
+
+// canonicalHost lowercases and strips a trailing dot for CNAME comparison.
+func canonicalHost(h string) string {
+	return strings.ToLower(strings.TrimSuffix(h, "."))
 }

--- a/web/dnsverify/doc.go
+++ b/web/dnsverify/doc.go
@@ -1,0 +1,44 @@
+// Package dnsverify performs single-shot DNS ownership and routing
+// verification behind a small Resolver seam that *net.Resolver satisfies.
+//
+// Two intents share one mechanic — look up a record at a host, compare the
+// observed value(s) against expected:
+//
+//   - Ownership token: TXTChallenge mints a random token; the domain owner
+//     publishes a TXT record; Verify confirms the token is present.
+//   - Routing target: CNAMEChallenge / AChallenge / AAAAChallenge check that a
+//     domain points at your ingress (for custom-domain onboarding with
+//     hostrouter + autocert).
+//
+// The package is stateless: TXTChallenge returns a plain, serializable
+// Challenge that you persist (e.g. a Postgres row) between showing setup
+// instructions and verifying later — nothing needs to survive a restart on
+// this side. Verify is single-shot; the caller owns polling cadence (a
+// scheduler/jobqueue re-checking a pending domain).
+//
+// A nil error from Verify has three states: verified (Result.Verified),
+// pending (!Verified && len(Found) == 0 — not published yet), and
+// misconfigured (!Verified && len(Found) > 0 — published but wrong). A genuine
+// resolver failure returns ErrLookup, distinct from "not published yet".
+//
+//	v, err := dnsverify.New()
+//	if err != nil { /* invalid config */ }
+//
+//	// Issue an ownership challenge and show the record to the user.
+//	c := v.TXTChallenge("example.com")
+//	// persist c (c.Host, c.Record, c.Expect) tied to the tenant/domain
+//
+//	// Later, after the user says they added it:
+//	res, err := v.Verify(ctx, c)
+//	switch {
+//	case err != nil:                 // errors.Is(err, dnsverify.ErrLookup)
+//	case res.Verified:               // done
+//	case len(res.Found) == 0:        // pending — ask them to wait for DNS
+//	default:                         // misconfigured — show res.Found
+//	}
+//
+// Consumers render setup instructions from the structured Challenge fields via
+// their own i18n layer; dnsverify emits no user-facing prose. The exported
+// StaticResolver is an in-memory test double for exercising these flows
+// without real DNS.
+package dnsverify

--- a/web/dnsverify/errors.go
+++ b/web/dnsverify/errors.go
@@ -1,0 +1,17 @@
+package dnsverify
+
+import "errors"
+
+var (
+	// ErrLookup wraps a genuine resolver failure (timeout, SERVFAIL, other
+	// temporary DNS error). It is distinct from "the record is not published
+	// yet", which Verify reports as an unverified Result with a nil error.
+	ErrLookup = errors.New("dnsverify: lookup failed")
+
+	// ErrInvalidChallenge marks a malformed Challenge — unknown Record, empty
+	// Host, or empty Expect — rejected before any lookup.
+	ErrInvalidChallenge = errors.New("dnsverify: invalid challenge")
+
+	// ErrInvalidConfig marks a Config that fails Validate at construction.
+	ErrInvalidConfig = errors.New("dnsverify: invalid config")
+)

--- a/web/dnsverify/example_test.go
+++ b/web/dnsverify/example_test.go
@@ -1,0 +1,32 @@
+package dnsverify_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/web/dnsverify"
+)
+
+func Example() {
+	// A resolver double stands in for real DNS so the example is deterministic.
+	v, err := dnsverify.New(dnsverify.WithResolver(
+		dnsverify.NewStaticResolver(
+			dnsverify.WithTXT("_forge-verify.example.com", "forge-verification=abc123"),
+		),
+	))
+	if err != nil {
+		panic(err)
+	}
+
+	// In production, mint a token and persist the Challenge (e.g. in Postgres):
+	//   c := v.TXTChallenge("example.com"); save(c)
+	// then reload it later and verify. Here we verify a known record.
+	c := dnsverify.Challenge{
+		Record: dnsverify.TXT,
+		Host:   "_forge-verify.example.com",
+		Expect: []string{"forge-verification=abc123"},
+	}
+	res, err := v.Verify(context.Background(), c)
+	fmt.Println(res.Verified, err)
+	// Output: true <nil>
+}

--- a/web/dnsverify/options.go
+++ b/web/dnsverify/options.go
@@ -1,0 +1,27 @@
+package dnsverify
+
+import "time"
+
+type config struct {
+	resolver Resolver
+	cfg      Config
+}
+
+// Option configures a Verifier.
+type Option func(*config)
+
+// WithConfig applies an env-loaded Config. Place it before other options so
+// they can override individual fields.
+func WithConfig(c Config) Option { return func(cf *config) { cf.cfg = c } }
+
+// WithResolver sets the DNS resolver seam (default net.DefaultResolver).
+func WithResolver(r Resolver) Option { return func(cf *config) { cf.resolver = r } }
+
+// WithTimeout sets the per-lookup deadline.
+func WithTimeout(d time.Duration) Option { return func(cf *config) { cf.cfg.Timeout = d } }
+
+// WithLabel sets the TXT ownership host prefix.
+func WithLabel(s string) Option { return func(cf *config) { cf.cfg.Label = s } }
+
+// WithTokenBytes sets the entropy (in bytes) of minted tokens.
+func WithTokenBytes(n int) Option { return func(cf *config) { cf.cfg.TokenBytes = n } }

--- a/web/dnsverify/resolver.go
+++ b/web/dnsverify/resolver.go
@@ -1,0 +1,126 @@
+package dnsverify
+
+import (
+	"context"
+	"net"
+	"net/netip"
+)
+
+// Resolver is the DNS seam. *net.Resolver satisfies it structurally, so
+// net.DefaultResolver is the zero-config default and a custom *net.Resolver
+// (own dialer/DNS server) drops in unchanged.
+type Resolver interface {
+	LookupTXT(ctx context.Context, host string) ([]string, error)
+	LookupCNAME(ctx context.Context, host string) (string, error)
+	LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error)
+}
+
+// StaticResolver is an in-memory Resolver for tests. Configure it entirely at
+// construction with the With* options; it is immutable afterward and safe to
+// share across goroutines. Unknown hosts resolve as not-found (IsNotFound),
+// which Verify reports as an unverified Result with a nil error.
+type StaticResolver struct {
+	txt   map[string][]string
+	cname map[string]string
+	ips   map[string][]netip.Addr
+	errs  map[string]error
+}
+
+// StaticOption configures a StaticResolver. It is distinct from the Verifier's
+// Option type.
+type StaticOption func(*StaticResolver)
+
+// NewStaticResolver builds an in-memory resolver from the given records.
+func NewStaticResolver(opts ...StaticOption) *StaticResolver {
+	r := &StaticResolver{
+		txt:   map[string][]string{},
+		cname: map[string]string{},
+		ips:   map[string][]netip.Addr{},
+		errs:  map[string]error{},
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
+}
+
+// WithTXT adds TXT values at host. Repeatable — each call appends, modeling
+// multiple TXT records at one host.
+func WithTXT(host string, values ...string) StaticOption {
+	return func(r *StaticResolver) { r.txt[host] = append(r.txt[host], values...) }
+}
+
+// WithCNAME sets the CNAME target at host.
+func WithCNAME(host, target string) StaticOption {
+	return func(r *StaticResolver) { r.cname[host] = target }
+}
+
+// WithIP adds A/AAAA addresses at host; the family is inferred per address at
+// lookup time.
+func WithIP(host string, ips ...netip.Addr) StaticOption {
+	return func(r *StaticResolver) { r.ips[host] = append(r.ips[host], ips...) }
+}
+
+// WithLookupError makes every lookup for host return err — used to exercise
+// the ErrLookup path.
+func WithLookupError(host string, err error) StaticOption {
+	return func(r *StaticResolver) { r.errs[host] = err }
+}
+
+func notFound(host string) error {
+	return &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+}
+
+// LookupTXT implements Resolver.
+func (r *StaticResolver) LookupTXT(_ context.Context, host string) ([]string, error) {
+	if err := r.errs[host]; err != nil {
+		return nil, err
+	}
+	v, ok := r.txt[host]
+	if !ok {
+		return nil, notFound(host)
+	}
+	return v, nil
+}
+
+// LookupCNAME implements Resolver.
+func (r *StaticResolver) LookupCNAME(_ context.Context, host string) (string, error) {
+	if err := r.errs[host]; err != nil {
+		return "", err
+	}
+	v, ok := r.cname[host]
+	if !ok {
+		return "", notFound(host)
+	}
+	return v, nil
+}
+
+// LookupNetIP implements Resolver. network is "ip4", "ip6", or "ip".
+func (r *StaticResolver) LookupNetIP(_ context.Context, network, host string) ([]netip.Addr, error) {
+	if err := r.errs[host]; err != nil {
+		return nil, err
+	}
+	all, ok := r.ips[host]
+	if !ok {
+		return nil, notFound(host)
+	}
+	out := make([]netip.Addr, 0, len(all))
+	for _, ip := range all {
+		switch network {
+		case "ip4":
+			if ip.Is4() {
+				out = append(out, ip)
+			}
+		case "ip6":
+			if !ip.Is4() {
+				out = append(out, ip)
+			}
+		default:
+			out = append(out, ip)
+		}
+	}
+	if len(out) == 0 {
+		return nil, notFound(host)
+	}
+	return out, nil
+}

--- a/web/dnsverify/resolver.go
+++ b/web/dnsverify/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/netip"
+	"slices"
 )
 
 // Resolver is the DNS seam. *net.Resolver satisfies it structurally, so
@@ -14,6 +15,10 @@ type Resolver interface {
 	LookupCNAME(ctx context.Context, host string) (string, error)
 	LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error)
 }
+
+// *net.Resolver satisfies Resolver — proven at compile time so a stdlib
+// signature drift breaks the build here, not in a downstream consumer.
+var _ Resolver = (*net.Resolver)(nil)
 
 // StaticResolver is an in-memory Resolver for tests. Configure it entirely at
 // construction with the With* options; it is immutable afterward and safe to
@@ -80,7 +85,7 @@ func (r *StaticResolver) LookupTXT(_ context.Context, host string) ([]string, er
 	if !ok {
 		return nil, notFound(host)
 	}
-	return v, nil
+	return slices.Clone(v), nil
 }
 
 // LookupCNAME implements Resolver.

--- a/web/dnsverify/resolver_test.go
+++ b/web/dnsverify/resolver_test.go
@@ -1,0 +1,68 @@
+package dnsverify_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/dnsverify"
+)
+
+func TestStaticResolverTXT(t *testing.T) {
+	r := dnsverify.NewStaticResolver(
+		dnsverify.WithTXT("h.example.com", "a"),
+		dnsverify.WithTXT("h.example.com", "b"), // repeatable → appends
+	)
+	got, err := r.LookupTXT(context.Background(), "h.example.com")
+	if err != nil {
+		t.Fatalf("LookupTXT: %v", err)
+	}
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("LookupTXT = %v, want [a b]", got)
+	}
+}
+
+func TestStaticResolverNotFound(t *testing.T) {
+	r := dnsverify.NewStaticResolver()
+	_, err := r.LookupTXT(context.Background(), "missing.example.com")
+	var d *net.DNSError
+	if !errors.As(err, &d) || !d.IsNotFound {
+		t.Fatalf("want IsNotFound DNSError, got %v", err)
+	}
+}
+
+func TestStaticResolverCNAME(t *testing.T) {
+	r := dnsverify.NewStaticResolver(dnsverify.WithCNAME("app.example.com", "ingress.svc.com."))
+	got, err := r.LookupCNAME(context.Background(), "app.example.com")
+	if err != nil || got != "ingress.svc.com." {
+		t.Fatalf("LookupCNAME = %q, %v", got, err)
+	}
+}
+
+func TestStaticResolverNetIPFamilyFilter(t *testing.T) {
+	r := dnsverify.NewStaticResolver(dnsverify.WithIP("example.com",
+		netip.MustParseAddr("203.0.113.10"),
+		netip.MustParseAddr("2001:db8::1"),
+	))
+	v4, err := r.LookupNetIP(context.Background(), "ip4", "example.com")
+	if err != nil || len(v4) != 1 || !v4[0].Is4() {
+		t.Fatalf("ip4 lookup = %v, %v", v4, err)
+	}
+	v6, err := r.LookupNetIP(context.Background(), "ip6", "example.com")
+	if err != nil || len(v6) != 1 || v6[0].Is4() {
+		t.Fatalf("ip6 lookup = %v, %v", v6, err)
+	}
+}
+
+func TestStaticResolverLookupError(t *testing.T) {
+	sentinel := errors.New("boom")
+	r := dnsverify.NewStaticResolver(
+		dnsverify.WithTXT("h.example.com", "a"),
+		dnsverify.WithLookupError("h.example.com", sentinel),
+	)
+	if _, err := r.LookupTXT(context.Background(), "h.example.com"); !errors.Is(err, sentinel) {
+		t.Fatalf("want sentinel, got %v", err)
+	}
+}

--- a/web/dnsverify/verify_test.go
+++ b/web/dnsverify/verify_test.go
@@ -155,3 +155,27 @@ func TestVerifyIPFamilyMismatchIsInvalidChallenge(t *testing.T) {
 		}
 	}
 }
+
+// emptyIPResolver returns zero addresses with a nil error from LookupNetIP,
+// modeling a resolver that answers the query but publishes no address of the
+// requested family. StaticResolver reports that as not-found instead, so this
+// double is the only way to exercise verifyIP's "resolved nothing → pending"
+// branch directly.
+type emptyIPResolver struct{ dnsverify.Resolver }
+
+func (emptyIPResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return nil, nil
+}
+
+func TestVerifyIPPendingOnEmptyResolvedSet(t *testing.T) {
+	v := newVerifier(t, emptyIPResolver{dnsverify.NewStaticResolver()})
+	c := dnsverify.Challenge{
+		Record: dnsverify.A,
+		Host:   "example.com",
+		Expect: []string{"203.0.113.10"},
+	}
+	res, err := v.Verify(context.Background(), c)
+	if err != nil || res.Verified || len(res.Found) != 0 {
+		t.Fatalf("want pending (nil err, not verified, empty found), got %+v err=%v", res, err)
+	}
+}

--- a/web/dnsverify/verify_test.go
+++ b/web/dnsverify/verify_test.go
@@ -90,6 +90,21 @@ func TestVerifyCNAMENormalizes(t *testing.T) {
 	}
 }
 
+func TestVerifyCNAMESelfReferenceIsPending(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver(
+		dnsverify.WithCNAME("app.example.com", "app.example.com"), // target equals host (no CNAME)
+	))
+	c := dnsverify.Challenge{
+		Record: dnsverify.CNAME,
+		Host:   "app.example.com",
+		Expect: []string{"some-other-target.com"},
+	}
+	res, err := v.Verify(context.Background(), c)
+	if err != nil || res.Verified || len(res.Found) != 0 {
+		t.Fatalf("want pending (nil err, not verified, empty found), got %+v err=%v", res, err)
+	}
+}
+
 func TestVerifyAIntersects(t *testing.T) {
 	v := newVerifier(t, dnsverify.NewStaticResolver(
 		dnsverify.WithIP("example.com", netip.MustParseAddr("198.51.100.7"), netip.MustParseAddr("203.0.113.10")),

--- a/web/dnsverify/verify_test.go
+++ b/web/dnsverify/verify_test.go
@@ -133,3 +133,25 @@ func TestVerifyInvalidChallenge(t *testing.T) {
 		}
 	}
 }
+
+func TestVerifyIPFamilyMismatchIsInvalidChallenge(t *testing.T) {
+	// A wrong-family or unparseable Expect entry can never verify against the
+	// family-filtered LookupNetIP results, so Verify rejects it up front rather
+	// than letting it sit "pending" forever.
+	v := newVerifier(t, dnsverify.NewStaticResolver(
+		dnsverify.WithIP("example.com",
+			netip.MustParseAddr("203.0.113.10"),
+			netip.MustParseAddr("2001:db8::1"),
+		),
+	))
+	cases := []dnsverify.Challenge{
+		{Record: dnsverify.A, Host: "example.com", Expect: []string{"2001:db8::1"}},              // IPv6 in an A challenge
+		{Record: dnsverify.AAAA, Host: "example.com", Expect: []string{"203.0.113.10"}},          // IPv4 in an AAAA challenge
+		{Record: dnsverify.A, Host: "example.com", Expect: []string{"203.0.113.10", "nonsense"}}, // unparseable entry
+	}
+	for i, c := range cases {
+		if _, err := v.Verify(context.Background(), c); !errors.Is(err, dnsverify.ErrInvalidChallenge) {
+			t.Errorf("case %d: want ErrInvalidChallenge, got %v", i, err)
+		}
+	}
+}

--- a/web/dnsverify/verify_test.go
+++ b/web/dnsverify/verify_test.go
@@ -1,0 +1,120 @@
+package dnsverify_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/dnsverify"
+)
+
+func newVerifier(t *testing.T, r dnsverify.Resolver) *dnsverify.Verifier {
+	t.Helper()
+	v, err := dnsverify.New(dnsverify.WithResolver(r))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return v
+}
+
+func TestVerifyTXT(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver(
+		dnsverify.WithTXT("_forge-verify.example.com", "other=1", "forge-verification=abc"),
+	))
+	c := dnsverify.Challenge{
+		Record: dnsverify.TXT,
+		Host:   "_forge-verify.example.com",
+		Expect: []string{"forge-verification=abc"},
+	}
+	res, err := v.Verify(context.Background(), c)
+	if err != nil || !res.Verified {
+		t.Fatalf("want verified, got %+v err=%v", res, err)
+	}
+}
+
+func TestVerifyTXTMisconfigured(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver(
+		dnsverify.WithTXT("_forge-verify.example.com", "forge-verification=WRONG"),
+	))
+	c := dnsverify.Challenge{
+		Record: dnsverify.TXT,
+		Host:   "_forge-verify.example.com",
+		Expect: []string{"forge-verification=abc"},
+	}
+	res, err := v.Verify(context.Background(), c)
+	if err != nil || res.Verified || len(res.Found) != 1 {
+		t.Fatalf("want misconfigured (found, not verified), got %+v err=%v", res, err)
+	}
+}
+
+func TestVerifyPendingIsNotError(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver()) // nothing published
+	c := dnsverify.Challenge{
+		Record: dnsverify.TXT,
+		Host:   "_forge-verify.example.com",
+		Expect: []string{"forge-verification=abc"},
+	}
+	res, err := v.Verify(context.Background(), c)
+	if err != nil || res.Verified || len(res.Found) != 0 {
+		t.Fatalf("want pending (nil err, empty found), got %+v err=%v", res, err)
+	}
+}
+
+func TestVerifyTemporaryErrorIsErrLookup(t *testing.T) {
+	temp := &net.DNSError{Err: "server misbehaving", Name: "h", IsTemporary: true}
+	v := newVerifier(t, dnsverify.NewStaticResolver(
+		dnsverify.WithTXT("h.example.com", "x"),
+		dnsverify.WithLookupError("h.example.com", temp),
+	))
+	c := dnsverify.Challenge{Record: dnsverify.TXT, Host: "h.example.com", Expect: []string{"y"}}
+	_, err := v.Verify(context.Background(), c)
+	if !errors.Is(err, dnsverify.ErrLookup) {
+		t.Fatalf("want ErrLookup, got %v", err)
+	}
+}
+
+func TestVerifyCNAMENormalizes(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver(
+		dnsverify.WithCNAME("app.example.com", "Ingress.SVC.com."), // mixed case + trailing dot
+	))
+	c := dnsverify.Challenge{
+		Record: dnsverify.CNAME,
+		Host:   "app.example.com",
+		Expect: []string{"ingress.svc.com"},
+	}
+	res, err := v.Verify(context.Background(), c)
+	if err != nil || !res.Verified {
+		t.Fatalf("want verified (normalized), got %+v err=%v", res, err)
+	}
+}
+
+func TestVerifyAIntersects(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver(
+		dnsverify.WithIP("example.com", netip.MustParseAddr("198.51.100.7"), netip.MustParseAddr("203.0.113.10")),
+	))
+	c := dnsverify.Challenge{
+		Record: dnsverify.A,
+		Host:   "example.com",
+		Expect: []string{"203.0.113.10"}, // one of the resolved set
+	}
+	res, err := v.Verify(context.Background(), c)
+	if err != nil || !res.Verified || len(res.Found) != 2 {
+		t.Fatalf("want verified with 2 found, got %+v err=%v", res, err)
+	}
+}
+
+func TestVerifyInvalidChallenge(t *testing.T) {
+	v := newVerifier(t, dnsverify.NewStaticResolver())
+	cases := []dnsverify.Challenge{
+		{Record: dnsverify.TXT, Host: "", Expect: []string{"x"}},             // empty host
+		{Record: dnsverify.TXT, Host: "h", Expect: nil},                      // empty expect
+		{Record: dnsverify.RecordType(99), Host: "h", Expect: []string{"x"}}, // unknown record
+	}
+	for i, c := range cases {
+		if _, err := v.Verify(context.Background(), c); !errors.Is(err, dnsverify.ErrInvalidChallenge) {
+			t.Errorf("case %d: want ErrInvalidChallenge, got %v", i, err)
+		}
+	}
+}


### PR DESCRIPTION
## Description

Adds `web/dnsverify` — a single-shot, stateless DNS ownership/routing verification package behind a small `Resolver` seam that `*net.Resolver` satisfies structurally.

**Why:** custom-domain onboarding (proving a tenant controls a domain via a TXT token, or that a domain points at our ingress via CNAME/A/AAAA) needs a reusable, testable verification primitive. This package provides it with zero external deps (stdlib `net`/`net/netip` + one forge dep, `core/random`, for token minting).

### What it does

- **`Verifier`** built via `New(...Option) (*Verifier, error)` — errors on invalid config (the erroring-`New` convention shared by `secheaders`/`timeout`/`compress`/`cors`/`cookie`).
- **`Verify(ctx, Challenge) (Result, error)`** — one lookup-and-compare per call, per-lookup timeout derived from the caller's ctx. Record kinds: TXT (exact match), CNAME (normalized: lowercase + trailing-dot strip), A/AAAA (set intersection, IPv4/IPv6-mapped normalized).
- **Error taxonomy** (a nil error has three states): verified · pending (`!Verified && len(Found)==0`, not published yet) · misconfigured (`!Verified && len(Found)>0`, published but wrong). A genuine resolver failure returns `ErrLookup`, distinct from "not published". Malformed `Challenge` → `ErrInvalidChallenge`.
- **Batteries-included, pure constructors** — `TXTChallenge` (mints a random `forge-verification=<token>` via `random.URLSafe`), `CNAMEChallenge`, `AChallenge`, `AAAAChallenge`. Constructors never error; `Verify` is the single validation gate.
- **Stateless** — `Challenge` is a plain, serializable value the consumer persists (e.g. a Postgres row) between issuing setup instructions and verifying later.
- **`StaticResolver`** — an in-memory `Resolver` test double (functional-options configured), shipped so consumers can exercise these flows without real DNS.

### Notes for reviewers

- Built task-by-task via subagent-driven development, each task spec+quality reviewed, plus a whole-branch review on the most capable model.
- `Config.Validate` rejects a non-positive `Timeout`, an empty **or syntactically invalid** `Label` (per-label 1–63 ASCII `[A-Za-z0-9_-]`, no leading/trailing hyphen, dot-separated; underscore-prefixed service labels like the default `_forge-verify` allowed), and `TokenBytes < 8`. Label is validated because it is concatenated as `Label + "." + domain` to form the host.
- `var _ Resolver = (*net.Resolver)(nil)` pins the package's central structural-typing claim at compile time.
- `docs/packages.md` drops the `web/dnsverify` roadmap entry (roadmap lists only unbuilt packages).
- Tests are black-box (`dnsverify_test`), including a runnable `Example` and a TXT mint→publish→verify round-trip. Coverage 90.4%, race-enabled.

## Checklist

- [x] `just lint` passes
- [x] `just test` passes
- [x] New code has tests
- [x] Commit messages follow conventional commits
