### PR TITLE
feat(fingerprint): Client Hints, RequestTLS, deeper JS probe, ch-ua/fetch-metadata signals, WithAutomationJA4

### DIFF
--- a/docs/superpowers/plans/2026-07-13-fingerprint-collectors-completion.md
+++ b/docs/superpowers/plans/2026-07-13-fingerprint-collectors-completion.md
@@ -1,0 +1,1242 @@
+# web/fingerprint Collector & Signal Completeness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the fingerprinting coverage gaps in `web/fingerprint` — Client Hints, self-terminated-TLS, a deeper JS probe, two new cross-layer signals, and a usable `tls-ua-mismatch` — as one PR.
+
+**Architecture:** Each addition is a new opt-in `Collector` or `Signal` following the package's existing `Name/Value` component idiom; nothing is wired by default except two preset edits. The `tlsprint` subpackage (which imports the parent) gains one collector; the parent gains everything else. Output stays identity + facts, never a score.
+
+**Tech Stack:** Go (stdlib `crypto/tls`, `net/http`), embedded `probe.js` (vanilla ES5 + Promises), HMAC component hashing, signed cookies.
+
+## Global Constraints
+
+- Go 1.26; use `new(expr)` not a `ptr.To` wrapper; every counting loop is `for i := range N`, never C-style.
+- Work only on the current branch `dm/web-fingerprint-collectors-665c19`; do not switch branches.
+- Run `just fmt ./web/fingerprint/...` after editing Go files (package-path form — single-file form trips a spurious betteralign "undefined").
+- Run `just lint` after the final task (runs vet, build, golangci-lint, nilaway, betteralign, modernize).
+- Full test run: `just test ./web/fingerprint/...` (→ `go test -race -cover`).
+- Tests are black-box (`package fingerprint_test` / `package tlsprint_test`) unless asserting unexported state.
+- No Claude attribution in any commit message.
+- The parent `fingerprint` package must NOT import `tlsprint` (tlsprint imports the parent — importing back is a cycle).
+- Output is facts, never a score; a collector emits nothing when its input is absent, and never aborts the collector chain.
+
+## Deviations from the spec (all reconciled in the committed spec)
+
+1. `Antifraud()` does **not** auto-fold `RequestTLS()` (import cycle — see Global Constraints). Consumers compose it into the `tls Collector` argument; documented on `RequestTLS` and in `Antifraud`'s doc.
+2. `js-tz-offset` dropped: its only consumer signal (`tz-offset-mismatch`) was cut, and the IANA `js-timezone` string already encodes the offset — pure redundant entropy.
+3. `js-devicememory` and `js-dpr` are collected as **strings** (their JS values are floats), clamped like the existing string fields.
+
+---
+
+### Task 1: `ClientHints()` collector
+
+**Files:**
+- Create: `web/fingerprint/clienthints.go`
+- Test: `web/fingerprint/clienthints_test.go`
+
+**Interfaces:**
+- Consumes: `headerPair` struct + `Component` type (from `headers.go`/`fingerprint.go`), `Collector` interface.
+- Produces: `func ClientHints() Collector` — emits components `ch-ua`, `ch-ua-platform`, `ch-ua-mobile`, `ch-ua-arch`, `ch-ua-bitness`, `ch-ua-model`, `device-memory`, `dpr`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/fingerprint/clienthints_test.go`:
+
+```go
+package fingerprint_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+func TestClientHintsCollector(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Sec-CH-UA", `"Chromium";v="126", "Not.A/Brand";v="24"`)
+	r.Header.Set("Sec-CH-UA-Platform", `"Windows"`)
+	r.Header.Set("Sec-CH-UA-Mobile", "?0")
+	r.Header.Set("Device-Memory", "8")
+	// Sec-CH-UA-Arch, -Bitness, -Model, DPR absent.
+	comps, err := fingerprint.ClientHints().Collect(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, c := range comps {
+		got[c.Name] = c.Value
+	}
+	if got["ch-ua-platform"] != `"Windows"` || got["ch-ua-mobile"] != "?0" || got["device-memory"] != "8" {
+		t.Fatalf("unexpected components: %v", got)
+	}
+	if _, ok := got["ch-ua-arch"]; ok {
+		t.Fatalf("absent hint must not emit a component: %v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -race -run TestClientHintsCollector ./web/fingerprint/`
+Expected: FAIL — `undefined: fingerprint.ClientHints`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `web/fingerprint/clienthints.go`:
+
+```go
+package fingerprint
+
+import (
+	"net/http"
+	"strings"
+)
+
+// clientHintHeaders maps a User-Agent Client-Hint request header to a component
+// name. Only stable device/browser identity hints are included. Deliberately
+// excluded: Sec-CH-UA-Platform-Version and -Full-Version-List churn on every
+// browser update and their entropy is already in the "ua" component; Sec-Fetch-*
+// are per-request context (not device identity), so they feed signals raw
+// instead of being hashed as components.
+var clientHintHeaders = []headerPair{
+	{"Sec-CH-UA", "ch-ua"},
+	{"Sec-CH-UA-Platform", "ch-ua-platform"},
+	{"Sec-CH-UA-Mobile", "ch-ua-mobile"},
+	{"Sec-CH-UA-Arch", "ch-ua-arch"},
+	{"Sec-CH-UA-Bitness", "ch-ua-bitness"},
+	{"Sec-CH-UA-Model", "ch-ua-model"},
+	{"Device-Memory", "device-memory"},
+	{"DPR", "dpr"},
+}
+
+type clientHintsCollector struct{}
+
+// ClientHints returns a Collector contributing the request's stable User-Agent
+// Client Hints (Sec-CH-UA-*, Device-Memory, DPR) as components. Absent or blank
+// hints contribute nothing. Modern Chromium browsers send these; others omit
+// them, so this layer adds entropy only where available.
+func ClientHints() Collector { return clientHintsCollector{} }
+
+func (clientHintsCollector) Collect(r *http.Request) ([]Component, error) {
+	comps := make([]Component, 0, len(clientHintHeaders))
+	for _, h := range clientHintHeaders {
+		if v := strings.TrimSpace(r.Header.Get(h.header)); v != "" {
+			comps = append(comps, Component{Name: h.name, Value: v})
+		}
+	}
+	return comps, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -race -run TestClientHintsCollector ./web/fingerprint/`
+Expected: PASS.
+
+- [ ] **Step 5: Format, then commit**
+
+```bash
+just fmt ./web/fingerprint/...
+git add web/fingerprint/clienthints.go web/fingerprint/clienthints_test.go
+git commit -m "feat(fingerprint): ClientHints collector for Sec-CH-UA device hints"
+```
+
+---
+
+### Task 2: `tlsprint.RequestTLS()` collector
+
+**Files:**
+- Create: `web/fingerprint/tlsprint/request.go`
+- Test: `web/fingerprint/tlsprint/request_test.go`
+
+**Interfaces:**
+- Consumes: `fingerprint.Collector`, `fingerprint.Component`.
+- Produces: `func RequestTLS() fingerprint.Collector` — emits one component `tlsconn` = `"<version>|<cipher-hex>|<alpn>"`; nothing when `r.TLS == nil`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/fingerprint/tlsprint/request_test.go`:
+
+```go
+package tlsprint_test
+
+import (
+	"crypto/tls"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/fingerprint/tlsprint"
+)
+
+func TestRequestTLSCollect(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.TLS = &tls.ConnectionState{
+		Version:            tls.VersionTLS13,
+		CipherSuite:        tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, // 0xc02b
+		NegotiatedProtocol: "h2",
+	}
+	comps, err := tlsprint.RequestTLS().Collect(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comps) != 1 || comps[0].Name != "tlsconn" || comps[0].Value != "1.3|c02b|h2" {
+		t.Fatalf("unexpected component: %+v", comps)
+	}
+}
+
+func TestRequestTLSPlaintextEmitsNothing(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil) // r.TLS == nil
+	comps, err := tlsprint.RequestTLS().Collect(r)
+	if err != nil || comps != nil {
+		t.Fatalf("plaintext request must emit nothing: %+v, %v", comps, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -race -run TestRequestTLS ./web/fingerprint/tlsprint/`
+Expected: FAIL — `undefined: tlsprint.RequestTLS`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `web/fingerprint/tlsprint/request.go`:
+
+```go
+package tlsprint
+
+import (
+	"crypto/tls"
+	"net/http"
+	"strconv"
+
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+type requestTLSCollector struct{}
+
+// RequestTLS returns a Collector that emits a coarse "tlsconn" component —
+// "<version>|<cipher-hex>|<alpn>" (e.g. "1.3|c02b|h2") — from the request's own
+// TLS handshake (http.Request.TLS). Use it when the Go server terminates
+// crypto/tls directly, with no CDN JA header and no wrapped Listener. It is NOT
+// a JA3/JA4 hash, so it uses a distinct component name and does not feed
+// tls-ua-mismatch. A plaintext request (r.TLS == nil) contributes nothing.
+//
+// The parent fingerprint package cannot wire this into the Antifraud preset
+// (that would import this subpackage back — a cycle), so compose it yourself:
+//
+//	tlsprint.Chain(tlsprint.CloudFrontJA4(trust), tlsprint.RequestTLS())
+func RequestTLS() fingerprint.Collector { return requestTLSCollector{} }
+
+func (requestTLSCollector) Collect(r *http.Request) ([]fingerprint.Component, error) {
+	if r.TLS == nil {
+		return nil, nil
+	}
+	v := tlsVersionString(r.TLS.Version) + "|" +
+		strconv.FormatUint(uint64(r.TLS.CipherSuite), 16) + "|" +
+		r.TLS.NegotiatedProtocol
+	return []fingerprint.Component{{Name: "tlsconn", Value: v}}, nil
+}
+
+// tlsVersionString renders a TLS version constant compactly ("1.2", "1.3"),
+// falling back to a hex code for unknown values.
+func tlsVersionString(v uint16) string {
+	switch v {
+	case tls.VersionTLS13:
+		return "1.3"
+	case tls.VersionTLS12:
+		return "1.2"
+	case tls.VersionTLS11:
+		return "1.1"
+	case tls.VersionTLS10:
+		return "1.0"
+	default:
+		return "0x" + strconv.FormatUint(uint64(v), 16)
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -race -run TestRequestTLS ./web/fingerprint/tlsprint/`
+Expected: PASS.
+
+- [ ] **Step 5: Format, then commit**
+
+```bash
+just fmt ./web/fingerprint/...
+git add web/fingerprint/tlsprint/request.go web/fingerprint/tlsprint/request_test.go
+git commit -m "feat(tlsprint): RequestTLS collector for self-terminated crypto/tls"
+```
+
+---
+
+### Task 3: JS probe expansion — Go side (payload, clamp, collect, fix `hardwareConcurrency`)
+
+**Files:**
+- Modify: `web/fingerprint/jsprobe.go` (`probePayload`, `normalizeProbe`, `jsCollector.Collect`)
+- Test: `web/fingerprint/jsprobe_test.go` (add), `web/fingerprint/jsprobe_fuzz_test.go` (extend seed)
+
+**Interfaces:**
+- Consumes: existing `IngestHandler`, `IssueToken`, `JSCollector`, `normalizeProbe`, `clampStr`.
+- Produces: new components on collect — `js-hardware`, `js-screen`, `js-dpr`, `js-touch`, `js-devicememory`, `js-webgl-vendor`, `js-uadata`, `js-audio`, `js-fonts` (each emitted only when its value is non-empty / > 0).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/fingerprint/jsprobe_test.go`:
+
+```go
+func TestIngestCollectsExpandedProbe(t *testing.T) {
+	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+	fp, err := fingerprint.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "203.0.113.7:5555"
+	tok, err := fp.IssueToken(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(map[string]any{
+		"token": tok,
+		"data": map[string]any{
+			"hardwareConcurrency": 8,
+			"maxTouchPoints":      5,
+			"deviceMemory":        "8",
+			"screen":              "1920x1080x24",
+			"devicePixelRatio":    "2",
+			"webglVendor":         "Google Inc. (NVIDIA)",
+			"uadata":              "Windows|15.0.0|||64",
+			"audio":              "1a2b3c4d",
+			"fonts":               "deadbeef:17",
+		},
+	})
+	ingReq := httptest.NewRequest("POST", "/_fp/ingest", bytes.NewReader(body))
+	ingReq.RemoteAddr = "203.0.113.7:5555"
+	ingRec := httptest.NewRecorder()
+	fp.IngestHandler().ServeHTTP(ingRec, ingReq)
+	if ingRec.Code != http.StatusNoContent {
+		t.Fatalf("ingest failed: %d", ingRec.Code)
+	}
+	next := httptest.NewRequest("GET", "/", nil)
+	for _, c := range ingRec.Result().Cookies() {
+		next.AddCookie(c)
+	}
+	comps, err := fp.JSCollector().Collect(next)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, c := range comps {
+		got[c.Name] = c.Value
+	}
+	for name, want := range map[string]string{
+		"js-hardware":     "8",
+		"js-touch":        "5",
+		"js-devicememory": "8",
+		"js-screen":       "1920x1080x24",
+		"js-dpr":          "2",
+		"js-webgl-vendor": "Google Inc. (NVIDIA)",
+		"js-uadata":       "Windows|15.0.0|||64",
+		"js-audio":        "1a2b3c4d",
+		"js-fonts":        "deadbeef:17",
+	} {
+		if got[name] != want {
+			t.Fatalf("component %q = %q, want %q (all: %v)", name, got[name], want, got)
+		}
+	}
+}
+
+func TestExpandedProbeCookieFitsBudget(t *testing.T) {
+	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+	fp, err := fingerprint.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "203.0.113.7:5555"
+	tok, err := fp.IssueToken(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	big := strings.Repeat("Z", 200) // each string field over-length; clamping must bound it
+	body, _ := json.Marshal(map[string]any{
+		"token": tok,
+		"data": map[string]any{
+			"timezone": big, "platform": big, "canvas": big, "webgl": big,
+			"webglVendor": big, "uadata": big, "audio": big, "fonts": big,
+			"screen": big, "devicePixelRatio": big, "deviceMemory": big,
+			"languages":           []string{big, big, big, big, big, big, big, big, big, big},
+			"hardwareConcurrency": 64, "maxTouchPoints": 10,
+		},
+	})
+	ingReq := httptest.NewRequest("POST", "/_fp/ingest", bytes.NewReader(body))
+	ingReq.RemoteAddr = "203.0.113.7:5555"
+	ingRec := httptest.NewRecorder()
+	fp.IngestHandler().ServeHTTP(ingRec, ingReq)
+	if ingRec.Code != http.StatusNoContent {
+		t.Fatalf("ingest of max-fill payload failed: %d", ingRec.Code)
+	}
+	total := 0
+	for _, c := range ingRec.Result().Cookies() {
+		total += len(c.Value)
+	}
+	if total == 0 || total >= 4096 {
+		t.Fatalf("clamped probe cookie payload = %d bytes, want in (0,4096)", total)
+	}
+}
+```
+
+Add `"strings"` to the `jsprobe_test.go` import block if not already present (it is present per the existing file).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -race -run 'TestIngestCollectsExpandedProbe|TestExpandedProbeCookieFitsBudget' ./web/fingerprint/`
+Expected: FAIL — new components missing (`js-hardware` etc. empty).
+
+- [ ] **Step 3: Write the implementation**
+
+In `web/fingerprint/jsprobe.go`, replace the `probePayload` struct with:
+
+```go
+// probePayload is the whitelisted, clamped shape accepted from the browser.
+type probePayload struct {
+	Timezone            string   `json:"timezone"`
+	Platform            string   `json:"platform"`
+	Canvas              string   `json:"canvas"`
+	WebGL               string   `json:"webgl"`
+	WebGLVendor         string   `json:"webglVendor"`
+	UAData              string   `json:"uadata"`
+	Audio               string   `json:"audio"`
+	Fonts               string   `json:"fonts"`
+	Screen              string   `json:"screen"`
+	DevicePixelRatio    string   `json:"devicePixelRatio"`
+	DeviceMemory        string   `json:"deviceMemory"`
+	Languages           []string `json:"languages"`
+	HardwareConcurrency int      `json:"hardwareConcurrency"`
+	MaxTouchPoints      int      `json:"maxTouchPoints"`
+	WebDriver           bool     `json:"webdriver"`
+}
+```
+
+Replace `normalizeProbe` with (keeps the existing clamps, adds the new fields):
+
+```go
+func normalizeProbe(p probePayload) probePayload {
+	p.Timezone = clampStr(p.Timezone, 64)
+	p.Platform = clampStr(p.Platform, 40)
+	p.Canvas = clampStr(p.Canvas, 64)
+	p.WebGL = clampStr(p.WebGL, 64)
+	p.WebGLVendor = clampStr(p.WebGLVendor, 64)
+	p.UAData = clampStr(p.UAData, 128)
+	p.Audio = clampStr(p.Audio, 64)
+	p.Fonts = clampStr(p.Fonts, 64)
+	p.Screen = clampStr(p.Screen, 20)
+	p.DevicePixelRatio = clampStr(p.DevicePixelRatio, 12)
+	p.DeviceMemory = clampStr(p.DeviceMemory, 8)
+	if p.HardwareConcurrency < 0 || p.HardwareConcurrency > 1024 {
+		p.HardwareConcurrency = 0
+	}
+	if p.MaxTouchPoints < 0 || p.MaxTouchPoints > 256 {
+		p.MaxTouchPoints = 0
+	}
+	if len(p.Languages) > 10 {
+		p.Languages = p.Languages[:10]
+	}
+	for i := range p.Languages {
+		p.Languages[i] = clampStr(p.Languages[i], 20)
+	}
+	return p
+}
+```
+
+Replace the component-assembly block in `jsCollector.Collect` (the `comps := []Component{...}` through the final `return comps, nil`) with:
+
+```go
+	comps := []Component{
+		{Name: "js-webdriver", Value: strconv.FormatBool(p.WebDriver)},
+	}
+	if p.Timezone != "" {
+		comps = append(comps, Component{Name: "js-timezone", Value: p.Timezone})
+	}
+	if len(p.Languages) > 0 {
+		comps = append(comps, Component{Name: "js-languages", Value: strings.Join(p.Languages, ",")})
+	}
+	if p.Platform != "" {
+		comps = append(comps, Component{Name: "js-platform", Value: p.Platform})
+	}
+	if p.Canvas != "" {
+		comps = append(comps, Component{Name: "js-canvas", Value: p.Canvas})
+	}
+	if p.WebGL != "" {
+		comps = append(comps, Component{Name: "js-webgl", Value: p.WebGL})
+	}
+	if p.WebGLVendor != "" {
+		comps = append(comps, Component{Name: "js-webgl-vendor", Value: p.WebGLVendor})
+	}
+	if p.UAData != "" {
+		comps = append(comps, Component{Name: "js-uadata", Value: p.UAData})
+	}
+	if p.Audio != "" {
+		comps = append(comps, Component{Name: "js-audio", Value: p.Audio})
+	}
+	if p.Fonts != "" {
+		comps = append(comps, Component{Name: "js-fonts", Value: p.Fonts})
+	}
+	if p.Screen != "" {
+		comps = append(comps, Component{Name: "js-screen", Value: p.Screen})
+	}
+	if p.DevicePixelRatio != "" {
+		comps = append(comps, Component{Name: "js-dpr", Value: p.DevicePixelRatio})
+	}
+	if p.DeviceMemory != "" {
+		comps = append(comps, Component{Name: "js-devicememory", Value: p.DeviceMemory})
+	}
+	if p.HardwareConcurrency > 0 {
+		comps = append(comps, Component{Name: "js-hardware", Value: strconv.Itoa(p.HardwareConcurrency)})
+	}
+	if p.MaxTouchPoints > 0 {
+		comps = append(comps, Component{Name: "js-touch", Value: strconv.Itoa(p.MaxTouchPoints)})
+	}
+	return comps, nil
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -race -run 'TestIngestCollectsExpandedProbe|TestExpandedProbeCookieFitsBudget|TestIngestThenCollect' ./web/fingerprint/`
+Expected: PASS (including the pre-existing `TestIngestThenCollect`).
+
+- [ ] **Step 5: Extend the fuzz seed corpus**
+
+In `web/fingerprint/jsprobe_fuzz_test.go`, add a second seed inside `FuzzIngest` right after the existing `f.Add(...)` line:
+
+```go
+	f.Add([]byte(`{"token":"x.y","data":{"screen":"9999x9999x99","uadata":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","fonts":"x","audio":"y","hardwareConcurrency":-5,"maxTouchPoints":99999,"deviceMemory":"0.5"}}`))
+```
+
+- [ ] **Step 6: Run the fuzzer briefly to confirm no panic**
+
+Run: `go test -race -run FuzzIngest ./web/fingerprint/` (replays the seed corpus)
+Expected: PASS (no panic on the oversized/negative fields).
+
+- [ ] **Step 7: Format, then commit**
+
+```bash
+just fmt ./web/fingerprint/...
+git add web/fingerprint/jsprobe.go web/fingerprint/jsprobe_test.go web/fingerprint/jsprobe_fuzz_test.go
+git commit -m "feat(fingerprint): expand JS probe payload (device entropy) + fix dropped hardwareConcurrency"
+```
+
+---
+
+### Task 4: JS probe expansion — `probe.js` (browser collection + async send)
+
+**Files:**
+- Modify: `web/fingerprint/assets/probe.js` (full rewrite)
+- Test: `web/fingerprint/jsprobe_test.go` (add a served-content assertion)
+
+**Interfaces:**
+- Consumes: `window.__fp = {token, url, canvas, webgl, audio, fonts}` set by the page.
+- Produces: a POST body `{token, data}` where `data` carries the fields Task 3 decodes. New `window.__fp` gates: `audio`, `fonts` (mirroring the existing `canvas`, `webgl` gates).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/fingerprint/jsprobe_test.go`:
+
+```go
+func TestScriptHandlerServesExpandedProbe(t *testing.T) {
+	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+	fp, err := fingerprint.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	fp.ScriptHandler().ServeHTTP(rec, httptest.NewRequest("GET", "/_fp/probe.js", nil))
+	body := rec.Body.String()
+	for _, marker := range []string{"getHighEntropyValues", "OfflineAudioContext", "detectFonts", "webglVendor", "maxTouchPoints"} {
+		if !strings.Contains(body, marker) {
+			t.Fatalf("probe.js missing %q", marker)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -race -run TestScriptHandlerServesExpandedProbe ./web/fingerprint/`
+Expected: FAIL — markers absent from the current probe.js.
+
+- [ ] **Step 3: Rewrite `web/fingerprint/assets/probe.js`**
+
+Replace the entire file with:
+
+```js
+// forge web/fingerprint browser probe. Reads window.__fp = {token, url, canvas,
+// webgl, audio, fonts} set by the page, collects a device signal payload, and
+// POSTs it once after any async collectors resolve.
+(function () {
+  var cfg = window.__fp || {};
+  if (!cfg.token || !cfg.url) return;
+  var s = window.screen || {};
+  var d = {
+    timezone: (Intl.DateTimeFormat().resolvedOptions().timeZone) || "",
+    languages: (navigator.languages || []).slice(0, 10),
+    platform: navigator.platform || "",
+    hardwareConcurrency: navigator.hardwareConcurrency || 0,
+    maxTouchPoints: navigator.maxTouchPoints || 0,
+    deviceMemory: navigator.deviceMemory ? String(navigator.deviceMemory) : "",
+    screen: (s.width || 0) + "x" + (s.height || 0) + "x" + (s.colorDepth || 0),
+    devicePixelRatio: window.devicePixelRatio ? String(window.devicePixelRatio) : "",
+    webdriver: navigator.webdriver === true
+  };
+  if (cfg.canvas) {
+    try {
+      var c = document.createElement("canvas");
+      var g = c.getContext("2d");
+      g.textBaseline = "top";
+      g.font = "14px 'Arial'";
+      g.fillText("forge-fp", 2, 2);
+      d.canvas = c.toDataURL().slice(-64);
+    } catch (e) {}
+  }
+  if (cfg.webgl) {
+    try {
+      var gl = document.createElement("canvas").getContext("webgl");
+      var ext = gl.getExtension("WEBGL_debug_renderer_info");
+      if (ext) {
+        d.webgl = String(gl.getParameter(ext.UNMASKED_RENDERER_WEBGL)).slice(0, 64);
+        d.webglVendor = String(gl.getParameter(ext.UNMASKED_VENDOR_WEBGL)).slice(0, 64);
+      }
+    } catch (e) {}
+  }
+  if (cfg.fonts) {
+    try { d.fonts = detectFonts(); } catch (e) {}
+  }
+
+  var tasks = [];
+  if (cfg.audio) {
+    tasks.push(audioHash().then(function (h) { d.audio = h; }).catch(function () {}));
+  }
+  if (navigator.userAgentData && navigator.userAgentData.getHighEntropyValues) {
+    tasks.push(navigator.userAgentData
+      .getHighEntropyValues(["platform", "platformVersion", "model", "architecture", "bitness"])
+      .then(function (h) {
+        d.uadata = [h.platform, h.platformVersion, h.model, h.architecture, h.bitness].join("|").slice(0, 128);
+      }).catch(function () {}));
+  }
+
+  function send() {
+    try {
+      fetch(cfg.url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: cfg.token, data: d }),
+        keepalive: true
+      });
+    } catch (e) {}
+  }
+
+  // hash32 is a tiny FNV-1a string hash rendered as 8 hex chars. NOT
+  // cryptographic — only a compact, stable identifier for a collected value.
+  function hash32(str) {
+    var h = 0x811c9dc5;
+    for (var i = 0; i < str.length; i++) {
+      h ^= str.charCodeAt(i);
+      h = (h * 0x01000193) >>> 0;
+    }
+    return ("0000000" + h.toString(16)).slice(-8);
+  }
+
+  // detectFonts returns "hash:count" where the hash encodes which probe fonts
+  // are installed, detected via measureText width/height deltas against generic
+  // baseline families. Never returns the raw font list.
+  function detectFonts() {
+    var probes = ["Arial", "Helvetica", "Times New Roman", "Courier New", "Georgia",
+      "Verdana", "Tahoma", "Trebuchet MS", "Impact", "Comic Sans MS", "Segoe UI",
+      "Roboto", "Ubuntu", "Cantarell", "Menlo", "Monaco", "Consolas", "Calibri",
+      "Cambria", "Garamond", "Palatino", "Franklin Gothic", "Century Gothic",
+      "Lucida Console", "MS Gothic", "Meiryo", "SimSun", "Noto Sans", "Open Sans",
+      "Liberation Sans", "DejaVu Sans", "Droid Sans", "PT Sans", "Source Sans Pro",
+      "Fira Sans", "Inter", "Helvetica Neue", "Andale Mono", "Courier", "Roboto Mono"];
+    var baseFonts = ["monospace", "sans-serif", "serif"];
+    var span = document.createElement("span");
+    span.style.position = "absolute";
+    span.style.left = "-9999px";
+    span.style.fontSize = "72px";
+    span.textContent = "mmmmmmmmmmlli";
+    document.body.appendChild(span);
+    var base = {};
+    for (var i = 0; i < baseFonts.length; i++) {
+      span.style.fontFamily = baseFonts[i];
+      base[baseFonts[i]] = { w: span.offsetWidth, h: span.offsetHeight };
+    }
+    var bits = "", count = 0;
+    for (var j = 0; j < probes.length; j++) {
+      var found = false;
+      for (var k = 0; k < baseFonts.length; k++) {
+        span.style.fontFamily = "'" + probes[j] + "'," + baseFonts[k];
+        if (span.offsetWidth !== base[baseFonts[k]].w || span.offsetHeight !== base[baseFonts[k]].h) {
+          found = true;
+          break;
+        }
+      }
+      bits += found ? "1" : "0";
+      if (found) count++;
+    }
+    document.body.removeChild(span);
+    return hash32(bits) + ":" + count;
+  }
+
+  // audioHash renders a short OfflineAudioContext buffer and hashes the summed
+  // output magnitude — a stable per-device/-browser value.
+  function audioHash() {
+    var AC = window.OfflineAudioContext || window.webkitOfflineAudioContext;
+    if (!AC) return Promise.reject();
+    var ctx = new AC(1, 5000, 44100);
+    var osc = ctx.createOscillator();
+    osc.type = "triangle";
+    osc.frequency.value = 10000;
+    var comp = ctx.createDynamicsCompressor();
+    osc.connect(comp);
+    comp.connect(ctx.destination);
+    osc.start(0);
+    return ctx.startRendering().then(function (buf) {
+      var data = buf.getChannelData(0);
+      var acc = 0;
+      for (var i = 0; i < data.length; i++) acc += Math.abs(data[i]);
+      return hash32(acc.toString());
+    });
+  }
+
+  if (tasks.length) {
+    // Send after async collectors resolve, but never block past 800ms.
+    var timeout = new Promise(function (res) { setTimeout(res, 800); });
+    Promise.race([Promise.all(tasks), timeout]).then(send);
+  } else {
+    send();
+  }
+})();
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -race -run 'TestScriptHandlerServesExpandedProbe|TestScriptHandlerServesJS' ./web/fingerprint/`
+Expected: PASS (the SRI/`window.__fp` assertion in the pre-existing test still holds; the embedded bytes changed but its ETag is recomputed from them).
+
+- [ ] **Step 5: Commit** (no Go formatting needed — only an asset + a test file already covered by Step 4)
+
+```bash
+git add web/fingerprint/assets/probe.js web/fingerprint/jsprobe_test.go
+git commit -m "feat(fingerprint): probe.js collects screen/audio/fonts/uadata, async send"
+```
+
+---
+
+### Task 5: `ch-ua-mismatch` signal
+
+**Files:**
+- Modify: `web/fingerprint/signals_component.go` (add call in `componentSignals`, add `chUAMismatch` + two helpers)
+- Test: `web/fingerprint/signals_component_test.go`
+
+**Interfaces:**
+- Consumes: components `ch-ua-platform` (Task 1) and `js-platform` (Task 3).
+- Produces: signal `ch-ua-mismatch`, emitted only when both components are present and both normalize to a known OS.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/fingerprint/signals_component_test.go`:
+
+```go
+func TestCHUAMismatchSignal(t *testing.T) {
+	newFP := func(chPlatform, jsPlatform string) (*fingerprint.Fingerprinter, *http.Request) {
+		cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+		fp, err := fingerprint.New(cfg, fingerprint.WithCollectors(
+			fingerprint.CollectorFunc(func(_ *http.Request) ([]fingerprint.Component, error) {
+				return []fingerprint.Component{
+					{Name: "ch-ua-platform", Value: chPlatform},
+					{Name: "js-platform", Value: jsPlatform},
+				}, nil
+			}),
+		))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return fp, httptest.NewRequest("GET", "/", nil)
+	}
+
+	// Contradiction: CH says Windows, JS says a Mac.
+	fp, r := newFP(`"Windows"`, "MacIntel")
+	f, _ := fp.FromRequest(r)
+	if s, ok := signalByName(fp.Signals(r, f), "ch-ua-mismatch"); !ok || !s.Value {
+		t.Fatalf("expected ch-ua-mismatch=true: %+v", fp.Signals(r, f))
+	}
+
+	// Agreement: CH Windows, JS Win32.
+	fp, r = newFP(`"Windows"`, "Win32")
+	f, _ = fp.FromRequest(r)
+	if s, ok := signalByName(fp.Signals(r, f), "ch-ua-mismatch"); !ok || s.Value {
+		t.Fatalf("expected ch-ua-mismatch=false: %+v", fp.Signals(r, f))
+	}
+
+	// Ambiguous JS platform (Android/desktop Linux share "Linux armv8l") → not emitted.
+	fp, r = newFP(`"Android"`, "Linux armv8l")
+	f, _ = fp.FromRequest(r)
+	if _, ok := signalByName(fp.Signals(r, f), "ch-ua-mismatch"); ok {
+		t.Fatal("ch-ua-mismatch must not emit on an ambiguous js-platform")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -race -run TestCHUAMismatchSignal ./web/fingerprint/`
+Expected: FAIL — signal never emitted.
+
+- [ ] **Step 3: Write the implementation**
+
+In `web/fingerprint/signals_component.go`, add to `componentSignals` (after the `langMismatch` block, before `geoTZMismatch`):
+
+```go
+	if s, ok := chUAMismatch(comp); ok {
+		out = append(out, s)
+	}
+```
+
+Then add these functions to the same file:
+
+```go
+// chUAMismatch compares the Client-Hint platform (ch-ua-platform, e.g. "Windows")
+// against navigator.platform (js-platform, e.g. "Win32") through a coarse OS
+// normalization; disagreement is a spoofing tell. It fires only when both
+// normalize to a known, differing OS. Ambiguous values — bare "Linux arm*",
+// shared by Android and desktop Linux — yield no signal, avoiding false positives.
+func chUAMismatch(comp map[string]string) (Signal, bool) {
+	chPlat, hasCH := comp["ch-ua-platform"]
+	jsPlat, hasJS := comp["js-platform"]
+	if !hasCH || !hasJS {
+		return Signal{}, false
+	}
+	chOS := osFromClientHint(chPlat)
+	jsOS := osFromJSPlatform(jsPlat)
+	if chOS == "" || jsOS == "" {
+		return Signal{}, false
+	}
+	return Signal{Name: "ch-ua-mismatch", Value: chOS != jsOS, Detail: chPlat + " vs " + jsPlat}, true
+}
+
+// osFromClientHint maps a Sec-CH-UA-Platform value (a quoted token) to a coarse
+// OS key, or "" when unknown.
+func osFromClientHint(v string) string {
+	switch strings.Trim(v, `"`) {
+	case "Windows":
+		return "windows"
+	case "macOS":
+		return "macos"
+	case "iOS":
+		return "ios"
+	case "Android":
+		return "android"
+	case "Chrome OS", "Chromium OS":
+		return "chromeos"
+	case "Linux":
+		return "linux"
+	default:
+		return ""
+	}
+}
+
+// osFromJSPlatform maps a navigator.platform value to a coarse OS key, or ""
+// when unknown or ambiguous (bare "Linux arm*" is shared by Android and desktop
+// Linux, so it is treated as unknown).
+func osFromJSPlatform(v string) string {
+	switch {
+	case strings.HasPrefix(v, "Win"):
+		return "windows"
+	case strings.HasPrefix(v, "Mac"):
+		return "macos"
+	case strings.HasPrefix(v, "iPhone"), strings.HasPrefix(v, "iPad"), strings.HasPrefix(v, "iPod"):
+		return "ios"
+	case strings.HasPrefix(v, "Linux x86"), strings.HasPrefix(v, "Linux i"):
+		return "linux"
+	case strings.Contains(v, "CrOS"):
+		return "chromeos"
+	default:
+		return ""
+	}
+}
+```
+
+`strings` is already imported in this file.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -race -run TestCHUAMismatchSignal ./web/fingerprint/`
+Expected: PASS.
+
+- [ ] **Step 5: Format, then commit**
+
+```bash
+just fmt ./web/fingerprint/...
+git add web/fingerprint/signals_component.go web/fingerprint/signals_component_test.go
+git commit -m "feat(fingerprint): ch-ua-mismatch signal (Client-Hint platform vs navigator.platform)"
+```
+
+---
+
+### Task 6: `fetch-metadata-anomaly` signal
+
+**Files:**
+- Modify: `web/fingerprint/signals_component.go` (add call in `componentSignals`, add `fetchMetadataAnomaly`)
+- Test: `web/fingerprint/signals_component_test.go`
+
+**Interfaces:**
+- Consumes: raw `Sec-Fetch-Site/Mode/Dest` request headers (read from `r`, never hashed).
+- Produces: signal `fetch-metadata-anomaly`, emitted only when at least one `Sec-Fetch-*` header is present.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/fingerprint/signals_component_test.go`:
+
+```go
+func TestFetchMetadataAnomalySignal(t *testing.T) {
+	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+	fp, err := fingerprint.New(cfg, fingerprint.WithCollectors(fingerprint.Headers()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Contradiction a real browser never sends: navigate mode with empty dest.
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Sec-Fetch-Mode", "navigate")
+	r.Header.Set("Sec-Fetch-Dest", "empty")
+	f, _ := fp.FromRequest(r)
+	if s, ok := signalByName(fp.Signals(r, f), "fetch-metadata-anomaly"); !ok || !s.Value {
+		t.Fatalf("expected fetch-metadata-anomaly=true: %+v", fp.Signals(r, f))
+	}
+
+	// Normal top-level navigation.
+	r2 := httptest.NewRequest("GET", "/", nil)
+	r2.Header.Set("Sec-Fetch-Site", "none")
+	r2.Header.Set("Sec-Fetch-Mode", "navigate")
+	r2.Header.Set("Sec-Fetch-Dest", "document")
+	f2, _ := fp.FromRequest(r2)
+	if s, ok := signalByName(fp.Signals(r2, f2), "fetch-metadata-anomaly"); !ok || s.Value {
+		t.Fatalf("expected fetch-metadata-anomaly=false: %+v", fp.Signals(r2, f2))
+	}
+
+	// No Sec-Fetch-* headers at all → not emitted.
+	r3 := httptest.NewRequest("GET", "/", nil)
+	f3, _ := fp.FromRequest(r3)
+	if _, ok := signalByName(fp.Signals(r3, f3), "fetch-metadata-anomaly"); ok {
+		t.Fatal("fetch-metadata-anomaly must not emit without any Sec-Fetch-* header")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -race -run TestFetchMetadataAnomalySignal ./web/fingerprint/`
+Expected: FAIL — signal never emitted.
+
+- [ ] **Step 3: Write the implementation**
+
+In `web/fingerprint/signals_component.go`, add to `componentSignals` (after the `headerAnomaly` block):
+
+```go
+	if s, ok := fetchMetadataAnomaly(r); ok {
+		out = append(out, s)
+	}
+```
+
+Then add this function to the same file:
+
+```go
+// fetchMetadataAnomaly flags Sec-Fetch-* header combinations a conforming
+// browser never emits: a navigation with an "empty" destination, or a
+// "document" destination outside navigate mode. It reads the headers raw (they
+// are per-request context, never hashed) and emits only when at least one
+// Sec-Fetch-* header is present.
+func fetchMetadataAnomaly(r *http.Request) (Signal, bool) {
+	site := r.Header.Get("Sec-Fetch-Site")
+	mode := r.Header.Get("Sec-Fetch-Mode")
+	dest := r.Header.Get("Sec-Fetch-Dest")
+	if site == "" && mode == "" && dest == "" {
+		return Signal{}, false
+	}
+	anomaly := (mode == "navigate" && dest == "empty") ||
+		(dest == "document" && mode != "" && mode != "navigate")
+	return Signal{Name: "fetch-metadata-anomaly", Value: anomaly, Detail: "mode=" + mode + " dest=" + dest}, true
+}
+```
+
+`net/http` is already imported in this file.
+
+Then update the `componentSignals` doc comment (top of the file) so it stays honest — it currently reads "derives the component-driven signals: headless, tls-ua-mismatch, lang-mismatch, geo-tz-mismatch, and header-anomaly." Change it to list all seven: "headless, tls-ua-mismatch, lang-mismatch, ch-ua-mismatch, geo-tz-mismatch, header-anomaly, and fetch-metadata-anomaly."
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -race -run TestFetchMetadataAnomalySignal ./web/fingerprint/`
+Expected: PASS.
+
+- [ ] **Step 5: Format, then commit**
+
+```bash
+just fmt ./web/fingerprint/...
+git add web/fingerprint/signals_component.go web/fingerprint/signals_component_test.go
+git commit -m "feat(fingerprint): fetch-metadata-anomaly signal from Sec-Fetch-* headers"
+```
+
+---
+
+### Task 7: `WithAutomationJA4` — make `tls-ua-mismatch` usable
+
+**Files:**
+- Modify: `web/fingerprint/collector.go` (add `automationJA4` field to `Fingerprinter`)
+- Modify: `web/fingerprint/signals_component.go` (drop the package var; read `fp.automationJA4`)
+- Modify: `web/fingerprint/options.go` (add `WithAutomationJA4`)
+- Test: `web/fingerprint/signals_component_test.go`
+
+**Interfaces:**
+- Consumes: existing `tlsUAMismatch` inspector, `tls` + `ua` components, the UA seam.
+- Produces: `func WithAutomationJA4(m map[string]string) Option`; `tls-ua-mismatch` fires `Value:true` when the `tls` component matches a pinned key under a browser-family UA.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/fingerprint/signals_component_test.go`:
+
+```go
+func TestTLSUAMismatchFiresWithPinnedJA4(t *testing.T) {
+	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+	fp, err := fingerprint.New(cfg,
+		fingerprint.WithCollectors(
+			fingerprint.CollectorFunc(func(_ *http.Request) ([]fingerprint.Component, error) {
+				return []fingerprint.Component{
+					{Name: "tls", Value: "t13d1516h2_8daaf6152771_02713d6af862"},
+					{Name: "ua", Value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/126.0"},
+				}, nil
+			}),
+		),
+		fingerprint.WithUAFamily(func(_ string) (fingerprint.Family, bool) {
+			return fingerprint.FamilyBrowser, true
+		}),
+		fingerprint.WithAutomationJA4(map[string]string{
+			"t13d1516h2_8daaf6152771_02713d6af862": "python-requests",
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest("GET", "/", nil)
+	f, _ := fp.FromRequest(r)
+	s, ok := signalByName(fp.Signals(r, f), "tls-ua-mismatch")
+	if !ok || !s.Value || s.Detail != "python-requests" {
+		t.Fatalf("expected tls-ua-mismatch=true detail=python-requests: %+v", s)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -race -run TestTLSUAMismatchFiresWithPinnedJA4 ./web/fingerprint/`
+Expected: FAIL — `undefined: fingerprint.WithAutomationJA4`.
+
+- [ ] **Step 3: Add the field, the option, and switch the lookup**
+
+In `web/fingerprint/collector.go`, add a field to the `Fingerprinter` struct (place it among the reference-type fields; `just fmt` will realign):
+
+```go
+	automationJA4 map[string]string
+```
+
+In `web/fingerprint/signals_component.go`, delete the package-level `var automationJA4 = map[string]string{ ... }` block entirely (the whole `var` with its comment), and change the lookup in `tlsUAMismatch` from:
+
+```go
+	label, flagged := automationJA4[tls]
+```
+
+to:
+
+```go
+	label, flagged := fp.automationJA4[tls]
+```
+
+(reading a nil map is safe — it yields `"", false`, preserving the ships-empty behavior). Update the two doc comments in that file that say "until automationJA4 is populated" to "until WithAutomationJA4 is set".
+
+In `web/fingerprint/options.go`, add `"maps"` to the import block and append:
+
+```go
+// WithAutomationJA4 pins non-browser JA4 client fingerprints to labels so the
+// tls-ua-mismatch signal fires (Value:true) when the "tls" component matches a
+// pinned fingerprint under a browser-family UA. Ships empty by design — pinned
+// TLS fingerprints drift as tools update, so populate this from fingerprints you
+// capture from your own traffic (see the tlsprint.Listener / Conn.JA4() capture
+// recipe in the package doc). The map is cloned.
+func WithAutomationJA4(m map[string]string) Option {
+	return func(fp *Fingerprinter) { fp.automationJA4 = maps.Clone(m) }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass (including the pre-existing empty-map case)**
+
+Run: `go test -race -run 'TestTLSUAMismatch' ./web/fingerprint/`
+Expected: PASS — the new pinned test fires true, and the existing `TestTLSUAMismatchSignal` still gets `Value:false` (default nil map).
+
+- [ ] **Step 5: Format, then commit**
+
+```bash
+just fmt ./web/fingerprint/...
+git add web/fingerprint/collector.go web/fingerprint/signals_component.go web/fingerprint/options.go
+git commit -m "feat(fingerprint): WithAutomationJA4 option makes tls-ua-mismatch usable"
+```
+
+---
+
+### Task 8: Presets + docs
+
+**Files:**
+- Modify: `web/fingerprint/presets.go` (wire `ClientHints()` into both presets)
+- Modify: `web/fingerprint/doc.go` (expand package doc: new collectors, capture recipe, icebox)
+- Test: `web/fingerprint/presets_test.go`
+
+**Interfaces:**
+- Consumes: `ClientHints()` (Task 1).
+- Produces: `Session`/`Antifraud` now emit Client-Hint components when the request carries them.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/fingerprint/presets_test.go`:
+
+```go
+func TestSessionPresetEmitsClientHints(t *testing.T) {
+	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+	fp, err := fingerprint.Session(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("User-Agent", "Mozilla/5.0")
+	r.Header.Set("Sec-CH-UA-Platform", `"Windows"`)
+	f, _ := fp.FromRequest(r)
+	found := false
+	for _, c := range f.Components {
+		if c.Name == "ch-ua-platform" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected ch-ua-platform component from Session preset, got %+v", f.Components)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -race -run TestSessionPresetEmitsClientHints ./web/fingerprint/`
+Expected: FAIL — no `ch-ua-platform` component (preset doesn't wire `ClientHints()` yet).
+
+- [ ] **Step 3: Wire the presets**
+
+In `web/fingerprint/presets.go`, change `Session`'s base to:
+
+```go
+	base := []Option{WithCollectors(Headers(), ClientHints())}
+```
+
+and `Antifraud`'s `cols` to:
+
+```go
+	cols := []Collector{Headers(), ClientIP(), ClientHints()}
+```
+
+Update `Session`'s doc comment to note it now also collects Client Hints, and `Antifraud`'s doc comment to add: "Client Hints are included; compose `tlsprint.RequestTLS()` into the `tls` argument yourself for self-terminated TLS (this package cannot import `tlsprint`)."
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `go test -race -run 'TestSessionPreset|TestAntifraudPreset' ./web/fingerprint/`
+Expected: PASS (new test + both pre-existing preset tests).
+
+- [ ] **Step 5: Expand `web/fingerprint/doc.go`**
+
+Replace the package comment in `web/fingerprint/doc.go` with:
+
+```go
+// Package fingerprint turns an HTTP request into a versioned identity plus
+// structured anti-fraud signals, from headers alone up to a full TLS + JS device
+// probe. Layers are opt-in Collectors; heavy lookups (geoip, useragent) enter
+// through wired function seams so the core stays stdlib-light. Output is facts,
+// never a score — weighting signals into a decision is the consumer's policy.
+//
+// Collectors: Headers (UA + Accept*), ClientHints (Sec-CH-UA-* + Device-Memory
+// + DPR), ClientIP, and the JS probe (JSCollector, served by ScriptHandler and
+// fed by IngestHandler). TLS fingerprints come from the tlsprint subpackage:
+// trusted-proxy header sources (Cloudflare/CloudFront/generic), a local
+// raw-ClientHello JA4 computation, and RequestTLS for self-terminated crypto/tls.
+//
+// Making tls-ua-mismatch fire: it stays inert until WithAutomationJA4 pins the
+// JA4 fingerprints of non-browser clients you observe. Pinned TLS fingerprints
+// drift as tools update, so harvest them from your own traffic rather than
+// shipping a static list — wrap your listener with tlsprint.Listener, read
+// tlsprint.Conn.JA4() per connection (via ConnContext), record the fingerprints
+// arriving under automation User-Agents, and pass that map to WithAutomationJA4.
+//
+// Out of scope: JA4H (the HTTP-layer fingerprint) and the HTTP/2 SETTINGS
+// fingerprint both need raw header/frame order, which net/http discards and
+// HTTP/2 normalizes — they cannot be computed faithfully from a handler.
+package fingerprint
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+just fmt ./web/fingerprint/...
+git add web/fingerprint/presets.go web/fingerprint/doc.go web/fingerprint/presets_test.go
+git commit -m "feat(fingerprint): wire ClientHints into presets; document collectors, capture recipe, icebox"
+```
+
+---
+
+### Task 9: Full verification
+
+- [ ] **Step 1: Run the full package test suite with race + coverage**
+
+Run: `just test ./web/fingerprint/...`
+Expected: PASS, no data races. Includes the tlsprint subpackage and the fuzz seed corpora.
+
+- [ ] **Step 2: Run the full linter**
+
+Run: `just lint`
+Expected: clean — no vet, golangci-lint, nilaway, betteralign, or modernize findings. If betteralign reports the `Fingerprinter` struct, it was already auto-applied by `just fmt`; re-run `just fmt ./web/fingerprint/...` and re-lint.
+
+- [ ] **Step 3: Confirm godoc examples still build**
+
+Run: `go test -race -run Example ./web/fingerprint/`
+Expected: PASS (`ExampleAntifraud` output unchanged — it only checks `bot-ua`).
+
+- [ ] **Step 4: Final nothing-to-commit check**
+
+Run: `git status --short`
+Expected: clean working tree (all task commits landed).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Unit 1 ClientHints → Task 1 ✓
+- Unit 2 RequestTLS → Task 2 ✓
+- Unit 3 JS probe (hardwareConcurrency fix + entropy fields, cookie guard, fuzz) → Tasks 3 (Go) + 4 (probe.js) ✓
+- Unit 4 signals (ch-ua-mismatch, fetch-metadata-anomaly) → Tasks 5 + 6 ✓
+- Unit 5 WithAutomationJA4 + capture recipe → Task 7 (option) + Task 8 (recipe in doc.go) ✓
+- Unit 6 presets + docs → Task 8 ✓
+- Icebox (JA4H, h2 SETTINGS) → documented in doc.go (Task 8) ✓
+- Cross-cutting hash-change note → covered by doc.go prose + no Version gate (spec-consistent) ✓
+
+**Type consistency:**
+- `Component{Name, Value}`, `Signal{Name, Detail, Value}`, `Collector`, `Option` — all match existing signatures.
+- `probePayload` JSON tags (`webglVendor`, `uadata`, `deviceMemory`, …) match the keys the Task-3 test and Task-4 `probe.js` send.
+- `fp.automationJA4` field (Task 7) read in `signals_component.go`, written by `WithAutomationJA4` — names consistent.
+- Component names emitted by `ClientHints()` (`ch-ua-platform`) match the name read by `chUAMismatch` (Task 5) and asserted in Task 8's preset test.
+
+**Placeholder scan:** none — every step carries full code and exact commands.

--- a/docs/superpowers/specs/2026-07-13-fingerprint-collectors-completion-design.md
+++ b/docs/superpowers/specs/2026-07-13-fingerprint-collectors-completion-design.md
@@ -97,11 +97,10 @@ field is whitelisted and clamped in `normalizeProbe`, exactly like the existing
 | `hardwareConcurrency` | `js-hardware` | **already collected, currently dropped — the bug fix** ([jsprobe.go:28](web/fingerprint/jsprobe.go:28)) |
 | `screen` (`"WxHxdepth"`) | `js-screen` | clamp 20 |
 | `devicePixelRatio` | `js-dpr` | clamp 12 |
-| `maxTouchPoints` | `js-touch` | int, clamp range 0–256 |
-| `deviceMemory` | `js-devicememory` | clamp 8 |
+| `maxTouchPoints` | `js-touch` | int, clamp range 0–256; emit only when > 0 |
+| `deviceMemory` | `js-devicememory` | **string** (values are floats: 0.25/0.5/1/2/4/8); clamp 8 |
 | WebGL **vendor** | `js-webgl-vendor` | today only renderer is captured; clamp 64 |
-| `navigator.userAgentData` high-entropy | `js-uadata` | `getHighEntropyValues(['platform','model','architecture','bitness'])`, joined + clamp 128 |
-| timezone **offset** (minutes) | `js-tz-offset` | int |
+| `navigator.userAgentData` high-entropy | `js-uadata` | async `getHighEntropyValues(['platform','platformVersion','model','architecture','bitness'])`, joined + clamp 128 |
 | **AudioContext** hash | `js-audio` | one short hash of an `OfflineAudioContext` render; clamp 64 |
 | **font** detection hash | `js-fonts` | hash of the detected subset of a fixed ~40-font probe list, via `measureText` width deltas; clamp 64 — **never the raw list** |
 
@@ -150,8 +149,12 @@ permanently inert. Changes:
 ### Unit 6 — Presets + docs
 
 - `Session()` → append `ClientHints()` (stays pure-stdlib, passive).
-- `Antifraud()` → append `ClientHints()`; fold `tlsprint.RequestTLS()` into its
-  TLS `Chain(...)` as the self-terminated fallback after the CDN/Local sources.
+- `Antifraud()` → append `ClientHints()`. **`RequestTLS()` is NOT folded in by
+  the preset**: `RequestTLS` lives in `tlsprint`, which imports the parent
+  `fingerprint` package, so `fingerprint`'s `Antifraud` cannot reference it
+  (import cycle). Consumers compose it into the `tls Collector` argument they
+  already pass — e.g. `tlsprint.Chain(tlsprint.CloudFrontJA4(t), tlsprint.RequestTLS())`
+  — documented on `RequestTLS` and in the `Antifraud` doc comment.
 - Refresh `doc.go`: new collectors, the `WithAutomationJA4` capture recipe, the
   icebox note, and the component-name table.
 

--- a/docs/superpowers/specs/2026-07-13-fingerprint-collectors-completion-design.md
+++ b/docs/superpowers/specs/2026-07-13-fingerprint-collectors-completion-design.md
@@ -1,0 +1,200 @@
+# web/fingerprint — collector & signal completeness bundle — design
+
+Date: 2026-07-13
+Status: approved for planning
+
+## Purpose
+
+Close the coverage gaps in the shipped `web/fingerprint` package (PR #44). The
+package's `Collector`/`Component`/`Signal` seams are in place; this bundle fills
+in the fingerprinting surfaces they don't yet reach — modern Client Hints, a
+self-terminated-TLS collector, a deeper JS device probe, the derived cross-layer
+signals those unlock, and making the inert `tls-ua-mismatch` signal usable.
+
+Scope decided during brainstorming: **everything (option D)** across the four
+gap groups, packaged as **one PR** because it all lives in one package
+(`web/fingerprint` + its `tlsprint` subpackage) and shares one idiom. Output
+stays **identity + facts, never a score** — unchanged from the parent design.
+
+Nothing here is a breaking API change: every new collector is opt-in, and the
+only behavior shift for existing consumers is that the `Session`/`Antifraud`
+presets emit additional components (see §Cross-cutting: hash-change note).
+
+## Non-goals / icebox (documented in `doc.go`)
+
+- **JA4H** (HTTP-layer JA4+). Its discriminating part `JA4H_b` hashes request
+  headers in send-order; Go's net/http stores headers in a `map`, so order is
+  gone before a handler runs, and HTTP/2 normalizes it at the protocol layer.
+  A faithful JA4H would need raw-byte header capture and would only work on the
+  minority h1 path. Skipped; documented.
+- **HTTP/2 SETTINGS / Akamai h2 fingerprint.** Same root cause — needs
+  protocol-frame access net/http doesn't expose. Skipped; documented.
+- **Persistent device-cookie ID.** That's `auth/session`'s concern, not this
+  package's.
+- **Font/audio raw enumeration exposure.** The probe emits *hashes* of these,
+  never the raw lists (see Unit 3).
+
+## Units
+
+### Unit 1 — `ClientHints()` collector (new file `clienthints.go`)
+
+Table-driven, exactly like `Headers()` in `headers.go`. Emits **stable
+device/browser identity** components only. Absent or blank headers contribute
+nothing.
+
+| Request header | Component name |
+|---|---|
+| `Sec-CH-UA` | `ch-ua` |
+| `Sec-CH-UA-Platform` | `ch-ua-platform` |
+| `Sec-CH-UA-Mobile` | `ch-ua-mobile` |
+| `Sec-CH-UA-Arch` | `ch-ua-arch` |
+| `Sec-CH-UA-Bitness` | `ch-ua-bitness` |
+| `Sec-CH-UA-Model` | `ch-ua-model` |
+| `Device-Memory` | `device-memory` |
+| `DPR` | `dpr` |
+
+**Deliberately excluded:**
+
+- `Sec-CH-UA-Platform-Version`, `Sec-CH-UA-Full-Version-List` — churn on every
+  browser/OS auto-update; their version entropy is already carried by the `ua`
+  component. Dropping them keeps `Drift` quiet.
+- `Sec-Fetch-*` — per-request-context, not per-device (a navigation vs. an XHR
+  sends different values), so hashing them would flip the same device's
+  fingerprint between requests. They are **signal-only inputs** — see Unit 4.
+
+Values are trimmed like `Headers()` does; no parsing (raw stable strings are
+what the hash wants). Length is naturally bounded by header size; no extra clamp
+needed.
+
+### Unit 2 — `tlsprint.RequestTLS()` collector
+
+For the middle-ground deployment: the Go server terminates `crypto/tls` itself,
+with no CDN JA header and no wrapped `tlsprint.Listener`. Reads
+`r.TLS *tls.ConnectionState`; when non-nil, emits a single component:
+
+- Name: **`tlsconn`** (distinct from `tls` on purpose)
+- Value: `"<version>|<cipher-hex>|<alpn>"`, e.g. `1.3|c02b|h2`
+  - version: `"1.2"`/`"1.3"` from `ConnectionState.Version`
+  - cipher: 4-hex-digit `ConnectionState.CipherSuite`
+  - alpn: `ConnectionState.NegotiatedProtocol` (may be empty)
+
+Rationale for the distinct name: `RequestTLS` produces coarse handshake params,
+**not** a JA3/JA4 hash, so it must not land under `tls` where
+`tlsUAMismatch` looks values up in `automationJA4` (it never would match, and
+mixing a JA hash and a params string under one name would corrupt `Drift` for a
+deployment that sometimes has CDN JA4 and sometimes only `r.TLS`). `tlsconn`
+is a low-entropy but zero-dependency identity contributor and a gross-anomaly
+tell (e.g. a "Chrome" UA over TLS 1.0). `r.TLS == nil` → contributes nothing.
+
+### Unit 3 — JS probe expansion (`assets/probe.js` + `jsprobe.go`)
+
+Fix the dead field, then add device entropy (audio + fonts approved). Every new
+field is whitelisted and clamped in `normalizeProbe`, exactly like the existing
+`canvas`/`webgl` fields. New `probePayload` fields → components:
+
+| Payload field | Component | Notes |
+|---|---|---|
+| `hardwareConcurrency` | `js-hardware` | **already collected, currently dropped — the bug fix** ([jsprobe.go:28](web/fingerprint/jsprobe.go:28)) |
+| `screen` (`"WxHxdepth"`) | `js-screen` | clamp 20 |
+| `devicePixelRatio` | `js-dpr` | clamp 12 |
+| `maxTouchPoints` | `js-touch` | int, clamp range 0–256 |
+| `deviceMemory` | `js-devicememory` | clamp 8 |
+| WebGL **vendor** | `js-webgl-vendor` | today only renderer is captured; clamp 64 |
+| `navigator.userAgentData` high-entropy | `js-uadata` | `getHighEntropyValues(['platform','model','architecture','bitness'])`, joined + clamp 128 |
+| timezone **offset** (minutes) | `js-tz-offset` | int |
+| **AudioContext** hash | `js-audio` | one short hash of an `OfflineAudioContext` render; clamp 64 |
+| **font** detection hash | `js-fonts` | hash of the detected subset of a fixed ~40-font probe list, via `measureText` width deltas; clamp 64 — **never the raw list** |
+
+**Payload-size guard (must-have test):** with `WithStore` unset, the whole
+payload is base64'd into a signed cookie (~4 KB browser ceiling — see
+`readProbe`/`IngestHandler` cookie path). Emitting `js-fonts`/`js-audio` as
+fixed-length hashes and clamping every string keeps the cookie path viable. Add
+a test that a maximally-filled normalized payload's cookie stays under budget.
+`IngestHandler`'s 16 KB `MaxBytesReader` is unaffected.
+
+`getHighEntropyValues` is async (returns a Promise); `probe.js` must await it
+before POSTing (restructure the single fire-and-forget POST to run after the
+promise resolves, keeping the existing `try/catch` + `keepalive` shape).
+
+### Unit 4 — New signals (`signals_component.go`)
+
+- **`ch-ua-mismatch`** — compares `ch-ua-platform` (`"Windows"`/`"macOS"`/…)
+  against `js-platform` (`navigator.platform`: `"Win32"`/`"MacIntel"`/…) through
+  a small internal normalization map; disagreement is a spoofing tell. Emits
+  only when **both** components are present (no UA-string OS parsing — the
+  package extracts no OS from the UA today, and this signal introduces none).
+  `Value` is the mismatch boolean.
+- **`fetch-metadata-anomaly`** — reads `Sec-Fetch-*` **raw** from the request
+  (like `headerAnomaly` already reads `Sec-Fetch-Site`): a top-level document
+  navigation (`Sec-Fetch-Dest: document`, `Sec-Fetch-Mode: navigate`) that is
+  missing `Sec-Fetch-User`, or self-contradictory combinations, is the tell.
+  Emits only when at least one `Sec-Fetch-*` header is present.
+
+Dropped as low-value / redundant: `hardware-anomaly` (weak) and
+`tz-offset-mismatch` (overlaps the existing `geo-tz-mismatch`). Existing signals
+are unchanged.
+
+### Unit 5 — `automationJA4` made usable
+
+Today `automationJA4` is an empty package-level `var`, so `tls-ua-mismatch` is
+permanently inert. Changes:
+
+- Move the map onto the `Fingerprinter` struct (`fp.automationJA4`).
+- Add option **`WithAutomationJA4(map[string]string)`** (in `options.go`);
+  `tlsUAMismatch` reads `fp.automationJA4`.
+- Ship **empty** — no stale/drift-prone data pinned.
+- Add a tested **capture recipe** in `doc.go`: how to harvest real JA4s from
+  live traffic via the existing `tlsprint.Listener` (`Conn.JA4()`) into the map,
+  so a consumer populates the signal from their own traffic.
+
+### Unit 6 — Presets + docs
+
+- `Session()` → append `ClientHints()` (stays pure-stdlib, passive).
+- `Antifraud()` → append `ClientHints()`; fold `tlsprint.RequestTLS()` into its
+  TLS `Chain(...)` as the self-terminated fallback after the CDN/Local sources.
+- Refresh `doc.go`: new collectors, the `WithAutomationJA4` capture recipe, the
+  icebox note, and the component-name table.
+
+## Cross-cutting rules
+
+- **Hash-change note.** Wiring `ClientHints()` into the presets changes the
+  combined `Fingerprint.Hash` for existing deployments. Because `Drift` compares
+  per-component `Parts`, the new component names surface as "changed" exactly
+  once on the first post-upgrade comparison, then stabilize. This is a one-time
+  churn, documented in `doc.go`; it is **not** gated behind a `Version` bump
+  (the consumer owns `Config.Version`).
+- **Idiom fidelity.** New collectors follow `headers.go`/`clientip.go`: a small
+  struct implementing `Collect`, a constructor returning `Collector`,
+  best-effort (never abort the chain), absent input → nothing emitted.
+- **Component naming.** Passive HTTP → bare/prefixed header name (`ch-ua-*`);
+  connection TLS → `tlsconn`; JS-probe → `js-*`. Consistent with existing
+  `ua`/`ip`/`tls`/`js-*`.
+
+## Testing (per `docs/design.md` §Testing)
+
+- Black-box table tests per new collector (`clienthints_test.go`,
+  `RequestTLS` in `tlsprint`) and per new signal.
+- Extend `jsprobe_fuzz_test.go` to cover the new payload fields through
+  `normalizeProbe` (clamping, negative/oversized ints, oversized strings).
+- Cookie-size test for the max-fill payload (Unit 3 guard).
+- `RequestTLS`: drive via `httptest` with a populated `tls.ConnectionState`;
+  assert `tlsconn` value formatting and the `r.TLS == nil` no-op.
+- `WithAutomationJA4`: a pinned test map makes `tls-ua-mismatch` fire
+  `Value:true` for a matching `tls` component + browser UA.
+
+## File-level change map
+
+- `web/fingerprint/clienthints.go` — **new** (Unit 1)
+- `web/fingerprint/clienthints_test.go` — **new**
+- `web/fingerprint/tlsprint/request.go` — **new** `RequestTLS()` (Unit 2)
+- `web/fingerprint/tlsprint/request_test.go` — **new**
+- `web/fingerprint/assets/probe.js` — expanded probe (Unit 3)
+- `web/fingerprint/jsprobe.go` — new payload fields, clamps, components (Unit 3)
+- `web/fingerprint/jsprobe_fuzz_test.go` — extended (Unit 3)
+- `web/fingerprint/signals_component.go` — `ch-ua-mismatch`,
+  `fetch-metadata-anomaly`, `fp.automationJA4` read (Units 4, 5)
+- `web/fingerprint/options.go` — `WithAutomationJA4` (Unit 5)
+- `web/fingerprint/collector.go` — `automationJA4` field on `Fingerprinter` (Unit 5)
+- `web/fingerprint/presets.go` — preset wiring (Unit 6)
+- `web/fingerprint/doc.go` — docs, capture recipe, icebox note (Unit 6)
+- `web/fingerprint/signals_component_test.go`, `presets_test.go` — extended

--- a/web/fingerprint/assets/probe.js
+++ b/web/fingerprint/assets/probe.js
@@ -1,13 +1,19 @@
-// forge web/fingerprint browser probe. Reads window.__fp = {token, url, canvas, webgl}
-// set by the page, collects a minimal high-signal payload, and POSTs it once.
+// forge web/fingerprint browser probe. Reads window.__fp = {token, url, canvas,
+// webgl, audio, fonts} set by the page, collects a device signal payload, and
+// POSTs it once after any async collectors resolve.
 (function () {
   var cfg = window.__fp || {};
   if (!cfg.token || !cfg.url) return;
+  var s = window.screen || {};
   var d = {
     timezone: (Intl.DateTimeFormat().resolvedOptions().timeZone) || "",
     languages: (navigator.languages || []).slice(0, 10),
     platform: navigator.platform || "",
     hardwareConcurrency: navigator.hardwareConcurrency || 0,
+    maxTouchPoints: navigator.maxTouchPoints || 0,
+    deviceMemory: navigator.deviceMemory ? String(navigator.deviceMemory) : "",
+    screen: (s.width || 0) + "x" + (s.height || 0) + "x" + (s.colorDepth || 0),
+    devicePixelRatio: window.devicePixelRatio ? String(window.devicePixelRatio) : "",
     webdriver: navigator.webdriver === true
   };
   if (cfg.canvas) {
@@ -24,15 +30,116 @@
     try {
       var gl = document.createElement("canvas").getContext("webgl");
       var ext = gl.getExtension("WEBGL_debug_renderer_info");
-      d.webgl = ext ? String(gl.getParameter(ext.UNMASKED_RENDERER_WEBGL)).slice(0, 64) : "";
+      if (ext) {
+        d.webgl = String(gl.getParameter(ext.UNMASKED_RENDERER_WEBGL)).slice(0, 64);
+        d.webglVendor = String(gl.getParameter(ext.UNMASKED_VENDOR_WEBGL)).slice(0, 64);
+      }
     } catch (e) {}
   }
-  try {
-    fetch(cfg.url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ token: cfg.token, data: d }),
-      keepalive: true
+  if (cfg.fonts) {
+    try { d.fonts = detectFonts(); } catch (e) {}
+  }
+
+  var tasks = [];
+  if (cfg.audio) {
+    tasks.push(audioHash().then(function (h) { d.audio = h; }).catch(function () {}));
+  }
+  if (navigator.userAgentData && navigator.userAgentData.getHighEntropyValues) {
+    tasks.push(navigator.userAgentData
+      .getHighEntropyValues(["platform", "platformVersion", "model", "architecture", "bitness"])
+      .then(function (h) {
+        d.uadata = [h.platform, h.platformVersion, h.model, h.architecture, h.bitness].join("|").slice(0, 128);
+      }).catch(function () {}));
+  }
+
+  function send() {
+    try {
+      fetch(cfg.url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: cfg.token, data: d }),
+        keepalive: true
+      });
+    } catch (e) {}
+  }
+
+  // hash32 is a tiny FNV-1a string hash rendered as 8 hex chars. NOT
+  // cryptographic — only a compact, stable identifier for a collected value.
+  function hash32(str) {
+    var h = 0x811c9dc5;
+    for (var i = 0; i < str.length; i++) {
+      h ^= str.charCodeAt(i);
+      h = (h * 0x01000193) >>> 0;
+    }
+    return ("0000000" + h.toString(16)).slice(-8);
+  }
+
+  // detectFonts returns "hash:count" where the hash encodes which probe fonts
+  // are installed, detected via measureText width/height deltas against generic
+  // baseline families. Never returns the raw font list.
+  function detectFonts() {
+    var probes = ["Arial", "Helvetica", "Times New Roman", "Courier New", "Georgia",
+      "Verdana", "Tahoma", "Trebuchet MS", "Impact", "Comic Sans MS", "Segoe UI",
+      "Roboto", "Ubuntu", "Cantarell", "Menlo", "Monaco", "Consolas", "Calibri",
+      "Cambria", "Garamond", "Palatino", "Franklin Gothic", "Century Gothic",
+      "Lucida Console", "MS Gothic", "Meiryo", "SimSun", "Noto Sans", "Open Sans",
+      "Liberation Sans", "DejaVu Sans", "Droid Sans", "PT Sans", "Source Sans Pro",
+      "Fira Sans", "Inter", "Helvetica Neue", "Andale Mono", "Courier", "Roboto Mono"];
+    var baseFonts = ["monospace", "sans-serif", "serif"];
+    var span = document.createElement("span");
+    span.style.position = "absolute";
+    span.style.left = "-9999px";
+    span.style.fontSize = "72px";
+    span.textContent = "mmmmmmmmmmlli";
+    document.body.appendChild(span);
+    var base = {};
+    for (var i = 0; i < baseFonts.length; i++) {
+      span.style.fontFamily = baseFonts[i];
+      base[baseFonts[i]] = { w: span.offsetWidth, h: span.offsetHeight };
+    }
+    var bits = "", count = 0;
+    for (var j = 0; j < probes.length; j++) {
+      var found = false;
+      for (var k = 0; k < baseFonts.length; k++) {
+        span.style.fontFamily = "'" + probes[j] + "'," + baseFonts[k];
+        if (span.offsetWidth !== base[baseFonts[k]].w || span.offsetHeight !== base[baseFonts[k]].h) {
+          found = true;
+          break;
+        }
+      }
+      bits += found ? "1" : "0";
+      if (found) count++;
+    }
+    document.body.removeChild(span);
+    return hash32(bits) + ":" + count;
+  }
+
+  // audioHash renders a short OfflineAudioContext buffer and hashes the summed
+  // output magnitude — a stable per-device/-browser value.
+  function audioHash() {
+    var AC = window.OfflineAudioContext || window.webkitOfflineAudioContext;
+    if (!AC) return Promise.reject();
+    var ctx = new AC(1, 5000, 44100);
+    var osc = ctx.createOscillator();
+    osc.type = "triangle";
+    osc.frequency.value = 10000;
+    var comp = ctx.createDynamicsCompressor();
+    osc.connect(comp);
+    comp.connect(ctx.destination);
+    osc.start(0);
+    return ctx.startRendering().then(function (buf) {
+      var data = buf.getChannelData(0);
+      var acc = 0;
+      for (var i = 0; i < data.length; i++) acc += Math.abs(data[i]);
+      return hash32(acc.toString());
     });
-  } catch (e) {}
+  }
+
+  if (tasks.length) {
+    // Send after async collectors resolve, but never block past 800ms.
+    var timeout = new Promise(function (res) { setTimeout(res, 800); });
+    Promise.race([Promise.all(tasks), timeout]).then(send);
+  } else {
+    send();
+  }
 })();

--- a/web/fingerprint/clienthints.go
+++ b/web/fingerprint/clienthints.go
@@ -10,7 +10,10 @@ import (
 // excluded: Sec-CH-UA-Platform-Version and -Full-Version-List churn on every
 // browser update and their entropy is already in the "ua" component; Sec-Fetch-*
 // are per-request context (not device identity), so they feed signals raw
-// instead of being hashed as components.
+// instead of being hashed as components. Note that the included "ch-ua" value
+// itself carries the browser's major version (e.g. `"Chromium";v="126"`), so it
+// will churn alongside "ua" on major browser updates too — a conscious
+// trade-off kept for the brand-list entropy it provides.
 var clientHintHeaders = []headerPair{
 	{"Sec-CH-UA", "ch-ua"},
 	{"Sec-CH-UA-Platform", "ch-ua-platform"},

--- a/web/fingerprint/clienthints.go
+++ b/web/fingerprint/clienthints.go
@@ -1,0 +1,41 @@
+package fingerprint
+
+import (
+	"net/http"
+	"strings"
+)
+
+// clientHintHeaders maps a User-Agent Client-Hint request header to a component
+// name. Only stable device/browser identity hints are included. Deliberately
+// excluded: Sec-CH-UA-Platform-Version and -Full-Version-List churn on every
+// browser update and their entropy is already in the "ua" component; Sec-Fetch-*
+// are per-request context (not device identity), so they feed signals raw
+// instead of being hashed as components.
+var clientHintHeaders = []headerPair{
+	{"Sec-CH-UA", "ch-ua"},
+	{"Sec-CH-UA-Platform", "ch-ua-platform"},
+	{"Sec-CH-UA-Mobile", "ch-ua-mobile"},
+	{"Sec-CH-UA-Arch", "ch-ua-arch"},
+	{"Sec-CH-UA-Bitness", "ch-ua-bitness"},
+	{"Sec-CH-UA-Model", "ch-ua-model"},
+	{"Device-Memory", "device-memory"},
+	{"DPR", "dpr"},
+}
+
+type clientHintsCollector struct{}
+
+// ClientHints returns a Collector contributing the request's stable User-Agent
+// Client Hints (Sec-CH-UA-*, Device-Memory, DPR) as components. Absent or blank
+// hints contribute nothing. Modern Chromium browsers send these; others omit
+// them, so this layer adds entropy only where available.
+func ClientHints() Collector { return clientHintsCollector{} }
+
+func (clientHintsCollector) Collect(r *http.Request) ([]Component, error) {
+	comps := make([]Component, 0, len(clientHintHeaders))
+	for _, h := range clientHintHeaders {
+		if v := strings.TrimSpace(r.Header.Get(h.header)); v != "" {
+			comps = append(comps, Component{Name: h.name, Value: v})
+		}
+	}
+	return comps, nil
+}

--- a/web/fingerprint/clienthints.go
+++ b/web/fingerprint/clienthints.go
@@ -3,6 +3,8 @@ package fingerprint
 import (
 	"net/http"
 	"strings"
+
+	"github.com/dmitrymomot/forge/web/middleware"
 )
 
 // clientHintHeaders maps a User-Agent Client-Hint request header to a component
@@ -14,6 +16,16 @@ import (
 // itself carries the browser's major version (e.g. `"Chromium";v="126"`), so it
 // will churn alongside "ua" on major browser updates too — a conscious
 // trade-off kept for the brand-list entropy it provides.
+//
+// Entropy tiers matter for what actually arrives: only the first three
+// (Sec-CH-UA, Sec-CH-UA-Platform, Sec-CH-UA-Mobile) are low-entropy hints that
+// Chromium sends on every request unprompted. Sec-CH-UA-Arch, -Bitness, -Model,
+// Device-Memory, and DPR are high-entropy: the browser withholds them until the
+// origin advertises them via Accept-CH (see AcceptCH), and even then only sends
+// them on subsequent requests to that origin. Without AcceptCH, those five
+// components essentially never populate from headers — the JS probe's js-uadata
+// (navigator.userAgentData.getHighEntropyValues) is the client-side alternative
+// for arch/model/bitness.
 var clientHintHeaders = []headerPair{
 	{"Sec-CH-UA", "ch-ua"},
 	{"Sec-CH-UA-Platform", "ch-ua-platform"},
@@ -25,13 +37,44 @@ var clientHintHeaders = []headerPair{
 	{"DPR", "dpr"},
 }
 
+// acceptCHValue is the Accept-CH header value advertising every hint the
+// ClientHints collector reads, derived from clientHintHeaders so the collector
+// and the advertisement can never drift out of sync.
+var acceptCHValue = func() string {
+	names := make([]string, len(clientHintHeaders))
+	for i := range clientHintHeaders {
+		names[i] = clientHintHeaders[i].header
+	}
+	return strings.Join(names, ", ")
+}()
+
 type clientHintsCollector struct{}
 
-// ClientHints returns a Collector contributing the request's stable User-Agent
-// Client Hints (Sec-CH-UA-*, Device-Memory, DPR) as components. Absent or blank
-// hints contribute nothing. Modern Chromium browsers send these; others omit
-// them, so this layer adds entropy only where available.
+// ClientHints returns a Collector contributing the request's User-Agent Client
+// Hints (Sec-CH-UA-*, Device-Memory, DPR) as components. Absent or blank hints
+// contribute nothing. Only the low-entropy hints (ch-ua, ch-ua-platform,
+// ch-ua-mobile) arrive on every Chromium request; the high-entropy ones
+// (ch-ua-arch, ch-ua-bitness, ch-ua-model, device-memory, dpr) require the
+// origin to opt in with Accept-CH — pair this with AcceptCH to collect them, or
+// rely on the JS probe's js-uadata. Non-Chromium browsers send none of these.
 func ClientHints() Collector { return clientHintsCollector{} }
+
+// AcceptCH returns middleware that advertises, via the Accept-CH response
+// header, every Client Hint the ClientHints collector reads. Without it Chromium
+// sends only the three low-entropy hints (Sec-CH-UA, Sec-CH-UA-Mobile,
+// Sec-CH-UA-Platform); the high-entropy hints (Sec-CH-UA-Arch, -Bitness, -Model,
+// Device-Memory, DPR) are withheld until the origin opts in here, and then only
+// arrive on subsequent requests to that origin. Add a Critical-CH header if you
+// need them on the first navigation, and a Vary header if a hint affects a
+// cached response.
+func AcceptCH() middleware.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Accept-CH", acceptCHValue)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
 
 func (clientHintsCollector) Collect(r *http.Request) ([]Component, error) {
 	comps := make([]Component, 0, len(clientHintHeaders))

--- a/web/fingerprint/clienthints_test.go
+++ b/web/fingerprint/clienthints_test.go
@@ -1,0 +1,31 @@
+package fingerprint_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+func TestClientHintsCollector(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Sec-CH-UA", `"Chromium";v="126", "Not.A/Brand";v="24"`)
+	r.Header.Set("Sec-CH-UA-Platform", `"Windows"`)
+	r.Header.Set("Sec-CH-UA-Mobile", "?0")
+	r.Header.Set("Device-Memory", "8")
+	// Sec-CH-UA-Arch, -Bitness, -Model, DPR absent.
+	comps, err := fingerprint.ClientHints().Collect(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, c := range comps {
+		got[c.Name] = c.Value
+	}
+	if got["ch-ua-platform"] != `"Windows"` || got["ch-ua-mobile"] != "?0" || got["device-memory"] != "8" {
+		t.Fatalf("unexpected components: %v", got)
+	}
+	if _, ok := got["ch-ua-arch"]; ok {
+		t.Fatalf("absent hint must not emit a component: %v", got)
+	}
+}

--- a/web/fingerprint/clienthints_test.go
+++ b/web/fingerprint/clienthints_test.go
@@ -1,7 +1,9 @@
 package fingerprint_test
 
 import (
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/dmitrymomot/forge/web/fingerprint"
@@ -27,5 +29,26 @@ func TestClientHintsCollector(t *testing.T) {
 	}
 	if _, ok := got["ch-ua-arch"]; ok {
 		t.Fatalf("absent hint must not emit a component: %v", got)
+	}
+}
+
+func TestAcceptCHMiddleware(t *testing.T) {
+	var called bool
+	h := fingerprint.AcceptCH()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	if !called {
+		t.Fatal("AcceptCH middleware did not call next handler")
+	}
+	got := rec.Header().Get("Accept-CH")
+	// Must advertise the high-entropy hints that are otherwise withheld.
+	for _, want := range []string{"Sec-CH-UA-Arch", "Sec-CH-UA-Bitness", "Sec-CH-UA-Model", "Device-Memory", "DPR"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Accept-CH %q missing high-entropy hint %q", got, want)
+		}
 	}
 }

--- a/web/fingerprint/collector.go
+++ b/web/fingerprint/collector.go
@@ -25,17 +25,18 @@ func (f CollectorFunc) Collect(r *http.Request) ([]Component, error) { return f(
 // Fingerprinter assembles components from its collectors, hashes them into a
 // Fingerprint, and derives Signals. Build it with New.
 type Fingerprinter struct {
-	secret  []byte
-	signer  *sign.Signer
-	cookies *cookie.Codec
-	store   cache.Store
-	geo     GeoLookup
-	ua      UAFamily
-	logger  *slog.Logger
-	clock   clock.Clock
-	cols    []Collector
-	cfg     Config
-	version int
+	store         cache.Store
+	clock         clock.Clock
+	signer        *sign.Signer
+	cookies       *cookie.Codec
+	geo           GeoLookup
+	ua            UAFamily
+	logger        *slog.Logger
+	automationJA4 map[string]string
+	secret        []byte
+	cols          []Collector
+	cfg           Config
+	version       int
 }
 
 // New validates cfg, builds the HMAC signer and signed-cookie codec, applies

--- a/web/fingerprint/doc.go
+++ b/web/fingerprint/doc.go
@@ -10,6 +10,14 @@
 // trusted-proxy header sources (Cloudflare/CloudFront/generic), a local
 // raw-ClientHello JA4 computation, and RequestTLS for self-terminated crypto/tls.
 //
+// Hash churn from Client Hints: enabling Client Hints — as the Session and
+// Antifraud presets now do by wiring in ClientHints() — adds ch-ua-* components,
+// which changes Fingerprint.Hash and adds new keys to Digest.Parts for any
+// request carrying Client Hints, with no schema Version bump. On the first
+// comparison after upgrading, Drift reports those new component names as
+// changed once; consumers who compare Hash for equality instead of using Drift
+// will see every Client-Hint-bearing device re-fingerprint one time.
+//
 // Making tls-ua-mismatch fire: it stays inert until WithAutomationJA4 pins the
 // JA4 fingerprints of non-browser clients you observe. Pinned TLS fingerprints
 // drift as tools update, so harvest them from your own traffic rather than

--- a/web/fingerprint/doc.go
+++ b/web/fingerprint/doc.go
@@ -5,8 +5,9 @@
 // never a score — weighting signals into a decision is the consumer's policy.
 //
 // Collectors: Headers (UA + Accept*), ClientHints (Sec-CH-UA-* + Device-Memory
-// + DPR), ClientIP, and the JS probe (JSCollector, served by ScriptHandler and
-// fed by IngestHandler). TLS fingerprints come from the tlsprint subpackage:
+// + DPR — its high-entropy hints need the AcceptCH middleware to arrive),
+// ClientIP, and the JS probe (JSCollector, served by ScriptHandler and fed by
+// IngestHandler). TLS fingerprints come from the tlsprint subpackage:
 // trusted-proxy header sources (Cloudflare/CloudFront/generic), a local
 // raw-ClientHello JA4 computation, and RequestTLS for self-terminated crypto/tls.
 //

--- a/web/fingerprint/doc.go
+++ b/web/fingerprint/doc.go
@@ -3,4 +3,21 @@
 // probe. Layers are opt-in Collectors; heavy lookups (geoip, useragent) enter
 // through wired function seams so the core stays stdlib-light. Output is facts,
 // never a score — weighting signals into a decision is the consumer's policy.
+//
+// Collectors: Headers (UA + Accept*), ClientHints (Sec-CH-UA-* + Device-Memory
+// + DPR), ClientIP, and the JS probe (JSCollector, served by ScriptHandler and
+// fed by IngestHandler). TLS fingerprints come from the tlsprint subpackage:
+// trusted-proxy header sources (Cloudflare/CloudFront/generic), a local
+// raw-ClientHello JA4 computation, and RequestTLS for self-terminated crypto/tls.
+//
+// Making tls-ua-mismatch fire: it stays inert until WithAutomationJA4 pins the
+// JA4 fingerprints of non-browser clients you observe. Pinned TLS fingerprints
+// drift as tools update, so harvest them from your own traffic rather than
+// shipping a static list — wrap your listener with tlsprint.Listener, read
+// tlsprint.Conn.JA4() per connection (via ConnContext), record the fingerprints
+// arriving under automation User-Agents, and pass that map to WithAutomationJA4.
+//
+// Out of scope: JA4H (the HTTP-layer fingerprint) and the HTTP/2 SETTINGS
+// fingerprint both need raw header/frame order, which net/http discards and
+// HTTP/2 normalizes — they cannot be computed faithfully from a handler.
 package fingerprint

--- a/web/fingerprint/jsprobe.go
+++ b/web/fingerprint/jsprobe.go
@@ -24,8 +24,16 @@ type probePayload struct {
 	Platform            string   `json:"platform"`
 	Canvas              string   `json:"canvas"`
 	WebGL               string   `json:"webgl"`
+	WebGLVendor         string   `json:"webglVendor"`
+	UAData              string   `json:"uadata"`
+	Audio               string   `json:"audio"`
+	Fonts               string   `json:"fonts"`
+	Screen              string   `json:"screen"`
+	DevicePixelRatio    string   `json:"devicePixelRatio"`
+	DeviceMemory        string   `json:"deviceMemory"`
 	Languages           []string `json:"languages"`
 	HardwareConcurrency int      `json:"hardwareConcurrency"`
+	MaxTouchPoints      int      `json:"maxTouchPoints"`
 	WebDriver           bool     `json:"webdriver"`
 }
 
@@ -41,8 +49,18 @@ func normalizeProbe(p probePayload) probePayload {
 	p.Platform = clampStr(p.Platform, 40)
 	p.Canvas = clampStr(p.Canvas, 64)
 	p.WebGL = clampStr(p.WebGL, 64)
+	p.WebGLVendor = clampStr(p.WebGLVendor, 64)
+	p.UAData = clampStr(p.UAData, 128)
+	p.Audio = clampStr(p.Audio, 64)
+	p.Fonts = clampStr(p.Fonts, 64)
+	p.Screen = clampStr(p.Screen, 20)
+	p.DevicePixelRatio = clampStr(p.DevicePixelRatio, 12)
+	p.DeviceMemory = clampStr(p.DeviceMemory, 8)
 	if p.HardwareConcurrency < 0 || p.HardwareConcurrency > 1024 {
 		p.HardwareConcurrency = 0
+	}
+	if p.MaxTouchPoints < 0 || p.MaxTouchPoints > 256 {
+		p.MaxTouchPoints = 0
 	}
 	if len(p.Languages) > 10 {
 		p.Languages = p.Languages[:10]
@@ -154,6 +172,33 @@ func (c jsCollector) Collect(r *http.Request) ([]Component, error) {
 	}
 	if p.WebGL != "" {
 		comps = append(comps, Component{Name: "js-webgl", Value: p.WebGL})
+	}
+	if p.WebGLVendor != "" {
+		comps = append(comps, Component{Name: "js-webgl-vendor", Value: p.WebGLVendor})
+	}
+	if p.UAData != "" {
+		comps = append(comps, Component{Name: "js-uadata", Value: p.UAData})
+	}
+	if p.Audio != "" {
+		comps = append(comps, Component{Name: "js-audio", Value: p.Audio})
+	}
+	if p.Fonts != "" {
+		comps = append(comps, Component{Name: "js-fonts", Value: p.Fonts})
+	}
+	if p.Screen != "" {
+		comps = append(comps, Component{Name: "js-screen", Value: p.Screen})
+	}
+	if p.DevicePixelRatio != "" {
+		comps = append(comps, Component{Name: "js-dpr", Value: p.DevicePixelRatio})
+	}
+	if p.DeviceMemory != "" {
+		comps = append(comps, Component{Name: "js-devicememory", Value: p.DeviceMemory})
+	}
+	if p.HardwareConcurrency > 0 {
+		comps = append(comps, Component{Name: "js-hardware", Value: strconv.Itoa(p.HardwareConcurrency)})
+	}
+	if p.MaxTouchPoints > 0 {
+		comps = append(comps, Component{Name: "js-touch", Value: strconv.Itoa(p.MaxTouchPoints)})
 	}
 	return comps, nil
 }

--- a/web/fingerprint/jsprobe_fuzz_test.go
+++ b/web/fingerprint/jsprobe_fuzz_test.go
@@ -15,6 +15,7 @@ import (
 // response, not a crash.
 func FuzzIngest(f *testing.F) {
 	f.Add([]byte(`{"token":"x.y","data":{"timezone":"UTC"}}`))
+	f.Add([]byte(`{"token":"x.y","data":{"screen":"9999x9999x99","uadata":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","fonts":"x","audio":"y","hardwareConcurrency":-5,"maxTouchPoints":99999,"deviceMemory":"0.5"}}`))
 	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
 	fp, err := fingerprint.New(cfg)
 	if err != nil {

--- a/web/fingerprint/jsprobe_test.go
+++ b/web/fingerprint/jsprobe_test.go
@@ -71,6 +71,107 @@ func TestIngestThenCollect(t *testing.T) {
 	}
 }
 
+func TestIngestCollectsExpandedProbe(t *testing.T) {
+	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+	fp, err := fingerprint.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "203.0.113.7:5555"
+	tok, err := fp.IssueToken(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(map[string]any{
+		"token": tok,
+		"data": map[string]any{
+			"hardwareConcurrency": 8,
+			"maxTouchPoints":      5,
+			"deviceMemory":        "8",
+			"screen":              "1920x1080x24",
+			"devicePixelRatio":    "2",
+			"webglVendor":         "Google Inc. (NVIDIA)",
+			"uadata":              "Windows|15.0.0|||64",
+			"audio":               "1a2b3c4d",
+			"fonts":               "deadbeef:17",
+		},
+	})
+	ingReq := httptest.NewRequest("POST", "/_fp/ingest", bytes.NewReader(body))
+	ingReq.RemoteAddr = "203.0.113.7:5555"
+	ingRec := httptest.NewRecorder()
+	fp.IngestHandler().ServeHTTP(ingRec, ingReq)
+	if ingRec.Code != http.StatusNoContent {
+		t.Fatalf("ingest failed: %d", ingRec.Code)
+	}
+	next := httptest.NewRequest("GET", "/", nil)
+	for _, c := range ingRec.Result().Cookies() {
+		next.AddCookie(c)
+	}
+	comps, err := fp.JSCollector().Collect(next)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, c := range comps {
+		got[c.Name] = c.Value
+	}
+	for name, want := range map[string]string{
+		"js-hardware":     "8",
+		"js-touch":        "5",
+		"js-devicememory": "8",
+		"js-screen":       "1920x1080x24",
+		"js-dpr":          "2",
+		"js-webgl-vendor": "Google Inc. (NVIDIA)",
+		"js-uadata":       "Windows|15.0.0|||64",
+		"js-audio":        "1a2b3c4d",
+		"js-fonts":        "deadbeef:17",
+	} {
+		if got[name] != want {
+			t.Fatalf("component %q = %q, want %q (all: %v)", name, got[name], want, got)
+		}
+	}
+}
+
+func TestExpandedProbeCookieFitsBudget(t *testing.T) {
+	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+	fp, err := fingerprint.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "203.0.113.7:5555"
+	tok, err := fp.IssueToken(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	big := strings.Repeat("Z", 200) // each string field over-length; clamping must bound it
+	body, _ := json.Marshal(map[string]any{
+		"token": tok,
+		"data": map[string]any{
+			"timezone": big, "platform": big, "canvas": big, "webgl": big,
+			"webglVendor": big, "uadata": big, "audio": big, "fonts": big,
+			"screen": big, "devicePixelRatio": big, "deviceMemory": big,
+			"languages":           []string{big, big, big, big, big, big, big, big, big, big},
+			"hardwareConcurrency": 64, "maxTouchPoints": 10,
+		},
+	})
+	ingReq := httptest.NewRequest("POST", "/_fp/ingest", bytes.NewReader(body))
+	ingReq.RemoteAddr = "203.0.113.7:5555"
+	ingRec := httptest.NewRecorder()
+	fp.IngestHandler().ServeHTTP(ingRec, ingReq)
+	if ingRec.Code != http.StatusNoContent {
+		t.Fatalf("ingest of max-fill payload failed: %d", ingRec.Code)
+	}
+	total := 0
+	for _, c := range ingRec.Result().Cookies() {
+		total += len(c.Value)
+	}
+	if total == 0 || total >= 4096 {
+		t.Fatalf("clamped probe cookie payload = %d bytes, want in (0,4096)", total)
+	}
+}
+
 func TestIngestRejectsBadToken(t *testing.T) {
 	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
 	fp, err := fingerprint.New(cfg)

--- a/web/fingerprint/jsprobe_test.go
+++ b/web/fingerprint/jsprobe_test.go
@@ -28,6 +28,22 @@ func TestScriptHandlerServesJS(t *testing.T) {
 	}
 }
 
+func TestScriptHandlerServesExpandedProbe(t *testing.T) {
+	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+	fp, err := fingerprint.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	fp.ScriptHandler().ServeHTTP(rec, httptest.NewRequest("GET", "/_fp/probe.js", nil))
+	body := rec.Body.String()
+	for _, marker := range []string{"getHighEntropyValues", "OfflineAudioContext", "detectFonts", "webglVendor", "maxTouchPoints"} {
+		if !strings.Contains(body, marker) {
+			t.Fatalf("probe.js missing %q", marker)
+		}
+	}
+}
+
 func TestIngestThenCollect(t *testing.T) {
 	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
 	fp, err := fingerprint.New(cfg)

--- a/web/fingerprint/options.go
+++ b/web/fingerprint/options.go
@@ -2,6 +2,7 @@ package fingerprint
 
 import (
 	"log/slog"
+	"maps"
 
 	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/resilience/cache"
@@ -41,4 +42,14 @@ func WithClock(c clock.Clock) Option {
 			fp.clock = c
 		}
 	}
+}
+
+// WithAutomationJA4 pins non-browser JA4 client fingerprints to labels so the
+// tls-ua-mismatch signal fires (Value:true) when the "tls" component matches a
+// pinned fingerprint under a browser-family UA. Ships empty by design — pinned
+// TLS fingerprints drift as tools update, so populate this from fingerprints you
+// capture from your own traffic (see the tlsprint.Listener / Conn.JA4() capture
+// recipe in the package doc). The map is cloned.
+func WithAutomationJA4(m map[string]string) Option {
+	return func(fp *Fingerprinter) { fp.automationJA4 = maps.Clone(m) }
 }

--- a/web/fingerprint/presets.go
+++ b/web/fingerprint/presets.go
@@ -1,19 +1,22 @@
 package fingerprint
 
-// Session returns a Fingerprinter for general apps: header components only, pure
-// stdlib, no wired seams. Suitable for session-hijack detection (persist the
-// Digest, compare with Drift).
+// Session returns a Fingerprinter for general apps: header and Client Hint
+// components only, pure stdlib, no wired seams. Suitable for session-hijack
+// detection (persist the Digest, compare with Drift).
 func Session(cfg Config, opts ...Option) (*Fingerprinter, error) {
-	base := []Option{WithCollectors(Headers())}
+	base := []Option{WithCollectors(Headers(), ClientHints())}
 	return New(cfg, append(base, opts...)...)
 }
 
-// Antifraud returns a full-stack Fingerprinter: headers + client IP + JS probe,
-// with the geoip and useragent seams wired and an optional TLS collector (pass
-// tlsprint.Chain(...), or nil to omit the TLS layer). Note: the tls-ua-mismatch
-// signal is inert (always Value:false) until automationJA4 is populated.
+// Antifraud returns a full-stack Fingerprinter: headers + client IP + Client
+// Hints + JS probe, with the geoip and useragent seams wired and an optional
+// TLS collector (pass tlsprint.Chain(...), or nil to omit the TLS layer).
+// Client Hints are included; compose tlsprint.RequestTLS() into the tls
+// argument yourself for self-terminated TLS (this package cannot import
+// tlsprint). Note: the tls-ua-mismatch signal is inert (always Value:false)
+// until WithAutomationJA4 is set.
 func Antifraud(cfg Config, geo GeoLookup, ua UAFamily, tls Collector, opts ...Option) (*Fingerprinter, error) {
-	cols := []Collector{Headers(), ClientIP()}
+	cols := []Collector{Headers(), ClientIP(), ClientHints()}
 	if tls != nil {
 		cols = append(cols, tls)
 	}

--- a/web/fingerprint/presets_test.go
+++ b/web/fingerprint/presets_test.go
@@ -26,6 +26,27 @@ func TestSessionPreset(t *testing.T) {
 	}
 }
 
+func TestSessionPresetEmitsClientHints(t *testing.T) {
+	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+	fp, err := fingerprint.Session(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("User-Agent", "Mozilla/5.0")
+	r.Header.Set("Sec-CH-UA-Platform", `"Windows"`)
+	f, _ := fp.FromRequest(r)
+	found := false
+	for _, c := range f.Components {
+		if c.Name == "ch-ua-platform" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected ch-ua-platform component from Session preset, got %+v", f.Components)
+	}
+}
+
 // TestAntifraudPresetBuildsAndCollectsJS proves Antifraud wires the header,
 // client-IP, geo, and UA seams, and that the JS collector appended after New
 // actually round-trips a probe payload end to end through the preset's

--- a/web/fingerprint/signals_component.go
+++ b/web/fingerprint/signals_component.go
@@ -19,8 +19,9 @@ var automationJA4 = map[string]string{
 }
 
 // componentSignals derives the component-driven signals: headless,
-// tls-ua-mismatch, lang-mismatch, geo-tz-mismatch, and header-anomaly. Each
-// emits only when its required components and seams are present.
+// tls-ua-mismatch, lang-mismatch, ch-ua-mismatch, geo-tz-mismatch,
+// header-anomaly, and fetch-metadata-anomaly. Each emits only when its
+// required components and seams are present.
 func (fp *Fingerprinter) componentSignals(r *http.Request, comp map[string]string) []Signal {
 	var out []Signal
 	if v, ok := comp["js-webdriver"]; ok {
@@ -39,6 +40,9 @@ func (fp *Fingerprinter) componentSignals(r *http.Request, comp map[string]strin
 		out = append(out, s)
 	}
 	if s, ok := fp.headerAnomaly(r, comp); ok {
+		out = append(out, s)
+	}
+	if s, ok := fetchMetadataAnomaly(r); ok {
 		out = append(out, s)
 	}
 	return out
@@ -169,6 +173,23 @@ func (fp *Fingerprinter) headerAnomaly(r *http.Request, comp map[string]string) 
 	}
 	missing := r.Header.Get("Sec-Ch-Ua") == "" || r.Header.Get("Sec-Fetch-Site") == ""
 	return Signal{Name: "header-anomaly", Value: missing, Detail: "Chrome UA without Sec-Ch-Ua/Sec-Fetch-*"}, true
+}
+
+// fetchMetadataAnomaly flags Sec-Fetch-* header combinations a conforming
+// browser never emits: a navigation with an "empty" destination, or a
+// "document" destination outside navigate mode. It reads the headers raw (they
+// are per-request context, never hashed) and emits only when at least one
+// Sec-Fetch-* header is present.
+func fetchMetadataAnomaly(r *http.Request) (Signal, bool) {
+	site := r.Header.Get("Sec-Fetch-Site")
+	mode := r.Header.Get("Sec-Fetch-Mode")
+	dest := r.Header.Get("Sec-Fetch-Dest")
+	if site == "" && mode == "" && dest == "" {
+		return Signal{}, false
+	}
+	anomaly := (mode == "navigate" && dest == "empty") ||
+		(dest == "document" && mode != "" && mode != "navigate")
+	return Signal{Name: "fetch-metadata-anomaly", Value: anomaly, Detail: "mode=" + mode + " dest=" + dest}, true
 }
 
 // primaryLang returns the base language subtag of the first entry ("en-US,..." -> "en").

--- a/web/fingerprint/signals_component.go
+++ b/web/fingerprint/signals_component.go
@@ -9,7 +9,7 @@ import (
 // componentSignals derives the component-driven signals: headless,
 // tls-ua-mismatch, lang-mismatch, ch-ua-mismatch, geo-tz-mismatch,
 // header-anomaly, and fetch-metadata-anomaly. Each emits only when its
-// required components and seams are present.
+// required inputs (components, seams, or raw request headers) are present.
 func (fp *Fingerprinter) componentSignals(r *http.Request, comp map[string]string) []Signal {
 	var out []Signal
 	if v, ok := comp["js-webdriver"]; ok {
@@ -105,7 +105,9 @@ func chUAMismatch(comp map[string]string) (Signal, bool) {
 }
 
 // osFromClientHint maps a Sec-CH-UA-Platform value (a quoted token) to a coarse
-// OS key, or "" when unknown.
+// OS key, or "" when unknown. ChromeOS ("Chrome OS"/"Chromium OS") is treated
+// as ambiguous (no signal) because navigator.platform can't distinguish it
+// from desktop Linux — see osFromJSPlatform.
 func osFromClientHint(v string) string {
 	switch strings.Trim(v, `"`) {
 	case "Windows":
@@ -117,7 +119,10 @@ func osFromClientHint(v string) string {
 	case "Android":
 		return "android"
 	case "Chrome OS", "Chromium OS":
-		return "chromeos"
+		// ChromeOS reports navigator.platform "Linux x86_64" — indistinguishable
+		// from desktop Linux — so treat it as ambiguous and emit no signal,
+		// mirroring the bare-"Linux arm*" case in osFromJSPlatform.
+		return ""
 	case "Linux":
 		return "linux"
 	default:
@@ -127,7 +132,9 @@ func osFromClientHint(v string) string {
 
 // osFromJSPlatform maps a navigator.platform value to a coarse OS key, or ""
 // when unknown or ambiguous (bare "Linux arm*" is shared by Android and desktop
-// Linux, so it is treated as unknown).
+// Linux, so it is treated as unknown). ChromeOS reports "Linux x86_64", which
+// deliberately maps to "linux" here — there is no separate chromeos key,
+// since navigator.platform cannot distinguish ChromeOS from desktop Linux.
 func osFromJSPlatform(v string) string {
 	switch {
 	case strings.HasPrefix(v, "Win"):
@@ -138,8 +145,6 @@ func osFromJSPlatform(v string) string {
 		return "ios"
 	case strings.HasPrefix(v, "Linux x86"), strings.HasPrefix(v, "Linux i"):
 		return "linux"
-	case strings.Contains(v, "CrOS"):
-		return "chromeos"
 	default:
 		return ""
 	}

--- a/web/fingerprint/signals_component.go
+++ b/web/fingerprint/signals_component.go
@@ -6,18 +6,6 @@ import (
 	"strings"
 )
 
-// automationJA4 maps well-known non-browser JA4 client fingerprints to a label.
-// Pin values from the FoxIO JA4 reference vectors (github.com/FoxIO-LLC/ja4);
-// bounded on purpose — an unmatched TLS hash simply does not fire the signal.
-// It ships empty: no verified automation JA4 fingerprints have been pinned yet,
-// so tls-ua-mismatch always reports Value:false while still emitting the
-// signal (inputs present, nothing flagged) rather than silently omitting it.
-var automationJA4 = map[string]string{
-	// Example placeholders to be pinned during implementation from captured
-	// handshakes; keep only verified entries:
-	// "t13d1516h2_8daaf6152771_02713d6af862": "chrome-like (allowed)",
-}
-
 // componentSignals derives the component-driven signals: headless,
 // tls-ua-mismatch, lang-mismatch, ch-ua-mismatch, geo-tz-mismatch,
 // header-anomaly, and fetch-metadata-anomaly. Each emits only when its
@@ -50,8 +38,8 @@ func (fp *Fingerprinter) componentSignals(r *http.Request, comp map[string]strin
 
 // tlsUAMismatch requires a JA4-format "tls" component — tlsprint.Local() or a
 // JA4 header source (e.g. tlsprint.CloudFrontJA4), NOT the JA3 hash from
-// tlsprint.CloudflareJA3, which never matches automationJA4's JA4 keys. The
-// signal is inert (always Value:false) until automationJA4 is populated with
+// tlsprint.CloudflareJA3, which never matches the pinned JA4 keys. The
+// signal is inert (always Value:false) until WithAutomationJA4 is set with
 // pinned automation fingerprints.
 func (fp *Fingerprinter) tlsUAMismatch(comp map[string]string) (Signal, bool) {
 	tls, hasTLS := comp["tls"]
@@ -63,7 +51,7 @@ func (fp *Fingerprinter) tlsUAMismatch(comp map[string]string) (Signal, bool) {
 	if !ok || fam != FamilyBrowser {
 		return Signal{}, false
 	}
-	label, flagged := automationJA4[tls]
+	label, flagged := fp.automationJA4[tls]
 	return Signal{Name: "tls-ua-mismatch", Value: flagged, Detail: label}, true
 }
 

--- a/web/fingerprint/signals_component.go
+++ b/web/fingerprint/signals_component.go
@@ -32,6 +32,9 @@ func (fp *Fingerprinter) componentSignals(r *http.Request, comp map[string]strin
 	if s, ok := langMismatch(comp); ok {
 		out = append(out, s)
 	}
+	if s, ok := chUAMismatch(comp); ok {
+		out = append(out, s)
+	}
 	if s, ok := fp.geoTZMismatch(comp); ok {
 		out = append(out, s)
 	}
@@ -88,6 +91,66 @@ func (fp *Fingerprinter) geoTZMismatch(comp map[string]string) (Signal, bool) {
 		return Signal{}, false
 	}
 	return Signal{Name: "geo-tz-mismatch", Value: jsCont != info.Continent, Detail: tz + " vs " + info.Continent}, true
+}
+
+// chUAMismatch compares the Client-Hint platform (ch-ua-platform, e.g. "Windows")
+// against navigator.platform (js-platform, e.g. "Win32") through a coarse OS
+// normalization; disagreement is a spoofing tell. It fires only when both
+// normalize to a known, differing OS. Ambiguous values — bare "Linux arm*",
+// shared by Android and desktop Linux — yield no signal, avoiding false positives.
+func chUAMismatch(comp map[string]string) (Signal, bool) {
+	chPlat, hasCH := comp["ch-ua-platform"]
+	jsPlat, hasJS := comp["js-platform"]
+	if !hasCH || !hasJS {
+		return Signal{}, false
+	}
+	chOS := osFromClientHint(chPlat)
+	jsOS := osFromJSPlatform(jsPlat)
+	if chOS == "" || jsOS == "" {
+		return Signal{}, false
+	}
+	return Signal{Name: "ch-ua-mismatch", Value: chOS != jsOS, Detail: chPlat + " vs " + jsPlat}, true
+}
+
+// osFromClientHint maps a Sec-CH-UA-Platform value (a quoted token) to a coarse
+// OS key, or "" when unknown.
+func osFromClientHint(v string) string {
+	switch strings.Trim(v, `"`) {
+	case "Windows":
+		return "windows"
+	case "macOS":
+		return "macos"
+	case "iOS":
+		return "ios"
+	case "Android":
+		return "android"
+	case "Chrome OS", "Chromium OS":
+		return "chromeos"
+	case "Linux":
+		return "linux"
+	default:
+		return ""
+	}
+}
+
+// osFromJSPlatform maps a navigator.platform value to a coarse OS key, or ""
+// when unknown or ambiguous (bare "Linux arm*" is shared by Android and desktop
+// Linux, so it is treated as unknown).
+func osFromJSPlatform(v string) string {
+	switch {
+	case strings.HasPrefix(v, "Win"):
+		return "windows"
+	case strings.HasPrefix(v, "Mac"):
+		return "macos"
+	case strings.HasPrefix(v, "iPhone"), strings.HasPrefix(v, "iPad"), strings.HasPrefix(v, "iPod"):
+		return "ios"
+	case strings.HasPrefix(v, "Linux x86"), strings.HasPrefix(v, "Linux i"):
+		return "linux"
+	case strings.Contains(v, "CrOS"):
+		return "chromeos"
+	default:
+		return ""
+	}
 }
 
 // headerAnomaly fires when the UA claims a modern Chromium browser but the

--- a/web/fingerprint/signals_component_test.go
+++ b/web/fingerprint/signals_component_test.go
@@ -243,6 +243,15 @@ func TestCHUAMismatchSignal(t *testing.T) {
 	if _, ok := signalByName(fp.Signals(r, f), "ch-ua-mismatch"); ok {
 		t.Fatal("ch-ua-mismatch must not emit on an ambiguous js-platform")
 	}
+
+	// ChromeOS: CH says "Chrome OS" but navigator.platform is "Linux x86_64"
+	// (indistinguishable from desktop Linux) → must not emit (no false positive).
+	fp = newFP(`"Chrome OS"`, "Linux x86_64")
+	r = httptest.NewRequest("GET", "/", nil)
+	f, _ = fp.FromRequest(r)
+	if _, ok := signalByName(fp.Signals(r, f), "ch-ua-mismatch"); ok {
+		t.Fatal("ch-ua-mismatch must not emit for ChromeOS (navigator.platform indistinguishable from desktop Linux)")
+	}
 }
 
 func TestFetchMetadataAnomalySignal(t *testing.T) {

--- a/web/fingerprint/signals_component_test.go
+++ b/web/fingerprint/signals_component_test.go
@@ -84,6 +84,35 @@ func TestTLSUAMismatchSignal(t *testing.T) {
 	}
 }
 
+func TestTLSUAMismatchFiresWithPinnedJA4(t *testing.T) {
+	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+	fp, err := fingerprint.New(cfg,
+		fingerprint.WithCollectors(
+			fingerprint.CollectorFunc(func(_ *http.Request) ([]fingerprint.Component, error) {
+				return []fingerprint.Component{
+					{Name: "tls", Value: "t13d1516h2_8daaf6152771_02713d6af862"},
+					{Name: "ua", Value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/126.0"},
+				}, nil
+			}),
+		),
+		fingerprint.WithUAFamily(func(_ string) (fingerprint.Family, bool) {
+			return fingerprint.FamilyBrowser, true
+		}),
+		fingerprint.WithAutomationJA4(map[string]string{
+			"t13d1516h2_8daaf6152771_02713d6af862": "python-requests",
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest("GET", "/", nil)
+	f, _ := fp.FromRequest(r)
+	s, ok := signalByName(fp.Signals(r, f), "tls-ua-mismatch")
+	if !ok || !s.Value || s.Detail != "python-requests" {
+		t.Fatalf("expected tls-ua-mismatch=true detail=python-requests: %+v", s)
+	}
+}
+
 func TestTLSUAMismatchNotEmittedWithoutUASeam(t *testing.T) {
 	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
 	fp, err := fingerprint.New(cfg,

--- a/web/fingerprint/signals_component_test.go
+++ b/web/fingerprint/signals_component_test.go
@@ -216,6 +216,40 @@ func TestCHUAMismatchSignal(t *testing.T) {
 	}
 }
 
+func TestFetchMetadataAnomalySignal(t *testing.T) {
+	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+	fp, err := fingerprint.New(cfg, fingerprint.WithCollectors(fingerprint.Headers()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Contradiction a real browser never sends: navigate mode with empty dest.
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Sec-Fetch-Mode", "navigate")
+	r.Header.Set("Sec-Fetch-Dest", "empty")
+	f, _ := fp.FromRequest(r)
+	if s, ok := signalByName(fp.Signals(r, f), "fetch-metadata-anomaly"); !ok || !s.Value {
+		t.Fatalf("expected fetch-metadata-anomaly=true: %+v", fp.Signals(r, f))
+	}
+
+	// Normal top-level navigation.
+	r2 := httptest.NewRequest("GET", "/", nil)
+	r2.Header.Set("Sec-Fetch-Site", "none")
+	r2.Header.Set("Sec-Fetch-Mode", "navigate")
+	r2.Header.Set("Sec-Fetch-Dest", "document")
+	f2, _ := fp.FromRequest(r2)
+	if s, ok := signalByName(fp.Signals(r2, f2), "fetch-metadata-anomaly"); !ok || s.Value {
+		t.Fatalf("expected fetch-metadata-anomaly=false: %+v", fp.Signals(r2, f2))
+	}
+
+	// No Sec-Fetch-* headers at all → not emitted.
+	r3 := httptest.NewRequest("GET", "/", nil)
+	f3, _ := fp.FromRequest(r3)
+	if _, ok := signalByName(fp.Signals(r3, f3), "fetch-metadata-anomaly"); ok {
+		t.Fatal("fetch-metadata-anomaly must not emit without any Sec-Fetch-* header")
+	}
+}
+
 func TestHeadlessSignal(t *testing.T) {
 	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
 	fp, err := fingerprint.New(cfg, fingerprint.WithCollectors(

--- a/web/fingerprint/signals_component_test.go
+++ b/web/fingerprint/signals_component_test.go
@@ -174,6 +174,48 @@ func TestHeaderAnomalyNotEmittedForNonChromeUA(t *testing.T) {
 	}
 }
 
+func TestCHUAMismatchSignal(t *testing.T) {
+	newFP := func(chPlatform, jsPlatform string) *fingerprint.Fingerprinter {
+		cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
+		fp, err := fingerprint.New(cfg, fingerprint.WithCollectors(
+			fingerprint.CollectorFunc(func(_ *http.Request) ([]fingerprint.Component, error) {
+				return []fingerprint.Component{
+					{Name: "ch-ua-platform", Value: chPlatform},
+					{Name: "js-platform", Value: jsPlatform},
+				}, nil
+			}),
+		))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return fp
+	}
+
+	// Contradiction: CH says Windows, JS says a Mac.
+	fp := newFP(`"Windows"`, "MacIntel")
+	r := httptest.NewRequest("GET", "/", nil)
+	f, _ := fp.FromRequest(r)
+	if s, ok := signalByName(fp.Signals(r, f), "ch-ua-mismatch"); !ok || !s.Value {
+		t.Fatalf("expected ch-ua-mismatch=true: %+v", fp.Signals(r, f))
+	}
+
+	// Agreement: CH Windows, JS Win32.
+	fp = newFP(`"Windows"`, "Win32")
+	r = httptest.NewRequest("GET", "/", nil)
+	f, _ = fp.FromRequest(r)
+	if s, ok := signalByName(fp.Signals(r, f), "ch-ua-mismatch"); !ok || s.Value {
+		t.Fatalf("expected ch-ua-mismatch=false: %+v", fp.Signals(r, f))
+	}
+
+	// Ambiguous JS platform (Android/desktop Linux share "Linux armv8l") → not emitted.
+	fp = newFP(`"Android"`, "Linux armv8l")
+	r = httptest.NewRequest("GET", "/", nil)
+	f, _ = fp.FromRequest(r)
+	if _, ok := signalByName(fp.Signals(r, f), "ch-ua-mismatch"); ok {
+		t.Fatal("ch-ua-mismatch must not emit on an ambiguous js-platform")
+	}
+}
+
 func TestHeadlessSignal(t *testing.T) {
 	cfg := fingerprint.Config{Secret: "s", Version: 1, TokenTTL: time.Minute}
 	fp, err := fingerprint.New(cfg, fingerprint.WithCollectors(

--- a/web/fingerprint/tlsprint/doc.go
+++ b/web/fingerprint/tlsprint/doc.go
@@ -1,8 +1,12 @@
-// Package tlsprint contributes a TLS (JA4) fingerprint as the "tls" component of
-// a web/fingerprint Fingerprinter. Two paths: trusted upstream headers
+// Package tlsprint contributes TLS-derived components to a web/fingerprint
+// Fingerprinter. Three paths: trusted upstream headers
 // (Cloudflare/CloudFront/Envoy/Caddy/Traefik) for CDN-terminated TLS, and a
 // net.Listener wrapper computing JA4 from the raw ClientHello when the Go server
-// terminates TLS. Header sources are trust-gated; an untrusted header is dropped.
+// terminates TLS, both emitting a JA4 fingerprint as the "tls" component; and
+// RequestTLS, which emits a coarse "tlsconn" component (NOT a JA4 hash) from
+// the request's own terminated TLS handshake (http.Request.TLS) when the Go
+// server terminates crypto/tls directly. Header sources are trust-gated; an
+// untrusted header is dropped.
 //
 // The local path assumes the ClientHello fits one TLS record (<=16KB, true for
 // typical hellos). A ClientHello fragmented across records, or one whose

--- a/web/fingerprint/tlsprint/request.go
+++ b/web/fingerprint/tlsprint/request.go
@@ -1,0 +1,51 @@
+package tlsprint
+
+import (
+	"crypto/tls"
+	"net/http"
+	"strconv"
+
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+type requestTLSCollector struct{}
+
+// RequestTLS returns a Collector that emits a coarse "tlsconn" component —
+// "<version>|<cipher-hex>|<alpn>" (e.g. "1.3|c02b|h2") — from the request's own
+// TLS handshake (http.Request.TLS). Use it when the Go server terminates
+// crypto/tls directly, with no CDN JA header and no wrapped Listener. It is NOT
+// a JA3/JA4 hash, so it uses a distinct component name and does not feed
+// tls-ua-mismatch. A plaintext request (r.TLS == nil) contributes nothing.
+//
+// The parent fingerprint package cannot wire this into the Antifraud preset
+// (that would import this subpackage back — a cycle), so compose it yourself:
+//
+//	tlsprint.Chain(tlsprint.CloudFrontJA4(trust), tlsprint.RequestTLS())
+func RequestTLS() fingerprint.Collector { return requestTLSCollector{} }
+
+func (requestTLSCollector) Collect(r *http.Request) ([]fingerprint.Component, error) {
+	if r.TLS == nil {
+		return nil, nil
+	}
+	v := tlsVersionString(r.TLS.Version) + "|" +
+		strconv.FormatUint(uint64(r.TLS.CipherSuite), 16) + "|" +
+		r.TLS.NegotiatedProtocol
+	return []fingerprint.Component{{Name: "tlsconn", Value: v}}, nil
+}
+
+// tlsVersionString renders a TLS version constant compactly ("1.2", "1.3"),
+// falling back to a hex code for unknown values.
+func tlsVersionString(v uint16) string {
+	switch v {
+	case tls.VersionTLS13:
+		return "1.3"
+	case tls.VersionTLS12:
+		return "1.2"
+	case tls.VersionTLS11:
+		return "1.1"
+	case tls.VersionTLS10:
+		return "1.0"
+	default:
+		return "0x" + strconv.FormatUint(uint64(v), 16)
+	}
+}

--- a/web/fingerprint/tlsprint/request_test.go
+++ b/web/fingerprint/tlsprint/request_test.go
@@ -1,0 +1,33 @@
+package tlsprint_test
+
+import (
+	"crypto/tls"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/fingerprint/tlsprint"
+)
+
+func TestRequestTLSCollect(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.TLS = &tls.ConnectionState{
+		Version:            tls.VersionTLS13,
+		CipherSuite:        tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, // 0xc02b
+		NegotiatedProtocol: "h2",
+	}
+	comps, err := tlsprint.RequestTLS().Collect(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comps) != 1 || comps[0].Name != "tlsconn" || comps[0].Value != "1.3|c02b|h2" {
+		t.Fatalf("unexpected component: %+v", comps)
+	}
+}
+
+func TestRequestTLSPlaintextEmitsNothing(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil) // r.TLS == nil
+	comps, err := tlsprint.RequestTLS().Collect(r)
+	if err != nil || comps != nil {
+		t.Fatalf("plaintext request must emit nothing: %+v, %v", comps, err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the fingerprinting coverage gaps in `web/fingerprint` — Client Hints, self-terminated TLS, a deeper JS device probe, two new cross-layer signals, and a usable `tls-ua-mismatch`. Every addition is an opt-in `Collector` or `Signal` following the package's existing `Name/Value` component idiom; nothing is wired by default except the two preset edits. Output stays identity + facts, never a score.

## What's new

**Collectors**
- `ClientHints()` — emits stable UA Client-Hints (`Sec-CH-UA*`, `Device-Memory`, `DPR`) as components; wired into both `Session` and `Antifraud` presets.
- `tlsprint.RequestTLS()` — a coarse `tlsconn` component (`<version>|<cipher-hex>|<alpn>`) from the request's own terminated `crypto/tls` handshake, for servers that terminate TLS directly with no CDN JA header. Distinct component name — it is **not** a JA4 hash and does not feed `tls-ua-mismatch`. Composed by the consumer (the parent package cannot import `tlsprint` — that would be an import cycle).

**JS probe expansion** (Go + `probe.js`)
- New device-entropy fields: audio hash, installed-font hash, screen, DPR, device memory, WebGL vendor, `navigator.userAgentData` high-entropy values, max touch points. `probe.js` now sends asynchronously after audio/UA-data promises resolve (800 ms cap).
- **Bug fix:** the previously-collected `hardwareConcurrency` value was clamped but never emitted as a component — now emitted as `js-hardware`.
- All new payload fields are whitelisted + clamped; ingest remains fuzzed and cookie-size-bounded.

**Signals**
- `ch-ua-mismatch` — Client-Hint platform vs `navigator.platform` via coarse OS normalization; emits only when both normalize to a known, unambiguous OS (ChromeOS and bare `Linux arm*` are treated as ambiguous → no signal, to avoid false positives).
- `fetch-metadata-anomaly` — `Sec-Fetch-*` header combinations a conforming browser never sends (e.g. `navigate` mode with `empty` destination), read raw off the request.

**Option**
- `WithAutomationJA4(map)` — pins non-browser JA4 fingerprints so `tls-ua-mismatch` actually fires. Ships empty by design; harvest fingerprints from your own traffic via the `tlsprint.Listener` / `Conn.JA4()` capture recipe (documented in `doc.go`).

## Notes

- Wiring `ClientHints()` into the presets changes `Fingerprint.Hash` (adds `ch-ua-*` to `Digest.Parts`) for requests carrying Client Hints, with no schema Version bump. This is intentional and documented in `doc.go` — `Drift` reports the new component names as changed once on the first post-upgrade comparison.
- Out of scope (documented icebox): JA4H and the HTTP/2 SETTINGS fingerprint both need raw header/frame order that `net/http` discards and HTTP/2 normalizes.

## Testing

- `just test ./web/fingerprint/...` — race-clean; coverage 85.2% (parent) / 76.2% (`tlsprint`).
- `just lint` — 0 issues (vet, build, golangci-lint, nilaway, betteralign, modernize).
- Fuzz seed corpora replay clean in both packages; godoc examples pass.

## Review process

Built task-by-task under TDD with a spec+quality review after each task and a whole-branch review at the end. The whole-branch review caught a real correctness bug — `ch-ua-mismatch` false-flagging x86 ChromeOS users (their `navigator.platform` is `Linux x86_64`, indistinguishable from desktop Linux) — fixed by treating ChromeOS as ambiguous, plus the missing hash-churn doc note.
