### PR TITLE
feat(guard): auth/guard request-authentication middleware

### DIFF
--- a/auth/guard/basicauth.go
+++ b/auth/guard/basicauth.go
@@ -1,0 +1,85 @@
+package guard
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/dmitrymomot/forge/crypto/consttime"
+	"github.com/dmitrymomot/forge/web/middleware"
+	"github.com/dmitrymomot/forge/web/problem"
+)
+
+// dummyPassword is compared for unknown usernames so user existence does
+// not leak through response timing.
+const dummyPassword = "guard-basicauth-dummy-password-for-unknown-users"
+
+// BasicAuth returns middleware gating requests with HTTP Basic Auth against
+// a static username→password map — for pprof/metrics/staging/admin gates,
+// never user login (no hashing; credentials come from env, see ParseUsers).
+// Password checks are constant-time and unknown users cost the same as
+// wrong passwords; unknown-user and wrong-password failures are
+// indistinguishable to the client. Every failure gets 401 with a
+// WWW-Authenticate Basic challenge through the responder (default
+// problem.JSON 401). On success the request carries
+// Identity{Subject: username, Method: "basic"} — From/MustFrom work as
+// behind New. Panics on an empty users map — a gate with no valid
+// credentials is a wiring bug. Accepted options: WithRealm, WithResponder;
+// WithExtractors, WithOptional, and WithChallenge are ignored (the scheme
+// and challenge are fixed).
+func BasicAuth(users map[string]string, opts ...Option) middleware.Middleware {
+	if len(users) == 0 {
+		panic("guard: BasicAuth requires at least one user")
+	}
+	cfg := config{
+		responder: problem.JSON(problem.WithStatus(http.StatusUnauthorized)),
+		realm:     "restricted",
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	challenge := fmt.Sprintf("Basic realm=%q, charset=%q", cfg.realm, "UTF-8")
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reject := func(err error) {
+				w.Header().Set("WWW-Authenticate", challenge)
+				cfg.responder(w, r, err)
+			}
+			user, pass, ok := r.BasicAuth()
+			if !ok {
+				reject(ErrNoCredential)
+				return
+			}
+			want, known := users[user]
+			if !known {
+				want = dummyPassword
+			}
+			if !consttime.StringEqual(pass, want) || !known {
+				reject(ErrInvalidCredential)
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(identityKey.With(r.Context(), Identity{Subject: user, Method: "basic"})))
+		})
+	}
+}
+
+// ParseUsers parses BasicAuth credentials from the "user1:pass1,user2:pass2"
+// env-string format. Passwords may contain colons (the split is at the first
+// colon) but not commas. It rejects (wrapping ErrInvalidUsers) empty input,
+// entries without a colon, empty usernames or passwords, and duplicate
+// usernames.
+func ParseUsers(s string) (map[string]string, error) {
+	entries := strings.Split(s, ",")
+	users := make(map[string]string, len(entries))
+	for _, e := range entries {
+		user, pass, found := strings.Cut(strings.TrimSpace(e), ":")
+		if !found || user == "" || pass == "" {
+			return nil, fmt.Errorf("%w: entry %q", ErrInvalidUsers, e)
+		}
+		if _, dup := users[user]; dup {
+			return nil, fmt.Errorf("%w: duplicate user %q", ErrInvalidUsers, user)
+		}
+		users[user] = pass
+	}
+	return users, nil
+}

--- a/auth/guard/basicauth.go
+++ b/auth/guard/basicauth.go
@@ -23,13 +23,19 @@ const dummyPassword = "guard-basicauth-dummy-password-for-unknown-users"
 // WWW-Authenticate Basic challenge through the responder (default
 // problem.JSON 401). On success the request carries
 // Identity{Subject: username, Method: "basic"} — From/MustFrom work as
-// behind New. Panics on an empty users map — a gate with no valid
-// credentials is a wiring bug. Accepted options: WithRealm, WithResponder;
-// WithExtractors, WithOptional, and WithChallenge are ignored (the scheme
-// and challenge are fixed).
+// behind New. Panics on an empty users map, or on an empty username or
+// password entry — a gate with no valid credentials, or with a credential
+// that authenticates unconditionally, is a wiring bug. Accepted options:
+// WithRealm, WithResponder; WithExtractors, WithOptional, and WithChallenge
+// are ignored (the scheme and challenge are fixed).
 func BasicAuth(users map[string]string, opts ...Option) middleware.Middleware {
 	if len(users) == 0 {
 		panic("guard: BasicAuth requires at least one user")
+	}
+	for user, pass := range users {
+		if user == "" || pass == "" {
+			panic("guard: BasicAuth users must have non-empty username and password")
+		}
 	}
 	cfg := config{
 		responder: problem.JSON(problem.WithStatus(http.StatusUnauthorized)),

--- a/auth/guard/basicauth.go
+++ b/auth/guard/basicauth.go
@@ -22,7 +22,7 @@ const dummyPassword = "guard-basicauth-dummy-password-for-unknown-users"
 // indistinguishable to the client. Every failure gets 401 with a
 // WWW-Authenticate Basic challenge through the responder (default
 // problem.JSON 401). On success the request carries
-// Identity{Subject: username, Method: "basic"} — From/MustFrom work as
+// Identity{Subject: username, Method: guard.MethodBasic} — From/MustFrom work as
 // behind New. Panics on an empty users map, or on an empty username or
 // password entry — a gate with no valid credentials, or with a credential
 // that authenticates unconditionally, is a wiring bug. Accepted options:

--- a/auth/guard/basicauth.go
+++ b/auth/guard/basicauth.go
@@ -64,21 +64,24 @@ func BasicAuth(users map[string]string, opts ...Option) middleware.Middleware {
 				reject(ErrInvalidCredential)
 				return
 			}
-			next.ServeHTTP(w, r.WithContext(identityKey.With(r.Context(), Identity{Subject: user, Method: "basic"})))
+			next.ServeHTTP(w, r.WithContext(identityKey.With(r.Context(), Identity{Subject: user, Method: MethodBasic})))
 		})
 	}
 }
 
 // ParseUsers parses BasicAuth credentials from the "user1:pass1,user2:pass2"
 // env-string format. Passwords may contain colons (the split is at the first
-// colon) but not commas. It rejects (wrapping ErrInvalidUsers) empty input,
-// entries without a colon, empty usernames or passwords, and duplicate
-// usernames.
+// colon) but not commas. Whitespace surrounding each username and password
+// is trimmed, so a password cannot carry leading/trailing spaces via this
+// helper; internal spaces are preserved. It rejects (wrapping
+// ErrInvalidUsers) empty input, entries without a colon, empty usernames or
+// passwords, and duplicate usernames.
 func ParseUsers(s string) (map[string]string, error) {
 	entries := strings.Split(s, ",")
 	users := make(map[string]string, len(entries))
 	for _, e := range entries {
 		user, pass, found := strings.Cut(strings.TrimSpace(e), ":")
+		user, pass = strings.TrimSpace(user), strings.TrimSpace(pass)
 		if !found || user == "" || pass == "" {
 			return nil, fmt.Errorf("%w: entry %q", ErrInvalidUsers, e)
 		}

--- a/auth/guard/basicauth_test.go
+++ b/auth/guard/basicauth_test.go
@@ -1,0 +1,143 @@
+package guard_test
+
+import (
+	"errors"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+func basicGet(t *testing.T, h http.Handler, setAuth func(*http.Request)) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	if setAuth != nil {
+		setAuth(r)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w
+}
+
+func TestBasicAuth_Success(t *testing.T) {
+	t.Parallel()
+	h := guard.BasicAuth(map[string]string{"ops": "s3cret"})(echoHandler(t))
+	w := basicGet(t, h, func(r *http.Request) { r.SetBasicAuth("ops", "s3cret") })
+	if w.Code != http.StatusOK || w.Body.String() != "ops" {
+		t.Fatalf("got %d %q, want 200 ops (Identity in context)", w.Code, w.Body.String())
+	}
+	if w.Header().Get("WWW-Authenticate") != "" {
+		t.Fatal("WWW-Authenticate set on success")
+	}
+}
+
+func TestBasicAuth_MethodIsBasic(t *testing.T) {
+	t.Parallel()
+	var got guard.Identity
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = guard.MustFrom(r.Context())
+	})
+	h := guard.BasicAuth(map[string]string{"ops": "s3cret"})(inner)
+	basicGet(t, h, func(r *http.Request) { r.SetBasicAuth("ops", "s3cret") })
+	if got.Subject != "ops" || got.Method != "basic" {
+		t.Fatalf("Identity = %+v, want Subject=ops Method=basic", got)
+	}
+}
+
+func TestBasicAuth_Failures(t *testing.T) {
+	t.Parallel()
+	const wantChallenge = `Basic realm="restricted", charset="UTF-8"`
+	tests := []struct {
+		name    string
+		setAuth func(*http.Request)
+		wantErr error
+	}{
+		{"missing header", nil, guard.ErrNoCredential},
+		{"malformed header", func(r *http.Request) { r.Header.Set("Authorization", "Basic !!!not-base64!!!") }, guard.ErrNoCredential},
+		{"wrong password", func(r *http.Request) { r.SetBasicAuth("ops", "wrong") }, guard.ErrInvalidCredential},
+		{"unknown user", func(r *http.Request) { r.SetBasicAuth("nobody", "s3cret") }, guard.ErrInvalidCredential},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var captured error
+			h := guard.BasicAuth(map[string]string{"ops": "s3cret"},
+				guard.WithResponder(func(w http.ResponseWriter, r *http.Request, err error) {
+					captured = err
+					w.WriteHeader(http.StatusUnauthorized)
+				}),
+			)(echoHandler(t))
+			w := basicGet(t, h, tt.setAuth)
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401", w.Code)
+			}
+			if got := w.Header().Get("WWW-Authenticate"); got != wantChallenge {
+				t.Fatalf("WWW-Authenticate = %q, want %q", got, wantChallenge)
+			}
+			if !errors.Is(captured, tt.wantErr) {
+				t.Fatalf("err = %v, want Is(%v)", captured, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBasicAuth_Realm(t *testing.T) {
+	t.Parallel()
+	h := guard.BasicAuth(map[string]string{"ops": "s3cret"}, guard.WithRealm("staging"))(echoHandler(t))
+	w := basicGet(t, h, nil)
+	if got := w.Header().Get("WWW-Authenticate"); got != `Basic realm="staging", charset="UTF-8"` {
+		t.Fatalf("WWW-Authenticate = %q", got)
+	}
+}
+
+func TestBasicAuth_DefaultProblemResponse(t *testing.T) {
+	t.Parallel()
+	h := guard.BasicAuth(map[string]string{"ops": "s3cret"})(echoHandler(t))
+	w := basicGet(t, h, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/problem+json") {
+		t.Fatalf("Content-Type = %q, want application/problem+json", ct)
+	}
+}
+
+func TestParseUsers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		in    string
+		want  map[string]string
+		isErr bool
+	}{
+		{"single", "ops:s3cret", map[string]string{"ops": "s3cret"}, false},
+		{"multiple with space", "a:1, b:2", map[string]string{"a": "1", "b": "2"}, false},
+		{"password with colon", "ops:pa:ss", map[string]string{"ops": "pa:ss"}, false},
+		{"empty input", "", nil, true},
+		{"no colon", "opspass", nil, true},
+		{"empty user", ":pass", nil, true},
+		{"empty password", "ops:", nil, true},
+		{"duplicate user", "ops:1,ops:2", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := guard.ParseUsers(tt.in)
+			if tt.isErr {
+				if !errors.Is(err, guard.ErrInvalidUsers) {
+					t.Fatalf("err = %v, want Is(ErrInvalidUsers)", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseUsers(%q): %v", tt.in, err)
+			}
+			if !maps.Equal(got, tt.want) {
+				t.Fatalf("ParseUsers(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/auth/guard/basicauth_test.go
+++ b/auth/guard/basicauth_test.go
@@ -116,6 +116,7 @@ func TestParseUsers(t *testing.T) {
 		{"single", "ops:s3cret", map[string]string{"ops": "s3cret"}, false},
 		{"multiple with space", "a:1, b:2", map[string]string{"a": "1", "b": "2"}, false},
 		{"password with colon", "ops:pa:ss", map[string]string{"ops": "pa:ss"}, false},
+		{"whitespace around colon", "ops : s3cret", map[string]string{"ops": "s3cret"}, false},
 		{"empty input", "", nil, true},
 		{"no colon", "opspass", nil, true},
 		{"empty user", ":pass", nil, true},

--- a/auth/guard/bench_test.go
+++ b/auth/guard/bench_test.go
@@ -1,0 +1,127 @@
+package guard_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+// nopWriter discards the response so benchmarks measure guard's work, not
+// httptest.ResponseRecorder's buffer growth.
+type nopWriter struct{ h http.Header }
+
+func (w *nopWriter) Header() http.Header         { return w.h }
+func (w *nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (w *nopWriter) WriteHeader(int)             {}
+
+func benchVerifier() guard.Verifier {
+	id := guard.Identity{Subject: "u1", Tenant: "t1", Method: "bearer"}
+	return guard.VerifierFunc(func(context.Context, string) (guard.Identity, error) {
+		return id, nil
+	})
+}
+
+func BenchmarkNew_ValidBearer(b *testing.B) {
+	var depth int
+	h := guard.New(benchVerifier())(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if id, ok := guard.From(r.Context()); ok {
+			depth += len(id.Subject)
+		}
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer tok")
+	w := &nopWriter{h: make(http.Header)}
+	b.ReportAllocs()
+	for b.Loop() {
+		h.ServeHTTP(w, r)
+	}
+	_ = depth
+}
+
+func BenchmarkNew_Reject401(b *testing.B) {
+	h := guard.New(benchVerifier(), guard.WithChallenge(`Bearer realm="api"`))(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	r := httptest.NewRequest(http.MethodGet, "/", nil) // no credential
+	w := &nopWriter{h: make(http.Header)}
+	b.ReportAllocs()
+	for b.Loop() {
+		h.ServeHTTP(w, r)
+	}
+}
+
+func BenchmarkExtractors(b *testing.B) {
+	bearer := httptest.NewRequest(http.MethodGet, "/", nil)
+	bearer.Header.Set("Authorization", "Bearer tok123")
+	apikey := httptest.NewRequest(http.MethodGet, "/", nil)
+	apikey.Header.Set("X-API-Key", "key123")
+	withCookie := httptest.NewRequest(http.MethodGet, "/", nil)
+	withCookie.AddCookie(&http.Cookie{Name: "sid", Value: "abc"})
+	withQuery := httptest.NewRequest(http.MethodGet, "/p?a=1&token=qtok&c=3", nil)
+
+	benches := []struct {
+		name string
+		x    guard.Extractor
+		r    *http.Request
+	}{
+		{"BearerHeader", guard.BearerHeader(), bearer},
+		{"Header", guard.Header("X-API-Key"), apikey},
+		{"Cookie", guard.Cookie("sid"), withCookie},
+		{"Query", guard.Query("token"), withQuery},
+	}
+	for _, bb := range benches {
+		b.Run(bb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, ok := bb.x(bb.r); !ok {
+					b.Fatal("extractor missed")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkBasicAuth(b *testing.B) {
+	users := map[string]string{"ops": "s3cret"}
+	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+
+	good := httptest.NewRequest(http.MethodGet, "/", nil)
+	good.SetBasicAuth("ops", "s3cret")
+	bad := httptest.NewRequest(http.MethodGet, "/", nil)
+	bad.SetBasicAuth("ops", "wrong")
+
+	h := guard.BasicAuth(users)(inner)
+	w := &nopWriter{h: make(http.Header)}
+
+	b.Run("success", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			h.ServeHTTP(w, good)
+		}
+	})
+	b.Run("wrong-password", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			h.ServeHTTP(w, bad)
+		}
+	})
+}
+
+func BenchmarkLogExtractor(b *testing.B) {
+	var ctx context.Context
+	h := guard.New(benchVerifier())(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		ctx = r.Context()
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer tok")
+	h.ServeHTTP(&nopWriter{h: make(http.Header)}, r)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, ok := guard.LogExtractor(ctx); !ok {
+			b.Fatal("no identity in ctx")
+		}
+	}
+}

--- a/auth/guard/context.go
+++ b/auth/guard/context.go
@@ -1,0 +1,36 @@
+package guard
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/dmitrymomot/forge/core/ctxkey"
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+var identityKey = ctxkey.New[Identity]("guard")
+
+// From returns the Identity stored by the guard middleware, if any.
+func From(ctx context.Context) (Identity, bool) {
+	return identityKey.From(ctx)
+}
+
+// MustFrom returns the Identity or panics if absent — for handlers mounted
+// behind the guard, where a missing Identity is a wiring bug.
+func MustFrom(ctx context.Context) Identity {
+	return identityKey.MustFrom(ctx)
+}
+
+// LogExtractor adds an "auth" group with the subject (and tenant when set)
+// for requests that carry an Identity.
+var LogExtractor logger.ContextExtractor = func(ctx context.Context) (slog.Attr, bool) {
+	id, ok := identityKey.From(ctx)
+	if !ok {
+		return slog.Attr{}, false
+	}
+	attrs := []any{slog.String("subject", id.Subject)}
+	if id.Tenant != "" {
+		attrs = append(attrs, slog.String("tenant", id.Tenant))
+	}
+	return slog.Group("auth", attrs...), true
+}

--- a/auth/guard/context_test.go
+++ b/auth/guard/context_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/dmitrymomot/forge/auth/guard"
@@ -59,11 +62,45 @@ func TestLogExtractor_NoIdentity(t *testing.T) {
 	}
 }
 
-func TestLogExtractor_SubjectOnly(t *testing.T) {
+func TestLogExtractor_ThroughMiddleware(t *testing.T) {
 	t.Parallel()
-	// There is no exported setter (only the middleware stores identities), so
-	// this test goes through the middleware in Task 3. For now assert only the
-	// empty-context contract above; this test body is extended in Task 3.
-	t.Skip("extended in Task 3 once New can store an Identity")
-	_ = slog.Attr{}
+	tests := []struct {
+		name   string
+		id     guard.Identity
+		tenant bool
+	}{
+		{"subject only", guard.Identity{Subject: "u1", Method: "test"}, false},
+		{"subject and tenant", guard.Identity{Subject: "u1", Tenant: "t1", Method: "test"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			v := guard.VerifierFunc(func(context.Context, string) (guard.Identity, error) {
+				return tt.id, nil
+			})
+			var attr slog.Attr
+			var ok bool
+			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attr, ok = guard.LogExtractor(r.Context())
+			})
+			h := guard.New(v)(inner)
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.Header.Set("Authorization", "Bearer tok")
+			h.ServeHTTP(httptest.NewRecorder(), r)
+
+			if !ok {
+				t.Fatal("LogExtractor: ok = false behind the guard")
+			}
+			if attr.Key != "auth" {
+				t.Fatalf("attr key = %q, want auth", attr.Key)
+			}
+			s := attr.Value.String()
+			if !strings.Contains(s, "u1") {
+				t.Fatalf("attr %q does not contain subject", s)
+			}
+			if tt.tenant != strings.Contains(s, "t1") {
+				t.Fatalf("attr %q tenant presence, want %v", s, tt.tenant)
+			}
+		})
+	}
 }

--- a/auth/guard/context_test.go
+++ b/auth/guard/context_test.go
@@ -1,0 +1,69 @@
+package guard_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+func TestFrom_Absent(t *testing.T) {
+	t.Parallel()
+	id, ok := guard.From(context.Background())
+	if ok {
+		t.Fatalf("From on empty ctx: ok = true, want false (id=%+v)", id)
+	}
+}
+
+func TestMustFrom_PanicsWhenAbsent(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("MustFrom on empty ctx did not panic")
+		}
+	}()
+	guard.MustFrom(context.Background())
+}
+
+func TestVerifierFunc_ImplementsVerifier(t *testing.T) {
+	t.Parallel()
+	want := guard.Identity{Subject: "u1", Method: "test"}
+	var v guard.Verifier = guard.VerifierFunc(func(_ context.Context, cred string) (guard.Identity, error) {
+		if cred != "tok" {
+			t.Fatalf("credential = %q, want %q", cred, "tok")
+		}
+		return want, nil
+	})
+	got, err := v.Verify(context.Background(), "tok")
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got.Subject != want.Subject || got.Method != want.Method {
+		t.Fatalf("Verify = %+v, want %+v", got, want)
+	}
+}
+
+func TestSentinels_AreDistinct(t *testing.T) {
+	t.Parallel()
+	if errors.Is(guard.ErrNoCredential, guard.ErrInvalidCredential) {
+		t.Fatal("ErrNoCredential must not match ErrInvalidCredential")
+	}
+}
+
+func TestLogExtractor_NoIdentity(t *testing.T) {
+	t.Parallel()
+	if _, ok := guard.LogExtractor(context.Background()); ok {
+		t.Fatal("LogExtractor on empty ctx: ok = true, want false")
+	}
+}
+
+func TestLogExtractor_SubjectOnly(t *testing.T) {
+	t.Parallel()
+	// There is no exported setter (only the middleware stores identities), so
+	// this test goes through the middleware in Task 3. For now assert only the
+	// empty-context contract above; this test body is extended in Task 3.
+	t.Skip("extended in Task 3 once New can store an Identity")
+	_ = slog.Attr{}
+}

--- a/auth/guard/doc.go
+++ b/auth/guard/doc.go
@@ -19,7 +19,7 @@
 //		if err != nil {
 //			return guard.Identity{}, err // client sees a generic 401
 //		}
-//		return guard.Identity{Subject: c.Subject, Tenant: c.TenantID, Scopes: c.Scopes, Method: "bearer"}, nil
+//		return guard.Identity{Subject: c.Subject, Tenant: c.TenantID, Scopes: c.Scopes, Method: guard.MethodBearer}, nil
 //	})
 //
 //	authn := guard.New(verifier, guard.WithChallenge(`Bearer realm="api"`))

--- a/auth/guard/doc.go
+++ b/auth/guard/doc.go
@@ -1,0 +1,52 @@
+// Package guard authenticates HTTP requests. A chain of credential
+// extractors finds the credential (Authorization header by default;
+// cookie and query opt-in), a Verifier resolves it to an Identity stored
+// in request context, and rejections are problem+json 401s. Authorization
+// (403, permissions) is out of scope — guard answers "who is this request
+// from"; session lifecycle (rotation, TTLs) belongs to auth/session and
+// scope checks to the future authorization seam.
+//
+// A Verifier adapter is a small closure — over auth/jwt:
+//
+//	type appClaims struct {
+//		jwt.Claims
+//		TenantID string   `json:"tid"`
+//		Scopes   []string `json:"scopes"`
+//	}
+//
+//	verifier := guard.VerifierFunc(func(ctx context.Context, token string) (guard.Identity, error) {
+//		c, err := jwt.Verify[appClaims](ctx, jwtVerifier, token)
+//		if err != nil {
+//			return guard.Identity{}, err // client sees a generic 401
+//		}
+//		return guard.Identity{Subject: c.Subject, Tenant: c.TenantID, Scopes: c.Scopes, Method: "bearer"}, nil
+//	})
+//
+//	authn := guard.New(verifier, guard.WithChallenge(`Bearer realm="api"`))
+//	mux.Handle("GET /api/me", authn(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//		id := guard.MustFrom(r.Context())
+//		_ = id.Subject
+//	})))
+//
+// Session-cookie flows swap the extractor and redirect instead of 401:
+//
+//	authn := guard.New(sessionVerifier,
+//		guard.WithExtractors(guard.Cookie("sid")),
+//		guard.WithResponder(func(w http.ResponseWriter, r *http.Request, err error) {
+//			http.Redirect(w, r, "/login?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusSeeOther)
+//		}),
+//	)
+//
+// Public-but-personalized routes use WithOptional: missing credential
+// passes anonymously (From reports ok=false), invalid credential still
+// gets 401.
+//
+// BasicAuth gates internal surfaces (pprof, metrics, staging) with static
+// env-sourced credentials, constant-time:
+//
+//	users, err := guard.ParseUsers(os.Getenv("ADMIN_BASIC_USERS")) // "ops:s3cret"
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	mux.Handle("/debug/pprof/", guard.BasicAuth(users, guard.WithRealm("staging"))(pprofHandler))
+package guard

--- a/auth/guard/errors.go
+++ b/auth/guard/errors.go
@@ -1,0 +1,22 @@
+package guard
+
+import (
+	"errors"
+
+	"github.com/dmitrymomot/forge/core/errorsx"
+)
+
+// ErrNoCredential is passed to the responder when no extractor found a
+// credential on the request (or the Basic Auth header is missing/malformed).
+var ErrNoCredential = errorsx.New("auth_missing", "no credential provided")
+
+// ErrInvalidCredential is passed to the responder when a credential was
+// present but rejected — the verifier returned an error (wrapped, so both
+// this sentinel and the verifier's own error match via errors.Is), the
+// verifier resolved an Identity without a Subject, or Basic Auth
+// credentials did not match.
+var ErrInvalidCredential = errorsx.New("auth_invalid", "credential rejected")
+
+// ErrInvalidUsers is wrapped in ParseUsers errors for unparseable
+// "user:pass,user:pass" credential strings.
+var ErrInvalidUsers = errors.New("guard: invalid users string")

--- a/auth/guard/extractors.go
+++ b/auth/guard/extractors.go
@@ -2,6 +2,7 @@ package guard
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -26,7 +27,13 @@ func BearerHeader() Extractor {
 }
 
 // Header extracts the named header's value verbatim (e.g. "X-API-Key").
+//
+// name is canonicalized once here instead of on every request: r.Header.Get
+// re-canonicalizes its argument on each call, which allocates whenever name
+// isn't already in canonical form (e.g. "X-API-Key" vs "X-Api-Key";
+// benchmark in the PR).
 func Header(name string) Extractor {
+	name = http.CanonicalHeaderKey(name)
 	return func(r *http.Request) (string, bool) {
 		v := r.Header.Get(name)
 		return v, v != ""
@@ -51,9 +58,35 @@ func Cookie(name string) Extractor {
 // Credentials in query strings leak into access logs, browser history, and
 // Referer headers. Prefer BearerHeader or Cookie; reserve Query for signed,
 // short-lived links.
+//
+// It scans RawQuery directly instead of calling r.URL.Query(), which would
+// allocate the full url.Values map per request (benchmark in the PR).
 func Query(name string) Extractor {
 	return func(r *http.Request) (string, bool) {
-		v := r.URL.Query().Get(name)
-		return v, v != ""
+		q := r.URL.RawQuery
+		for q != "" {
+			var pair string
+			pair, q, _ = strings.Cut(q, "&")
+			k, v, _ := strings.Cut(pair, "=")
+			if strings.ContainsAny(k, "%+") {
+				dec, err := url.QueryUnescape(k)
+				if err != nil {
+					continue
+				}
+				k = dec
+			}
+			if k != name {
+				continue
+			}
+			if strings.ContainsAny(v, "%+") {
+				dec, err := url.QueryUnescape(v)
+				if err != nil {
+					return "", false
+				}
+				v = dec
+			}
+			return v, v != ""
+		}
+		return "", false
 	}
 }

--- a/auth/guard/extractors.go
+++ b/auth/guard/extractors.go
@@ -67,6 +67,9 @@ func Query(name string) Extractor {
 		for q != "" {
 			var pair string
 			pair, q, _ = strings.Cut(q, "&")
+			if strings.Contains(pair, ";") {
+				continue
+			}
 			k, v, _ := strings.Cut(pair, "=")
 			if strings.ContainsAny(k, "%+") {
 				dec, err := url.QueryUnescape(k)
@@ -81,7 +84,7 @@ func Query(name string) Extractor {
 			if strings.ContainsAny(v, "%+") {
 				dec, err := url.QueryUnescape(v)
 				if err != nil {
-					return "", false
+					continue
 				}
 				v = dec
 			}

--- a/auth/guard/extractors.go
+++ b/auth/guard/extractors.go
@@ -61,6 +61,11 @@ func Cookie(name string) Extractor {
 //
 // It scans RawQuery directly instead of calling r.URL.Query(), which would
 // allocate the full url.Values map per request (benchmark in the PR).
+//
+// Unlike r.URL.Query(), the scan does not enforce net/url's 10,000-parameter
+// cap, so it still resolves a credential in a pathologically long query
+// string (a benign divergence — finding a valid credential is not a
+// bypass).
 func Query(name string) Extractor {
 	return func(r *http.Request) (string, bool) {
 		q := r.URL.RawQuery

--- a/auth/guard/extractors.go
+++ b/auth/guard/extractors.go
@@ -1,0 +1,59 @@
+package guard
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Extractor pulls a raw credential from a request. ok=false means "not
+// present" — the middleware tries the next extractor in the chain; it never
+// means "present but bad" (that judgment belongs to the Verifier).
+type Extractor func(r *http.Request) (credential string, ok bool)
+
+// BearerHeader extracts the token from an "Authorization: Bearer <token>"
+// header (scheme match is case-insensitive). A non-Bearer Authorization
+// header reads as no credential, so e.g. a Basic header on a
+// bearer-guarded route falls through to the next extractor.
+func BearerHeader() Extractor {
+	return func(r *http.Request) (string, bool) {
+		scheme, token, found := strings.Cut(r.Header.Get("Authorization"), " ")
+		if !found || !strings.EqualFold(scheme, "Bearer") {
+			return "", false
+		}
+		token = strings.TrimSpace(token)
+		return token, token != ""
+	}
+}
+
+// Header extracts the named header's value verbatim (e.g. "X-API-Key").
+func Header(name string) Extractor {
+	return func(r *http.Request) (string, bool) {
+		v := r.Header.Get(name)
+		return v, v != ""
+	}
+}
+
+// Cookie extracts the named cookie's value. For signed or encrypted cookies
+// write a closure over web/cookie's Codec instead — any func with this
+// signature is an Extractor.
+func Cookie(name string) Extractor {
+	return func(r *http.Request) (string, bool) {
+		c, err := r.Cookie(name)
+		if err != nil || c.Value == "" {
+			return "", false
+		}
+		return c.Value, true
+	}
+}
+
+// Query extracts the named query parameter.
+//
+// Credentials in query strings leak into access logs, browser history, and
+// Referer headers. Prefer BearerHeader or Cookie; reserve Query for signed,
+// short-lived links.
+func Query(name string) Extractor {
+	return func(r *http.Request) (string, bool) {
+		v := r.URL.Query().Get(name)
+		return v, v != ""
+	}
+}

--- a/auth/guard/extractors_test.go
+++ b/auth/guard/extractors_test.go
@@ -55,6 +55,11 @@ func TestHeader(t *testing.T) {
 	if _, ok := guard.Header("X-Empty")(r); ok {
 		t.Fatal("Header(X-Empty): empty value must read as no credential")
 	}
+	// name canonicalization must stay case-insensitive regardless of the
+	// casing passed in (guard.Header pre-canonicalizes once at construction).
+	if got, ok := guard.Header("x-api-key")(r); !ok || got != "key123" {
+		t.Fatalf("Header(x-api-key) = (%q, %v), want (key123, true)", got, ok)
+	}
 }
 
 func TestCookie(t *testing.T) {
@@ -86,5 +91,16 @@ func TestQuery(t *testing.T) {
 	}
 	if _, ok := guard.Query("empty")(r); ok {
 		t.Fatal("Query(empty): empty value must read as no credential")
+	}
+
+	enc := httptest.NewRequest(http.MethodGet, "/p?tok%65n=q%74ok&plus=a+b&first=1&first=2", nil)
+	if got, ok := guard.Query("token")(enc); !ok || got != "qtok" {
+		t.Fatalf("Query(token) encoded = (%q, %v), want (qtok, true)", got, ok)
+	}
+	if got, ok := guard.Query("plus")(enc); !ok || got != "a b" {
+		t.Fatalf("Query(plus) = (%q, %v), want (a b, true)", got, ok)
+	}
+	if got, ok := guard.Query("first")(enc); !ok || got != "1" {
+		t.Fatalf("Query(first) = (%q, %v), want first occurrence (1, true)", got, ok)
 	}
 }

--- a/auth/guard/extractors_test.go
+++ b/auth/guard/extractors_test.go
@@ -1,0 +1,90 @@
+package guard_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+func TestBearerHeader(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		header string
+		want   string
+		wantOK bool
+	}{
+		{"valid", "Bearer tok123", "tok123", true},
+		{"lowercase scheme", "bearer tok123", "tok123", true},
+		{"extra spaces after scheme", "Bearer   tok123", "tok123", true},
+		{"absent", "", "", false},
+		{"scheme only", "Bearer", "", false},
+		{"scheme with empty token", "Bearer   ", "", false},
+		{"basic scheme reads as no credential", "Basic dXNlcjpwYXNz", "", false},
+		{"no scheme", "tok123", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.header != "" {
+				r.Header.Set("Authorization", tt.header)
+			}
+			got, ok := guard.BearerHeader()(r)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("BearerHeader() = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestHeader(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-API-Key", "key123")
+
+	if got, ok := guard.Header("X-API-Key")(r); !ok || got != "key123" {
+		t.Fatalf("Header(X-API-Key) = (%q, %v), want (key123, true)", got, ok)
+	}
+	if got, ok := guard.Header("X-Missing")(r); ok {
+		t.Fatalf("Header(X-Missing) = (%q, %v), want ok=false", got, ok)
+	}
+	r.Header.Set("X-Empty", "")
+	if _, ok := guard.Header("X-Empty")(r); ok {
+		t.Fatal("Header(X-Empty): empty value must read as no credential")
+	}
+}
+
+func TestCookie(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.AddCookie(&http.Cookie{Name: "sid", Value: "abc"})
+	r.AddCookie(&http.Cookie{Name: "empty", Value: ""})
+
+	if got, ok := guard.Cookie("sid")(r); !ok || got != "abc" {
+		t.Fatalf("Cookie(sid) = (%q, %v), want (abc, true)", got, ok)
+	}
+	if _, ok := guard.Cookie("missing")(r); ok {
+		t.Fatal("Cookie(missing): want ok=false")
+	}
+	if _, ok := guard.Cookie("empty")(r); ok {
+		t.Fatal("Cookie(empty): empty value must read as no credential")
+	}
+}
+
+func TestQuery(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/path?token=qtok&empty=", nil)
+
+	if got, ok := guard.Query("token")(r); !ok || got != "qtok" {
+		t.Fatalf("Query(token) = (%q, %v), want (qtok, true)", got, ok)
+	}
+	if _, ok := guard.Query("missing")(r); ok {
+		t.Fatal("Query(missing): want ok=false")
+	}
+	if _, ok := guard.Query("empty")(r); ok {
+		t.Fatal("Query(empty): empty value must read as no credential")
+	}
+}

--- a/auth/guard/extractors_test.go
+++ b/auth/guard/extractors_test.go
@@ -103,4 +103,17 @@ func TestQuery(t *testing.T) {
 	if got, ok := guard.Query("first")(enc); !ok || got != "1" {
 		t.Fatalf("Query(first) = (%q, %v), want first occurrence (1, true)", got, ok)
 	}
+
+	// Regression: malformed %-escape on the first occurrence must not abort the
+	// scan — a later valid occurrence still wins (matches url.Values.Get).
+	dup := httptest.NewRequest(http.MethodGet, "/p?token=%zz&token=realtoken", nil)
+	if got, ok := guard.Query("token")(dup); !ok || got != "realtoken" {
+		t.Fatalf("Query(token) malformed-then-valid = (%q, %v), want (realtoken, true)", got, ok)
+	}
+	// Regression: a raw semicolon in a pair invalidates it (stdlib parseQuery
+	// drops the whole pair), so the credential reads as absent.
+	semi := httptest.NewRequest(http.MethodGet, "/p?token=abc;xyz", nil)
+	if _, ok := guard.Query("token")(semi); ok {
+		t.Fatal("Query(token) with raw semicolon: want ok=false (matches url.Values.Get)")
+	}
 }

--- a/auth/guard/guard.go
+++ b/auth/guard/guard.go
@@ -1,0 +1,33 @@
+package guard
+
+import "context"
+
+// Identity is the authenticated principal a Verifier resolved. Subject is
+// never empty on a successful verification; Tenant, Scopes, and Meta are
+// optional. Scopes is carried for the future authorization decision seam
+// (401-vs-403 split) — guard itself never reads it.
+type Identity struct {
+	Meta    map[string]string // verifier-specific extras (email, key id, …)
+	Subject string            // principal id — never empty on success
+	Tenant  string            // optional tenant id
+	Method  string            // how the request authenticated: "bearer", "session", "apikey", "basic"
+	Scopes  []string          // permissions/scopes for the future authz seam
+}
+
+// Verifier turns an extracted credential into an Identity. A returned error
+// means the credential is rejected: the middleware answers 401 and never
+// surfaces error detail to the client. Implementations must be safe for
+// concurrent use.
+type Verifier interface {
+	Verify(ctx context.Context, credential string) (Identity, error)
+}
+
+// VerifierFunc adapts a function to Verifier. It doubles as the package's
+// test fake — provider adapters (auth/jwt, auth/apikey, auth/session) are
+// closures over it or their own types.
+type VerifierFunc func(ctx context.Context, credential string) (Identity, error)
+
+// Verify implements Verifier.
+func (f VerifierFunc) Verify(ctx context.Context, credential string) (Identity, error) {
+	return f(ctx, credential)
+}

--- a/auth/guard/guard.go
+++ b/auth/guard/guard.go
@@ -18,9 +18,21 @@ type Identity struct {
 	Meta    map[string]string // verifier-specific extras (email, key id, …)
 	Subject string            // principal id — never empty on success
 	Tenant  string            // optional tenant id
-	Method  string            // how the request authenticated: "bearer", "session", "apikey", "basic"
+	Method  Method            // how the request authenticated; see the Method* constants
 	Scopes  []string          // permissions/scopes for the future authz seam
 }
+
+// Method names how a request authenticated. The constants below cover the
+// built-in gate (MethodBasic) and the first-party adapters; Method is a plain
+// string type, so a custom Verifier may set its own value.
+type Method string
+
+const (
+	MethodBearer  Method = "bearer"  // Authorization: Bearer (auth/jwt, auth/apikey)
+	MethodSession Method = "session" // session cookie (auth/session)
+	MethodAPIKey  Method = "apikey"  // API key
+	MethodBasic   Method = "basic"   // HTTP Basic Auth (guard.BasicAuth)
+)
 
 // Verifier turns an extracted credential into an Identity. A returned error
 // means the credential is rejected: the middleware answers 401 and never

--- a/auth/guard/guard.go
+++ b/auth/guard/guard.go
@@ -1,6 +1,14 @@
 package guard
 
-import "context"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/dmitrymomot/forge/web/middleware"
+	"github.com/dmitrymomot/forge/web/problem"
+)
 
 // Identity is the authenticated principal a Verifier resolved. Subject is
 // never empty on a successful verification; Tenant, Scopes, and Meta are
@@ -30,4 +38,79 @@ type VerifierFunc func(ctx context.Context, credential string) (Identity, error)
 // Verify implements Verifier.
 func (f VerifierFunc) Verify(ctx context.Context, credential string) (Identity, error) {
 	return f(ctx, credential)
+}
+
+// New returns middleware that authenticates every request through v: the
+// extractor chain (default BearerHeader) finds the credential, v resolves
+// it to an Identity stored in request context for From/MustFrom. A request
+// with no credential gets 401 (or passes anonymously with WithOptional); a
+// rejected credential gets 401 always. Rejections go through the responder
+// (default problem.JSON 401) after setting WWW-Authenticate when a
+// challenge is configured. New panics on a nil verifier — a wiring bug.
+func New(v Verifier, opts ...Option) middleware.Middleware {
+	if v == nil {
+		panic("guard: nil verifier")
+	}
+	jsonResponder := problem.JSON(problem.WithStatus(http.StatusUnauthorized))
+	cfg := config{
+		// The default responder never lets a verifier's error text reach the
+		// client: it collapses the wrapped chain down to the guard-level
+		// sentinel before handing off to problem.JSON, which otherwise puts
+		// err.Error() straight into the response body for any 4xx status.
+		// Custom responders (WithResponder) still see the full wrapped
+		// chain via errors.Is.
+		responder: func(w http.ResponseWriter, r *http.Request, err error) {
+			safe := ErrInvalidCredential
+			if errors.Is(err, ErrNoCredential) {
+				safe = ErrNoCredential
+			}
+			jsonResponder(w, r, safe)
+		},
+		extractors: []Extractor{BearerHeader()},
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cred, found := extract(cfg.extractors, r)
+			if !found {
+				if cfg.optional {
+					next.ServeHTTP(w, r)
+					return
+				}
+				cfg.reject(w, r, ErrNoCredential)
+				return
+			}
+			id, err := v.Verify(r.Context(), cred)
+			if err != nil {
+				cfg.reject(w, r, fmt.Errorf("%w: %w", ErrInvalidCredential, err))
+				return
+			}
+			if id.Subject == "" {
+				// A successful verification with no Subject is a verifier
+				// bug; treat it as a rejection rather than admitting an
+				// anonymous principal.
+				cfg.reject(w, r, ErrInvalidCredential)
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(identityKey.With(r.Context(), id)))
+		})
+	}
+}
+
+func extract(xs []Extractor, r *http.Request) (string, bool) {
+	for _, x := range xs {
+		if cred, ok := x(r); ok {
+			return cred, true
+		}
+	}
+	return "", false
+}
+
+func (c config) reject(w http.ResponseWriter, r *http.Request, err error) {
+	if c.challenge != "" {
+		w.Header().Set("WWW-Authenticate", c.challenge)
+	}
+	c.responder(w, r, err)
 }

--- a/auth/guard/guard_test.go
+++ b/auth/guard/guard_test.go
@@ -1,0 +1,226 @@
+package guard_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+// okVerifier accepts credential "good" as user u1; everything else fails
+// with errBadToken.
+var errBadToken = errors.New("bad token")
+
+func okVerifier() guard.Verifier {
+	return guard.VerifierFunc(func(_ context.Context, cred string) (guard.Identity, error) {
+		if cred == "good" {
+			return guard.Identity{Subject: "u1", Tenant: "t1", Method: "bearer"}, nil
+		}
+		return guard.Identity{}, errBadToken
+	})
+}
+
+// echoHandler writes the context Identity's subject, proving the request
+// passed the guard and the Identity is readable.
+func echoHandler(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, ok := guard.From(r.Context())
+		if !ok {
+			_, _ = w.Write([]byte("anonymous"))
+			return
+		}
+		_, _ = w.Write([]byte(id.Subject))
+	})
+}
+
+func get(t *testing.T, h http.Handler, mutate func(*http.Request)) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	if mutate != nil {
+		mutate(r)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w
+}
+
+func TestNew_ValidCredential(t *testing.T) {
+	t.Parallel()
+	h := guard.New(okVerifier())(echoHandler(t))
+	w := get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer good") })
+	if w.Code != http.StatusOK || w.Body.String() != "u1" {
+		t.Fatalf("got %d %q, want 200 u1", w.Code, w.Body.String())
+	}
+}
+
+func TestNew_MissingCredential(t *testing.T) {
+	t.Parallel()
+	h := guard.New(okVerifier())(echoHandler(t))
+	w := get(t, h, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/problem+json") {
+		t.Fatalf("Content-Type = %q, want application/problem+json", ct)
+	}
+	if w.Header().Get("WWW-Authenticate") != "" {
+		t.Fatal("WWW-Authenticate set without WithChallenge")
+	}
+}
+
+func TestNew_InvalidCredential(t *testing.T) {
+	t.Parallel()
+	h := guard.New(okVerifier())(echoHandler(t))
+	w := get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer evil") })
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if body := w.Body.String(); strings.Contains(body, "bad token") {
+		t.Fatalf("verifier error leaked to client: %q", body)
+	}
+}
+
+func TestNew_ErrorWrapping(t *testing.T) {
+	t.Parallel()
+	var captured error
+	responder := func(w http.ResponseWriter, r *http.Request, err error) {
+		captured = err
+		w.WriteHeader(http.StatusUnauthorized)
+	}
+
+	h := guard.New(okVerifier(), guard.WithResponder(responder))(echoHandler(t))
+	get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer evil") })
+	if !errors.Is(captured, guard.ErrInvalidCredential) {
+		t.Fatalf("err = %v, want Is(ErrInvalidCredential)", captured)
+	}
+	if !errors.Is(captured, errBadToken) {
+		t.Fatalf("err = %v, want Is(errBadToken) — verifier error must stay matchable", captured)
+	}
+
+	get(t, h, nil)
+	if !errors.Is(captured, guard.ErrNoCredential) {
+		t.Fatalf("err = %v, want Is(ErrNoCredential)", captured)
+	}
+}
+
+func TestNew_EmptySubjectIsRejected(t *testing.T) {
+	t.Parallel()
+	var captured error
+	v := guard.VerifierFunc(func(context.Context, string) (guard.Identity, error) {
+		return guard.Identity{}, nil // buggy verifier: success with zero Identity
+	})
+	h := guard.New(v, guard.WithResponder(func(w http.ResponseWriter, r *http.Request, err error) {
+		captured = err
+		w.WriteHeader(http.StatusUnauthorized)
+	}))(echoHandler(t))
+	w := get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer good") })
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if !errors.Is(captured, guard.ErrInvalidCredential) {
+		t.Fatalf("err = %v, want Is(ErrInvalidCredential)", captured)
+	}
+}
+
+func TestNew_Optional(t *testing.T) {
+	t.Parallel()
+	h := guard.New(okVerifier(), guard.WithOptional())(echoHandler(t))
+
+	// Missing credential: anonymous pass-through.
+	w := get(t, h, nil)
+	if w.Code != http.StatusOK || w.Body.String() != "anonymous" {
+		t.Fatalf("optional missing: got %d %q, want 200 anonymous", w.Code, w.Body.String())
+	}
+	// Valid credential: identity attached.
+	w = get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer good") })
+	if w.Code != http.StatusOK || w.Body.String() != "u1" {
+		t.Fatalf("optional valid: got %d %q, want 200 u1", w.Code, w.Body.String())
+	}
+	// Invalid credential: still 401.
+	w = get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer evil") })
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("optional invalid: status = %d, want 401", w.Code)
+	}
+}
+
+func TestNew_Challenge(t *testing.T) {
+	t.Parallel()
+	h := guard.New(okVerifier(), guard.WithChallenge(`Bearer realm="api"`))(echoHandler(t))
+
+	for name, mutate := range map[string]func(*http.Request){
+		"missing": nil,
+		"invalid": func(r *http.Request) { r.Header.Set("Authorization", "Bearer evil") },
+	} {
+		w := get(t, h, mutate)
+		if got := w.Header().Get("WWW-Authenticate"); got != `Bearer realm="api"` {
+			t.Fatalf("%s: WWW-Authenticate = %q, want Bearer realm=\"api\"", name, got)
+		}
+	}
+
+	// Success must not carry the challenge.
+	w := get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer good") })
+	if w.Header().Get("WWW-Authenticate") != "" {
+		t.Fatal("WWW-Authenticate set on success")
+	}
+}
+
+func TestNew_ExtractorChainOrder(t *testing.T) {
+	t.Parallel()
+	var seen []string
+	v := guard.VerifierFunc(func(_ context.Context, cred string) (guard.Identity, error) {
+		seen = append(seen, cred)
+		return guard.Identity{Subject: cred, Method: "test"}, nil
+	})
+	h := guard.New(v, guard.WithExtractors(
+		guard.Header("X-First"),
+		guard.Header("X-Second"),
+	))(echoHandler(t))
+
+	// Both present: first extractor wins, second never consulted.
+	w := get(t, h, func(r *http.Request) {
+		r.Header.Set("X-First", "one")
+		r.Header.Set("X-Second", "two")
+	})
+	if w.Body.String() != "one" {
+		t.Fatalf("body = %q, want one (first extractor wins)", w.Body.String())
+	}
+	// First absent: chain falls through to the second.
+	w = get(t, h, func(r *http.Request) { r.Header.Set("X-Second", "two") })
+	if w.Body.String() != "two" {
+		t.Fatalf("body = %q, want two (fallthrough)", w.Body.String())
+	}
+	if len(seen) != 2 {
+		t.Fatalf("verifier calls = %d, want 2 (one per request)", len(seen))
+	}
+}
+
+func TestNew_NoVerifyFallbackAfterExtract(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	v := guard.VerifierFunc(func(context.Context, string) (guard.Identity, error) {
+		calls++
+		return guard.Identity{}, errBadToken
+	})
+	h := guard.New(v, guard.WithExtractors(
+		guard.Header("X-First"),
+		guard.Header("X-Second"),
+	))(echoHandler(t))
+
+	// First extractor hits, verify fails: 401 — the second extractor must
+	// NOT be offered as a fallback.
+	w := get(t, h, func(r *http.Request) {
+		r.Header.Set("X-First", "bad")
+		r.Header.Set("X-Second", "good")
+	})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if calls != 1 {
+		t.Fatalf("verifier calls = %d, want 1 (no fallback after extraction)", calls)
+	}
+}

--- a/auth/guard/options.go
+++ b/auth/guard/options.go
@@ -1,0 +1,69 @@
+package guard
+
+import (
+	"strings"
+
+	"github.com/dmitrymomot/forge/web/problem"
+)
+
+type config struct {
+	responder  problem.Responder
+	challenge  string
+	realm      string
+	extractors []Extractor
+	optional   bool
+}
+
+// Option configures New and BasicAuth. Options that don't apply to a
+// constructor are ignored by it (each option documents which constructor
+// reads it).
+type Option func(*config)
+
+// WithExtractors replaces the default extractor chain (BearerHeader only).
+// Extractors run in order and the first hit wins — later extractors are not
+// fallbacks for a credential that fails verification. Panics on an empty
+// list: a guard that can never find a credential is a wiring bug. BasicAuth
+// ignores this option (its scheme is fixed).
+func WithExtractors(xs ...Extractor) Option {
+	if len(xs) == 0 {
+		panic("guard: WithExtractors requires at least one extractor")
+	}
+	return func(c *config) { c.extractors = xs }
+}
+
+// WithOptional lets requests without a credential pass through anonymously
+// (From reports ok=false). A present-but-invalid credential still gets 401 —
+// silently ignoring bad tokens masks expired sessions and probing. BasicAuth
+// ignores this option.
+func WithOptional() Option {
+	return func(c *config) { c.optional = true }
+}
+
+// WithResponder overrides the rejection response (default problem.JSON 401).
+// The error passed to the responder matches guard.ErrNoCredential or
+// guard.ErrInvalidCredential via errors.Is; verify failures also match the
+// verifier's own error.
+func WithResponder(r problem.Responder) Option {
+	return func(c *config) {
+		if r != nil {
+			c.responder = r
+		}
+	}
+}
+
+// WithChallenge sets the WWW-Authenticate header value emitted with every
+// 401, e.g. `Bearer realm="api"` (RFC 6750). Default: none. BasicAuth
+// ignores this option — it always emits its own Basic challenge.
+func WithChallenge(v string) Option {
+	return func(c *config) { c.challenge = v }
+}
+
+// WithRealm sets the Basic Auth realm (default "restricted"). Panics on
+// quotes, backslashes, or control characters — the realm is echoed into the
+// WWW-Authenticate header. New ignores this option.
+func WithRealm(realm string) Option {
+	if strings.ContainsAny(realm, "\"\\") || strings.ContainsFunc(realm, func(r rune) bool { return r < 0x20 || r == 0x7f }) {
+		panic("guard: realm must not contain quotes, backslashes, or control characters")
+	}
+	return func(c *config) { c.realm = realm }
+}

--- a/auth/guard/options.go
+++ b/auth/guard/options.go
@@ -43,6 +43,14 @@ func WithOptional() Option {
 // The error passed to the responder matches guard.ErrNoCredential or
 // guard.ErrInvalidCredential via errors.Is; verify failures also match the
 // verifier's own error.
+//
+// The error passed to a custom responder carries the verifier's own message
+// (so errors.Is matches both the guard sentinel and the verifier error). A
+// responder that renders err.Error() into the client response —
+// problem.JSON does this for 4xx — therefore leaks that message. To keep
+// the "no verifier detail to the client" guarantee, render only a generic
+// message or the guard sentinel (as New's default responder does), not the
+// raw error.
 func WithResponder(r problem.Responder) Option {
 	return func(c *config) {
 		if r != nil {

--- a/auth/guard/options.go
+++ b/auth/guard/options.go
@@ -22,11 +22,16 @@ type Option func(*config)
 // WithExtractors replaces the default extractor chain (BearerHeader only).
 // Extractors run in order and the first hit wins — later extractors are not
 // fallbacks for a credential that fails verification. Panics on an empty
-// list: a guard that can never find a credential is a wiring bug. BasicAuth
-// ignores this option (its scheme is fixed).
+// list or a nil extractor: a guard that can never find a credential is a
+// wiring bug. BasicAuth ignores this option (its scheme is fixed).
 func WithExtractors(xs ...Extractor) Option {
 	if len(xs) == 0 {
 		panic("guard: WithExtractors requires at least one extractor")
+	}
+	for _, x := range xs {
+		if x == nil {
+			panic("guard: WithExtractors received a nil extractor")
+		}
 	}
 	return func(c *config) { c.extractors = xs }
 }

--- a/auth/guard/panic_test.go
+++ b/auth/guard/panic_test.go
@@ -28,6 +28,13 @@ func TestWithExtractors_EmptyPanics(t *testing.T) {
 	})
 }
 
+func TestWithExtractors_NilElementPanics(t *testing.T) {
+	t.Parallel()
+	mustPanic(t, "WithExtractors(nil)", func() {
+		guard.New(okVerifier(), guard.WithExtractors(nil))
+	})
+}
+
 func TestBasicAuth_EmptyUsersPanics(t *testing.T) {
 	t.Parallel()
 	mustPanic(t, "BasicAuth(nil)", func() { guard.BasicAuth(nil) })

--- a/auth/guard/panic_test.go
+++ b/auth/guard/panic_test.go
@@ -1,0 +1,29 @@
+package guard_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+func mustPanic(t *testing.T, name string, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("%s did not panic", name)
+		}
+	}()
+	fn()
+}
+
+func TestNew_NilVerifierPanics(t *testing.T) {
+	t.Parallel()
+	mustPanic(t, "New(nil)", func() { guard.New(nil) })
+}
+
+func TestWithExtractors_EmptyPanics(t *testing.T) {
+	t.Parallel()
+	mustPanic(t, "WithExtractors()", func() {
+		guard.New(okVerifier(), guard.WithExtractors())
+	})
+}

--- a/auth/guard/panic_test.go
+++ b/auth/guard/panic_test.go
@@ -34,6 +34,12 @@ func TestBasicAuth_EmptyUsersPanics(t *testing.T) {
 	mustPanic(t, "BasicAuth(empty)", func() { guard.BasicAuth(map[string]string{}) })
 }
 
+func TestBasicAuth_EmptyCredentialPanics(t *testing.T) {
+	t.Parallel()
+	mustPanic(t, "BasicAuth(empty password)", func() { guard.BasicAuth(map[string]string{"admin": ""}) })
+	mustPanic(t, "BasicAuth(empty username)", func() { guard.BasicAuth(map[string]string{"": "pw"}) })
+}
+
 func TestWithRealm_InvalidPanics(t *testing.T) {
 	t.Parallel()
 	mustPanic(t, `WithRealm(quote)`, func() { guard.WithRealm(`sta"ging`) })

--- a/auth/guard/panic_test.go
+++ b/auth/guard/panic_test.go
@@ -27,3 +27,15 @@ func TestWithExtractors_EmptyPanics(t *testing.T) {
 		guard.New(okVerifier(), guard.WithExtractors())
 	})
 }
+
+func TestBasicAuth_EmptyUsersPanics(t *testing.T) {
+	t.Parallel()
+	mustPanic(t, "BasicAuth(nil)", func() { guard.BasicAuth(nil) })
+	mustPanic(t, "BasicAuth(empty)", func() { guard.BasicAuth(map[string]string{}) })
+}
+
+func TestWithRealm_InvalidPanics(t *testing.T) {
+	t.Parallel()
+	mustPanic(t, `WithRealm(quote)`, func() { guard.WithRealm(`sta"ging`) })
+	mustPanic(t, "WithRealm(control)", func() { guard.WithRealm("sta\nging") })
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -620,18 +620,6 @@ Deps: `auth/session`, `ops/auditlog`, `ops/approval` (all planned).
 
 ---
 
-**auth/guard**
-
-Request-authentication middleware over a `Verifier` seam (session, jwt,
-apikey all satisfy it) with chained credential extractors (header → cookie
-→ query), built-in Basic Auth (constant-time, correct 401 +
-WWW-Authenticate — gates pprof/metrics/staging/admin), and
-`IdentityFromContext`.
-
-Deps: `crypto/consttime`, `web/problem`.
-
----
-
 **auth/lockout**
 
 Login/OTP failure counting with exponential delay and lockout windows over
@@ -672,7 +660,7 @@ scopes, optional expiry, last-used-at tracking) behind a storage-agnostic
 Store, and request verification as a `guard.Verifier` (constant-time, key →
 identity/tenant resolution).
 
-Deps: `core/random`, `crypto/consttime`; `auth/guard` (planned).
+Deps: `core/random`, `crypto/consttime`, `auth/guard`.
 
 ---
 
@@ -717,7 +705,7 @@ authenticated via `apikey` or `oauthserver` tokens. The enterprise
 checkbox next to SSO; SAML stays out (`oauthclient` OIDC covers modern
 IdPs).
 
-Deps: `auth/guard` (planned).
+Deps: `auth/guard`.
 
 ---
 
@@ -903,7 +891,7 @@ One internal diagnostics surface: `/debug/pprof/*`, `/debug/stats`
 (runtime/GC/goroutines JSON), `/debug/vars`, with an auth guard and a
 dedicated-port `supervisor.Service`.
 
-Deps: `ops/supervisor`; `auth/guard` (planned).
+Deps: `ops/supervisor`, `auth/guard`.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-13-auth-guard.md
+++ b/docs/superpowers/plans/2026-07-13-auth-guard.md
@@ -1,0 +1,1362 @@
+# auth/guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `auth/guard` — request-authentication middleware (Verifier seam + chained extractors + Basic Auth + context Identity) per the approved spec at `docs/superpowers/specs/2026-07-13-auth-guard-design.md`.
+
+**Architecture:** One package, no subpackages. A `Verifier` interface turns an extracted credential string into a concrete `Identity`; `New` wires an extractor chain (default `BearerHeader()`) in front of one verifier and stores the `Identity` via `core/ctxkey`; `BasicAuth` is a dedicated constant-time constructor. Failures are 401s through a `problem.Responder`.
+
+**Tech Stack:** Go stdlib + forge-internal only: `web/middleware`, `web/problem`, `crypto/consttime`, `core/ctxkey`, `core/errorsx`, `ops/logger`.
+
+## Global Constraints
+
+- Work ONLY in the current branch; never switch branches.
+- Module path: `github.com/dmitrymomot/forge`. New package: `auth/guard`.
+- Black-box tests only: test files use `package guard_test`.
+- After changing files run `just fmt ./auth/guard/` (package-path form — the single-file form trips a spurious betteralign "undefined" error). betteralign may reorder struct fields; accept its output.
+- After the final task run `just lint` (includes vet, golangci-lint, nilaway, betteralign, modernize) and `just test ./auth/guard/`.
+- In tests use `httptest.NewRequest` — nilaway rejects `http.NewRequest(...)` with a discarded error.
+- Use `for i := range n` for counted loops (modernize enforces it); Go 1.26 `new(expr)` allowed, no ptr-wrapper helpers.
+- Error sentinels are single-line, `errors.Is`-matchable; client-facing ones are coded via `errorsx.New(code, msg)`.
+- Options are `type Option func(*config)` — never builders.
+- No Claude/AI attribution lines in any commit message.
+- Package size target ~350–450 LOC excluding tests (spec).
+
+---
+
+### Task 1: Foundation — types, errors, context accessors
+
+**Files:**
+- Create: `auth/guard/guard.go` (types only in this task; `New` arrives in Task 3)
+- Create: `auth/guard/errors.go`
+- Create: `auth/guard/context.go`
+- Test: `auth/guard/context_test.go`
+
+**Interfaces:**
+- Consumes: `core/ctxkey` (`ctxkey.New[T](name)`, `.With/.From/.MustFrom`), `core/errorsx` (`errorsx.New(code, msg string) error`), `ops/logger` (`type ContextExtractor func(ctx context.Context) (slog.Attr, bool)`).
+- Produces (used by Tasks 3–5):
+  - `type Identity struct { Subject, Tenant string; Scopes []string; Method string; Meta map[string]string }`
+  - `type Verifier interface { Verify(ctx context.Context, credential string) (Identity, error) }`
+  - `type VerifierFunc func(ctx context.Context, credential string) (Identity, error)` (implements `Verifier`)
+  - `var ErrNoCredential, ErrInvalidCredential error` (coded) and `var ErrInvalidUsers error` (plain; consumed by Task 4's ParseUsers)
+  - `var identityKey = ctxkey.New[Identity]("guard")` (package-private; Tasks 3–4 store through it)
+  - `func From(ctx context.Context) (Identity, bool)`, `func MustFrom(ctx context.Context) Identity`
+  - `var LogExtractor logger.ContextExtractor` — emits `slog.Group("auth", slog.String("subject", …)[, slog.String("tenant", …)])`
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/guard/context_test.go`:
+
+```go
+package guard_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+func TestFrom_Absent(t *testing.T) {
+	t.Parallel()
+	id, ok := guard.From(context.Background())
+	if ok {
+		t.Fatalf("From on empty ctx: ok = true, want false (id=%+v)", id)
+	}
+}
+
+func TestMustFrom_PanicsWhenAbsent(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("MustFrom on empty ctx did not panic")
+		}
+	}()
+	guard.MustFrom(context.Background())
+}
+
+func TestVerifierFunc_ImplementsVerifier(t *testing.T) {
+	t.Parallel()
+	want := guard.Identity{Subject: "u1", Method: "test"}
+	var v guard.Verifier = guard.VerifierFunc(func(_ context.Context, cred string) (guard.Identity, error) {
+		if cred != "tok" {
+			t.Fatalf("credential = %q, want %q", cred, "tok")
+		}
+		return want, nil
+	})
+	got, err := v.Verify(context.Background(), "tok")
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got.Subject != want.Subject || got.Method != want.Method {
+		t.Fatalf("Verify = %+v, want %+v", got, want)
+	}
+}
+
+func TestSentinels_AreDistinct(t *testing.T) {
+	t.Parallel()
+	if errors.Is(guard.ErrNoCredential, guard.ErrInvalidCredential) {
+		t.Fatal("ErrNoCredential must not match ErrInvalidCredential")
+	}
+}
+
+func TestLogExtractor_NoIdentity(t *testing.T) {
+	t.Parallel()
+	if _, ok := guard.LogExtractor(context.Background()); ok {
+		t.Fatal("LogExtractor on empty ctx: ok = true, want false")
+	}
+}
+
+func TestLogExtractor_SubjectOnly(t *testing.T) {
+	t.Parallel()
+	// There is no exported setter (only the middleware stores identities), so
+	// this test goes through the middleware in Task 3. For now assert only the
+	// empty-context contract above; this test body is extended in Task 3.
+	t.Skip("extended in Task 3 once New can store an Identity")
+	_ = slog.Attr{}
+}
+```
+
+Note: `From`/`MustFrom`/`LogExtractor` positive paths need the middleware to store an `Identity` (the ctx key is unexported by design). Task 3 replaces the `t.Skip` test with real coverage through `guard.New`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/guard/`
+Expected: FAIL — `no required module provides package .../auth/guard` (package does not exist yet).
+
+- [ ] **Step 3: Write the implementation**
+
+`auth/guard/guard.go`:
+
+```go
+package guard
+
+import "context"
+
+// Identity is the authenticated principal a Verifier resolved. Subject is
+// never empty on a successful verification; Tenant, Scopes, and Meta are
+// optional. Scopes is carried for the future authorization decision seam
+// (401-vs-403 split) — guard itself never reads it.
+type Identity struct {
+	Scopes  []string          // permissions/scopes for the future authz seam
+	Subject string            // principal id — never empty on success
+	Tenant  string            // optional tenant id
+	Method  string            // how the request authenticated: "bearer", "session", "apikey", "basic"
+	Meta    map[string]string // verifier-specific extras (email, key id, …)
+}
+
+// Verifier turns an extracted credential into an Identity. A returned error
+// means the credential is rejected: the middleware answers 401 and never
+// surfaces error detail to the client. Implementations must be safe for
+// concurrent use.
+type Verifier interface {
+	Verify(ctx context.Context, credential string) (Identity, error)
+}
+
+// VerifierFunc adapts a function to Verifier. It doubles as the package's
+// test fake — provider adapters (auth/jwt, auth/apikey, auth/session) are
+// closures over it or their own types.
+type VerifierFunc func(ctx context.Context, credential string) (Identity, error)
+
+// Verify implements Verifier.
+func (f VerifierFunc) Verify(ctx context.Context, credential string) (Identity, error) {
+	return f(ctx, credential)
+}
+```
+
+`auth/guard/errors.go`:
+
+```go
+package guard
+
+import (
+	"errors"
+
+	"github.com/dmitrymomot/forge/core/errorsx"
+)
+
+// ErrNoCredential is passed to the responder when no extractor found a
+// credential on the request (or the Basic Auth header is missing/malformed).
+var ErrNoCredential = errorsx.New("auth_missing", "no credential provided")
+
+// ErrInvalidCredential is passed to the responder when a credential was
+// present but rejected — the verifier returned an error (wrapped, so both
+// this sentinel and the verifier's own error match via errors.Is), the
+// verifier resolved an Identity without a Subject, or Basic Auth
+// credentials did not match.
+var ErrInvalidCredential = errorsx.New("auth_invalid", "credential rejected")
+
+// ErrInvalidUsers is wrapped in ParseUsers errors for unparseable
+// "user:pass,user:pass" credential strings.
+var ErrInvalidUsers = errors.New("guard: invalid users string")
+```
+
+`auth/guard/context.go`:
+
+```go
+package guard
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/dmitrymomot/forge/core/ctxkey"
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+var identityKey = ctxkey.New[Identity]("guard")
+
+// From returns the Identity stored by the guard middleware, if any.
+func From(ctx context.Context) (Identity, bool) {
+	return identityKey.From(ctx)
+}
+
+// MustFrom returns the Identity or panics if absent — for handlers mounted
+// behind the guard, where a missing Identity is a wiring bug.
+func MustFrom(ctx context.Context) Identity {
+	return identityKey.MustFrom(ctx)
+}
+
+// LogExtractor adds an "auth" group with the subject (and tenant when set)
+// for requests that carry an Identity.
+var LogExtractor logger.ContextExtractor = func(ctx context.Context) (slog.Attr, bool) {
+	id, ok := identityKey.From(ctx)
+	if !ok {
+		return slog.Attr{}, false
+	}
+	attrs := []any{slog.String("subject", id.Subject)}
+	if id.Tenant != "" {
+		attrs = append(attrs, slog.String("tenant", id.Tenant))
+	}
+	return slog.Group("auth", attrs...), true
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./auth/guard/`
+Expected: PASS (one skip: `TestLogExtractor_SubjectOnly`).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/guard/
+git add auth/guard/
+git commit -m "feat(guard): Identity, Verifier seam, coded sentinels, context accessors"
+```
+
+---
+
+### Task 2: Extractors
+
+**Files:**
+- Create: `auth/guard/extractors.go`
+- Test: `auth/guard/extractors_test.go`
+
+**Interfaces:**
+- Consumes: nothing from other tasks (stdlib only).
+- Produces (used by Tasks 3, 5):
+  - `type Extractor func(r *http.Request) (credential string, ok bool)`
+  - `func BearerHeader() Extractor`
+  - `func Header(name string) Extractor`
+  - `func Cookie(name string) Extractor`
+  - `func Query(name string) Extractor`
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/guard/extractors_test.go`:
+
+```go
+package guard_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+func TestBearerHeader(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		header string
+		want   string
+		wantOK bool
+	}{
+		{"valid", "Bearer tok123", "tok123", true},
+		{"lowercase scheme", "bearer tok123", "tok123", true},
+		{"extra spaces after scheme", "Bearer   tok123", "tok123", true},
+		{"absent", "", "", false},
+		{"scheme only", "Bearer", "", false},
+		{"scheme with empty token", "Bearer   ", "", false},
+		{"basic scheme reads as no credential", "Basic dXNlcjpwYXNz", "", false},
+		{"no scheme", "tok123", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.header != "" {
+				r.Header.Set("Authorization", tt.header)
+			}
+			got, ok := guard.BearerHeader()(r)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("BearerHeader() = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestHeader(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-API-Key", "key123")
+
+	if got, ok := guard.Header("X-API-Key")(r); !ok || got != "key123" {
+		t.Fatalf("Header(X-API-Key) = (%q, %v), want (key123, true)", got, ok)
+	}
+	if got, ok := guard.Header("X-Missing")(r); ok {
+		t.Fatalf("Header(X-Missing) = (%q, %v), want ok=false", got, ok)
+	}
+	r.Header.Set("X-Empty", "")
+	if _, ok := guard.Header("X-Empty")(r); ok {
+		t.Fatal("Header(X-Empty): empty value must read as no credential")
+	}
+}
+
+func TestCookie(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.AddCookie(&http.Cookie{Name: "sid", Value: "abc"})
+	r.AddCookie(&http.Cookie{Name: "empty", Value: ""})
+
+	if got, ok := guard.Cookie("sid")(r); !ok || got != "abc" {
+		t.Fatalf("Cookie(sid) = (%q, %v), want (abc, true)", got, ok)
+	}
+	if _, ok := guard.Cookie("missing")(r); ok {
+		t.Fatal("Cookie(missing): want ok=false")
+	}
+	if _, ok := guard.Cookie("empty")(r); ok {
+		t.Fatal("Cookie(empty): empty value must read as no credential")
+	}
+}
+
+func TestQuery(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/path?token=qtok&empty=", nil)
+
+	if got, ok := guard.Query("token")(r); !ok || got != "qtok" {
+		t.Fatalf("Query(token) = (%q, %v), want (qtok, true)", got, ok)
+	}
+	if _, ok := guard.Query("missing")(r); ok {
+		t.Fatal("Query(missing): want ok=false")
+	}
+	if _, ok := guard.Query("empty")(r); ok {
+		t.Fatal("Query(empty): empty value must read as no credential")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/guard/`
+Expected: FAIL — `undefined: guard.BearerHeader` (and Header/Cookie/Query).
+
+- [ ] **Step 3: Write the implementation**
+
+`auth/guard/extractors.go`:
+
+```go
+package guard
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Extractor pulls a raw credential from a request. ok=false means "not
+// present" — the middleware tries the next extractor in the chain; it never
+// means "present but bad" (that judgment belongs to the Verifier).
+type Extractor func(r *http.Request) (credential string, ok bool)
+
+// BearerHeader extracts the token from an "Authorization: Bearer <token>"
+// header (scheme match is case-insensitive). A non-Bearer Authorization
+// header reads as no credential, so e.g. a Basic header on a
+// bearer-guarded route falls through to the next extractor.
+func BearerHeader() Extractor {
+	return func(r *http.Request) (string, bool) {
+		scheme, token, found := strings.Cut(r.Header.Get("Authorization"), " ")
+		if !found || !strings.EqualFold(scheme, "Bearer") {
+			return "", false
+		}
+		token = strings.TrimSpace(token)
+		return token, token != ""
+	}
+}
+
+// Header extracts the named header's value verbatim (e.g. "X-API-Key").
+func Header(name string) Extractor {
+	return func(r *http.Request) (string, bool) {
+		v := r.Header.Get(name)
+		return v, v != ""
+	}
+}
+
+// Cookie extracts the named cookie's value. For signed or encrypted cookies
+// write a closure over web/cookie's Codec instead — any func with this
+// signature is an Extractor.
+func Cookie(name string) Extractor {
+	return func(r *http.Request) (string, bool) {
+		c, err := r.Cookie(name)
+		if err != nil || c.Value == "" {
+			return "", false
+		}
+		return c.Value, true
+	}
+}
+
+// Query extracts the named query parameter.
+//
+// Credentials in query strings leak into access logs, browser history, and
+// Referer headers. Prefer BearerHeader or Cookie; reserve Query for signed,
+// short-lived links.
+func Query(name string) Extractor {
+	return func(r *http.Request) (string, bool) {
+		v := r.URL.Query().Get(name)
+		return v, v != ""
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./auth/guard/`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/guard/
+git add auth/guard/extractors.go auth/guard/extractors_test.go
+git commit -m "feat(guard): credential extractors (bearer, header, cookie, query)"
+```
+
+---
+
+### Task 3: Options + New middleware
+
+**Files:**
+- Create: `auth/guard/options.go`
+- Modify: `auth/guard/guard.go` (append `New`, `extract`, `config.reject`)
+- Modify: `auth/guard/context_test.go` (replace the skipped `TestLogExtractor_SubjectOnly`)
+- Test: `auth/guard/guard_test.go`, `auth/guard/panic_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 (`Identity`, `Verifier`, `VerifierFunc`, `identityKey`, `ErrNoCredential`, `ErrInvalidCredential`), Task 2 (`Extractor`, `BearerHeader`), `web/middleware` (`type Middleware func(http.Handler) http.Handler`), `web/problem` (`type Responder func(w http.ResponseWriter, r *http.Request, err error)`, `problem.JSON(problem.WithStatus(401))`).
+- Produces (used by Tasks 4, 5):
+  - `func New(v Verifier, opts ...Option) middleware.Middleware`
+  - `type Option func(*config)` with `WithExtractors(...Extractor)`, `WithOptional()`, `WithResponder(problem.Responder)`, `WithChallenge(string)`, `WithRealm(string)` (realm validated here; consumed by Task 4)
+  - unexported: `config` struct (fields `extractors []Extractor`, `challenge, realm string`, `responder problem.Responder`, `optional bool`), `func (c config) reject(w, r, err)` setting `WWW-Authenticate` from `c.challenge` before invoking the responder
+
+- [ ] **Step 1: Write the failing tests**
+
+`auth/guard/guard_test.go`:
+
+```go
+package guard_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+// okVerifier accepts credential "good" as user u1; everything else fails
+// with errBadToken.
+var errBadToken = errors.New("bad token")
+
+func okVerifier() guard.Verifier {
+	return guard.VerifierFunc(func(_ context.Context, cred string) (guard.Identity, error) {
+		if cred == "good" {
+			return guard.Identity{Subject: "u1", Tenant: "t1", Method: "bearer"}, nil
+		}
+		return guard.Identity{}, errBadToken
+	})
+}
+
+// echoHandler writes the context Identity's subject, proving the request
+// passed the guard and the Identity is readable.
+func echoHandler(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, ok := guard.From(r.Context())
+		if !ok {
+			_, _ = w.Write([]byte("anonymous"))
+			return
+		}
+		_, _ = w.Write([]byte(id.Subject))
+	})
+}
+
+func get(t *testing.T, h http.Handler, mutate func(*http.Request)) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	if mutate != nil {
+		mutate(r)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w
+}
+
+func TestNew_ValidCredential(t *testing.T) {
+	t.Parallel()
+	h := guard.New(okVerifier())(echoHandler(t))
+	w := get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer good") })
+	if w.Code != http.StatusOK || w.Body.String() != "u1" {
+		t.Fatalf("got %d %q, want 200 u1", w.Code, w.Body.String())
+	}
+}
+
+func TestNew_MissingCredential(t *testing.T) {
+	t.Parallel()
+	h := guard.New(okVerifier())(echoHandler(t))
+	w := get(t, h, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/problem+json") {
+		t.Fatalf("Content-Type = %q, want application/problem+json", ct)
+	}
+	if w.Header().Get("WWW-Authenticate") != "" {
+		t.Fatal("WWW-Authenticate set without WithChallenge")
+	}
+}
+
+func TestNew_InvalidCredential(t *testing.T) {
+	t.Parallel()
+	h := guard.New(okVerifier())(echoHandler(t))
+	w := get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer evil") })
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if body := w.Body.String(); strings.Contains(body, "bad token") {
+		t.Fatalf("verifier error leaked to client: %q", body)
+	}
+}
+
+func TestNew_ErrorWrapping(t *testing.T) {
+	t.Parallel()
+	var captured error
+	responder := func(w http.ResponseWriter, r *http.Request, err error) {
+		captured = err
+		w.WriteHeader(http.StatusUnauthorized)
+	}
+
+	h := guard.New(okVerifier(), guard.WithResponder(responder))(echoHandler(t))
+	get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer evil") })
+	if !errors.Is(captured, guard.ErrInvalidCredential) {
+		t.Fatalf("err = %v, want Is(ErrInvalidCredential)", captured)
+	}
+	if !errors.Is(captured, errBadToken) {
+		t.Fatalf("err = %v, want Is(errBadToken) — verifier error must stay matchable", captured)
+	}
+
+	get(t, h, nil)
+	if !errors.Is(captured, guard.ErrNoCredential) {
+		t.Fatalf("err = %v, want Is(ErrNoCredential)", captured)
+	}
+}
+
+func TestNew_EmptySubjectIsRejected(t *testing.T) {
+	t.Parallel()
+	var captured error
+	v := guard.VerifierFunc(func(context.Context, string) (guard.Identity, error) {
+		return guard.Identity{}, nil // buggy verifier: success with zero Identity
+	})
+	h := guard.New(v, guard.WithResponder(func(w http.ResponseWriter, r *http.Request, err error) {
+		captured = err
+		w.WriteHeader(http.StatusUnauthorized)
+	}))(echoHandler(t))
+	w := get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer good") })
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if !errors.Is(captured, guard.ErrInvalidCredential) {
+		t.Fatalf("err = %v, want Is(ErrInvalidCredential)", captured)
+	}
+}
+
+func TestNew_Optional(t *testing.T) {
+	t.Parallel()
+	h := guard.New(okVerifier(), guard.WithOptional())(echoHandler(t))
+
+	// Missing credential: anonymous pass-through.
+	w := get(t, h, nil)
+	if w.Code != http.StatusOK || w.Body.String() != "anonymous" {
+		t.Fatalf("optional missing: got %d %q, want 200 anonymous", w.Code, w.Body.String())
+	}
+	// Valid credential: identity attached.
+	w = get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer good") })
+	if w.Code != http.StatusOK || w.Body.String() != "u1" {
+		t.Fatalf("optional valid: got %d %q, want 200 u1", w.Code, w.Body.String())
+	}
+	// Invalid credential: still 401.
+	w = get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer evil") })
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("optional invalid: status = %d, want 401", w.Code)
+	}
+}
+
+func TestNew_Challenge(t *testing.T) {
+	t.Parallel()
+	h := guard.New(okVerifier(), guard.WithChallenge(`Bearer realm="api"`))(echoHandler(t))
+
+	for name, mutate := range map[string]func(*http.Request){
+		"missing": nil,
+		"invalid": func(r *http.Request) { r.Header.Set("Authorization", "Bearer evil") },
+	} {
+		w := get(t, h, mutate)
+		if got := w.Header().Get("WWW-Authenticate"); got != `Bearer realm="api"` {
+			t.Fatalf("%s: WWW-Authenticate = %q, want Bearer realm=\"api\"", name, got)
+		}
+	}
+
+	// Success must not carry the challenge.
+	w := get(t, h, func(r *http.Request) { r.Header.Set("Authorization", "Bearer good") })
+	if w.Header().Get("WWW-Authenticate") != "" {
+		t.Fatal("WWW-Authenticate set on success")
+	}
+}
+
+func TestNew_ExtractorChainOrder(t *testing.T) {
+	t.Parallel()
+	var seen []string
+	v := guard.VerifierFunc(func(_ context.Context, cred string) (guard.Identity, error) {
+		seen = append(seen, cred)
+		return guard.Identity{Subject: cred, Method: "test"}, nil
+	})
+	h := guard.New(v, guard.WithExtractors(
+		guard.Header("X-First"),
+		guard.Header("X-Second"),
+	))(echoHandler(t))
+
+	// Both present: first extractor wins, second never consulted.
+	w := get(t, h, func(r *http.Request) {
+		r.Header.Set("X-First", "one")
+		r.Header.Set("X-Second", "two")
+	})
+	if w.Body.String() != "one" {
+		t.Fatalf("body = %q, want one (first extractor wins)", w.Body.String())
+	}
+	// First absent: chain falls through to the second.
+	w = get(t, h, func(r *http.Request) { r.Header.Set("X-Second", "two") })
+	if w.Body.String() != "two" {
+		t.Fatalf("body = %q, want two (fallthrough)", w.Body.String())
+	}
+	if len(seen) != 2 {
+		t.Fatalf("verifier calls = %d, want 2 (one per request)", len(seen))
+	}
+}
+
+func TestNew_NoVerifyFallbackAfterExtract(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	v := guard.VerifierFunc(func(context.Context, string) (guard.Identity, error) {
+		calls++
+		return guard.Identity{}, errBadToken
+	})
+	h := guard.New(v, guard.WithExtractors(
+		guard.Header("X-First"),
+		guard.Header("X-Second"),
+	))(echoHandler(t))
+
+	// First extractor hits, verify fails: 401 — the second extractor must
+	// NOT be offered as a fallback.
+	w := get(t, h, func(r *http.Request) {
+		r.Header.Set("X-First", "bad")
+		r.Header.Set("X-Second", "good")
+	})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if calls != 1 {
+		t.Fatalf("verifier calls = %d, want 1 (no fallback after extraction)", calls)
+	}
+}
+```
+
+`auth/guard/panic_test.go`:
+
+```go
+package guard_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+func mustPanic(t *testing.T, name string, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("%s did not panic", name)
+		}
+	}()
+	fn()
+}
+
+func TestNew_NilVerifierPanics(t *testing.T) {
+	t.Parallel()
+	mustPanic(t, "New(nil)", func() { guard.New(nil) })
+}
+
+func TestWithExtractors_EmptyPanics(t *testing.T) {
+	t.Parallel()
+	mustPanic(t, "WithExtractors()", func() {
+		guard.New(okVerifier(), guard.WithExtractors())
+	})
+}
+```
+
+Replace the skipped test in `auth/guard/context_test.go` (delete `TestLogExtractor_SubjectOnly` with its `t.Skip` and the now-unused `log/slog` import if nothing else uses it) with:
+
+```go
+func TestLogExtractor_ThroughMiddleware(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		id     guard.Identity
+		tenant bool
+	}{
+		{"subject only", guard.Identity{Subject: "u1", Method: "test"}, false},
+		{"subject and tenant", guard.Identity{Subject: "u1", Tenant: "t1", Method: "test"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			v := guard.VerifierFunc(func(context.Context, string) (guard.Identity, error) {
+				return tt.id, nil
+			})
+			var attr slog.Attr
+			var ok bool
+			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attr, ok = guard.LogExtractor(r.Context())
+			})
+			h := guard.New(v)(inner)
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.Header.Set("Authorization", "Bearer tok")
+			h.ServeHTTP(httptest.NewRecorder(), r)
+
+			if !ok {
+				t.Fatal("LogExtractor: ok = false behind the guard")
+			}
+			if attr.Key != "auth" {
+				t.Fatalf("attr key = %q, want auth", attr.Key)
+			}
+			s := attr.Value.String()
+			if !strings.Contains(s, "u1") {
+				t.Fatalf("attr %q does not contain subject", s)
+			}
+			if tt.tenant != strings.Contains(s, "t1") {
+				t.Fatalf("attr %q tenant presence, want %v", s, tt.tenant)
+			}
+		})
+	}
+}
+```
+
+(Add `net/http`, `net/http/httptest`, `strings` to `context_test.go` imports.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./auth/guard/`
+Expected: FAIL — `undefined: guard.New`, `undefined: guard.WithResponder`, etc.
+
+- [ ] **Step 3: Write the implementation**
+
+`auth/guard/options.go`:
+
+```go
+package guard
+
+import (
+	"strings"
+
+	"github.com/dmitrymomot/forge/web/problem"
+)
+
+type config struct {
+	extractors []Extractor
+	challenge  string
+	realm      string
+	responder  problem.Responder
+	optional   bool
+}
+
+// Option configures New and BasicAuth. Options that don't apply to a
+// constructor are ignored by it (each option documents which constructor
+// reads it).
+type Option func(*config)
+
+// WithExtractors replaces the default extractor chain (BearerHeader only).
+// Extractors run in order and the first hit wins — later extractors are not
+// fallbacks for a credential that fails verification. Panics on an empty
+// list: a guard that can never find a credential is a wiring bug. BasicAuth
+// ignores this option (its scheme is fixed).
+func WithExtractors(xs ...Extractor) Option {
+	if len(xs) == 0 {
+		panic("guard: WithExtractors requires at least one extractor")
+	}
+	return func(c *config) { c.extractors = xs }
+}
+
+// WithOptional lets requests without a credential pass through anonymously
+// (From reports ok=false). A present-but-invalid credential still gets 401 —
+// silently ignoring bad tokens masks expired sessions and probing. BasicAuth
+// ignores this option.
+func WithOptional() Option {
+	return func(c *config) { c.optional = true }
+}
+
+// WithResponder overrides the rejection response (default problem.JSON 401).
+// The error passed to the responder matches guard.ErrNoCredential or
+// guard.ErrInvalidCredential via errors.Is; verify failures also match the
+// verifier's own error.
+func WithResponder(r problem.Responder) Option {
+	return func(c *config) {
+		if r != nil {
+			c.responder = r
+		}
+	}
+}
+
+// WithChallenge sets the WWW-Authenticate header value emitted with every
+// 401, e.g. `Bearer realm="api"` (RFC 6750). Default: none. BasicAuth
+// ignores this option — it always emits its own Basic challenge.
+func WithChallenge(v string) Option {
+	return func(c *config) { c.challenge = v }
+}
+
+// WithRealm sets the Basic Auth realm (default "restricted"). Panics on
+// quotes, backslashes, or control characters — the realm is echoed into the
+// WWW-Authenticate header. New ignores this option.
+func WithRealm(realm string) Option {
+	if strings.ContainsAny(realm, "\"\\") || strings.ContainsFunc(realm, func(r rune) bool { return r < 0x20 || r == 0x7f }) {
+		panic("guard: realm must not contain quotes, backslashes, or control characters")
+	}
+	return func(c *config) { c.realm = realm }
+}
+```
+
+Append to `auth/guard/guard.go`:
+
+```go
+// New returns middleware that authenticates every request through v: the
+// extractor chain (default BearerHeader) finds the credential, v resolves
+// it to an Identity stored in request context for From/MustFrom. A request
+// with no credential gets 401 (or passes anonymously with WithOptional); a
+// rejected credential gets 401 always. Rejections go through the responder
+// (default problem.JSON 401) after setting WWW-Authenticate when a
+// challenge is configured. New panics on a nil verifier — a wiring bug.
+func New(v Verifier, opts ...Option) middleware.Middleware {
+	if v == nil {
+		panic("guard: nil verifier")
+	}
+	cfg := config{
+		responder:  problem.JSON(problem.WithStatus(http.StatusUnauthorized)),
+		extractors: []Extractor{BearerHeader()},
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cred, found := extract(cfg.extractors, r)
+			if !found {
+				if cfg.optional {
+					next.ServeHTTP(w, r)
+					return
+				}
+				cfg.reject(w, r, ErrNoCredential)
+				return
+			}
+			id, err := v.Verify(r.Context(), cred)
+			if err != nil {
+				cfg.reject(w, r, fmt.Errorf("%w: %w", ErrInvalidCredential, err))
+				return
+			}
+			if id.Subject == "" {
+				// A successful verification with no Subject is a verifier
+				// bug; treat it as a rejection rather than admitting an
+				// anonymous principal.
+				cfg.reject(w, r, ErrInvalidCredential)
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(identityKey.With(r.Context(), id)))
+		})
+	}
+}
+
+func extract(xs []Extractor, r *http.Request) (string, bool) {
+	for _, x := range xs {
+		if cred, ok := x(r); ok {
+			return cred, true
+		}
+	}
+	return "", false
+}
+
+func (c config) reject(w http.ResponseWriter, r *http.Request, err error) {
+	if c.challenge != "" {
+		w.Header().Set("WWW-Authenticate", c.challenge)
+	}
+	c.responder(w, r, err)
+}
+```
+
+Update `guard.go` imports to:
+
+```go
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/dmitrymomot/forge/web/middleware"
+	"github.com/dmitrymomot/forge/web/problem"
+)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `just test ./auth/guard/`
+Expected: PASS, no skips, race-clean.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/guard/
+git add auth/guard/
+git commit -m "feat(guard): New middleware — extractor chain, optional mode, challenge, problem 401s"
+```
+
+---
+
+### Task 4: BasicAuth + ParseUsers
+
+**Files:**
+- Create: `auth/guard/basicauth.go`
+- Test: `auth/guard/basicauth_test.go`
+- Modify: `auth/guard/panic_test.go` (add BasicAuth panic case)
+
+**Interfaces:**
+- Consumes: Task 1 (`Identity`, `identityKey`, `ErrNoCredential`, `ErrInvalidCredential`, `ErrInvalidUsers`), Task 3 (`config`, `Option`, `WithRealm`, `WithResponder`; test helpers `echoHandler(t)` from `guard_test.go` and `mustPanic(t, name, fn)` from `panic_test.go` — same `guard_test` package, already defined), `crypto/consttime` (`consttime.StringEqual(a, b string) bool`).
+- Produces (used by Task 5):
+  - `func BasicAuth(users map[string]string, opts ...Option) middleware.Middleware`
+  - `func ParseUsers(s string) (map[string]string, error)`
+
+- [ ] **Step 1: Write the failing tests**
+
+`auth/guard/basicauth_test.go`:
+
+```go
+package guard_test
+
+import (
+	"errors"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+func basicGet(t *testing.T, h http.Handler, setAuth func(*http.Request)) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	if setAuth != nil {
+		setAuth(r)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w
+}
+
+func TestBasicAuth_Success(t *testing.T) {
+	t.Parallel()
+	h := guard.BasicAuth(map[string]string{"ops": "s3cret"})(echoHandler(t))
+	w := basicGet(t, h, func(r *http.Request) { r.SetBasicAuth("ops", "s3cret") })
+	if w.Code != http.StatusOK || w.Body.String() != "ops" {
+		t.Fatalf("got %d %q, want 200 ops (Identity in context)", w.Code, w.Body.String())
+	}
+	if w.Header().Get("WWW-Authenticate") != "" {
+		t.Fatal("WWW-Authenticate set on success")
+	}
+}
+
+func TestBasicAuth_MethodIsBasic(t *testing.T) {
+	t.Parallel()
+	var got guard.Identity
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = guard.MustFrom(r.Context())
+	})
+	h := guard.BasicAuth(map[string]string{"ops": "s3cret"})(inner)
+	basicGet(t, h, func(r *http.Request) { r.SetBasicAuth("ops", "s3cret") })
+	if got.Subject != "ops" || got.Method != "basic" {
+		t.Fatalf("Identity = %+v, want Subject=ops Method=basic", got)
+	}
+}
+
+func TestBasicAuth_Failures(t *testing.T) {
+	t.Parallel()
+	const wantChallenge = `Basic realm="restricted", charset="UTF-8"`
+	tests := []struct {
+		name    string
+		setAuth func(*http.Request)
+		wantErr error
+	}{
+		{"missing header", nil, guard.ErrNoCredential},
+		{"malformed header", func(r *http.Request) { r.Header.Set("Authorization", "Basic !!!not-base64!!!") }, guard.ErrNoCredential},
+		{"wrong password", func(r *http.Request) { r.SetBasicAuth("ops", "wrong") }, guard.ErrInvalidCredential},
+		{"unknown user", func(r *http.Request) { r.SetBasicAuth("nobody", "s3cret") }, guard.ErrInvalidCredential},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var captured error
+			h := guard.BasicAuth(map[string]string{"ops": "s3cret"},
+				guard.WithResponder(func(w http.ResponseWriter, r *http.Request, err error) {
+					captured = err
+					w.WriteHeader(http.StatusUnauthorized)
+				}),
+			)(echoHandler(t))
+			w := basicGet(t, h, tt.setAuth)
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401", w.Code)
+			}
+			if got := w.Header().Get("WWW-Authenticate"); got != wantChallenge {
+				t.Fatalf("WWW-Authenticate = %q, want %q", got, wantChallenge)
+			}
+			if !errors.Is(captured, tt.wantErr) {
+				t.Fatalf("err = %v, want Is(%v)", captured, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBasicAuth_Realm(t *testing.T) {
+	t.Parallel()
+	h := guard.BasicAuth(map[string]string{"ops": "s3cret"}, guard.WithRealm("staging"))(echoHandler(t))
+	w := basicGet(t, h, nil)
+	if got := w.Header().Get("WWW-Authenticate"); got != `Basic realm="staging", charset="UTF-8"` {
+		t.Fatalf("WWW-Authenticate = %q", got)
+	}
+}
+
+func TestBasicAuth_DefaultProblemResponse(t *testing.T) {
+	t.Parallel()
+	h := guard.BasicAuth(map[string]string{"ops": "s3cret"})(echoHandler(t))
+	w := basicGet(t, h, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/problem+json") {
+		t.Fatalf("Content-Type = %q, want application/problem+json", ct)
+	}
+}
+
+func TestParseUsers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		in    string
+		want  map[string]string
+		isErr bool
+	}{
+		{"single", "ops:s3cret", map[string]string{"ops": "s3cret"}, false},
+		{"multiple with space", "a:1, b:2", map[string]string{"a": "1", "b": "2"}, false},
+		{"password with colon", "ops:pa:ss", map[string]string{"ops": "pa:ss"}, false},
+		{"empty input", "", nil, true},
+		{"no colon", "opspass", nil, true},
+		{"empty user", ":pass", nil, true},
+		{"empty password", "ops:", nil, true},
+		{"duplicate user", "ops:1,ops:2", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := guard.ParseUsers(tt.in)
+			if tt.isErr {
+				if !errors.Is(err, guard.ErrInvalidUsers) {
+					t.Fatalf("err = %v, want Is(ErrInvalidUsers)", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseUsers(%q): %v", tt.in, err)
+			}
+			if !maps.Equal(got, tt.want) {
+				t.Fatalf("ParseUsers(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+Append to `auth/guard/panic_test.go`:
+
+```go
+func TestBasicAuth_EmptyUsersPanics(t *testing.T) {
+	t.Parallel()
+	mustPanic(t, "BasicAuth(nil)", func() { guard.BasicAuth(nil) })
+	mustPanic(t, "BasicAuth(empty)", func() { guard.BasicAuth(map[string]string{}) })
+}
+
+func TestWithRealm_InvalidPanics(t *testing.T) {
+	t.Parallel()
+	mustPanic(t, `WithRealm(quote)`, func() { guard.WithRealm(`sta"ging`) })
+	mustPanic(t, "WithRealm(control)", func() { guard.WithRealm("sta\nging") })
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./auth/guard/`
+Expected: FAIL — `undefined: guard.BasicAuth`, `undefined: guard.ParseUsers`.
+
+- [ ] **Step 3: Write the implementation**
+
+`auth/guard/basicauth.go`:
+
+```go
+package guard
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/dmitrymomot/forge/crypto/consttime"
+	"github.com/dmitrymomot/forge/web/middleware"
+	"github.com/dmitrymomot/forge/web/problem"
+)
+
+// dummyPassword is compared for unknown usernames so user existence does
+// not leak through response timing.
+const dummyPassword = "guard-basicauth-dummy-password-for-unknown-users"
+
+// BasicAuth returns middleware gating requests with HTTP Basic Auth against
+// a static username→password map — for pprof/metrics/staging/admin gates,
+// never user login (no hashing; credentials come from env, see ParseUsers).
+// Password checks are constant-time and unknown users cost the same as
+// wrong passwords; unknown-user and wrong-password failures are
+// indistinguishable to the client. Every failure gets 401 with a
+// WWW-Authenticate Basic challenge through the responder (default
+// problem.JSON 401). On success the request carries
+// Identity{Subject: username, Method: "basic"} — From/MustFrom work as
+// behind New. Panics on an empty users map — a gate with no valid
+// credentials is a wiring bug. Accepted options: WithRealm, WithResponder;
+// WithExtractors, WithOptional, and WithChallenge are ignored (the scheme
+// and challenge are fixed).
+func BasicAuth(users map[string]string, opts ...Option) middleware.Middleware {
+	if len(users) == 0 {
+		panic("guard: BasicAuth requires at least one user")
+	}
+	cfg := config{
+		responder: problem.JSON(problem.WithStatus(http.StatusUnauthorized)),
+		realm:     "restricted",
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	challenge := fmt.Sprintf("Basic realm=%q, charset=%q", cfg.realm, "UTF-8")
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reject := func(err error) {
+				w.Header().Set("WWW-Authenticate", challenge)
+				cfg.responder(w, r, err)
+			}
+			user, pass, ok := r.BasicAuth()
+			if !ok {
+				reject(ErrNoCredential)
+				return
+			}
+			want, known := users[user]
+			if !known {
+				want = dummyPassword
+			}
+			if !consttime.StringEqual(pass, want) || !known {
+				reject(ErrInvalidCredential)
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(identityKey.With(r.Context(), Identity{Subject: user, Method: "basic"})))
+		})
+	}
+}
+
+// ParseUsers parses BasicAuth credentials from the "user1:pass1,user2:pass2"
+// env-string format. Passwords may contain colons (the split is at the first
+// colon) but not commas. It rejects (wrapping ErrInvalidUsers) empty input,
+// entries without a colon, empty usernames or passwords, and duplicate
+// usernames.
+func ParseUsers(s string) (map[string]string, error) {
+	entries := strings.Split(s, ",")
+	users := make(map[string]string, len(entries))
+	for _, e := range entries {
+		user, pass, found := strings.Cut(strings.TrimSpace(e), ":")
+		if !found || user == "" || pass == "" {
+			return nil, fmt.Errorf("%w: entry %q", ErrInvalidUsers, e)
+		}
+		if _, dup := users[user]; dup {
+			return nil, fmt.Errorf("%w: duplicate user %q", ErrInvalidUsers, user)
+		}
+		users[user] = pass
+	}
+	return users, nil
+}
+```
+
+Note on the comparison: `consttime.StringEqual` runs first and `|| !known` second, so the constant-time compare always executes; the `known` flag only flips the outcome for the (already-compared) dummy path — including when a client happens to present the dummy password itself.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `just test ./auth/guard/`
+Expected: PASS, race-clean.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/guard/
+git add auth/guard/
+git commit -m "feat(guard): constant-time BasicAuth gate and ParseUsers env-format helper"
+```
+
+---
+
+### Task 5: doc.go, catalog updates, full verification
+
+**Files:**
+- Create: `auth/guard/doc.go`
+- Modify: `docs/packages.md` (delete the `auth/guard` entry; un-tag three dependents)
+
+**Interfaces:**
+- Consumes: the complete public API from Tasks 1–4 (doc.go references `New`, `VerifierFunc`, `Identity`, `WithChallenge`, `WithExtractors`, `Cookie`, `From`, `BasicAuth`, `ParseUsers`, `WithRealm`).
+- Produces: nothing new — documentation and roadmap bookkeeping.
+
+- [ ] **Step 1: Write doc.go**
+
+`auth/guard/doc.go`:
+
+```go
+// Package guard authenticates HTTP requests. A chain of credential
+// extractors finds the credential (Authorization header by default;
+// cookie and query opt-in), a Verifier resolves it to an Identity stored
+// in request context, and rejections are problem+json 401s. Authorization
+// (403, permissions) is out of scope — guard answers "who is this request
+// from"; session lifecycle (rotation, TTLs) belongs to auth/session and
+// scope checks to the future authorization seam.
+//
+// A Verifier adapter is a small closure — over auth/jwt:
+//
+//	type appClaims struct {
+//		jwt.Claims
+//		TenantID string   `json:"tid"`
+//		Scopes   []string `json:"scopes"`
+//	}
+//
+//	verifier := guard.VerifierFunc(func(ctx context.Context, token string) (guard.Identity, error) {
+//		c, err := jwt.Verify[appClaims](ctx, jwtVerifier, token)
+//		if err != nil {
+//			return guard.Identity{}, err // client sees a generic 401
+//		}
+//		return guard.Identity{Subject: c.Subject, Tenant: c.TenantID, Scopes: c.Scopes, Method: "bearer"}, nil
+//	})
+//
+//	authn := guard.New(verifier, guard.WithChallenge(`Bearer realm="api"`))
+//	mux.Handle("GET /api/me", authn(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//		id := guard.MustFrom(r.Context())
+//		_ = id.Subject
+//	})))
+//
+// Session-cookie flows swap the extractor and redirect instead of 401:
+//
+//	authn := guard.New(sessionVerifier,
+//		guard.WithExtractors(guard.Cookie("sid")),
+//		guard.WithResponder(func(w http.ResponseWriter, r *http.Request, err error) {
+//			http.Redirect(w, r, "/login?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusSeeOther)
+//		}),
+//	)
+//
+// Public-but-personalized routes use WithOptional: missing credential
+// passes anonymously (From reports ok=false), invalid credential still
+// gets 401.
+//
+// BasicAuth gates internal surfaces (pprof, metrics, staging) with static
+// env-sourced credentials, constant-time:
+//
+//	users, err := guard.ParseUsers(os.Getenv("ADMIN_BASIC_USERS")) // "ops:s3cret"
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	mux.Handle("/debug/pprof/", guard.BasicAuth(users, guard.WithRealm("staging"))(pprofHandler))
+package guard
+```
+
+- [ ] **Step 2: Update docs/packages.md**
+
+Delete the whole `auth/guard` entry (the `**auth/guard**` heading, its paragraph, its `Deps:` line, and one surrounding `---` separator — currently lines 621–631).
+
+Un-tag the three dependents (guard is now shipped):
+
+- `auth/apikey` entry: `Deps: `core/random`, `crypto/consttime`; `auth/guard` (planned).` → `Deps: `core/random`, `crypto/consttime`, `auth/guard`.`
+- `auth/scim` entry: `Deps: `auth/guard` (planned).` → `Deps: `auth/guard`.`
+- `ops/debug` entry: `Deps: `ops/supervisor`; `auth/guard` (planned).` → `Deps: `ops/supervisor`, `auth/guard`.`
+
+Verify no stragglers: `grep -n "auth/guard" docs/packages.md` must show only the three un-tagged dependent lines.
+
+- [ ] **Step 3: Full verification**
+
+```bash
+just fmt ./auth/guard/
+just lint
+just test ./auth/guard/
+```
+
+Expected: lint clean (vet, build, golangci-lint, nilaway, betteralign, modernize), tests PASS with race detector and coverage reported. If a stale "undefined" LSP diagnostic appears after subagent work, trust the build/test output at HEAD, not the diagnostic.
+
+Sanity-check package size (target ~350–450 LOC excluding tests):
+
+```bash
+wc -l auth/guard/*.go | grep -v _test
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add auth/guard/doc.go docs/packages.md
+git commit -m "docs(guard): package docs; mark auth/guard shipped in catalog"
+```
+
+---
+
+## Verification Checklist (post-plan)
+
+- [ ] `just test ./auth/guard/` — all green, race-clean
+- [ ] `just lint` — clean
+- [ ] `grep -rn "IdentityFromContext" auth/guard/` — empty (reader is `From`/`MustFrom`)
+- [ ] `grep -n "auth/guard" docs/packages.md` — only the three dependent `Deps:` lines
+- [ ] doc.go compiles as prose examples (no Example funcs needed; ipfilter precedent)
+- [ ] No commit message contains AI attribution

--- a/docs/superpowers/plans/2026-07-13-auth-guard.md
+++ b/docs/superpowers/plans/2026-07-13-auth-guard.md
@@ -21,6 +21,7 @@
 - Options are `type Option func(*config)` — never builders.
 - No Claude/AI attribution lines in any commit message.
 - Package size target ~350–450 LOC excluding tests (spec).
+- Benchmarks are REQUIRED (project policy for all packages): `bench_test.go` with `b.ReportAllocs()`, baseline recorded, then a post-benchmark optimization pass applying only measured wins (Task 6). Before/after numbers go in the PR description.
 
 ---
 
@@ -1352,10 +1353,254 @@ git commit -m "docs(guard): package docs; mark auth/guard shipped in catalog"
 
 ---
 
+### Task 6: Benchmarks + post-benchmark optimization
+
+**Files:**
+- Create: `auth/guard/bench_test.go`
+- Modify (only where a benchmark justifies it): `auth/guard/extractors.go`
+
+**Interfaces:**
+- Consumes: the complete public API from Tasks 1–4 (`New`, `VerifierFunc`, `Identity`, `From`, `BearerHeader`, `Header`, `Cookie`, `Query`, `BasicAuth`, `LogExtractor`, `WithExtractors`).
+- Produces: the benchmark suite, a recorded baseline, and measured optimizations. Record the before/after table — it goes in the PR description (design.md: perf-motivated complexity requires a benchmark in the PR).
+
+- [ ] **Step 1: Write the benchmarks**
+
+`auth/guard/bench_test.go`:
+
+```go
+package guard_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+// nopWriter discards the response so benchmarks measure guard's work, not
+// httptest.ResponseRecorder's buffer growth.
+type nopWriter struct{ h http.Header }
+
+func (w *nopWriter) Header() http.Header         { return w.h }
+func (w *nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (w *nopWriter) WriteHeader(int)             {}
+
+func benchVerifier() guard.Verifier {
+	id := guard.Identity{Subject: "u1", Tenant: "t1", Method: "bearer"}
+	return guard.VerifierFunc(func(context.Context, string) (guard.Identity, error) {
+		return id, nil
+	})
+}
+
+func BenchmarkNew_ValidBearer(b *testing.B) {
+	var depth int
+	h := guard.New(benchVerifier())(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if id, ok := guard.From(r.Context()); ok {
+			depth += len(id.Subject)
+		}
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer tok")
+	w := &nopWriter{h: make(http.Header)}
+	b.ReportAllocs()
+	for b.Loop() {
+		h.ServeHTTP(w, r)
+	}
+	_ = depth
+}
+
+func BenchmarkNew_Reject401(b *testing.B) {
+	h := guard.New(benchVerifier(), guard.WithChallenge(`Bearer realm="api"`))(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	r := httptest.NewRequest(http.MethodGet, "/", nil) // no credential
+	w := &nopWriter{h: make(http.Header)}
+	b.ReportAllocs()
+	for b.Loop() {
+		h.ServeHTTP(w, r)
+	}
+}
+
+func BenchmarkExtractors(b *testing.B) {
+	bearer := httptest.NewRequest(http.MethodGet, "/", nil)
+	bearer.Header.Set("Authorization", "Bearer tok123")
+	apikey := httptest.NewRequest(http.MethodGet, "/", nil)
+	apikey.Header.Set("X-API-Key", "key123")
+	withCookie := httptest.NewRequest(http.MethodGet, "/", nil)
+	withCookie.AddCookie(&http.Cookie{Name: "sid", Value: "abc"})
+	withQuery := httptest.NewRequest(http.MethodGet, "/p?a=1&token=qtok&c=3", nil)
+
+	benches := []struct {
+		name string
+		x    guard.Extractor
+		r    *http.Request
+	}{
+		{"BearerHeader", guard.BearerHeader(), bearer},
+		{"Header", guard.Header("X-API-Key"), apikey},
+		{"Cookie", guard.Cookie("sid"), withCookie},
+		{"Query", guard.Query("token"), withQuery},
+	}
+	for _, bb := range benches {
+		b.Run(bb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, ok := bb.x(bb.r); !ok {
+					b.Fatal("extractor missed")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkBasicAuth(b *testing.B) {
+	users := map[string]string{"ops": "s3cret"}
+	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+
+	good := httptest.NewRequest(http.MethodGet, "/", nil)
+	good.SetBasicAuth("ops", "s3cret")
+	bad := httptest.NewRequest(http.MethodGet, "/", nil)
+	bad.SetBasicAuth("ops", "wrong")
+
+	h := guard.BasicAuth(users)(inner)
+	w := &nopWriter{h: make(http.Header)}
+
+	b.Run("success", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			h.ServeHTTP(w, good)
+		}
+	})
+	b.Run("wrong-password", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			h.ServeHTTP(w, bad)
+		}
+	})
+}
+
+func BenchmarkLogExtractor(b *testing.B) {
+	var ctx context.Context
+	h := guard.New(benchVerifier())(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		ctx = r.Context()
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer tok")
+	h.ServeHTTP(&nopWriter{h: make(http.Header)}, r)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, ok := guard.LogExtractor(ctx); !ok {
+			b.Fatal("no identity in ctx")
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the baseline and record it**
+
+Run: `just bench ./auth/guard/`
+Expected: all benchmarks run; save the full output (it becomes the "before" column of the PR table).
+
+- [ ] **Step 3: Interpret against expected findings**
+
+Optimize only measured wins; these costs are **inherent — do not "fix" them**:
+
+- `New_ValidBearer`: ~2 allocs/op from `r.WithContext` + `context.WithValue` — the ctx-storage idiom itself (requestid pays the same). Extractor and verify dispatch must add 0.
+- `Extractors/BearerHeader`, `Extractors/Header`: expect **0 allocs/op** (substring sharing). If either allocates, that's a bug to fix, not a trade-off.
+- `Extractors/Cookie`: stdlib `r.Cookie` parses the Cookie header per call — do NOT hand-roll cookie parsing (correctness risk, cold-ish path).
+- `Extractors/Query`: `r.URL.Query()` builds the full `url.Values` map per call — expect several allocs/op. This is the one expected optimization; apply Step 4 only if the baseline confirms it.
+- `BasicAuth/*`: dominated by base64 decode + `consttime` HMAC — constant-time is the point; success and wrong-password should cost roughly the same (sanity-check that, it validates the timing design).
+- `New_Reject401`: error wrap + problem JSON encode — cold path by definition; no action.
+
+- [ ] **Step 4: Apply the Query optimization (only if baseline confirms the allocs)**
+
+Replace the `Query` body in `auth/guard/extractors.go` (keep the doc comment, add the perf note):
+
+```go
+// Query extracts the named query parameter.
+//
+// Credentials in query strings leak into access logs, browser history, and
+// Referer headers. Prefer BearerHeader or Cookie; reserve Query for signed,
+// short-lived links.
+//
+// It scans RawQuery directly instead of calling r.URL.Query(), which would
+// allocate the full url.Values map per request (benchmark in the PR).
+func Query(name string) Extractor {
+	return func(r *http.Request) (string, bool) {
+		q := r.URL.RawQuery
+		for q != "" {
+			var pair string
+			pair, q, _ = strings.Cut(q, "&")
+			k, v, _ := strings.Cut(pair, "=")
+			if strings.ContainsAny(k, "%+") {
+				dec, err := url.QueryUnescape(k)
+				if err != nil {
+					continue
+				}
+				k = dec
+			}
+			if k != name {
+				continue
+			}
+			if strings.ContainsAny(v, "%+") {
+				dec, err := url.QueryUnescape(v)
+				if err != nil {
+					return "", false
+				}
+				v = dec
+			}
+			return v, v != ""
+		}
+		return "", false
+	}
+}
+```
+
+Add `"net/url"` to the imports of `extractors.go`. Semantics must stay identical to `r.URL.Query().Get(name)` for present/absent/empty and first-occurrence-wins; extend `TestQuery` in `auth/guard/extractors_test.go` with the encoding cases:
+
+```go
+	// appended to the TestQuery body:
+	enc := httptest.NewRequest(http.MethodGet, "/p?tok%65n=q%74ok&plus=a+b&first=1&first=2", nil)
+	if got, ok := guard.Query("token")(enc); !ok || got != "qtok" {
+		t.Fatalf("Query(token) encoded = (%q, %v), want (qtok, true)", got, ok)
+	}
+	if got, ok := guard.Query("plus")(enc); !ok || got != "a b" {
+		t.Fatalf("Query(plus) = (%q, %v), want (a b, true)", got, ok)
+	}
+	if got, ok := guard.Query("first")(enc); !ok || got != "1" {
+		t.Fatalf("Query(first) = (%q, %v), want first occurrence (1, true)", got, ok)
+	}
+```
+
+- [ ] **Step 5: Verify tests still pass, re-run the benchmark, record the delta**
+
+```bash
+just test ./auth/guard/
+just bench ./auth/guard/
+```
+
+Expected: tests PASS; `Extractors/Query` allocs drop to 0–1/op (0 for unescaped values). Keep both baseline and after numbers for the PR description.
+
+- [ ] **Step 6: Full check and commit**
+
+```bash
+just fmt ./auth/guard/
+just lint
+git add auth/guard/
+git commit -m "perf(guard): benchmark suite; Query extractor scans RawQuery (no url.Values alloc)"
+```
+
+(If Step 4 was skipped because the baseline showed no win, commit just the benchmarks: `test(guard): benchmark suite for middleware hot paths`.)
+
+---
+
 ## Verification Checklist (post-plan)
 
 - [ ] `just test ./auth/guard/` — all green, race-clean
 - [ ] `just lint` — clean
+- [ ] `just bench ./auth/guard/` — suite runs; baseline + after numbers captured for the PR description; BearerHeader/Header at 0 allocs/op
+- [ ] BasicAuth success vs wrong-password benchmark times roughly equal (constant-time sanity check)
 - [ ] `grep -rn "IdentityFromContext" auth/guard/` — empty (reader is `From`/`MustFrom`)
 - [ ] `grep -n "auth/guard" docs/packages.md` — only the three dependent `Deps:` lines
 - [ ] doc.go compiles as prose examples (no Example funcs needed; ipfilter precedent)

--- a/docs/superpowers/specs/2026-07-13-auth-guard-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-guard-design.md
@@ -1,0 +1,275 @@
+# auth/guard — design
+
+Date: 2026-07-13
+Status: approved for planning
+
+## Purpose
+
+Request-authentication middleware: turn a credential on the request into an
+`Identity` in request context, or reject with 401. **Authentication only** —
+authorization (403, `RequirePermission`, the rbac/acl/abac decision seam)
+arrives later with `auth/rbac`; guard's `Identity` carries what that future
+seam will consume (Subject, Tenant, Scopes).
+
+Primary consumers: every authenticated route group. Named verifier providers:
+`auth/jwt` (shipped — adapter closure), `auth/session` and `auth/apikey`
+(planned — both catalogued as satisfying `guard.Verifier`). Built-in Basic
+Auth gates pprof/metrics/staging/admin. `ops/debug` and `auth/scim` list
+guard as a dep.
+
+## Placement
+
+`auth/guard`, single package, no subpackages. Imports: `web/middleware`,
+`web/problem`, `crypto/consttime`, `core/ctxkey`, `core/errorsx`,
+`ops/logger` (LogExtractor only). No external deps. ~350–450 LOC plus
+black-box tests. Standard anatomy: `doc.go` (runnable example), `options.go`,
+`errors.go`, `guard.go`, `extractors.go`, `basicauth.go`, `context.go`.
+
+When this ships: delete the `auth/guard` entry from docs/packages.md and
+un-tag `auth/guard (planned)` in the `auth/apikey`, `auth/scim`, and
+`ops/debug` entries.
+
+## Decisions (resolved during brainstorming)
+
+1. **Scope: authn only.** No decision-seam interface, no `RequirePermission`
+   in v1 — rbac/acl/abac don't exist yet; designing the Allow/Deny seam
+   against zero implementations was rejected. `Identity` is deliberately
+   rich enough (Subject/Tenant/Scopes) for the 401-vs-403 split later.
+2. **`Identity` is a concrete struct** — not generic, not an interface. One
+   type all verifiers agree on; no generics ceremony in middleware, options,
+   or context reads.
+3. **One `Verifier` per guard + chained `Extractor`s.** Extractors pull the
+   raw credential string; the single verifier validates it. Multi-scheme
+   apps (session UI + API keys) mount separate guards per route group —
+   `middleware.When`/`Skip` already cover routing. A `Scheme` pairing
+   concept was rejected for v1 (second concept, ambiguous try-next
+   semantics); it can be added later without breaking the seam.
+4. **`WithOptional()` ships.** Missing credential → anonymous pass-through;
+   present-but-invalid credential → 401 even in optional mode (silently
+   ignoring bad tokens masks expired sessions and probing).
+5. **Basic Auth is a dedicated constructor**, not forced through the
+   Verifier seam — the credential would be an awkward `user:pass` blob and
+   the middleware needs Basic-specific challenge knowledge anyway. It still
+   writes an `Identity` to context so `guard.From` works uniformly.
+6. **Default extractor chain is `BearerHeader()` only.** The catalog's
+   "header → cookie → query" describes the available chain, not defaults:
+   there is no universal cookie/param name to guess, and query-string
+   credentials leak into access logs. `Cookie`/`Query` are explicit opt-ins;
+   `Query`'s doc comment carries the leak warning.
+7. **Context reader is `guard.From`/`guard.MustFrom`**, deviating from the
+   catalog's `IdentityFromContext` — every shipped context reader in the
+   repo is bare `From` (`requestid.From`, `geoip.From`); the catalog entry
+   is deleted at ship time anyway.
+8. **No `Config` type.** Guard has no env-tunable knobs; BasicAuth
+   credentials arrive as a `map[string]string` (with a `ParseUsers` helper
+   for `"u1:p1,u2:p2"` env strings) — consumers load env via `ops/config`
+   in their own structs. doc.go shows the recipe.
+
+## Core types
+
+```go
+// Identity is the authenticated principal a Verifier resolved.
+type Identity struct {
+    Subject string            // principal id — never empty on success
+    Tenant  string            // optional tenant id
+    Scopes  []string          // carried for the future authz decision seam
+    Method  string            // "bearer", "session", "apikey", "basic", …
+    Meta    map[string]string // verifier-specific extras (email, key id, …)
+}
+
+// Verifier turns an extracted credential into an Identity.
+type Verifier interface {
+    Verify(ctx context.Context, credential string) (Identity, error)
+}
+
+// VerifierFunc adapts a func to Verifier; doubles as the test fake
+// (test doubles live with the seam owner).
+type VerifierFunc func(ctx context.Context, credential string) (Identity, error)
+
+// Extractor pulls a raw credential from a request. ok=false means
+// "not present" (try the next extractor), never "present but bad".
+type Extractor func(r *http.Request) (credential string, ok bool)
+```
+
+Verifier contract: a returned error means the credential is rejected —
+guard maps it to 401 and never surfaces detail to the client. `Verify` must
+be safe for concurrent use. A success with empty `Subject` is a verifier
+bug; guard treats it as a rejection — 401 with `ErrInvalidCredential`
+(defense against a zero-value `Identity, nil` return).
+
+## Middleware
+
+```go
+func New(v Verifier, opts ...Option) middleware.Middleware
+```
+
+Per-request flow:
+
+1. Run extractors in order; first `ok=true` wins. Extraction stops there —
+   later extractors are not fallbacks for a failed verify.
+2. No extractor hit: `WithOptional` → `next` untouched (no Identity in
+   context); otherwise respond 401 with `ErrNoCredential`.
+3. Credential found: `v.Verify(r.Context(), cred)`. Error → 401 with the
+   verifier error wrapped in `ErrInvalidCredential` (both `errors.Is`
+   matchable), **also in optional mode**. Success → store `Identity` via
+   the package ctxkey, `next.ServeHTTP(w, r.WithContext(...))`.
+
+On every 401, if a challenge is configured (`WithChallenge`), set
+`WWW-Authenticate: <value>` before invoking the responder.
+
+`New` panics on nil verifier (wiring bug — csrf/ipfilter precedent).
+Options:
+
+```go
+func WithExtractors(xs ...Extractor) Option // replaces default; panics if empty
+func WithOptional() Option
+func WithResponder(r problem.Responder) Option // default problem.JSON(problem.WithStatus(401)); nil ignored
+func WithChallenge(v string) Option // e.g. `Bearer realm="api"`; default none
+```
+
+## Shipped extractors
+
+```go
+func BearerHeader() Extractor  // Authorization: Bearer <token> (case-insensitive scheme)
+func Header(name string) Extractor // raw header value, e.g. X-API-Key
+func Cookie(name string) Extractor // cookie value
+func Query(name string) Extractor  // query param — doc warning: leaks into access logs
+```
+
+All return `ok=false` on absent or empty values. `BearerHeader` returns
+`ok=false` for a non-Bearer `Authorization` header (a Basic header on a
+bearer-guarded route reads as "no credential", not a malformed one).
+Custom extraction (signed cookies via `web/cookie.Codec`, etc.) is a
+consumer closure — `Extractor` is just a func.
+
+## Basic Auth
+
+```go
+func BasicAuth(users map[string]string, opts ...Option) middleware.Middleware
+func WithRealm(realm string) Option // default "restricted"
+func ParseUsers(s string) (map[string]string, error) // "u1:p1,u2:p2"
+```
+
+- Parses `Authorization: Basic` via `r.BasicAuth()`.
+- Password check via `consttime.StringEqual`. Unknown username compares
+  against a fixed dummy password so user existence doesn't leak via timing.
+- Every failure → 401 with `WWW-Authenticate: Basic realm="<realm>",
+  charset="UTF-8"` through the responder (default problem.JSON 401).
+  Unknown user and wrong password are indistinguishable to the client —
+  same `ErrInvalidCredential` (`auth_invalid`), same timing (dummy
+  compare). Missing/malformed header → `ErrNoCredential` (`auth_missing`);
+  that distinction leaks nothing (the client knows what it sent).
+- Success → `Identity{Subject: username, Method: "basic"}` in context.
+- Panics on empty/nil users map (a guard with no valid credentials is a
+  wiring bug). Accepted options: `WithRealm`, `WithResponder`; `BasicAuth`
+  ignores extractor/optional/challenge options (documented) — its scheme
+  is fixed.
+- `ParseUsers` rejects empty input, entries without `:`, empty usernames,
+  and duplicate usernames. Realm values are sanitized (quotes/control
+  chars rejected) since they're echoed into a header.
+
+## Context & logging
+
+```go
+var identityKey = ctxkey.New[Identity]("guard")
+
+func From(ctx context.Context) (Identity, bool)
+func MustFrom(ctx context.Context) Identity // panics if absent — for handlers behind the guard
+
+var LogExtractor logger.ContextExtractor // adds subject (+ tenant when set)
+```
+
+## Errors
+
+`errors.go`, coded via `errorsx` so problem+json carries machine-readable
+codes (`errorsx.Code`):
+
+```go
+var ErrNoCredential      = errorsx.New("auth_missing", "no credential provided")
+var ErrInvalidCredential = errorsx.New("auth_invalid", "credential rejected")
+```
+
+Verify failures reach the responder as
+`fmt.Errorf("%w: %w", ErrInvalidCredential, verifierErr)` — custom
+responders can branch on `guard.Err*` or on provider sentinels
+(`jwt.ErrExpired`) via `errors.Is`; `problem` resolves the code from the
+outermost coded error (`auth_invalid`). The default responder forces
+status 401 (`problem.WithStatus`) — never rely on error→status inference
+(`request.StatusCode` maps unknown errors to 400). Response bodies stay
+generic; verifier detail is server-side only.
+
+## Usage (doc.go example, abridged)
+
+```go
+// JWT-backed API guard (auth/jwt shipped):
+type appClaims struct {
+    jwt.Claims
+    TenantID string   `json:"tid"`
+    Scopes   []string `json:"scopes"`
+}
+verifier := guard.VerifierFunc(func(ctx context.Context, token string) (guard.Identity, error) {
+    c, err := jwt.Verify[appClaims](ctx, jwtVerifier, token)
+    if err != nil {
+        return guard.Identity{}, err
+    }
+    return guard.Identity{Subject: c.Subject, Tenant: c.TenantID, Scopes: c.Scopes, Method: "bearer"}, nil
+})
+authn := guard.New(verifier, guard.WithChallenge(`Bearer realm="api"`))
+
+// Session-cookie browser guard (auth/session planned; redirect responder):
+authn := guard.New(sessionVerifier,
+    guard.WithExtractors(guard.Cookie("sid")),
+    guard.WithResponder(func(w http.ResponseWriter, r *http.Request, err error) {
+        http.Redirect(w, r, "/login?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusSeeOther)
+    }),
+)
+
+// Staging gate:
+users, _ := guard.ParseUsers(os.Getenv("ADMIN_BASIC_USERS"))
+mux.Handle("/debug/pprof/", guard.BasicAuth(users, guard.WithRealm("staging"))(pprof))
+```
+
+Boundary note (documented in doc.go): guard answers "who is this request
+from" only — session rotation, sliding TTLs, and Save-on-response are
+`auth/session` middleware concerns; scope/permission checks are the future
+authz seam.
+
+## Performance
+
+Hot path (valid credential): one extractor scan (header reads, no
+allocation), one Verify call (verifier-owned cost), one context value.
+No regex, no per-request option evaluation (config resolved in `New`).
+Zero-alloc target for the guard's own work per design.md §Performance;
+no benchmark-gated complexity anticipated.
+
+## Testing
+
+Black-box `guard_test` package, `httptest` + `VerifierFunc` fakes:
+
+- Extractor chain: order, first-hit-wins, no-fallback-after-extract,
+  each shipped extractor (present/absent/empty/malformed header forms).
+- `New`: missing vs invalid vs valid credential; optional-mode matrix
+  (missing→anonymous, invalid→401); challenge header set on both 401
+  paths; responder override; wrapped-error `errors.Is` matching (guard
+  sentinel + fake verifier sentinel); empty-Subject success treated as
+  rejection; nil-verifier and empty-extractors panics.
+- `BasicAuth`: correct login → Identity in context; wrong password,
+  unknown user, malformed header → identical 401 + WWW-Authenticate with
+  realm; `ParseUsers` accept/reject table; realm sanitization; empty
+  users panic.
+- Context: `From` ok/absent, `MustFrom` panic, `LogExtractor` attrs.
+
+No fuzz targets — parsing is stdlib (`r.BasicAuth`, `strings.Cut` on the
+Authorization header). No integration/external deps.
+
+## Anti-scope
+
+- No authorization: no Allow/Deny seam, no `RequirePermission`, no scope
+  checks — `auth/rbac`+friends later.
+- No credential issuance, no login/logout handlers, no session lifecycle.
+- No multi-scheme `Scheme` pairing in v1 (separate guards per route group).
+- No rate limiting / lockout on failures (`auth/lockout`'s job; composes
+  as an outer middleware or inside a consumer's Verifier).
+- No htpasswd/bcrypt file support in BasicAuth — static env credentials
+  for internal gates only (documented; real user login belongs to
+  session/password flows).

--- a/docs/superpowers/specs/2026-07-13-auth-guard-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-guard-design.md
@@ -239,8 +239,17 @@ authz seam.
 Hot path (valid credential): one extractor scan (header reads, no
 allocation), one Verify call (verifier-owned cost), one context value.
 No regex, no per-request option evaluation (config resolved in `New`).
-Zero-alloc target for the guard's own work per design.md §Performance;
-no benchmark-gated complexity anticipated.
+Zero-alloc target for the guard's own work per design.md §Performance.
+
+**Benchmarks are required** (project policy, all packages): `bench_test.go`
+covers the valid-bearer flow, the 401 path, each shipped extractor,
+BasicAuth success/failure, and LogExtractor. After the baseline run, a
+post-benchmark optimization pass applies only measured wins (expected:
+`Query` swaps `r.URL.Query()`'s full-map alloc for a `RawQuery` scan).
+Inherent costs are documented, not optimized away: ~2 allocs/op for the
+context store (`WithContext` + `WithValue`, requestid-identical), stdlib
+cookie parsing in `Cookie`, and base64+HMAC in BasicAuth (constant-time is
+the point). Before/after numbers go in the PR description.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Ships `auth/guard` — request-authentication middleware. A chain of credential extractors finds the credential, a `Verifier` seam resolves it to an `Identity` stored in request context, and rejections are `problem+json` 401s. Authorization (403/scopes) is deliberately out of scope. Built per the approved design spec and plan under `docs/superpowers/`.

One package, ~440 LOC (excl. tests), 99.2% coverage.

### Public API

- **`New(v Verifier, opts ...Option) middleware.Middleware`** — extractor chain (default `BearerHeader`) → `Verifier.Verify(ctx, credential) (Identity, error)` → stores `Identity` in ctx for `From`/`MustFrom`. Missing credential → 401 (or anonymous pass-through with `WithOptional`); rejected credential → 401 always. Empty-`Subject` verify success is treated as a rejection (buggy-verifier net).
- **`BasicAuth(users map[string]string, opts ...Option) middleware.Middleware`** — constant-time Basic Auth gate for pprof/metrics/staging/admin (not user login). Unknown users compare against a dummy password so existence doesn't leak via timing.
- **Extractors:** `BearerHeader`, `Header`, `Cookie`, `Query` (+ the `Extractor` seam — any `func(*http.Request) (string, bool)`).
- **Options:** `WithExtractors`, `WithOptional`, `WithResponder`, `WithChallenge`, `WithRealm`.
- **Context/observability:** `From`, `MustFrom`, `LogExtractor` (an `ops/logger.ContextExtractor`).
- **Helpers/sentinels:** `ParseUsers`, `ErrNoCredential`, `ErrInvalidCredential`, `ErrInvalidUsers`.

Adapters for `auth/jwt`, `auth/session`, `auth/apikey` are small closures over `VerifierFunc` — no coupling.

## Benchmarks (required per project policy)

Baseline recorded, then a benchmark-gated optimization pass applying only measured wins:

| Benchmark | Before (ns/op, B/op, allocs/op) | After | Delta |
|---|---|---|---|
| `Extractors/Query` | 235.3, 448, **5** | 57.7, 0, **0** | −75% time, −5 allocs/op (scan `RawQuery`, no `url.Values` map) |
| `Extractors/Header` | 50.1, 16, **1** | 20.0, 0, **0** | −60% time, −1 alloc/op (canonicalize name once at construction) |
| `Extractors/BearerHeader` | 34.0, 0, 0 | 33.1, 0, 0 | — (already 0-alloc) |
| `New` valid bearer | 158.8, 448, 3 | 138.9, 448, 3 | inherent ctx-storage cost (`r.WithContext` + `context.WithValue`) |
| `BasicAuth` success | 1054, 1552, 20 | 947, 1552, 20 | — |
| `BasicAuth` wrong-password | 1410, 1297, 22 | 1279, 1297, 22 | — |

The `Query` scan is verified semantically equivalent to `r.URL.Query().Get(name)` (present/absent/empty/first-wins/percent-decode/`+`/`;`/malformed-escape). `Header` pre-canonicalization is behavior-identical to per-call `Header.Get`. `BasicAuth` success vs wrong-password: the compare itself is length-independent double-HMAC (`crypto/consttime`); the time delta is the post-decision path (JSON error rendering), not the credential comparison.

## Review loop caught 3 bugs in the plan's own example code

This was implemented via per-task TDD + independent review + a whole-branch Opus review. Three real bugs that would have shipped verbatim were caught and fixed:

1. **Error-detail leak in `New`'s default responder** — the plan's literal `New` fed the wrapped verifier error straight to `problem.JSON`, which renders `err.Error()` into the 401 body (`web/problem` puts detail into any status < 500), leaking the verifier's raw message and failing the plan's own `TestNew_InvalidCredential` + `Verifier` doc. Fixed: the default responder collapses the error to the bare sentinel; custom responders still receive the full wrapped chain (`errors.Is` matches both the sentinel and the verifier error).
2. **`Query` scan diverged from stdlib** — aborted the whole scan on a malformed `%`-escape (breaking first-occurrence-wins) and accepted raw `;` pairs. Fixed to mirror `net/url.parseQuery` (`continue` on malformed pair; reject `;`-tainted pairs), with regression tests.
3. **`WithResponder(problem.JSON(...))` re-leaks** (whole-branch review) — the natural custom-responder wiring re-opens the leak the default path protects. Added a doc warning; also hardened `BasicAuth` to reject empty-credential map entries at construction (mirrors `New`'s empty-principal net).

## Catalog

`docs/packages.md`: removed the `auth/guard` roadmap entry (now shipped); un-tagged `auth/apikey`, `auth/scim`, `ops/debug` from `auth/guard (planned)`.

## Verification

- `just test ./auth/guard/` — PASS, race-clean, **99.2%** coverage
- `just lint` — clean (vet, build, golangci-lint 0 issues, nilaway, betteralign, modernize)
- `just bench ./auth/guard/` — suite runs; BearerHeader/Header/Query all 0 allocs/op
