### PR TITLE
feat(auth/otp): short numeric OTP codes — HMAC-peppered, single-use, dual-mode tenancy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,4 +5,6 @@
 - Run `just lint` after task finished.
 - `docs/packages.md` = package catalog & roadmap (list only). `docs/design.md` = ALL design rules — layout/naming, package idioms & anatomy, dependency policy, seams, performance rules, testing policy, anti-scope. Read design.md BEFORE creating or changing any package and follow it exactly.
 - Perf: readable first, optimize only proven-hot paths; any perf-motivated complexity requires a benchmark in the PR. Hot-path rules: docs/design.md §Performance.
+- Benchmarks are REQUIRED for every package: `bench_test.go` + post-benchmark optimization pass (measured wins only); before/after numbers in the PR.
+- Every package must work in BOTH single-tenant and multi-tenant apps: tenant scoping enters via an optional construction-time seam (e.g. a scope-from-context hook), never per-call-site string composition; fail closed when a configured scope is missing; single-tenant use pays zero ceremony.
 - PR flow: create new PR -> whait all CI passed -> fix failed workflows -> learn Claude's review -> fix all found issues and resolve fixed threads -> commit -> repeat until all issues will be fixed.

--- a/auth/otp/bench_test.go
+++ b/auth/otp/bench_test.go
@@ -12,7 +12,7 @@ func newBenchOTP(b *testing.B, opts ...otp.Option) *otp.OTP {
 	b.Helper()
 	store := cache.NewMemoryStore()
 	b.Cleanup(func() { _ = store.Close() })
-	o, err := otp.New([]byte("0123456789abcdef"), store, opts...)
+	o, err := otp.New([]byte("0123456789abcdef0123456789abcdef"), store, opts...)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/auth/otp/bench_test.go
+++ b/auth/otp/bench_test.go
@@ -1,0 +1,69 @@
+package otp_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/otp"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+func newBenchOTP(b *testing.B, opts ...otp.Option) *otp.OTP {
+	b.Helper()
+	store := cache.NewMemoryStore()
+	b.Cleanup(func() { _ = store.Close() })
+	o, err := otp.New([]byte("0123456789abcdef"), store, opts...)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return o
+}
+
+func BenchmarkGenerate(b *testing.B) {
+	o := newBenchOTP(b)
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := o.Generate(ctx, "user@example.com"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkGenerateVerify measures the full happy cycle — the real-world
+// unit of work is one verify per generate (verify is single-use).
+func BenchmarkGenerateVerify(b *testing.B) {
+	o := newBenchOTP(b)
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		code, err := o.Generate(ctx, "user@example.com")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := o.Verify(ctx, "user@example.com", code); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyMismatch(b *testing.B) {
+	o := newBenchOTP(b, otp.WithMaxAttempts(255))
+	ctx := b.Context()
+	if _, err := o.Generate(ctx, "user@example.com"); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		err := o.Verify(ctx, "user@example.com", "999999999") // wrong length: can never match
+		if errors.Is(err, otp.ErrTooManyAttempts) || errors.Is(err, otp.ErrNotFound) {
+			if _, err := o.Generate(ctx, "user@example.com"); err != nil {
+				b.Fatal(err)
+			}
+			continue
+		}
+		if !errors.Is(err, otp.ErrCodeMismatch) {
+			b.Fatal(err)
+		}
+	}
+}

--- a/auth/otp/doc.go
+++ b/auth/otp/doc.go
@@ -11,7 +11,7 @@
 // Create one instance per flow — the purpose isolates codes so a login code
 // can never verify a password reset:
 //
-//	secret := []byte(os.Getenv("OTP_SECRET")) // min 16 bytes
+//	secret := []byte(os.Getenv("OTP_SECRET")) // min 32 bytes
 //	store := redis.NewStore(client)           // resilience/cache/redis; memory store for dev/tests
 //
 //	loginOTP, err := otp.New(secret, store, otp.WithPurpose("login"))

--- a/auth/otp/doc.go
+++ b/auth/otp/doc.go
@@ -62,12 +62,15 @@
 //
 // State rides the resilience/cache.Store seam. Keys carry no PII (scope and
 // identifier are hashed with length-prefixed domain separation); values are
-// 42-byte records holding the attempt counter, expiry, and the
-// HMAC-SHA256(secret, code) digest. The in-memory store's LRU eviction makes
-// it unsuitable for production codes — use cache/redis or another durable
+// 42-byte records holding a format-version byte, the attempt counter, expiry,
+// and the HMAC-SHA256(secret, code) digest. The in-memory store's LRU eviction
+// makes it unsuitable for production codes — use cache/redis or another durable
 // Store. A failed attempt rewrites the record with its remaining TTL, so
 // retries never extend a code's life. The attempt counter is
 // read-modify-write: concurrent wrong guesses can overshoot the limit by the
 // in-flight count, which is immaterial against a million-value keyspace;
-// per-identifier lockout is auth/lockout's layer.
+// per-identifier lockout is auth/lockout's layer. Single-use is enforced per
+// completed verification, not as a mutual exclusion: concurrent submissions of
+// the correct code may each succeed before either deletes the record — harmless,
+// since that requires already holding the valid code.
 package otp

--- a/auth/otp/doc.go
+++ b/auth/otp/doc.go
@@ -58,6 +58,22 @@
 // ErrScope instead of falling through to a shared bucket. Single-tenant
 // applications omit the option.
 //
+// The hook is arbitrary — it maps the request context to a scope string — so
+// one construction serves every tenancy shape:
+//
+//   - Single-tenant: omit WithScope; every identifier shares one namespace.
+//   - White-label (tenant-locked): return the tenant the request is bound to.
+//     A sibling tenant with the same identifier gets a different code, and a
+//     request that arrives without a tenant fails closed.
+//   - Global user switching tenants: return the active tenant while the user is
+//     inside one, and a reserved, non-empty global sentinel (e.g. "@global") at
+//     the platform level. "Switching" is just a different context per request;
+//     each scope is an isolated bucket.
+//
+// Because the hook fails closed on an empty string, the global case must return
+// a non-empty sentinel, not "". Keep that sentinel disjoint from real tenant
+// IDs so a global user and a tenant can never collide in the same bucket.
+//
 // # Storage
 //
 // State rides the resilience/cache.Store seam. Keys carry no PII (scope and

--- a/auth/otp/doc.go
+++ b/auth/otp/doc.go
@@ -1,0 +1,73 @@
+// Package otp issues and verifies short numeric one-time codes for email and
+// SMS verification and passwordless login. Codes are attempt-limited, TTL'd,
+// single-use, and stored only as keyed hashes: a store-only compromise
+// reveals nothing without the application's secret, because the 10^6 space
+// of a 6-digit code makes any unkeyed hash reversible in milliseconds.
+//
+// Delivery is the caller's channel; anti-enumeration responses and request
+// throttling stay in the caller's handlers (compose auth/lockout and
+// resilience/ratelimit). TOTP/HOTP authenticator apps are auth/totp.
+//
+// Create one instance per flow — the purpose isolates codes so a login code
+// can never verify a password reset:
+//
+//	secret := []byte(os.Getenv("OTP_SECRET")) // min 16 bytes
+//	store := redis.NewStore(client)           // resilience/cache/redis; memory store for dev/tests
+//
+//	loginOTP, err := otp.New(secret, store, otp.WithPurpose("login"))
+//	if err != nil { ... }
+//
+//	// Request a code. Deliver over your channel; reply 202 whether or not
+//	// the account exists.
+//	code, err := loginOTP.Generate(ctx, email)
+//
+//	// Verify. Map ErrNotFound and ErrCodeMismatch to ONE user-facing
+//	// message so responses reveal nothing about code existence.
+//	err = loginOTP.Verify(ctx, email, submitted)
+//	switch {
+//	case err == nil:
+//		// authenticated
+//	case errors.Is(err, otp.ErrTooManyAttempts):
+//		// "too many attempts — request a new code"
+//	default:
+//		// "invalid or expired code"
+//	}
+//
+// The identifier is an opaque string the package never interprets.
+// Canonicalize it (lowercase and trim emails, E.164 phone numbers) in ONE
+// helper used by both Generate and Verify — different forms derive different
+// storage keys and the code will never match. Calling Generate again for the
+// same identifier replaces the outstanding code ("resend"); Revoke cancels
+// it.
+//
+// # Multi-tenancy
+//
+// Multi-tenant applications wire tenant isolation once, at construction,
+// with WithScope — never by concatenating tenant IDs into identifiers at
+// call sites:
+//
+//	loginOTP, err := otp.New(secret, store,
+//		otp.WithPurpose("login"),
+//		otp.WithScope(func(ctx context.Context) (string, error) {
+//			return tenantFromContext(ctx) // e.g. data/tenant middleware
+//		}),
+//	)
+//
+// The hook runs inside every Generate, Verify, and Revoke, so no call site
+// can forget it. It fails closed: an error or empty scope aborts with
+// ErrScope instead of falling through to a shared bucket. Single-tenant
+// applications omit the option.
+//
+// # Storage
+//
+// State rides the resilience/cache.Store seam. Keys carry no PII (scope and
+// identifier are hashed with length-prefixed domain separation); values are
+// 42-byte records holding the attempt counter, expiry, and the
+// HMAC-SHA256(secret, code) digest. The in-memory store's LRU eviction makes
+// it unsuitable for production codes — use cache/redis or another durable
+// Store. A failed attempt rewrites the record with its remaining TTL, so
+// retries never extend a code's life. The attempt counter is
+// read-modify-write: concurrent wrong guesses can overshoot the limit by the
+// in-flight count, which is immaterial against a million-value keyspace;
+// per-identifier lockout is auth/lockout's layer.
+package otp

--- a/auth/otp/errors.go
+++ b/auth/otp/errors.go
@@ -1,0 +1,19 @@
+package otp
+
+import "errors"
+
+var (
+	// ErrNotFound reports that no active code exists for the identifier —
+	// never issued, expired, revoked, or already consumed.
+	ErrNotFound = errors.New("otp: code not found")
+	// ErrCodeMismatch reports a wrong code with attempts remaining.
+	ErrCodeMismatch = errors.New("otp: code mismatch")
+	// ErrTooManyAttempts reports a consumed attempt limit; the code is invalidated.
+	ErrTooManyAttempts = errors.New("otp: too many attempts")
+	// ErrScope reports a configured scope hook that failed or returned empty.
+	ErrScope = errors.New("otp: scope resolution failed")
+	// ErrStore wraps failures of the underlying cache.Store.
+	ErrStore = errors.New("otp: store operation failed")
+	// ErrInvalidConfig reports invalid constructor input.
+	ErrInvalidConfig = errors.New("otp: invalid config")
+)

--- a/auth/otp/fuzz_test.go
+++ b/auth/otp/fuzz_test.go
@@ -16,7 +16,7 @@ import (
 func FuzzVerify(f *testing.F) {
 	store := cache.NewMemoryStore()
 	f.Cleanup(func() { _ = store.Close() })
-	o, err := otp.New([]byte("0123456789abcdef"), store)
+	o, err := otp.New([]byte("0123456789abcdef0123456789abcdef"), store)
 	if err != nil {
 		f.Fatal(err)
 	}

--- a/auth/otp/fuzz_test.go
+++ b/auth/otp/fuzz_test.go
@@ -1,0 +1,50 @@
+package otp_test
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/otp"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+// FuzzVerify feeds arbitrary submitted codes through a full generate/verify
+// cycle: only the exact issued code may verify; everything else must return
+// ErrCodeMismatch, and nothing may panic.
+func FuzzVerify(f *testing.F) {
+	store := cache.NewMemoryStore()
+	f.Cleanup(func() { _ = store.Close() })
+	o, err := otp.New([]byte("0123456789abcdef"), store)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	f.Add("123456")
+	f.Add("")
+	f.Add("000000")
+	f.Add("abcdef")
+	f.Add("12345678901234567890")
+	f.Add("\x00\x01\x02")
+
+	var n atomic.Int64
+	f.Fuzz(func(t *testing.T, submitted string) {
+		identifier := fmt.Sprintf("user-%d@example.com", n.Add(1))
+		ctx := t.Context()
+		want, err := o.Generate(ctx, identifier)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = o.Verify(ctx, identifier, submitted)
+		if submitted == want {
+			if err != nil {
+				t.Fatalf("exact code rejected: %v", err)
+			}
+			return
+		}
+		if !errors.Is(err, otp.ErrCodeMismatch) {
+			t.Fatalf("wrong code %q: err = %v, want ErrCodeMismatch", submitted, err)
+		}
+	})
+}

--- a/auth/otp/options.go
+++ b/auth/otp/options.go
@@ -1,0 +1,49 @@
+package otp
+
+import (
+	"context"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type config struct {
+	scope       func(context.Context) (string, error)
+	clock       clock.Clock
+	purpose     string
+	ttl         time.Duration
+	length      int
+	maxAttempts int
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithPurpose isolates codes per flow (login, email-verify, password-reset).
+// Two instances with different purposes never see each other's codes.
+// Default "default".
+func WithPurpose(p string) Option { return func(c *config) { c.purpose = p } }
+
+// WithTTL sets the code lifetime. Default 10 minutes; must be positive.
+func WithTTL(d time.Duration) Option { return func(c *config) { c.ttl = d } }
+
+// WithLength sets the number of code digits. Default 6; valid range 4-10.
+func WithLength(n int) Option { return func(c *config) { c.length = n } }
+
+// WithMaxAttempts sets the per-code verify attempt limit. Default 5; valid
+// range 1-255 (the counter is stored as a single byte).
+func WithMaxAttempts(n int) Option { return func(c *config) { c.maxAttempts = n } }
+
+// WithScope derives a tenant scope from the request context on every
+// Generate, Verify, and Revoke call, so multi-tenant isolation is wired once
+// at construction instead of at every call site. The hook fails closed: an
+// error or empty scope aborts the operation with ErrScope — a code issued
+// for one tenant can never resolve in another tenant's (or a global) bucket.
+// Single-tenant applications omit this option.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) { c.scope = fn }
+}
+
+// WithClock substitutes the time source used for expiry math. Default
+// clock.System(). Tests use clock.Mock.
+func WithClock(clk clock.Clock) Option { return func(c *config) { c.clock = clk } }

--- a/auth/otp/otp.go
+++ b/auth/otp/otp.go
@@ -1,10 +1,16 @@
 package otp
 
 import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/random"
+	"github.com/dmitrymomot/forge/crypto/digest"
 	"github.com/dmitrymomot/forge/resilience/cache"
 )
 
@@ -50,4 +56,54 @@ func New(secret []byte, store cache.Store, opts ...Option) (*OTP, error) {
 		return nil, fmt.Errorf("%w: clock must not be nil", ErrInvalidConfig)
 	}
 	return &OTP{store: store, cfg: cfg, secret: secret}, nil
+}
+
+// Generate issues a fresh code for identifier and stores its keyed hash with
+// the configured TTL, replacing any previous code for the same (purpose,
+// scope, identifier) — calling it again is "resend". The returned plaintext
+// code is for the caller to deliver over their own channel; it is never
+// stored. identifier must arrive canonicalized (lowercased email, E.164
+// phone) in the exact same form Verify will receive.
+func (o *OTP) Generate(ctx context.Context, identifier string) (string, error) {
+	scope, err := o.resolveScope(ctx)
+	if err != nil {
+		return "", err
+	}
+	code := random.DigitCode(o.cfg.length)
+	rec := record{expiresAt: o.cfg.clock.Now().Add(o.cfg.ttl).Unix()}
+	copy(rec.codeHash[:], digest.HMACSHA256(o.secret, []byte(code)))
+	key := o.storageKey(scope, identifier)
+	if err := o.store.Set(ctx, key, encodeRecord(rec), cache.WithTTL(o.cfg.ttl)); err != nil {
+		return "", errors.Join(ErrStore, err)
+	}
+	return code, nil
+}
+
+// resolveScope runs the configured scope hook, failing closed: a hook error
+// or empty scope aborts the operation so a scoped code can never land in an
+// unscoped (or another tenant's) bucket.
+func (o *OTP) resolveScope(ctx context.Context) (string, error) {
+	if o.cfg.scope == nil {
+		return "", nil
+	}
+	s, err := o.cfg.scope(ctx)
+	if err != nil {
+		return "", errors.Join(ErrScope, err)
+	}
+	if s == "" {
+		return "", ErrScope
+	}
+	return s, nil
+}
+
+// storageKey derives the deterministic store key. Scope and identifier are
+// length-prefixed before hashing so composite values cannot collide, and
+// hashed so no PII (emails, phone numbers) appears in store keys.
+func (o *OTP) storageKey(scope, identifier string) string {
+	buf := make([]byte, 0, 8+len(scope)+len(identifier))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(scope)))
+	buf = append(buf, scope...)
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(identifier)))
+	buf = append(buf, identifier...)
+	return "otp:" + o.cfg.purpose + ":" + hex.EncodeToString(digest.SHA256(buf))
 }

--- a/auth/otp/otp.go
+++ b/auth/otp/otp.go
@@ -2,6 +2,7 @@ package otp
 
 import (
 	"context"
+	"crypto/hmac"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -106,4 +107,66 @@ func (o *OTP) storageKey(scope, identifier string) string {
 	buf = binary.BigEndian.AppendUint32(buf, uint32(len(identifier)))
 	buf = append(buf, identifier...)
 	return "otp:" + o.cfg.purpose + ":" + hex.EncodeToString(digest.SHA256(buf))
+}
+
+// Verify checks code against the active record for identifier. It is
+// single-use: a successful verification deletes the record. A mismatch
+// consumes one attempt; consuming the last attempt (or meeting an already
+// consumed limit) invalidates the code. Callers should map ErrNotFound and
+// ErrCodeMismatch to one user-facing message ("invalid or expired code") so
+// responses reveal nothing about code existence.
+func (o *OTP) Verify(ctx context.Context, identifier, code string) error {
+	scope, err := o.resolveScope(ctx)
+	if err != nil {
+		return err
+	}
+	key := o.storageKey(scope, identifier)
+
+	raw, err := o.store.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, cache.ErrNotFound) {
+			return ErrNotFound
+		}
+		return errors.Join(ErrStore, err)
+	}
+	rec, ok := decodeRecord(raw)
+	if !ok {
+		// Unknown version or corrupt payload: treat as revoked. Best-effort
+		// cleanup — the entry also dies by store TTL.
+		_ = o.store.Delete(ctx, key)
+		return ErrNotFound
+	}
+	now := o.cfg.clock.Now()
+	remaining := time.Unix(rec.expiresAt, 0).Sub(now)
+	if remaining <= 0 {
+		// Defense-in-depth for stores that ignore TTL; also closes the
+		// cache seam's TTL<=0-means-eternal edge on the rewrite below.
+		_ = o.store.Delete(ctx, key)
+		return ErrNotFound
+	}
+	if int(rec.attempts) >= o.cfg.maxAttempts {
+		// Only reachable when a concurrent mismatch raced the rewrite;
+		// deletion already happened or happens here.
+		_ = o.store.Delete(ctx, key)
+		return ErrTooManyAttempts
+	}
+	if !hmac.Equal(digest.HMACSHA256(o.secret, []byte(code)), rec.codeHash[:]) {
+		rec.attempts++
+		if int(rec.attempts) >= o.cfg.maxAttempts {
+			if err := o.store.Delete(ctx, key); err != nil {
+				return errors.Join(ErrStore, err)
+			}
+			return ErrTooManyAttempts
+		}
+		if err := o.store.Set(ctx, key, encodeRecord(rec), cache.WithTTL(remaining)); err != nil {
+			return errors.Join(ErrStore, err)
+		}
+		return ErrCodeMismatch
+	}
+	// Single-use: the delete must succeed before success is reported, or a
+	// live code would outlive a "verified" response.
+	if err := o.store.Delete(ctx, key); err != nil {
+		return errors.Join(ErrStore, err)
+	}
+	return nil
 }

--- a/auth/otp/otp.go
+++ b/auth/otp/otp.go
@@ -1,0 +1,53 @@
+package otp
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+const minSecretLen = 16
+
+// OTP issues and verifies short numeric one-time codes for a single flow
+// (purpose). Create one instance per flow; see WithPurpose.
+type OTP struct {
+	store  cache.Store
+	secret []byte
+	cfg    config
+}
+
+// New returns an OTP issuer/verifier. secret is the HMAC pepper for codes
+// at rest (min 16 bytes; load it from the environment, e.g. OTP_SECRET) and
+// store is the shared TTL-KV seam (cache.NewMemoryStore for tests/dev,
+// cache/redis in production).
+func New(secret []byte, store cache.Store, opts ...Option) (*OTP, error) {
+	cfg := config{
+		clock:       clock.System(),
+		purpose:     "default",
+		ttl:         10 * time.Minute,
+		length:      6,
+		maxAttempts: 5,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	switch {
+	case len(secret) < minSecretLen:
+		return nil, fmt.Errorf("%w: secret must be at least %d bytes", ErrInvalidConfig, minSecretLen)
+	case store == nil:
+		return nil, fmt.Errorf("%w: store is required", ErrInvalidConfig)
+	case cfg.purpose == "":
+		return nil, fmt.Errorf("%w: purpose must not be empty", ErrInvalidConfig)
+	case cfg.ttl <= 0:
+		return nil, fmt.Errorf("%w: ttl must be positive", ErrInvalidConfig)
+	case cfg.length < 4 || cfg.length > 10:
+		return nil, fmt.Errorf("%w: length must be in [4,10]", ErrInvalidConfig)
+	case cfg.maxAttempts < 1 || cfg.maxAttempts > 255:
+		return nil, fmt.Errorf("%w: max attempts must be in [1,255]", ErrInvalidConfig)
+	case cfg.clock == nil:
+		return nil, fmt.Errorf("%w: clock must not be nil", ErrInvalidConfig)
+	}
+	return &OTP{store: store, cfg: cfg, secret: secret}, nil
+}

--- a/auth/otp/otp.go
+++ b/auth/otp/otp.go
@@ -15,7 +15,10 @@ import (
 	"github.com/dmitrymomot/forge/resilience/cache"
 )
 
-const minSecretLen = 16
+// minSecretLen is the smallest accepted HMAC pepper. 32 bytes matches the
+// SHA-256 output size, the floor RFC 2104 recommends for an HMAC key: a
+// shorter key adds no security over one hashed down to the block size.
+const minSecretLen = 32
 
 // OTP issues and verifies short numeric one-time codes for a single flow
 // (purpose). Create one instance per flow; see WithPurpose.
@@ -26,9 +29,10 @@ type OTP struct {
 }
 
 // New returns an OTP issuer/verifier. secret is the HMAC pepper for codes
-// at rest (min 16 bytes; load it from the environment, e.g. OTP_SECRET) and
+// at rest (min 32 bytes; load it from the environment, e.g. OTP_SECRET) and
 // store is the shared TTL-KV seam (cache.NewMemoryStore for tests/dev,
-// cache/redis in production).
+// cache/redis in production). secret is copied, so a caller may reuse or zero
+// its backing array afterward without affecting the returned OTP.
 func New(secret []byte, store cache.Store, opts ...Option) (*OTP, error) {
 	cfg := config{
 		clock:       clock.System(),
@@ -56,7 +60,11 @@ func New(secret []byte, store cache.Store, opts ...Option) (*OTP, error) {
 	case cfg.clock == nil:
 		return nil, fmt.Errorf("%w: clock must not be nil", ErrInvalidConfig)
 	}
-	return &OTP{store: store, cfg: cfg, secret: secret}, nil
+	// Copy the pepper so a caller reusing or zeroing its backing array can't
+	// silently change how codes hash.
+	sec := make([]byte, len(secret))
+	copy(sec, secret)
+	return &OTP{store: store, cfg: cfg, secret: sec}, nil
 }
 
 // Generate issues a fresh code for identifier and stores its keyed hash with

--- a/auth/otp/otp.go
+++ b/auth/otp/otp.go
@@ -99,7 +99,10 @@ func (o *OTP) resolveScope(ctx context.Context) (string, error) {
 
 // storageKey derives the deterministic store key. Scope and identifier are
 // length-prefixed before hashing so composite values cannot collide, and
-// hashed so no PII (emails, phone numbers) appears in store keys.
+// hashed so no PII (emails, phone numbers) appears in store keys. purpose is
+// trusted construction-time input, so it rides the key prefix unhashed; the
+// fixed-width hex suffix still prevents cross-purpose collision. If purpose
+// ever comes to carry untrusted input, length-prefix it into the hash too.
 func (o *OTP) storageKey(scope, identifier string) string {
 	buf := make([]byte, 0, 8+len(scope)+len(identifier))
 	buf = binary.BigEndian.AppendUint32(buf, uint32(len(scope)))

--- a/auth/otp/otp.go
+++ b/auth/otp/otp.go
@@ -170,3 +170,17 @@ func (o *OTP) Verify(ctx context.Context, identifier, code string) error {
 	}
 	return nil
 }
+
+// Revoke deletes any outstanding code for identifier — cancel a pending
+// flow, or invalidate after an account-state change. Revoking when nothing
+// is outstanding is a no-op.
+func (o *OTP) Revoke(ctx context.Context, identifier string) error {
+	scope, err := o.resolveScope(ctx)
+	if err != nil {
+		return err
+	}
+	if err := o.store.Delete(ctx, o.storageKey(scope, identifier)); err != nil {
+		return errors.Join(ErrStore, err)
+	}
+	return nil
+}

--- a/auth/otp/otp_test.go
+++ b/auth/otp/otp_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/dmitrymomot/forge/auth/otp"
+	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/crypto/digest"
 	"github.com/dmitrymomot/forge/resilience/cache"
 )
@@ -195,4 +196,209 @@ func TestGenerate_ScopeFailClosed(t *testing.T) {
 			t.Fatalf("err = %v, want ErrScope", err)
 		}
 	})
+}
+
+var baseTime = time.Unix(1_700_000_000, 0)
+
+// wrongCode returns a code of the same length guaranteed != code.
+func wrongCode(code string) string {
+	b := []byte(code)
+	if b[0] == '0' {
+		b[0] = '1'
+	} else {
+		b[0] = '0'
+	}
+	return string(b)
+}
+
+func TestVerify_HappyPathSingleUse(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", code); err != nil {
+		t.Fatalf("Verify correct code: %v", err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("second Verify = %v, want ErrNotFound (single-use)", err)
+	}
+}
+
+func TestVerify_NeverIssued(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", "123456"); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestVerify_AttemptExhaustion(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t), otp.WithMaxAttempts(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad := wrongCode(code)
+
+	// Attempts 1 and 2: mismatch with attempts remaining.
+	for i := range 2 {
+		if err := o.Verify(t.Context(), "user@example.com", bad); !errors.Is(err, otp.ErrCodeMismatch) {
+			t.Fatalf("attempt %d: err = %v, want ErrCodeMismatch", i+1, err)
+		}
+	}
+	// Attempt 3 consumes the limit.
+	if err := o.Verify(t.Context(), "user@example.com", bad); !errors.Is(err, otp.ErrTooManyAttempts) {
+		t.Fatalf("limit-consuming attempt: err = %v, want ErrTooManyAttempts", err)
+	}
+	// The code is dead even for the CORRECT value.
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("correct code after exhaustion: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestVerify_Expiry(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(baseTime)
+	o, err := otp.New(testSecret, newStore(t), otp.WithTTL(10*time.Minute), otp.WithClock(clk))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clk.Advance(10*time.Minute + time.Second)
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("expired code: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestVerify_FailedAttemptDoesNotExtendLife(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(baseTime)
+	o, err := otp.New(testSecret, newStore(t), otp.WithTTL(10*time.Minute), otp.WithClock(clk))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A wrong attempt at minute 9 rewrites the record...
+	clk.Advance(9 * time.Minute)
+	if err := o.Verify(t.Context(), "user@example.com", wrongCode(code)); !errors.Is(err, otp.ErrCodeMismatch) {
+		t.Fatal(err)
+	}
+	// ...but the code still dies at the ORIGINAL deadline.
+	clk.Advance(time.Minute + time.Second)
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("code outlived its original deadline: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestVerify_ReplaceOnGenerate(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code1, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code2, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code1 != code2 {
+		// Old code is dead (mismatch consumes an attempt against code2's record).
+		if err := o.Verify(t.Context(), "user@example.com", code1); !errors.Is(err, otp.ErrCodeMismatch) {
+			t.Fatalf("old code: err = %v, want ErrCodeMismatch", err)
+		}
+	}
+	if err := o.Verify(t.Context(), "user@example.com", code2); err != nil {
+		t.Fatalf("new code: %v", err)
+	}
+}
+
+func TestVerify_CorruptRecord(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	o, err := otp.New(testSecret, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := o.Generate(t.Context(), "user@example.com"); err != nil {
+		t.Fatal(err)
+	}
+	key := storageKey("default", "", "user@example.com")
+	// Unknown version byte reads as absent (forward-compat / revoked).
+	if err := store.Set(t.Context(), key, []byte{0xFF, 0, 0, 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", "123456"); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("corrupt record: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestVerify_TenantIsolation(t *testing.T) {
+	t.Parallel()
+	tenantScope := func(ctx context.Context) (string, error) {
+		s, _ := ctx.Value(ctxTenant{}).(string)
+		return s, nil
+	}
+	o, err := otp.New(testSecret, newStore(t), otp.WithScope(tenantScope))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctxA := context.WithValue(t.Context(), ctxTenant{}, "tenant-a")
+	ctxB := context.WithValue(t.Context(), ctxTenant{}, "tenant-b")
+
+	code, err := o.Generate(ctxA, "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Tenant B never sees tenant A's code — not even as a mismatch.
+	if err := o.Verify(ctxB, "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("cross-tenant verify: err = %v, want ErrNotFound", err)
+	}
+	// Missing tenant in ctx fails closed, not into a global bucket.
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrScope) {
+		t.Fatalf("scopeless ctx: err = %v, want ErrScope", err)
+	}
+	if err := o.Verify(ctxA, "user@example.com", code); err != nil {
+		t.Fatalf("same-tenant verify: %v", err)
+	}
+}
+
+func TestVerify_PurposeIsolation(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	login, err := otp.New(testSecret, store, otp.WithPurpose("login"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reset, err := otp.New(testSecret, store, otp.WithPurpose("password-reset"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := login.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reset.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("cross-purpose verify: err = %v, want ErrNotFound", err)
+	}
 }

--- a/auth/otp/otp_test.go
+++ b/auth/otp/otp_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -22,6 +23,31 @@ func newStore(t *testing.T) cache.Store {
 	store := cache.NewMemoryStore()
 	t.Cleanup(func() { _ = store.Close() })
 	return store
+}
+
+// ttlSpyStore wraps a cache.Store and records the effective TTL passed to
+// the most recent Set call, so tests can assert on the TTL argument itself
+// rather than on effects that could pass for other reasons.
+type ttlSpyStore struct {
+	cache.Store
+	mu       sync.Mutex
+	lastTTL  time.Duration
+	setCalls int
+}
+
+func (s *ttlSpyStore) Set(ctx context.Context, key string, val []byte, opts ...cache.SetOption) error {
+	resolved := cache.ApplySetOptions(opts...)
+	s.mu.Lock()
+	s.lastTTL = resolved.TTL
+	s.setCalls++
+	s.mu.Unlock()
+	return s.Store.Set(ctx, key, val, opts...)
+}
+
+func (s *ttlSpyStore) LastTTL() time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastTTL
 }
 
 func TestNew_Valid(t *testing.T) {
@@ -400,5 +426,60 @@ func TestVerify_PurposeIsolation(t *testing.T) {
 	}
 	if err := reset.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
 		t.Fatalf("cross-purpose verify: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestVerify_MismatchRewriteUsesRemainingTTL(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(baseTime)
+	spy := &ttlSpyStore{Store: cache.NewMemoryStore()}
+	t.Cleanup(func() { _ = spy.Close() })
+	o, err := otp.New(testSecret, spy, otp.WithClock(clk), otp.WithTTL(10*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := spy.LastTTL(); got != 10*time.Minute {
+		t.Fatalf("Generate TTL = %v, want 10m", got)
+	}
+
+	clk.Advance(4 * time.Minute)
+	if err := o.Verify(t.Context(), "user@example.com", wrongCode(code)); !errors.Is(err, otp.ErrCodeMismatch) {
+		t.Fatalf("err = %v, want ErrCodeMismatch", err)
+	}
+
+	got := spy.LastTTL()
+	if got != 6*time.Minute {
+		t.Fatalf("mismatch-rewrite TTL = %v, want exactly 6m (remaining time), not the full ttl", got)
+	}
+	if got >= 10*time.Minute {
+		t.Fatalf("mismatch-rewrite TTL = %v, must be strictly less than the full 10m ttl", got)
+	}
+}
+
+func TestVerify_WrongVersionByte(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	o, err := otp.New(testSecret, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := o.Generate(t.Context(), "user@example.com"); err != nil {
+		t.Fatal(err)
+	}
+	key := storageKey("default", "", "user@example.com")
+	// Correct length (42 bytes), wrong version byte: exercises the
+	// wrong-version-at-correct-length branch of decodeRecord, distinct from
+	// the too-short-to-parse case in TestVerify_CorruptRecord.
+	bad := make([]byte, 42)
+	bad[0] = 0xFF
+	if err := store.Set(t.Context(), key, bad); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", "123456"); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("wrong-version record: err = %v, want ErrNotFound", err)
 	}
 }

--- a/auth/otp/otp_test.go
+++ b/auth/otp/otp_test.go
@@ -523,13 +523,11 @@ func TestVerify_ConcurrentWrongGuesses(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 20 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if err := o.Verify(t.Context(), "user@example.com", bad); err == nil {
 				t.Error("wrong code verified")
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/auth/otp/otp_test.go
+++ b/auth/otp/otp_test.go
@@ -1,0 +1,76 @@
+package otp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/otp"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+var testSecret = []byte("0123456789abcdef")
+
+func newStore(t *testing.T) cache.Store {
+	t.Helper()
+	store := cache.NewMemoryStore()
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestNew_Valid(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatalf("New with defaults: %v", err)
+	}
+	if o == nil {
+		t.Fatal("New returned nil *OTP")
+	}
+}
+
+func TestNew_InvalidConfig(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	tests := []struct {
+		name   string
+		secret []byte
+		store  cache.Store
+		opts   []otp.Option
+	}{
+		{"short secret", []byte("tooshort"), store, nil},
+		{"nil secret", nil, store, nil},
+		{"nil store", testSecret, nil, nil},
+		{"empty purpose", testSecret, store, []otp.Option{otp.WithPurpose("")}},
+		{"zero ttl", testSecret, store, []otp.Option{otp.WithTTL(0)}},
+		{"negative ttl", testSecret, store, []otp.Option{otp.WithTTL(-time.Minute)}},
+		{"length too short", testSecret, store, []otp.Option{otp.WithLength(3)}},
+		{"length too long", testSecret, store, []otp.Option{otp.WithLength(11)}},
+		{"zero attempts", testSecret, store, []otp.Option{otp.WithMaxAttempts(0)}},
+		{"attempts over byte", testSecret, store, []otp.Option{otp.WithMaxAttempts(256)}},
+		{"nil clock", testSecret, store, []otp.Option{otp.WithClock(nil)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := otp.New(tt.secret, tt.store, tt.opts...); !errors.Is(err, otp.ErrInvalidConfig) {
+				t.Fatalf("err = %v, want ErrInvalidConfig", err)
+			}
+		})
+	}
+}
+
+func TestNew_BoundaryValues(t *testing.T) {
+	t.Parallel()
+	opts := []otp.Option{
+		otp.WithLength(4), otp.WithMaxAttempts(255), otp.WithTTL(time.Second),
+		otp.WithScope(func(context.Context) (string, error) { return "t1", nil }),
+	}
+	if _, err := otp.New(testSecret, newStore(t), opts...); err != nil {
+		t.Fatalf("boundary values rejected: %v", err)
+	}
+	if _, err := otp.New(testSecret, newStore(t), otp.WithLength(10)); err != nil {
+		t.Fatalf("length 10 rejected: %v", err)
+	}
+}

--- a/auth/otp/otp_test.go
+++ b/auth/otp/otp_test.go
@@ -483,3 +483,53 @@ func TestVerify_WrongVersionByte(t *testing.T) {
 		t.Fatalf("wrong-version record: err = %v, want ErrNotFound", err)
 	}
 }
+
+func TestRevoke(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Revoke(t.Context(), "user@example.com"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("revoked code: err = %v, want ErrNotFound", err)
+	}
+	// Revoking with nothing outstanding is a no-op, not an error.
+	if err := o.Revoke(t.Context(), "user@example.com"); err != nil {
+		t.Fatalf("idempotent Revoke: %v", err)
+	}
+}
+
+// TestVerify_ConcurrentWrongGuesses exercises the documented read-modify-write
+// attempt counter under the race detector. The limit may be overshot by the
+// in-flight count (documented caveat), but a wrong code must NEVER verify.
+func TestVerify_ConcurrentWrongGuesses(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t), otp.WithMaxAttempts(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad := wrongCode(code)
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := o.Verify(t.Context(), "user@example.com", bad); err == nil {
+				t.Error("wrong code verified")
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/auth/otp/otp_test.go
+++ b/auth/otp/otp_test.go
@@ -2,11 +2,15 @@ package otp_test
 
 import (
 	"context"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/dmitrymomot/forge/auth/otp"
+	"github.com/dmitrymomot/forge/crypto/digest"
 	"github.com/dmitrymomot/forge/resilience/cache"
 )
 
@@ -73,4 +77,122 @@ func TestNew_BoundaryValues(t *testing.T) {
 	if _, err := otp.New(testSecret, newStore(t), otp.WithLength(10)); err != nil {
 		t.Fatalf("length 10 rejected: %v", err)
 	}
+}
+
+// storageKey replicates the documented storage-key contract so tests can
+// inspect raw records black-box.
+func storageKey(purpose, scope, identifier string) string {
+	buf := make([]byte, 0, 8+len(scope)+len(identifier))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(scope)))
+	buf = append(buf, scope...)
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(identifier)))
+	buf = append(buf, identifier...)
+	return "otp:" + purpose + ":" + hex.EncodeToString(digest.SHA256(buf))
+}
+
+func TestGenerate_CodeFormat(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(code) != 6 {
+		t.Fatalf("code length = %d, want 6", len(code))
+	}
+	for _, r := range code {
+		if r < '0' || r > '9' {
+			t.Fatalf("code %q contains non-digit %q", code, r)
+		}
+	}
+}
+
+func TestGenerate_HashedAtRest(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	o, err := otp.New(testSecret, store, otp.WithPurpose("login"), otp.WithLength(8))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := store.Get(t.Context(), storageKey("login", "", "user@example.com"))
+	if err != nil {
+		t.Fatalf("record not at documented key: %v", err)
+	}
+	if len(raw) != 42 {
+		t.Fatalf("record size = %d, want 42", len(raw))
+	}
+	if raw[0] != 0x01 {
+		t.Fatalf("version byte = %#x, want 0x01", raw[0])
+	}
+	if raw[1] != 0 {
+		t.Fatalf("initial attempts = %d, want 0", raw[1])
+	}
+	if strings.Contains(string(raw), code) {
+		t.Fatal("plaintext code stored in record")
+	}
+	wantHash := digest.HMACSHA256(testSecret, []byte(code))
+	if string(raw[10:]) != string(wantHash) {
+		t.Fatal("stored hash is not HMAC-SHA256(secret, code)")
+	}
+}
+
+func TestGenerate_ScopeSeparatesKeys(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	tenantScope := func(ctx context.Context) (string, error) {
+		s, _ := ctx.Value(ctxTenant{}).(string)
+		return s, nil
+	}
+	o, err := otp.New(testSecret, store, otp.WithScope(tenantScope))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctxA := context.WithValue(t.Context(), ctxTenant{}, "tenant-a")
+	if _, err := o.Generate(ctxA, "user@example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Get(t.Context(), storageKey("default", "tenant-a", "user@example.com")); err != nil {
+		t.Fatalf("record not under tenant-scoped key: %v", err)
+	}
+	// Delimiter games cannot collide: ("a:b","c") vs ("a","b:c").
+	if storageKey("default", "a:b", "c") == storageKey("default", "a", "b:c") {
+		t.Fatal("length-prefixed key derivation collided")
+	}
+}
+
+type ctxTenant struct{}
+
+func TestGenerate_ScopeFailClosed(t *testing.T) {
+	t.Parallel()
+	t.Run("hook error", func(t *testing.T) {
+		t.Parallel()
+		o, err := otp.New(testSecret, newStore(t),
+			otp.WithScope(func(context.Context) (string, error) { return "", errors.New("no tenant") }))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := o.Generate(t.Context(), "user@example.com"); !errors.Is(err, otp.ErrScope) {
+			t.Fatalf("err = %v, want ErrScope", err)
+		}
+	})
+	t.Run("empty scope", func(t *testing.T) {
+		t.Parallel()
+		o, err := otp.New(testSecret, newStore(t),
+			otp.WithScope(func(context.Context) (string, error) { return "", nil }))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := o.Generate(t.Context(), "user@example.com"); !errors.Is(err, otp.ErrScope) {
+			t.Fatalf("err = %v, want ErrScope", err)
+		}
+	})
 }

--- a/auth/otp/otp_test.go
+++ b/auth/otp/otp_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/dmitrymomot/forge/resilience/cache"
 )
 
-var testSecret = []byte("0123456789abcdef")
+var testSecret = []byte("0123456789abcdef0123456789abcdef")
 
 func newStore(t *testing.T) cache.Store {
 	t.Helper()

--- a/auth/otp/record.go
+++ b/auth/otp/record.go
@@ -1,0 +1,37 @@
+package otp
+
+import "encoding/binary"
+
+// recordVersion is the storage-format version byte. Records with any other
+// version decode as absent, so a future format change invalidates in-flight
+// codes instead of misreading them.
+const recordVersion = 0x01
+
+// recordSize is version(1) + attempts(1) + expiresAt(8) + HMAC-SHA256(32).
+const recordSize = 42
+
+type record struct {
+	expiresAt int64
+	codeHash  [32]byte
+	attempts  uint8
+}
+
+func encodeRecord(r record) []byte {
+	buf := make([]byte, recordSize)
+	buf[0] = recordVersion
+	buf[1] = r.attempts
+	binary.BigEndian.PutUint64(buf[2:10], uint64(r.expiresAt))
+	copy(buf[10:], r.codeHash[:])
+	return buf
+}
+
+func decodeRecord(b []byte) (record, bool) {
+	if len(b) != recordSize || b[0] != recordVersion {
+		return record{}, false
+	}
+	var r record
+	r.attempts = b[1]
+	r.expiresAt = int64(binary.BigEndian.Uint64(b[2:10]))
+	copy(r.codeHash[:], b[10:])
+	return r, true
+}

--- a/auth/otp/tenancy_test.go
+++ b/auth/otp/tenancy_test.go
@@ -124,3 +124,36 @@ func TestTenancy_GlobalUserSwitchingTenants(t *testing.T) {
 		t.Fatalf("acme verify: %v", err)
 	}
 }
+
+// TestTenancy_SentinelTenantCollision makes the doc's disjointness caveat
+// verifiable: if the reserved global sentinel is NOT kept distinct from real
+// tenant IDs, a global user and the colliding tenant share one bucket. This
+// test deliberately violates the rule to prove the failure mode exists —
+// production apps must keep the sentinel disjoint from tenant IDs.
+func TestTenancy_SentinelTenantCollision(t *testing.T) {
+	t.Parallel()
+	const sentinel = "@global"
+	scope := func(ctx context.Context) (string, error) {
+		if tenant, ok := ctx.Value(ctxTenant{}).(string); ok && tenant != "" {
+			return tenant, nil
+		}
+		return sentinel, nil
+	}
+	o, err := otp.New(testSecret, newStore(t), otp.WithScope(scope))
+	if err != nil {
+		t.Fatal(err)
+	}
+	platform := t.Context()                                            // resolves to sentinel
+	colliding := context.WithValue(t.Context(), ctxTenant{}, sentinel) // tenant id == sentinel
+
+	code, err := o.Generate(platform, "admin@platform.com")
+	if err != nil {
+		t.Fatalf("platform Generate: %v", err)
+	}
+	// Same identifier + same resolved scope -> same bucket, so a code issued at
+	// the platform level IS visible to the colliding tenant. That shared
+	// visibility is exactly why the sentinel must stay disjoint from tenant IDs.
+	if err := o.Verify(colliding, "admin@platform.com", code); err != nil {
+		t.Fatalf("collision: verify = %v, want success (proves the shared-bucket failure mode)", err)
+	}
+}

--- a/auth/otp/tenancy_test.go
+++ b/auth/otp/tenancy_test.go
@@ -1,0 +1,126 @@
+package otp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/otp"
+)
+
+// The tests below are executable proof that a single WithScope construction
+// seam serves the three tenancy shapes a real application needs: a
+// single-tenant app, a white-label app where every user is locked to one
+// tenant, and a platform where a global user switches between tenants. The
+// scope hook is arbitrary app logic mapping the request context to a scope
+// string, so "switching tenants" is nothing more than a different context per
+// request.
+
+// TestTenancy_SingleTenant: omit WithScope entirely. Scope resolves to "" and
+// every identifier shares one flat namespace — zero ceremony.
+func TestTenancy_SingleTenant(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", code); err != nil {
+		t.Fatalf("single-tenant verify: %v", err)
+	}
+}
+
+// TestTenancy_WhiteLabelTenantLocked: every request is bound to exactly one
+// tenant. The same identifier in a sibling tenant is a different code, and a
+// request that arrives without a tenant fails closed rather than leaking into a
+// shared bucket.
+func TestTenancy_WhiteLabelTenantLocked(t *testing.T) {
+	t.Parallel()
+	scope := func(ctx context.Context) (string, error) {
+		tenant, _ := ctx.Value(ctxTenant{}).(string)
+		return tenant, nil // "" -> resolveScope fails closed with ErrScope
+	}
+	o, err := otp.New(testSecret, newStore(t), otp.WithScope(scope))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	acme := context.WithValue(t.Context(), ctxTenant{}, "acme")
+	globex := context.WithValue(t.Context(), ctxTenant{}, "globex")
+
+	code, err := o.Generate(acme, "user@example.com")
+	if err != nil {
+		t.Fatalf("Generate under acme: %v", err)
+	}
+	// A sibling white-label tenant with the SAME identifier never sees the code.
+	if err := o.Verify(globex, "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("cross-tenant verify = %v, want ErrNotFound", err)
+	}
+	// The owning tenant verifies.
+	if err := o.Verify(acme, "user@example.com", code); err != nil {
+		t.Fatalf("owning-tenant verify: %v", err)
+	}
+	// A request that lost its tenant fails closed — no fall-through to a global
+	// bucket, on Generate, Verify, and Revoke alike.
+	if _, err := o.Generate(t.Context(), "user@example.com"); !errors.Is(err, otp.ErrScope) {
+		t.Fatalf("tenantless Generate = %v, want ErrScope", err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrScope) {
+		t.Fatalf("tenantless Verify = %v, want ErrScope", err)
+	}
+	if err := o.Revoke(t.Context(), "user@example.com"); !errors.Is(err, otp.ErrScope) {
+		t.Fatalf("tenantless Revoke = %v, want ErrScope", err)
+	}
+}
+
+// TestTenancy_GlobalUserSwitchingTenants: one global identity operates at the
+// platform level AND inside tenants it switches into. The app's hook returns
+// the active tenant when the user is inside one, and a reserved non-empty
+// global sentinel at the platform level. Codes issued in one scope are
+// isolated from every other scope.
+func TestTenancy_GlobalUserSwitchingTenants(t *testing.T) {
+	t.Parallel()
+	const globalScope = "@global" // reserved; must not equal any real tenant id
+	scope := func(ctx context.Context) (string, error) {
+		if tenant, ok := ctx.Value(ctxTenant{}).(string); ok && tenant != "" {
+			return tenant, nil // acting inside a tenant the user switched into
+		}
+		return globalScope, nil // platform level — a global, non-empty bucket
+	}
+	o, err := otp.New(testSecret, newStore(t), otp.WithScope(scope))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	platform := t.Context()                                     // no tenant selected
+	acme := context.WithValue(t.Context(), ctxTenant{}, "acme") // switched in
+
+	// A platform-level code lives in the global bucket, isolated from tenants:
+	// switching into acme cannot verify a platform-issued code.
+	gcode, err := o.Generate(platform, "admin@platform.com")
+	if err != nil {
+		t.Fatalf("platform Generate: %v", err)
+	}
+	if err := o.Verify(acme, "admin@platform.com", gcode); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("global code inside tenant = %v, want ErrNotFound", err)
+	}
+	if err := o.Verify(platform, "admin@platform.com", gcode); err != nil {
+		t.Fatalf("platform verify: %v", err)
+	}
+
+	// After switching into acme, the SAME user gets an acme-scoped code that is
+	// independent of anything at the platform level.
+	tcode, err := o.Generate(acme, "admin@platform.com")
+	if err != nil {
+		t.Fatalf("acme Generate: %v", err)
+	}
+	if err := o.Verify(platform, "admin@platform.com", tcode); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("tenant code at platform = %v, want ErrNotFound", err)
+	}
+	if err := o.Verify(acme, "admin@platform.com", tcode); err != nil {
+		t.Fatalf("acme verify: %v", err)
+	}
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -653,16 +653,6 @@ Deps: `core/qrcode`, `core/random`, `crypto/consttime`.
 
 ---
 
-**auth/otp**
-
-Short numeric codes for email/SMS verification: attempt-limited, TTL'd,
-hashed at rest; generation via `random.DigitCode`; delivery is the
-caller's channel.
-
-Deps: `core/random`, `crypto/digest`.
-
----
-
 **auth/apikey**
 
 The full API-key product for tenant- or user-owned keys: Stripe-style

--- a/docs/superpowers/plans/2026-07-13-auth-otp.md
+++ b/docs/superpowers/plans/2026-07-13-auth-otp.md
@@ -1,0 +1,1291 @@
+# auth/otp Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `auth/otp` — short numeric codes for email/SMS verification and passwordless login: attempt-limited, TTL'd, HMAC-peppered at rest, single-use, dual-mode tenancy.
+
+**Architecture:** One `*otp.OTP` instance per flow (purpose baked in at construction). State rides the `resilience/cache.Store` byte-KV seam under deterministic hashed keys `otp:<purpose>:<hex(SHA256(lenPrefix(scope)||lenPrefix(identifier)))>`. Records are 42-byte fixed binary: `version|attempts|expiresAt|HMAC-SHA256(secret, code)`. Multi-tenancy enters via an optional fail-closed `WithScope` context hook, never per-call-site composition.
+
+**Tech Stack:** Go 1.26, stdlib + forge-internal deps only: `core/random`, `core/clock`, `crypto/digest`, `resilience/cache`.
+
+**Spec:** `docs/superpowers/specs/2026-07-13-auth-otp-design.md` (approved).
+
+## Global Constraints
+
+- Module `github.com/dmitrymomot/forge`; Go 1.26; work ONLY in branch `dm/busy-moser-ee47b8`.
+- Run `just fmt ./auth/otp/` after file changes (package form — single-file form trips a betteralign bug). Run `just lint` when a task finishes.
+- Tests: `just test ./auth/otp/` (runs `go test -race -cover`). Black-box only — test package is `otp_test`. Use `t.Context()` for contexts.
+- Benchmarks REQUIRED: `bench_test.go` with `b.ReportAllocs()` + `for b.Loop()`; before/after numbers go in the PR description.
+- Errors: single-line sentinels, `errors.Is`-matchable, message prefix `otp: `.
+- Loops over ints: `for i := range n` (modernize enforces). Use `new(expr)` not ptr helpers.
+- No Claude/AI attribution in any commit message or PR content.
+- Secret for all tests: `[]byte("0123456789abcdef")` (exactly 16 bytes).
+
+---
+
+### Task 1: Package skeleton — errors, options, `New` validation
+
+**Files:**
+- Create: `auth/otp/errors.go`
+- Create: `auth/otp/options.go`
+- Create: `auth/otp/otp.go`
+- Create: `auth/otp/otp_test.go`
+- Modify: `docs/superpowers/specs/2026-07-13-auth-otp-design.md` (one row: maxAttempts range)
+
+**Interfaces:**
+- Consumes: `resilience/cache.Store`, `core/clock.Clock`/`clock.System()`.
+- Produces: `otp.New(secret []byte, store cache.Store, opts ...Option) (*OTP, error)`; options `WithPurpose(string)`, `WithTTL(time.Duration)`, `WithLength(int)`, `WithMaxAttempts(int)`, `WithScope(func(context.Context) (string, error))`, `WithClock(clock.Clock)`; sentinels `ErrNotFound`, `ErrCodeMismatch`, `ErrTooManyAttempts`, `ErrScope`, `ErrStore`, `ErrInvalidConfig`. Later tasks add methods to `*OTP` and read its fields.
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/otp/otp_test.go`:
+
+```go
+package otp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/otp"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+var testSecret = []byte("0123456789abcdef")
+
+func newStore(t *testing.T) cache.Store {
+	t.Helper()
+	store := cache.NewMemoryStore()
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestNew_Valid(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatalf("New with defaults: %v", err)
+	}
+	if o == nil {
+		t.Fatal("New returned nil *OTP")
+	}
+}
+
+func TestNew_InvalidConfig(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	tests := []struct {
+		name   string
+		secret []byte
+		store  cache.Store
+		opts   []otp.Option
+	}{
+		{"short secret", []byte("tooshort"), store, nil},
+		{"nil secret", nil, store, nil},
+		{"nil store", testSecret, nil, nil},
+		{"empty purpose", testSecret, store, []otp.Option{otp.WithPurpose("")}},
+		{"zero ttl", testSecret, store, []otp.Option{otp.WithTTL(0)}},
+		{"negative ttl", testSecret, store, []otp.Option{otp.WithTTL(-time.Minute)}},
+		{"length too short", testSecret, store, []otp.Option{otp.WithLength(3)}},
+		{"length too long", testSecret, store, []otp.Option{otp.WithLength(11)}},
+		{"zero attempts", testSecret, store, []otp.Option{otp.WithMaxAttempts(0)}},
+		{"attempts over byte", testSecret, store, []otp.Option{otp.WithMaxAttempts(256)}},
+		{"nil clock", testSecret, store, []otp.Option{otp.WithClock(nil)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := otp.New(tt.secret, tt.store, tt.opts...); !errors.Is(err, otp.ErrInvalidConfig) {
+				t.Fatalf("err = %v, want ErrInvalidConfig", err)
+			}
+		})
+	}
+}
+
+func TestNew_BoundaryValues(t *testing.T) {
+	t.Parallel()
+	opts := []otp.Option{
+		otp.WithLength(4), otp.WithMaxAttempts(255), otp.WithTTL(time.Second),
+		otp.WithScope(func(context.Context) (string, error) { return "t1", nil }),
+	}
+	if _, err := otp.New(testSecret, newStore(t), opts...); err != nil {
+		t.Fatalf("boundary values rejected: %v", err)
+	}
+	if _, err := otp.New(testSecret, newStore(t), otp.WithLength(10)); err != nil {
+		t.Fatalf("length 10 rejected: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./auth/otp/`
+Expected: FAIL — compile error, `undefined: otp.New` (package does not exist yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+`auth/otp/errors.go`:
+
+```go
+package otp
+
+import "errors"
+
+var (
+	// ErrNotFound reports that no active code exists for the identifier —
+	// never issued, expired, revoked, or already consumed.
+	ErrNotFound = errors.New("otp: code not found")
+	// ErrCodeMismatch reports a wrong code with attempts remaining.
+	ErrCodeMismatch = errors.New("otp: code mismatch")
+	// ErrTooManyAttempts reports a consumed attempt limit; the code is invalidated.
+	ErrTooManyAttempts = errors.New("otp: too many attempts")
+	// ErrScope reports a configured scope hook that failed or returned empty.
+	ErrScope = errors.New("otp: scope resolution failed")
+	// ErrStore wraps failures of the underlying cache.Store.
+	ErrStore = errors.New("otp: store operation failed")
+	// ErrInvalidConfig reports invalid constructor input.
+	ErrInvalidConfig = errors.New("otp: invalid config")
+)
+```
+
+`auth/otp/options.go`:
+
+```go
+package otp
+
+import (
+	"context"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type config struct {
+	scope       func(context.Context) (string, error)
+	clock       clock.Clock
+	purpose     string
+	ttl         time.Duration
+	length      int
+	maxAttempts int
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithPurpose isolates codes per flow (login, email-verify, password-reset).
+// Two instances with different purposes never see each other's codes.
+// Default "default".
+func WithPurpose(p string) Option { return func(c *config) { c.purpose = p } }
+
+// WithTTL sets the code lifetime. Default 10 minutes; must be positive.
+func WithTTL(d time.Duration) Option { return func(c *config) { c.ttl = d } }
+
+// WithLength sets the number of code digits. Default 6; valid range 4-10.
+func WithLength(n int) Option { return func(c *config) { c.length = n } }
+
+// WithMaxAttempts sets the per-code verify attempt limit. Default 5; valid
+// range 1-255 (the counter is stored as a single byte).
+func WithMaxAttempts(n int) Option { return func(c *config) { c.maxAttempts = n } }
+
+// WithScope derives a tenant scope from the request context on every
+// Generate, Verify, and Revoke call, so multi-tenant isolation is wired once
+// at construction instead of at every call site. The hook fails closed: an
+// error or empty scope aborts the operation with ErrScope — a code issued
+// for one tenant can never resolve in another tenant's (or a global) bucket.
+// Single-tenant applications omit this option.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) { c.scope = fn }
+}
+
+// WithClock substitutes the time source used for expiry math. Default
+// clock.System(). Tests use clock.Mock.
+func WithClock(clk clock.Clock) Option { return func(c *config) { c.clock = clk } }
+```
+
+`auth/otp/otp.go`:
+
+```go
+package otp
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+const minSecretLen = 16
+
+// OTP issues and verifies short numeric one-time codes for a single flow
+// (purpose). Create one instance per flow; see WithPurpose.
+type OTP struct {
+	store cache.Store
+	cfg   config
+	secret []byte
+}
+
+// New returns an OTP issuer/verifier. secret is the HMAC pepper for codes
+// at rest (min 16 bytes; load it from the environment, e.g. OTP_SECRET) and
+// store is the shared TTL-KV seam (cache.NewMemoryStore for tests/dev,
+// cache/redis in production).
+func New(secret []byte, store cache.Store, opts ...Option) (*OTP, error) {
+	cfg := config{
+		clock:       clock.System(),
+		purpose:     "default",
+		ttl:         10 * time.Minute,
+		length:      6,
+		maxAttempts: 5,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	switch {
+	case len(secret) < minSecretLen:
+		return nil, fmt.Errorf("%w: secret must be at least %d bytes", ErrInvalidConfig, minSecretLen)
+	case store == nil:
+		return nil, fmt.Errorf("%w: store is required", ErrInvalidConfig)
+	case cfg.purpose == "":
+		return nil, fmt.Errorf("%w: purpose must not be empty", ErrInvalidConfig)
+	case cfg.ttl <= 0:
+		return nil, fmt.Errorf("%w: ttl must be positive", ErrInvalidConfig)
+	case cfg.length < 4 || cfg.length > 10:
+		return nil, fmt.Errorf("%w: length must be in [4,10]", ErrInvalidConfig)
+	case cfg.maxAttempts < 1 || cfg.maxAttempts > 255:
+		return nil, fmt.Errorf("%w: max attempts must be in [1,255]", ErrInvalidConfig)
+	case cfg.clock == nil:
+		return nil, fmt.Errorf("%w: clock must not be nil", ErrInvalidConfig)
+	}
+	return &OTP{store: store, cfg: cfg, secret: secret}, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test ./auth/otp/`
+Expected: PASS (3 test functions).
+
+- [ ] **Step 5: Sync spec with the 1-255 attempts bound**
+
+In `docs/superpowers/specs/2026-07-13-auth-otp-design.md`, change the options-table row
+
+```
+| `WithMaxAttempts(int)` | 5 | per-code verify attempts; must be > 0 |
+```
+
+to
+
+```
+| `WithMaxAttempts(int)` | 5 | per-code verify attempts; valid 1-255 (stored as one byte) |
+```
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+just fmt ./auth/otp/
+git add auth/otp/ docs/superpowers/specs/2026-07-13-auth-otp-design.md
+git commit -m "feat(otp): package skeleton — sentinels, options, New validation"
+```
+
+---
+
+### Task 2: Generate — domain-separated keys, HMAC-hashed records
+
+**Files:**
+- Modify: `auth/otp/otp.go`
+- Create: `auth/otp/record.go`
+- Test: `auth/otp/otp_test.go` (append)
+
+**Interfaces:**
+- Consumes: Task 1's `*OTP`, config, sentinels; `random.DigitCode(n int) string`; `digest.SHA256(b []byte) []byte`; `digest.HMACSHA256(key, msg []byte) []byte`; `cache.WithTTL(d time.Duration) cache.SetOption`.
+- Produces: `(*OTP).Generate(ctx context.Context, identifier string) (string, error)`; unexported `(*OTP).storageKey(scope, identifier string) string`, `(*OTP).resolveScope(ctx) (string, error)`, `record{expiresAt int64; codeHash [32]byte; attempts uint8}`, `encodeRecord(record) []byte`, `decodeRecord([]byte) (record, bool)`, `const recordSize = 42`. Tasks 3-4 call all of these.
+- **Storage contract (documented in the spec, tests assert it):** key `otp:<purpose>:<hex(SHA256(bigendian-uint32-len(scope) || scope || bigendian-uint32-len(identifier) || identifier))>`; value `version(1)=0x01 | attempts(1) | expiresAt int64 unix seconds big-endian(8) | HMAC-SHA256(secret, code)(32)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `auth/otp/otp_test.go` (add imports `"encoding/binary"`, `"encoding/hex"`, `"strings"`, `"github.com/dmitrymomot/forge/crypto/digest"`):
+
+```go
+// storageKey replicates the documented storage-key contract so tests can
+// inspect raw records black-box.
+func storageKey(purpose, scope, identifier string) string {
+	buf := make([]byte, 0, 8+len(scope)+len(identifier))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(scope)))
+	buf = append(buf, scope...)
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(identifier)))
+	buf = append(buf, identifier...)
+	return "otp:" + purpose + ":" + hex.EncodeToString(digest.SHA256(buf))
+}
+
+func TestGenerate_CodeFormat(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(code) != 6 {
+		t.Fatalf("code length = %d, want 6", len(code))
+	}
+	for _, r := range code {
+		if r < '0' || r > '9' {
+			t.Fatalf("code %q contains non-digit %q", code, r)
+		}
+	}
+}
+
+func TestGenerate_HashedAtRest(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	o, err := otp.New(testSecret, store, otp.WithPurpose("login"), otp.WithLength(8))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := store.Get(t.Context(), storageKey("login", "", "user@example.com"))
+	if err != nil {
+		t.Fatalf("record not at documented key: %v", err)
+	}
+	if len(raw) != 42 {
+		t.Fatalf("record size = %d, want 42", len(raw))
+	}
+	if raw[0] != 0x01 {
+		t.Fatalf("version byte = %#x, want 0x01", raw[0])
+	}
+	if raw[1] != 0 {
+		t.Fatalf("initial attempts = %d, want 0", raw[1])
+	}
+	if strings.Contains(string(raw), code) {
+		t.Fatal("plaintext code stored in record")
+	}
+	wantHash := digest.HMACSHA256(testSecret, []byte(code))
+	if string(raw[10:]) != string(wantHash) {
+		t.Fatal("stored hash is not HMAC-SHA256(secret, code)")
+	}
+}
+
+func TestGenerate_ScopeSeparatesKeys(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	tenantScope := func(ctx context.Context) (string, error) {
+		s, _ := ctx.Value(ctxTenant{}).(string)
+		return s, nil
+	}
+	o, err := otp.New(testSecret, store, otp.WithScope(tenantScope))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctxA := context.WithValue(t.Context(), ctxTenant{}, "tenant-a")
+	if _, err := o.Generate(ctxA, "user@example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Get(t.Context(), storageKey("default", "tenant-a", "user@example.com")); err != nil {
+		t.Fatalf("record not under tenant-scoped key: %v", err)
+	}
+	// Delimiter games cannot collide: ("a:b","c") vs ("a","b:c").
+	if storageKey("default", "a:b", "c") == storageKey("default", "a", "b:c") {
+		t.Fatal("length-prefixed key derivation collided")
+	}
+}
+
+type ctxTenant struct{}
+
+func TestGenerate_ScopeFailClosed(t *testing.T) {
+	t.Parallel()
+	t.Run("hook error", func(t *testing.T) {
+		t.Parallel()
+		o, err := otp.New(testSecret, newStore(t),
+			otp.WithScope(func(context.Context) (string, error) { return "", errors.New("no tenant") }))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := o.Generate(t.Context(), "user@example.com"); !errors.Is(err, otp.ErrScope) {
+			t.Fatalf("err = %v, want ErrScope", err)
+		}
+	})
+	t.Run("empty scope", func(t *testing.T) {
+		t.Parallel()
+		o, err := otp.New(testSecret, newStore(t),
+			otp.WithScope(func(context.Context) (string, error) { return "", nil }))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := o.Generate(t.Context(), "user@example.com"); !errors.Is(err, otp.ErrScope) {
+			t.Fatalf("err = %v, want ErrScope", err)
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./auth/otp/`
+Expected: FAIL — compile error `o.Generate undefined`.
+
+- [ ] **Step 3: Write the implementation**
+
+`auth/otp/record.go`:
+
+```go
+package otp
+
+import "encoding/binary"
+
+// recordVersion is the storage-format version byte. Records with any other
+// version decode as absent, so a future format change invalidates in-flight
+// codes instead of misreading them.
+const recordVersion = 0x01
+
+// recordSize is version(1) + attempts(1) + expiresAt(8) + HMAC-SHA256(32).
+const recordSize = 42
+
+type record struct {
+	expiresAt int64
+	codeHash  [32]byte
+	attempts  uint8
+}
+
+func encodeRecord(r record) []byte {
+	buf := make([]byte, recordSize)
+	buf[0] = recordVersion
+	buf[1] = r.attempts
+	binary.BigEndian.PutUint64(buf[2:10], uint64(r.expiresAt))
+	copy(buf[10:], r.codeHash[:])
+	return buf
+}
+
+func decodeRecord(b []byte) (record, bool) {
+	if len(b) != recordSize || b[0] != recordVersion {
+		return record{}, false
+	}
+	var r record
+	r.attempts = b[1]
+	r.expiresAt = int64(binary.BigEndian.Uint64(b[2:10]))
+	copy(r.codeHash[:], b[10:])
+	return r, true
+}
+```
+
+In `auth/otp/otp.go`, append:
+
+```go
+// Generate issues a fresh code for identifier and stores its keyed hash with
+// the configured TTL, replacing any previous code for the same (purpose,
+// scope, identifier) — calling it again is "resend". The returned plaintext
+// code is for the caller to deliver over their own channel; it is never
+// stored. identifier must arrive canonicalized (lowercased email, E.164
+// phone) in the exact same form Verify will receive.
+func (o *OTP) Generate(ctx context.Context, identifier string) (string, error) {
+	scope, err := o.resolveScope(ctx)
+	if err != nil {
+		return "", err
+	}
+	code := random.DigitCode(o.cfg.length)
+	rec := record{expiresAt: o.cfg.clock.Now().Add(o.cfg.ttl).Unix()}
+	copy(rec.codeHash[:], digest.HMACSHA256(o.secret, []byte(code)))
+	key := o.storageKey(scope, identifier)
+	if err := o.store.Set(ctx, key, encodeRecord(rec), cache.WithTTL(o.cfg.ttl)); err != nil {
+		return "", errors.Join(ErrStore, err)
+	}
+	return code, nil
+}
+
+// resolveScope runs the configured scope hook, failing closed: a hook error
+// or empty scope aborts the operation so a scoped code can never land in an
+// unscoped (or another tenant's) bucket.
+func (o *OTP) resolveScope(ctx context.Context) (string, error) {
+	if o.cfg.scope == nil {
+		return "", nil
+	}
+	s, err := o.cfg.scope(ctx)
+	if err != nil {
+		return "", errors.Join(ErrScope, err)
+	}
+	if s == "" {
+		return "", ErrScope
+	}
+	return s, nil
+}
+
+// storageKey derives the deterministic store key. Scope and identifier are
+// length-prefixed before hashing so composite values cannot collide, and
+// hashed so no PII (emails, phone numbers) appears in store keys.
+func (o *OTP) storageKey(scope, identifier string) string {
+	buf := make([]byte, 0, 8+len(scope)+len(identifier))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(scope)))
+	buf = append(buf, scope...)
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(identifier)))
+	buf = append(buf, identifier...)
+	return "otp:" + o.cfg.purpose + ":" + hex.EncodeToString(digest.SHA256(buf))
+}
+```
+
+Final import block of `otp.go` after this task:
+
+```go
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/random"
+	"github.com/dmitrymomot/forge/crypto/digest"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test ./auth/otp/`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/otp/
+git add auth/otp/
+git commit -m "feat(otp): Generate — HMAC-hashed records under domain-separated keys"
+```
+
+---
+
+### Task 3: Verify — single-use, attempt-limited, TTL-preserving
+
+**Files:**
+- Modify: `auth/otp/otp.go`
+- Test: `auth/otp/otp_test.go` (append)
+
+**Interfaces:**
+- Consumes: Task 2's `Generate`, `resolveScope`, `storageKey`, `record`, `encodeRecord`, `decodeRecord`; stdlib `crypto/hmac.Equal`.
+- Produces: `(*OTP).Verify(ctx context.Context, identifier, code string) error` returning nil / `ErrNotFound` / `ErrCodeMismatch` / `ErrTooManyAttempts` / `ErrScope` / `ErrStore`-wrapped.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `auth/otp/otp_test.go` (add import `"github.com/dmitrymomot/forge/core/clock"`; the fixed base time keeps expiry math deterministic):
+
+```go
+var baseTime = time.Unix(1_700_000_000, 0)
+
+// wrongCode returns a code of the same length guaranteed != code.
+func wrongCode(code string) string {
+	b := []byte(code)
+	if b[0] == '0' {
+		b[0] = '1'
+	} else {
+		b[0] = '0'
+	}
+	return string(b)
+}
+
+func TestVerify_HappyPathSingleUse(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", code); err != nil {
+		t.Fatalf("Verify correct code: %v", err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("second Verify = %v, want ErrNotFound (single-use)", err)
+	}
+}
+
+func TestVerify_NeverIssued(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", "123456"); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestVerify_AttemptExhaustion(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t), otp.WithMaxAttempts(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad := wrongCode(code)
+
+	// Attempts 1 and 2: mismatch with attempts remaining.
+	for i := range 2 {
+		if err := o.Verify(t.Context(), "user@example.com", bad); !errors.Is(err, otp.ErrCodeMismatch) {
+			t.Fatalf("attempt %d: err = %v, want ErrCodeMismatch", i+1, err)
+		}
+	}
+	// Attempt 3 consumes the limit.
+	if err := o.Verify(t.Context(), "user@example.com", bad); !errors.Is(err, otp.ErrTooManyAttempts) {
+		t.Fatalf("limit-consuming attempt: err = %v, want ErrTooManyAttempts", err)
+	}
+	// The code is dead even for the CORRECT value.
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("correct code after exhaustion: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestVerify_Expiry(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(baseTime)
+	o, err := otp.New(testSecret, newStore(t), otp.WithTTL(10*time.Minute), otp.WithClock(clk))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clk.Advance(10*time.Minute + time.Second)
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("expired code: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestVerify_FailedAttemptDoesNotExtendLife(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(baseTime)
+	o, err := otp.New(testSecret, newStore(t), otp.WithTTL(10*time.Minute), otp.WithClock(clk))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A wrong attempt at minute 9 rewrites the record...
+	clk.Advance(9 * time.Minute)
+	if err := o.Verify(t.Context(), "user@example.com", wrongCode(code)); !errors.Is(err, otp.ErrCodeMismatch) {
+		t.Fatal(err)
+	}
+	// ...but the code still dies at the ORIGINAL deadline.
+	clk.Advance(time.Minute + time.Second)
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("code outlived its original deadline: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestVerify_ReplaceOnGenerate(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code1, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code2, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code1 != code2 {
+		// Old code is dead (mismatch consumes an attempt against code2's record).
+		if err := o.Verify(t.Context(), "user@example.com", code1); !errors.Is(err, otp.ErrCodeMismatch) {
+			t.Fatalf("old code: err = %v, want ErrCodeMismatch", err)
+		}
+	}
+	if err := o.Verify(t.Context(), "user@example.com", code2); err != nil {
+		t.Fatalf("new code: %v", err)
+	}
+}
+
+func TestVerify_CorruptRecord(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	o, err := otp.New(testSecret, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := o.Generate(t.Context(), "user@example.com"); err != nil {
+		t.Fatal(err)
+	}
+	key := storageKey("default", "", "user@example.com")
+	// Unknown version byte reads as absent (forward-compat / revoked).
+	if err := store.Set(t.Context(), key, []byte{0xFF, 0, 0, 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", "123456"); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("corrupt record: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestVerify_TenantIsolation(t *testing.T) {
+	t.Parallel()
+	tenantScope := func(ctx context.Context) (string, error) {
+		s, _ := ctx.Value(ctxTenant{}).(string)
+		return s, nil
+	}
+	o, err := otp.New(testSecret, newStore(t), otp.WithScope(tenantScope))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctxA := context.WithValue(t.Context(), ctxTenant{}, "tenant-a")
+	ctxB := context.WithValue(t.Context(), ctxTenant{}, "tenant-b")
+
+	code, err := o.Generate(ctxA, "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Tenant B never sees tenant A's code — not even as a mismatch.
+	if err := o.Verify(ctxB, "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("cross-tenant verify: err = %v, want ErrNotFound", err)
+	}
+	// Missing tenant in ctx fails closed, not into a global bucket.
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrScope) {
+		t.Fatalf("scopeless ctx: err = %v, want ErrScope", err)
+	}
+	if err := o.Verify(ctxA, "user@example.com", code); err != nil {
+		t.Fatalf("same-tenant verify: %v", err)
+	}
+}
+
+func TestVerify_PurposeIsolation(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	login, err := otp.New(testSecret, store, otp.WithPurpose("login"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reset, err := otp.New(testSecret, store, otp.WithPurpose("password-reset"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := login.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reset.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("cross-purpose verify: err = %v, want ErrNotFound", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./auth/otp/`
+Expected: FAIL — compile error `o.Verify undefined`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `auth/otp/otp.go` (add `"crypto/hmac"` to imports):
+
+```go
+// Verify checks code against the active record for identifier. It is
+// single-use: a successful verification deletes the record. A mismatch
+// consumes one attempt; consuming the last attempt (or meeting an already
+// consumed limit) invalidates the code. Callers should map ErrNotFound and
+// ErrCodeMismatch to one user-facing message ("invalid or expired code") so
+// responses reveal nothing about code existence.
+func (o *OTP) Verify(ctx context.Context, identifier, code string) error {
+	scope, err := o.resolveScope(ctx)
+	if err != nil {
+		return err
+	}
+	key := o.storageKey(scope, identifier)
+
+	raw, err := o.store.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, cache.ErrNotFound) {
+			return ErrNotFound
+		}
+		return errors.Join(ErrStore, err)
+	}
+	rec, ok := decodeRecord(raw)
+	if !ok {
+		// Unknown version or corrupt payload: treat as revoked. Best-effort
+		// cleanup — the entry also dies by store TTL.
+		_ = o.store.Delete(ctx, key)
+		return ErrNotFound
+	}
+	now := o.cfg.clock.Now()
+	remaining := time.Unix(rec.expiresAt, 0).Sub(now)
+	if remaining <= 0 {
+		// Defense-in-depth for stores that ignore TTL; also closes the
+		// cache seam's TTL<=0-means-eternal edge on the rewrite below.
+		_ = o.store.Delete(ctx, key)
+		return ErrNotFound
+	}
+	if int(rec.attempts) >= o.cfg.maxAttempts {
+		// Only reachable when a concurrent mismatch raced the rewrite;
+		// deletion already happened or happens here.
+		_ = o.store.Delete(ctx, key)
+		return ErrTooManyAttempts
+	}
+	if !hmac.Equal(digest.HMACSHA256(o.secret, []byte(code)), rec.codeHash[:]) {
+		rec.attempts++
+		if int(rec.attempts) >= o.cfg.maxAttempts {
+			if err := o.store.Delete(ctx, key); err != nil {
+				return errors.Join(ErrStore, err)
+			}
+			return ErrTooManyAttempts
+		}
+		if err := o.store.Set(ctx, key, encodeRecord(rec), cache.WithTTL(remaining)); err != nil {
+			return errors.Join(ErrStore, err)
+		}
+		return ErrCodeMismatch
+	}
+	// Single-use: the delete must succeed before success is reported, or a
+	// live code would outlive a "verified" response.
+	if err := o.store.Delete(ctx, key); err != nil {
+		return errors.Join(ErrStore, err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test ./auth/otp/`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/otp/
+git add auth/otp/
+git commit -m "feat(otp): Verify — single-use, attempt-limited, TTL-preserving"
+```
+
+---
+
+### Task 4: Revoke + concurrency coverage
+
+**Files:**
+- Modify: `auth/otp/otp.go`
+- Test: `auth/otp/otp_test.go` (append)
+
+**Interfaces:**
+- Consumes: Tasks 2-3.
+- Produces: `(*OTP).Revoke(ctx context.Context, identifier string) error`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `auth/otp/otp_test.go` (add import `"sync"`):
+
+```go
+func TestRevoke(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Revoke(t.Context(), "user@example.com"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if err := o.Verify(t.Context(), "user@example.com", code); !errors.Is(err, otp.ErrNotFound) {
+		t.Fatalf("revoked code: err = %v, want ErrNotFound", err)
+	}
+	// Revoking with nothing outstanding is a no-op, not an error.
+	if err := o.Revoke(t.Context(), "user@example.com"); err != nil {
+		t.Fatalf("idempotent Revoke: %v", err)
+	}
+}
+
+// TestVerify_ConcurrentWrongGuesses exercises the documented read-modify-write
+// attempt counter under the race detector. The limit may be overshot by the
+// in-flight count (documented caveat), but a wrong code must NEVER verify.
+func TestVerify_ConcurrentWrongGuesses(t *testing.T) {
+	t.Parallel()
+	o, err := otp.New(testSecret, newStore(t), otp.WithMaxAttempts(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := o.Generate(t.Context(), "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad := wrongCode(code)
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := o.Verify(t.Context(), "user@example.com", bad); err == nil {
+				t.Error("wrong code verified")
+			}
+		}()
+	}
+	wg.Wait()
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./auth/otp/`
+Expected: FAIL — compile error `o.Revoke undefined`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `auth/otp/otp.go`:
+
+```go
+// Revoke deletes any outstanding code for identifier — cancel a pending
+// flow, or invalidate after an account-state change. Revoking when nothing
+// is outstanding is a no-op.
+func (o *OTP) Revoke(ctx context.Context, identifier string) error {
+	scope, err := o.resolveScope(ctx)
+	if err != nil {
+		return err
+	}
+	if err := o.store.Delete(ctx, o.storageKey(scope, identifier)); err != nil {
+		return errors.Join(ErrStore, err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test ./auth/otp/`
+Expected: PASS, race detector clean.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/otp/
+git add auth/otp/
+git commit -m "feat(otp): Revoke + concurrent-verify race coverage"
+```
+
+---
+
+### Task 5: doc.go + fuzz
+
+**Files:**
+- Create: `auth/otp/doc.go`
+- Create: `auth/otp/fuzz_test.go`
+
+**Interfaces:**
+- Consumes: the complete Task 1-4 public API.
+- Produces: package documentation; `FuzzVerify`.
+
+- [ ] **Step 1: Write doc.go**
+
+```go
+// Package otp issues and verifies short numeric one-time codes for email and
+// SMS verification and passwordless login. Codes are attempt-limited, TTL'd,
+// single-use, and stored only as keyed hashes: a store-only compromise
+// reveals nothing without the application's secret, because the 10^6 space
+// of a 6-digit code makes any unkeyed hash reversible in milliseconds.
+//
+// Delivery is the caller's channel; anti-enumeration responses and request
+// throttling stay in the caller's handlers (compose auth/lockout and
+// resilience/ratelimit). TOTP/HOTP authenticator apps are auth/totp.
+//
+// Create one instance per flow — the purpose isolates codes so a login code
+// can never verify a password reset:
+//
+//	secret := []byte(os.Getenv("OTP_SECRET")) // min 16 bytes
+//	store := redis.NewStore(client)           // resilience/cache/redis; memory store for dev/tests
+//
+//	loginOTP, err := otp.New(secret, store, otp.WithPurpose("login"))
+//	if err != nil { ... }
+//
+//	// Request a code. Deliver over your channel; reply 202 whether or not
+//	// the account exists.
+//	code, err := loginOTP.Generate(ctx, email)
+//
+//	// Verify. Map ErrNotFound and ErrCodeMismatch to ONE user-facing
+//	// message so responses reveal nothing about code existence.
+//	err = loginOTP.Verify(ctx, email, submitted)
+//	switch {
+//	case err == nil:
+//		// authenticated
+//	case errors.Is(err, otp.ErrTooManyAttempts):
+//		// "too many attempts — request a new code"
+//	default:
+//		// "invalid or expired code"
+//	}
+//
+// The identifier is an opaque string the package never interprets.
+// Canonicalize it (lowercase and trim emails, E.164 phone numbers) in ONE
+// helper used by both Generate and Verify — different forms derive different
+// storage keys and the code will never match. Calling Generate again for the
+// same identifier replaces the outstanding code ("resend"); Revoke cancels
+// it.
+//
+// # Multi-tenancy
+//
+// Multi-tenant applications wire tenant isolation once, at construction,
+// with WithScope — never by concatenating tenant IDs into identifiers at
+// call sites:
+//
+//	loginOTP, err := otp.New(secret, store,
+//		otp.WithPurpose("login"),
+//		otp.WithScope(func(ctx context.Context) (string, error) {
+//			return tenantFromContext(ctx) // e.g. data/tenant middleware
+//		}),
+//	)
+//
+// The hook runs inside every Generate, Verify, and Revoke, so no call site
+// can forget it. It fails closed: an error or empty scope aborts with
+// ErrScope instead of falling through to a shared bucket. Single-tenant
+// applications omit the option.
+//
+// # Storage
+//
+// State rides the resilience/cache.Store seam. Keys carry no PII (scope and
+// identifier are hashed with length-prefixed domain separation); values are
+// 42-byte records holding the attempt counter, expiry, and the
+// HMAC-SHA256(secret, code) digest. The in-memory store's LRU eviction makes
+// it unsuitable for production codes — use cache/redis or another durable
+// Store. A failed attempt rewrites the record with its remaining TTL, so
+// retries never extend a code's life. The attempt counter is
+// read-modify-write: concurrent wrong guesses can overshoot the limit by the
+// in-flight count, which is immaterial against a million-value keyspace;
+// per-identifier lockout is auth/lockout's layer.
+package otp
+```
+
+- [ ] **Step 2: Write the fuzz test**
+
+`auth/otp/fuzz_test.go`:
+
+```go
+package otp_test
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/otp"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+// FuzzVerify feeds arbitrary submitted codes through a full generate/verify
+// cycle: only the exact issued code may verify; everything else must return
+// ErrCodeMismatch, and nothing may panic.
+func FuzzVerify(f *testing.F) {
+	store := cache.NewMemoryStore()
+	f.Cleanup(func() { _ = store.Close() })
+	o, err := otp.New([]byte("0123456789abcdef"), store)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	f.Add("123456")
+	f.Add("")
+	f.Add("000000")
+	f.Add("abcdef")
+	f.Add("12345678901234567890")
+	f.Add("\x00\x01\x02")
+
+	var n atomic.Int64
+	f.Fuzz(func(t *testing.T, submitted string) {
+		identifier := fmt.Sprintf("user-%d@example.com", n.Add(1))
+		ctx := t.Context()
+		want, err := o.Generate(ctx, identifier)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = o.Verify(ctx, identifier, submitted)
+		if submitted == want {
+			if err != nil {
+				t.Fatalf("exact code rejected: %v", err)
+			}
+			return
+		}
+		if !errors.Is(err, otp.ErrCodeMismatch) {
+			t.Fatalf("wrong code %q: err = %v, want ErrCodeMismatch", submitted, err)
+		}
+	})
+}
+```
+
+- [ ] **Step 3: Run tests and a short fuzz burst**
+
+Run: `just test ./auth/otp/`
+Expected: PASS (fuzz seeds run as unit tests).
+
+Run: `go test -fuzz=FuzzVerify -fuzztime=30s ./auth/otp/`
+Expected: no crashers; interrupt-free 30s run.
+
+- [ ] **Step 4: Format and commit**
+
+```bash
+just fmt ./auth/otp/
+git add auth/otp/
+git commit -m "docs(otp): package documentation; fuzz Verify"
+```
+
+---
+
+### Task 6: Benchmarks + post-benchmark optimization pass
+
+**Files:**
+- Create: `auth/otp/bench_test.go`
+
+**Interfaces:**
+- Consumes: the complete public API.
+- Produces: `BenchmarkGenerate`, `BenchmarkGenerateVerify`, `BenchmarkVerifyMismatch`; before/after numbers for the PR description.
+
+- [ ] **Step 1: Write the benchmarks**
+
+`auth/otp/bench_test.go`:
+
+```go
+package otp_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/otp"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+func newBenchOTP(b *testing.B, opts ...otp.Option) *otp.OTP {
+	b.Helper()
+	store := cache.NewMemoryStore()
+	b.Cleanup(func() { _ = store.Close() })
+	o, err := otp.New([]byte("0123456789abcdef"), store, opts...)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return o
+}
+
+func BenchmarkGenerate(b *testing.B) {
+	o := newBenchOTP(b)
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := o.Generate(ctx, "user@example.com"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkGenerateVerify measures the full happy cycle — the real-world
+// unit of work is one verify per generate (verify is single-use).
+func BenchmarkGenerateVerify(b *testing.B) {
+	o := newBenchOTP(b)
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		code, err := o.Generate(ctx, "user@example.com")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := o.Verify(ctx, "user@example.com", code); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyMismatch(b *testing.B) {
+	o := newBenchOTP(b, otp.WithMaxAttempts(255))
+	ctx := b.Context()
+	if _, err := o.Generate(ctx, "user@example.com"); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		err := o.Verify(ctx, "user@example.com", "999999999") // wrong length: can never match
+		if errors.Is(err, otp.ErrTooManyAttempts) || errors.Is(err, otp.ErrNotFound) {
+			if _, err := o.Generate(ctx, "user@example.com"); err != nil {
+				b.Fatal(err)
+			}
+			continue
+		}
+		if !errors.Is(err, otp.ErrCodeMismatch) {
+			b.Fatal(err)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Record the baseline**
+
+Run: `just bench ./auth/otp/`
+Save the full output — it is the "before" column for the PR description.
+
+- [ ] **Step 3: Post-benchmark optimization pass — measured wins only**
+
+Expected inherent costs — do NOT "optimize" these away: two SHA-256 HMAC computations plus one SHA-256 key hash per operation (crypto by design), store round-trips, the `[]byte(code)` conversions feeding HMAC (crypto API boundary). Candidate wins to check if the profile shows them: preallocation already covers `storageKey`; `encodeRecord`'s fixed 42-byte alloc is required by the Store contract (`Set` takes `[]byte`). If no measured win exists, say so in the PR — readable-first stands, and any complexity added here REQUIRES the before/after benchmark in the PR.
+
+- [ ] **Step 4: Run everything, format, commit**
+
+Run: `just test ./auth/otp/` — Expected: PASS.
+Run: `just bench ./auth/otp/` — record "after" numbers.
+
+```bash
+just fmt ./auth/otp/
+git add auth/otp/
+git commit -m "perf(otp): benchmarks for Generate/Verify paths"
+```
+
+---
+
+### Task 7: Ship prep — catalog cleanup, full-repo gates
+
+**Files:**
+- Modify: `docs/packages.md` (delete the auth/otp entry)
+
+**Interfaces:**
+- Consumes: everything shipped in Tasks 1-6.
+- Produces: a branch ready for PR.
+
+- [ ] **Step 1: Delete the shipped catalog entry**
+
+In `docs/packages.md`, delete the `**auth/otp**` block (the heading line, its paragraph "Short numeric codes for email/SMS verification...", its `Deps:` line, and ONE adjacent `---` separator so exactly one separator remains between the neighboring entries). Design.md's rule: "the moment a package ships, delete its entry." Do not touch the `auth/totp` or `auth/lockout` entries, and leave design.md's seam-consumer mentions of `otp` alone (they describe the seam, not the roadmap).
+
+- [ ] **Step 2: Full-repo gates**
+
+Run: `just lint`
+Expected: clean (goimports/betteralign already applied via `just fmt`; nilaway, modernize, golangci all pass).
+
+Run: `just test ./auth/otp/`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/packages.md
+git commit -m "docs(packages): drop shipped auth/otp catalog entry"
+```
+
+---
+
+## Verification checklist (whole plan vs spec)
+
+- Purpose-per-instance API, `New(secret, store, ...Option)` — Task 1.
+- Options with defaults/ranges incl. 1-255 attempts (spec synced) — Task 1.
+- Dual-mode tenancy: `WithScope` fail-closed, key separation, single-tenant zero ceremony — Tasks 2-3.
+- Storage contract: hashed PII-free keys, 42-byte versioned record, HMAC pepper — Task 2.
+- Verify semantics: single-use, attempt exhaustion, expiry, remaining-TTL rewrite, corrupt-record-as-absent, constant-time compare — Task 3.
+- Revoke + documented concurrency caveat under race detector — Task 4.
+- doc.go example incl. normalization warning, layering, storage note; fuzz — Task 5.
+- Benchmarks + optimization pass with PR numbers — Task 6.
+- Catalog entry deletion on ship — Task 7.

--- a/docs/superpowers/specs/2026-07-13-auth-otp-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-otp-design.md
@@ -49,7 +49,7 @@ func (o *OTP) Revoke(ctx context.Context, identifier string) error
 | `WithPurpose(string)` | `"default"` | one instance per flow (login, email-verify, …); purpose isolates keys |
 | `WithTTL(time.Duration)` | 10 min | code lifetime; must be > 0 |
 | `WithLength(int)` | 6 | digits; valid range 4–10 |
-| `WithMaxAttempts(int)` | 5 | per-code verify attempts; must be > 0 |
+| `WithMaxAttempts(int)` | 5 | per-code verify attempts; valid 1-255 (stored as one byte) |
 | `WithScope(func(ctx) (string, error))` | nil | tenant hook, see below |
 | `WithClock(clock.Clock)` | `clock.System()` | expiry math in tests |
 

--- a/docs/superpowers/specs/2026-07-13-auth-otp-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-otp-design.md
@@ -1,0 +1,214 @@
+# auth/otp — Design
+
+Date: 2026-07-13
+Status: approved for planning
+
+## Purpose
+
+Short numeric codes for email/SMS verification and passwordless login:
+attempt-limited, TTL'd, hashed at rest, single-use. Delivery is the
+caller's channel; HTTP behavior (anti-enumeration responses, throttling)
+stays in the consumer. A complete product per the product-or-brick test:
+wire a store and a secret and it works.
+
+Catalog correction: the packages.md entry lists deps `core/random` +
+`crypto/digest` only, but design.md's TTL-KV seam rule explicitly names
+`otp` a consumer of `resilience/cache.Store` ("no package defines a
+private byte-KV store"). The seam rule wins; `resilience/cache` is a dep.
+
+## API surface
+
+```go
+func New(secret []byte, store cache.Store, opts ...Option) (*OTP, error)
+
+func (o *OTP) Generate(ctx context.Context, identifier string) (string, error)
+func (o *OTP) Verify(ctx context.Context, identifier, code string) error
+func (o *OTP) Revoke(ctx context.Context, identifier string) error
+```
+
+- `secret` — HMAC pepper, required, min 16 bytes, validated in `New`
+  (`ErrInvalidConfig`). Consumers load it from env themselves
+  (`OTP_SECRET`); no Config struct — positional-required + options follows
+  the `token.New(key, ...)` / `cookie.New(ks, ...)` precedent.
+- `Generate` returns the plaintext code for the caller to deliver.
+  Generating again for the same (purpose, scope, identifier) overwrites
+  the previous record — "resend" semantics, exactly one active code per
+  key.
+- `Verify` is single-use: the record is deleted on success.
+- `Revoke` deletes any outstanding code. Included because consumers
+  cannot compute the storage key themselves; use cases: cancel a pending
+  flow, invalidate on account-state change.
+- `identifier` is an opaque, caller-canonicalized string (lowercased
+  email, E.164 phone). The package never interprets it. doc.go warns:
+  `Generate` and `Verify` must receive the identical canonical form.
+
+### Options
+
+| Option | Default | Notes |
+|---|---|---|
+| `WithPurpose(string)` | `"default"` | one instance per flow (login, email-verify, …); purpose isolates keys |
+| `WithTTL(time.Duration)` | 10 min | code lifetime; must be > 0 |
+| `WithLength(int)` | 6 | digits; valid range 4–10 |
+| `WithMaxAttempts(int)` | 5 | per-code verify attempts; must be > 0 |
+| `WithScope(func(ctx) (string, error))` | nil | tenant hook, see below |
+| `WithClock(clock.Clock)` | `clock.System()` | expiry math in tests |
+
+## Tenancy — dual-mode (repo-wide rule)
+
+Every forge package works single- AND multi-tenant (CLAUDE.md rule,
+2026-07-13). For otp:
+
+- **Single-tenant:** omit `WithScope`; no scope part in keys; zero
+  ceremony.
+- **Multi-tenant:** `WithScope(hook)` where the hook reads TenantID from
+  context (the planned `data/tenant` middleware puts it there; until it
+  ships the hook is a plain func — no dependency). Scope is resolved
+  inside every `Generate`/`Verify`/`Revoke`, so no call site can forget
+  the tenant.
+- **Fail closed:** if a hook is configured and errors or returns empty,
+  the operation returns `ErrScope` — never a silent fall-through to an
+  unscoped key (a tenant-A code must never verify in a global bucket).
+- Consumers never compose key strings; the package builds keys with
+  unambiguous domain separation (below), so there are no delimiter
+  collisions and no per-call-site conventions.
+
+## Storage
+
+Rides `resilience/cache.Store` (memory store for dev/tests, cache/redis
+in prod; the LRU memory store is documented as unsuitable for production
+OTP just as for sessions).
+
+**Key:** `otp:<purpose>:<hex(SHA256(lenPrefix(scope) || lenPrefix(identifier)))>`
+
+- Deterministic — `Verify`/`Revoke` recompute it; no server-minted ID to
+  round-trip.
+- Hashed — no email/phone PII in store keys.
+- Length-prefixed parts — `("a:b","c")` and `("a","b:c")` cannot collide.
+
+**Value:** fixed manual binary encoding (no reflection), 42 bytes:
+
+```
+version(1) | attempts(1) | expiresAt unix seconds int64 BE (8) | HMAC-SHA256(secret, code) (32)
+```
+
+- Written with `Set` + `WithTTL` (plain overwrite → replace-on-generate;
+  SetNX not needed).
+- `expiresAt` inside the record serves two jobs: attempt-increment
+  rewrites preserve the *remaining* TTL (never extend a code's life), and
+  defense-in-depth if a store ignores TTL — `Verify` checks it
+  explicitly.
+- Remaining-TTL guard: `cache` treats TTL <= 0 as never-expire, so a
+  record that expired between Get and the rewrite is deleted and treated
+  as `ErrNotFound`, never written back immortal.
+- Unknown version byte → treated as `ErrNotFound` (code effectively
+  revoked; forward-compat).
+
+**Why keyed HMAC, not plain SHA256:** a 6-digit code has 10^6 values;
+plain (even salted) hashes of that keyspace are reversible in
+milliseconds from a store dump. `HMAC-SHA256(secret, code)` makes a
+store-only compromise worthless without the app's env secret. Precedent:
+web/fingerprint's keyed digests.
+
+## Verify semantics
+
+1. Resolve scope (fail closed), recompute key, `Get`.
+2. Miss, or record `expiresAt` passed → `ErrNotFound`.
+3. `attempts >= maxAttempts` → delete record, `ErrTooManyAttempts`.
+4. Constant-time compare via stdlib `hmac.Equal` (no `crypto/consttime`
+   dep needed).
+5. Mismatch → `attempts+1`; if the limit is now consumed, delete and
+   return `ErrTooManyAttempts`, else write back with remaining TTL and
+   return `ErrCodeMismatch`.
+6. Match → delete (single-use), return nil.
+
+Documented caveat: the attempt counter is read-modify-write, so N
+*concurrent* wrong guesses can overshoot the limit by the in-flight
+count. Immaterial against a 10^6 keyspace; sustained abuse is
+`auth/lockout`'s layer (per-identifier lockout over the counter seam),
+and request throttling is `ratelimit` middleware in the consumer.
+
+## Errors (`errors.go`, single-line, `errors.Is`-matchable)
+
+| Sentinel | Meaning |
+|---|---|
+| `ErrNotFound` | no active code (never issued, expired, or revoked) |
+| `ErrCodeMismatch` | wrong code; attempts remain |
+| `ErrTooManyAttempts` | attempt limit consumed; code invalidated |
+| `ErrScope` | scope hook errored or returned empty |
+| `ErrStore` | wraps underlying store failures (unwrap for driver error) |
+| `ErrInvalidConfig` | `New` validation (secret too short, bad option values) |
+
+doc.go guidance: consumers map `ErrNotFound` and `ErrCodeMismatch` to one
+user-facing message ("invalid or expired code") — no oracle.
+
+## Dependencies
+
+`core/random` (DigitCode), `crypto/digest` (SHA256 + HMAC-SHA256),
+`resilience/cache` (Store seam), `core/clock`. All existing; no new
+external deps.
+
+## Package anatomy
+
+`auth/otp/`: `doc.go` (runnable passwordless-login example +
+normalization warning + multi-tenant wiring + lockout/ratelimit
+composition notes) · `options.go` · `errors.go` · `otp.go` (incl. record
+encode/decode) · `otp_test.go` · `bench_test.go`. Estimated ~300 LOC
+non-test — within the single-responsibility band.
+
+## Testing
+
+Black-box `otp_test` using cache's memory store + `clock.Mock`:
+
+- happy path generate → verify → second verify is `ErrNotFound`
+  (single-use)
+- wrong code until `ErrTooManyAttempts`; correct code afterwards fails
+- expiry via mock clock → `ErrNotFound`; attempt rewrite preserves
+  remaining TTL (record dies at original deadline)
+- replace-on-generate kills the old code
+- purpose isolation (two instances, same identifier)
+- scope isolation (two tenants, same identifier) + fail-closed missing
+  scope + no-scope-hook single-tenant mode
+- `Revoke` → `ErrNotFound`
+- concurrent wrong guesses: limit overshoot bounded by in-flight count
+  (race detector clean)
+- fuzz `Verify` with arbitrary code strings (non-digit, wrong length,
+  huge input)
+
+Benchmarks per repo rule: `Generate` and `Verify` (memory store),
+`b.ReportAllocs()`; post-benchmark optimization pass with before/after
+numbers in the PR. Expected inherent costs: HMAC + SHA256 and store
+round-trips; do not "optimize" crypto away.
+
+## Out of scope
+
+Delivery (caller's channel), rate limiting / lockout (`ratelimit`,
+`auth/lockout`), TOTP/HOTP (`auth/totp`), alphanumeric codes, HTTP
+handlers/middleware, challenge-ID round-trips (expressible by using a
+random ID as the identifier — documented, not a feature).
+
+## Consumer example (doc.go sketch)
+
+```go
+secret := []byte(os.Getenv("OTP_SECRET"))
+store := redis.NewStore(client) // resilience/cache/redis; memory store for dev/tests
+
+loginOTP, err := otp.New(secret, store,
+    otp.WithPurpose("login"),
+    // multi-tenant apps add:
+    // otp.WithScope(func(ctx context.Context) (string, error) {
+    //     return tenant.FromContext(ctx)
+    // }),
+)
+
+// request a code
+code, err := loginOTP.Generate(ctx, canonicalEmail)
+// deliver via your channel; respond 202 whether or not the account exists
+
+// verify
+err = loginOTP.Verify(ctx, canonicalEmail, submitted)
+switch {
+case err == nil:                              // authenticated
+case errors.Is(err, otp.ErrTooManyAttempts):  // "request a new code"
+default:                                      // one message, no oracle
+}
+```


### PR DESCRIPTION
## auth/otp — short numeric OTP codes for email/SMS verification & passwordless login

Ships `auth/otp`: attempt-limited, TTL'd, single-use numeric codes, HMAC-peppered at rest, dual-mode tenancy. Implemented TDD, one instance per flow (purpose baked in at construction), state on the `resilience/cache.Store` seam.

### What it does
- `New(secret, store, ...Option)` with `WithPurpose/WithTTL/WithLength/WithMaxAttempts/WithScope/WithClock`; six `errors.Is`-matchable sentinels (`otp:` prefix).
- `Generate` → issues a code, stores only `HMAC-SHA256(secret, code)` in a 42-byte binary record (`version | attempts | expiresAt(be int64) | hmac(32)`) under a PII-free, length-prefixed, hashed key `otp:<purpose>:<hex(SHA256(len(scope)||scope||len(id)||id))>`.
- `Verify` → single-use (deletes on success), constant-time `hmac.Equal`, attempt-limited, TTL-preserving on mismatch (a failed attempt never extends the code's life), corrupt/unknown-version record reads as absent.
- `Revoke` → idempotent cancel.

### Security properties
- Plaintext code and secret are never stored; store-only compromise reveals nothing (keyed HMAC defeats the 10^6-space rainbow attack an unkeyed hash would allow).
- Constant-time compare; `ErrNotFound`/`ErrCodeMismatch` meant to map to one user-facing message (no existence oracle).
- Length-prefixed key derivation → no cross-identifier/cross-scope collisions.

### Dual-mode tenancy (verified end-to-end)
One `WithScope` construction seam serves every shape; fail-closed (error or empty scope → `ErrScope`, never a shared bucket). `tenancy_test.go` proves, on one instance + one store:
- **Single-tenant** — omit `WithScope`, zero ceremony.
- **White-label (tenant-locked)** — per-tenant isolation; tenantless request fails closed on Generate/Verify/Revoke.
- **Global user switching tenants** — active-tenant bucket vs a reserved non-empty global sentinel, isolated both directions.
- **Collision caveat** — a negative test proving why the global sentinel must stay disjoint from real tenant IDs.

### Benchmarks
No optimization applied — the per-op cost is inherent crypto (2× HMAC-SHA256 + 1× SHA-256 key hash), store round-trips, and the fixed 42-byte record alloc required by the `Store.Set([]byte)` contract; readable-first stands. Before == after:

| Benchmark | ns/op | allocs/op |
|---|---|---|
| `BenchmarkGenerate` | 754 | 17 |
| `BenchmarkGenerateVerify` | 1414 | 30 |
| `BenchmarkVerifyMismatch` | 757 | 16 |

### Testing
- `go test -race -cover ./auth/otp/` → **92.0%**, race clean.
- `FuzzVerify` → 13.8M execs, 0 crashers.
- Full-repo `just lint` (vet, golangci-lint, nilaway, betteralign, modernize) → exit 0.

### Docs
- `doc.go` with usage, normalization warning, layering (`auth/lockout`/`resilience/ratelimit` own throttling/enumeration responses), storage & tenancy notes.
- Shipped-catalog entry removed from `docs/packages.md`.
