### PR TITLE
feat(auth/magiclink): signed, TTL'd, single-use magic links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 - Be concise!
+- Never use line breaks to limit line length (no manual wrapping of prose, markdown, PR/commit bodies; let lines run and soft-wrap).
 - Work ONLY in CURRENT branch, don't switch!
 - Use `just` recipes.
 - Run `just fmt file_path.go` after file changes.

--- a/auth/magiclink/bench_test.go
+++ b/auth/magiclink/bench_test.go
@@ -1,0 +1,63 @@
+package magiclink_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/magiclink"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+func BenchmarkIssue(b *testing.B) {
+	m, err := magiclink.New[loginClaims](testKey, "bench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := m.Issue(ctx, loginClaims{UserID: "u_1"}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPeek(b *testing.B) {
+	m, err := magiclink.New[loginClaims](testKey, "bench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	link, err := m.Issue(ctx, loginClaims{UserID: "u_1"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := m.Peek(ctx, link); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRedeemSingleUse(b *testing.B) {
+	store := cache.NewMemoryStore()
+	defer func() { _ = store.Close() }()
+	m, err := magiclink.New[loginClaims](testKey, "bench", magiclink.WithStore(store))
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		b.StopTimer()
+		link, err := m.Issue(ctx, loginClaims{UserID: "u_1"})
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		if _, err := m.Redeem(ctx, link); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/auth/magiclink/doc.go
+++ b/auth/magiclink/doc.go
@@ -1,0 +1,57 @@
+// Package magiclink issues and redeems signed, TTL'd, optionally single-use
+// links: passwordless login, team invites, email verification, and
+// unsubscribe flows. It builds on crypto/token for the token format and adds
+// single-use redemption over the resilience/cache Store seam, tenant-scope
+// binding, and URL construction. It does not send email — delivery is the
+// caller's channel.
+//
+// Stateless by default: without WithStore a link verifies until its TTL
+// expires and may be redeemed repeatedly (fine for unsubscribe and verify
+// flows where replay is harmless). WithStore makes Redeem atomically
+// single-use. The bundled LRU memory store can evict live keys under
+// pressure; production single-use needs cache/redis or another durable
+// Store.
+//
+// Email scanners (Outlook SafeLinks and friends) prefetch links before the
+// user clicks. Serve GET with Peek — it verifies without consuming — and
+// consume with Redeem on an explicit POST:
+//
+//	type LoginClaims struct {
+//		UserID string `json:"uid"`
+//	}
+//
+//	links, err := magiclink.New[LoginClaims](key, "login",
+//		magiclink.WithTTL(15*time.Minute),
+//		magiclink.WithStore(store), // single-use; omit for stateless links
+//		magiclink.WithBaseURL("https://app.example.com/auth/verify"),
+//	)
+//
+//	// Request: build the link and deliver it yourself.
+//	url, err := links.IssueURL(ctx, "", LoginClaims{UserID: "u_1"})
+//
+//	// GET /auth/verify?token=... — show a confirm button, do not consume.
+//	claims, err := links.Peek(r.Context(), r.URL.Query().Get("token"))
+//
+//	// POST /auth/verify — consume; a second redeem returns ErrUsed.
+//	claims, err = links.Redeem(r.Context(), r.FormValue("token"))
+//
+// Errors are matched with errors.Is: ErrInvalid (malformed, bad signature,
+// wrong purpose), ErrExpired, ErrUsed, ErrScopeMismatch, and ErrStore (store
+// failure; redemption fails closed).
+//
+// Multi-tenant apps bind links to a tenant with WithScope: Issue stamps the
+// scope resolved from ctx into the token, Peek/Redeem recompute it and fail
+// closed on mismatch. A link issued with an empty scope is global and
+// redeems in any tenant context — a hook that wants to forbid global
+// issuance returns an error when ctx lacks a tenant. White-label callers
+// pass the tenant's domain as IssueURL's base argument:
+//
+//	invites, err := magiclink.New[InviteClaims](key, "invite",
+//		magiclink.WithStore(store),
+//		magiclink.WithScope(func(ctx context.Context) (string, error) {
+//			return tenant.FromContext(ctx), nil // "" = global link
+//		}),
+//	)
+//	url, err := invites.IssueURL(ctx, "https://acme.example.com/join",
+//		InviteClaims{Email: "new@hire.com", Role: "admin"})
+package magiclink

--- a/auth/magiclink/doc.go
+++ b/auth/magiclink/doc.go
@@ -39,6 +39,10 @@
 // wrong purpose), ErrExpired, ErrUsed, ErrScopeMismatch, and ErrStore (store
 // failure; redemption fails closed).
 //
+// The token arrives as attacker-controlled input before signature
+// verification, and verification cost is linear in its length, so callers
+// should bound the token query-parameter/form-field size at the HTTP layer.
+//
 // Multi-tenant apps bind links to a tenant with WithScope: Issue stamps the
 // scope resolved from ctx into the token, Peek/Redeem recompute it and fail
 // closed on mismatch. A link issued with an empty scope is global and

--- a/auth/magiclink/doc.go
+++ b/auth/magiclink/doc.go
@@ -40,8 +40,10 @@
 // failure; redemption fails closed).
 //
 // The token arrives as attacker-controlled input before signature
-// verification, and verification cost is linear in its length, so callers
-// should bound the token query-parameter/form-field size at the HTTP layer.
+// verification, and verification cost is linear in its length. Peek and Redeem
+// reject links over a generous default cap (8192 bytes) before any decode as
+// defense-in-depth; tune it with WithMaxTokenLength, and still prefer bounding
+// the token query-parameter/form-field size at the HTTP layer.
 //
 // Multi-tenant apps bind links to a tenant with WithScope: Issue stamps the
 // scope resolved from ctx into the token, Peek/Redeem recompute it and fail

--- a/auth/magiclink/errors.go
+++ b/auth/magiclink/errors.go
@@ -1,0 +1,21 @@
+package magiclink
+
+import "errors"
+
+// Sentinel errors returned by Peek and Redeem. All are errors.Is-matchable;
+// runtime wrapping keeps the underlying cause inspectable for logs.
+var (
+	// ErrInvalid is returned when a link is malformed, its signature does not
+	// verify, or it was issued for a different purpose.
+	ErrInvalid = errors.New("magiclink: invalid link")
+	// ErrExpired is returned when the link's TTL has passed.
+	ErrExpired = errors.New("magiclink: link expired")
+	// ErrUsed is returned when a single-use link has already been redeemed.
+	ErrUsed = errors.New("magiclink: link already used")
+	// ErrScopeMismatch is returned when a scoped link is verified outside the
+	// tenant scope it was issued in.
+	ErrScopeMismatch = errors.New("magiclink: scope mismatch")
+	// ErrStore is returned when the single-use store fails; redemption fails
+	// closed.
+	ErrStore = errors.New("magiclink: store operation failed")
+)

--- a/auth/magiclink/magiclink.go
+++ b/auth/magiclink/magiclink.go
@@ -1,0 +1,92 @@
+package magiclink
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/crypto/keyset"
+	"github.com/dmitrymomot/forge/crypto/token"
+)
+
+// envelope wraps the consumer payload inside the signed token.
+type envelope[T any] struct {
+	Payload T `json:"pld"`
+}
+
+// Manager issues and redeems magic-link tokens carrying a payload of type T.
+type Manager[T any] struct {
+	codec *token.Codec[envelope[T]]
+}
+
+// New builds a single-key Manager. Purpose is required: two managers with the
+// same key but different purposes never accept each other's links.
+func New[T any](key []byte, purpose string, opts ...Option) (*Manager[T], error) {
+	c, err := newConfig(purpose, opts...)
+	if err != nil {
+		return nil, err
+	}
+	codec, err := token.New[envelope[T]](key, c.codecOptions(purpose)...)
+	if err != nil {
+		return nil, err
+	}
+	return &Manager[T]{codec: codec}, nil
+}
+
+// FromKeyset builds a rotation-aware Manager (signs under the primary key,
+// verifies links signed under any version).
+func FromKeyset[T any](ks *keyset.Keyset, purpose string, opts ...Option) (*Manager[T], error) {
+	c, err := newConfig(purpose, opts...)
+	if err != nil {
+		return nil, err
+	}
+	codec, err := token.FromKeyset[envelope[T]](ks, c.codecOptions(purpose)...)
+	if err != nil {
+		return nil, err
+	}
+	return &Manager[T]{codec: codec}, nil
+}
+
+// Issue creates a signed link token for payload.
+func (m *Manager[T]) Issue(ctx context.Context, payload T) (string, error) {
+	return m.codec.Issue(envelope[T]{Payload: payload})
+}
+
+// Peek verifies a link without consuming it. Serve it on GET so email
+// scanners that prefetch links cannot burn them.
+func (m *Manager[T]) Peek(ctx context.Context, link string) (T, error) {
+	var zero T
+	env, err := m.verify(ctx, link)
+	if err != nil {
+		return zero, err
+	}
+	return env.Payload, nil
+}
+
+// Redeem verifies a link and, when a store is configured, atomically consumes
+// it. Without a store it is verify-only and multi-use.
+func (m *Manager[T]) Redeem(ctx context.Context, link string) (T, error) {
+	var zero T
+	env, err := m.verify(ctx, link)
+	if err != nil {
+		return zero, err
+	}
+	return env.Payload, nil
+}
+
+// verify parses the token and maps crypto/token errors to package sentinels.
+// Signature verification runs before any store I/O.
+func (m *Manager[T]) verify(ctx context.Context, link string) (envelope[T], error) {
+	env, err := m.codec.Parse(link)
+	if err != nil {
+		return envelope[T]{}, mapTokenErr(err)
+	}
+	return env, nil
+}
+
+func mapTokenErr(err error) error {
+	if errors.Is(err, token.ErrExpired) {
+		return fmt.Errorf("%w: %w", ErrExpired, err)
+	}
+	return fmt.Errorf("%w: %w", ErrInvalid, err)
+}

--- a/auth/magiclink/magiclink.go
+++ b/auth/magiclink/magiclink.go
@@ -15,13 +15,15 @@ import (
 
 // envelope wraps the consumer payload inside the signed token.
 type envelope[T any] struct {
-	Payload T `json:"pld"`
+	Payload T      `json:"pld"`
+	Scope   string `json:"scp,omitempty"`
 }
 
 // Manager issues and redeems magic-link tokens carrying a payload of type T.
 type Manager[T any] struct {
 	codec   *token.Codec[envelope[T]]
 	store   cache.Store
+	scopeFn func(context.Context) (string, error)
 	purpose string
 	ttl     time.Duration
 }
@@ -37,7 +39,7 @@ func New[T any](key []byte, purpose string, opts ...Option) (*Manager[T], error)
 	if err != nil {
 		return nil, err
 	}
-	return &Manager[T]{codec: codec, store: c.store, purpose: purpose, ttl: c.ttl}, nil
+	return &Manager[T]{codec: codec, store: c.store, scopeFn: c.scopeFn, purpose: purpose, ttl: c.ttl}, nil
 }
 
 // FromKeyset builds a rotation-aware Manager (signs under the primary key,
@@ -51,12 +53,17 @@ func FromKeyset[T any](ks *keyset.Keyset, purpose string, opts ...Option) (*Mana
 	if err != nil {
 		return nil, err
 	}
-	return &Manager[T]{codec: codec, store: c.store, purpose: purpose, ttl: c.ttl}, nil
+	return &Manager[T]{codec: codec, store: c.store, scopeFn: c.scopeFn, purpose: purpose, ttl: c.ttl}, nil
 }
 
-// Issue creates a signed link token for payload.
+// Issue creates a signed link token for payload. With a scope hook configured
+// the resolved scope is stamped into the token; a hook error aborts issuance.
 func (m *Manager[T]) Issue(ctx context.Context, payload T) (string, error) {
-	return m.codec.Issue(envelope[T]{Payload: payload})
+	scope, err := m.resolveScope(ctx)
+	if err != nil {
+		return "", err
+	}
+	return m.codec.Issue(envelope[T]{Payload: payload, Scope: scope})
 }
 
 // Peek verifies a link without consuming it. Serve it on GET so email
@@ -110,14 +117,28 @@ func (m *Manager[T]) storeKey(link string) string {
 	return "magiclink:" + m.purpose + ":" + base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
-// verify parses the token and maps crypto/token errors to package sentinels.
-// Signature verification runs before any store I/O.
+// verify parses the token, maps crypto/token errors to package sentinels, and
+// enforces scope. Signature verification runs before any store I/O.
 func (m *Manager[T]) verify(ctx context.Context, link string) (envelope[T], error) {
 	env, err := m.codec.Parse(link)
 	if err != nil {
 		return envelope[T]{}, mapTokenErr(err)
 	}
+	scope, err := m.resolveScope(ctx)
+	if err != nil {
+		return envelope[T]{}, err
+	}
+	if env.Scope != "" && env.Scope != scope {
+		return envelope[T]{}, ErrScopeMismatch
+	}
 	return env, nil
+}
+
+func (m *Manager[T]) resolveScope(ctx context.Context) (string, error) {
+	if m.scopeFn == nil {
+		return "", nil
+	}
+	return m.scopeFn(ctx)
 }
 
 func mapTokenErr(err error) error {

--- a/auth/magiclink/magiclink.go
+++ b/auth/magiclink/magiclink.go
@@ -9,15 +9,20 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/crypto/keyset"
 	"github.com/dmitrymomot/forge/crypto/token"
 	"github.com/dmitrymomot/forge/resilience/cache"
 )
 
-// envelope wraps the consumer payload inside the signed token.
+// envelope wraps the consumer payload inside the signed token. Exp (Unix
+// nanoseconds) is stamped only for single-use managers and sizes the store
+// claim's TTL to the link's remaining lifetime; crypto/token remains
+// authoritative for actual expiry.
 type envelope[T any] struct {
 	Payload T      `json:"pld"`
 	Scope   string `json:"scp,omitempty"`
+	Exp     int64  `json:"exp,omitempty"`
 }
 
 // Manager issues and redeems magic-link tokens carrying a payload of type T.
@@ -25,10 +30,12 @@ type Manager[T any] struct {
 	codec   *token.Codec[envelope[T]]
 	store   cache.Store
 	scopeFn func(context.Context) (string, error)
+	clk     clock.Clock
 	purpose string
 	baseURL string
 	param   string
 	ttl     time.Duration
+	maxLen  int
 }
 
 // New builds a single-key Manager. Purpose is required: two managers with the
@@ -46,10 +53,12 @@ func New[T any](key []byte, purpose string, opts ...Option) (*Manager[T], error)
 		codec:   codec,
 		store:   c.store,
 		scopeFn: c.scopeFn,
+		clk:     c.clk,
 		purpose: purpose,
 		baseURL: c.baseURL,
 		param:   c.param,
 		ttl:     c.ttl,
+		maxLen:  c.maxLen,
 	}, nil
 }
 
@@ -68,10 +77,12 @@ func FromKeyset[T any](ks *keyset.Keyset, purpose string, opts ...Option) (*Mana
 		codec:   codec,
 		store:   c.store,
 		scopeFn: c.scopeFn,
+		clk:     c.clk,
 		purpose: purpose,
 		baseURL: c.baseURL,
 		param:   c.param,
 		ttl:     c.ttl,
+		maxLen:  c.maxLen,
 	}, nil
 }
 
@@ -82,7 +93,13 @@ func (m *Manager[T]) Issue(ctx context.Context, payload T) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return m.codec.Issue(envelope[T]{Payload: payload, Scope: scope})
+	env := envelope[T]{Payload: payload, Scope: scope}
+	// Stamp expiry only for single-use managers, where Redeem uses it to size
+	// the claim TTL; stateless tokens stay lean (omitempty drops it).
+	if m.store != nil {
+		env.Exp = m.clk.Now().Add(m.ttl).UnixNano()
+	}
+	return m.codec.Issue(env)
 }
 
 // parseAbsoluteURL parses u and requires an absolute URL (both scheme and
@@ -159,7 +176,7 @@ func (m *Manager[T]) Redeem(ctx context.Context, link string) (T, error) {
 	}
 	if m.store != nil {
 		err := m.store.Set(ctx, m.storeKey(link), []byte{1},
-			cache.WithTTL(m.ttl), cache.WithSetNonExist())
+			cache.WithTTL(m.claimTTL(env)), cache.WithSetNonExist())
 		switch {
 		case errors.Is(err, cache.ErrExists):
 			return zero, ErrUsed
@@ -168,6 +185,28 @@ func (m *Manager[T]) Redeem(ctx context.Context, link string) (T, error) {
 		}
 	}
 	return env.Payload, nil
+}
+
+// claimGrace covers crypto/token's one-second expiry granularity: Parse rejects
+// a token only once now.Unix() passes its exp second, so a token stays
+// presentable for up to ~1s beyond the nanosecond Exp stamped here. The claim
+// adds this margin so it always outlives the window in which a replay could
+// still pass verify — never a weaker guarantee than a full-TTL claim.
+const claimGrace = 5 * time.Second
+
+// claimTTL sizes the single-use claim to the link's remaining lifetime (plus
+// claimGrace) rather than the full configured TTL, so a link redeemed near
+// expiry does not pin a store key for a further full TTL. It never returns a
+// non-positive value (which cache.WithTTL treats as "never expire"): if the
+// remaining time is unavailable (Exp unset — a token issued by a store-less
+// manager) it falls back to the full TTL, which always outlives the link.
+func (m *Manager[T]) claimTTL(env envelope[T]) time.Duration {
+	if env.Exp > 0 {
+		if ttl := time.Duration(env.Exp-m.clk.Now().UnixNano()) + claimGrace; ttl > 0 {
+			return ttl
+		}
+	}
+	return m.ttl
 }
 
 // storeKey derives the single-use claim key. The token hash is globally
@@ -180,6 +219,12 @@ func (m *Manager[T]) storeKey(link string) string {
 // verify parses the token, maps crypto/token errors to package sentinels, and
 // enforces scope. Signature verification runs before any store I/O.
 func (m *Manager[T]) verify(ctx context.Context, link string) (envelope[T], error) {
+	// Defense-in-depth: reject oversized input before any base64/JSON/HMAC
+	// work, so a forgotten HTTP-layer size limit can't turn an oversized
+	// token query param into cheap CPU abuse.
+	if len(link) > m.maxLen {
+		return envelope[T]{}, fmt.Errorf("%w: link exceeds %d bytes", ErrInvalid, m.maxLen)
+	}
 	env, err := m.codec.Parse(link)
 	if err != nil {
 		return envelope[T]{}, mapTokenErr(err)

--- a/auth/magiclink/magiclink.go
+++ b/auth/magiclink/magiclink.go
@@ -2,11 +2,15 @@ package magiclink
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/dmitrymomot/forge/crypto/keyset"
 	"github.com/dmitrymomot/forge/crypto/token"
+	"github.com/dmitrymomot/forge/resilience/cache"
 )
 
 // envelope wraps the consumer payload inside the signed token.
@@ -16,7 +20,10 @@ type envelope[T any] struct {
 
 // Manager issues and redeems magic-link tokens carrying a payload of type T.
 type Manager[T any] struct {
-	codec *token.Codec[envelope[T]]
+	codec   *token.Codec[envelope[T]]
+	store   cache.Store
+	purpose string
+	ttl     time.Duration
 }
 
 // New builds a single-key Manager. Purpose is required: two managers with the
@@ -30,7 +37,7 @@ func New[T any](key []byte, purpose string, opts ...Option) (*Manager[T], error)
 	if err != nil {
 		return nil, err
 	}
-	return &Manager[T]{codec: codec}, nil
+	return &Manager[T]{codec: codec, store: c.store, purpose: purpose, ttl: c.ttl}, nil
 }
 
 // FromKeyset builds a rotation-aware Manager (signs under the primary key,
@@ -44,7 +51,7 @@ func FromKeyset[T any](ks *keyset.Keyset, purpose string, opts ...Option) (*Mana
 	if err != nil {
 		return nil, err
 	}
-	return &Manager[T]{codec: codec}, nil
+	return &Manager[T]{codec: codec, store: c.store, purpose: purpose, ttl: c.ttl}, nil
 }
 
 // Issue creates a signed link token for payload.
@@ -53,25 +60,54 @@ func (m *Manager[T]) Issue(ctx context.Context, payload T) (string, error) {
 }
 
 // Peek verifies a link without consuming it. Serve it on GET so email
-// scanners that prefetch links cannot burn them.
+// scanners that prefetch links cannot burn them. With a store configured it
+// reports ErrUsed for already-redeemed links (best-effort; the consuming
+// Redeem is authoritative).
 func (m *Manager[T]) Peek(ctx context.Context, link string) (T, error) {
 	var zero T
 	env, err := m.verify(ctx, link)
 	if err != nil {
 		return zero, err
 	}
+	if m.store != nil {
+		used, err := m.store.Has(ctx, m.storeKey(link))
+		if err != nil {
+			return zero, fmt.Errorf("%w: %w", ErrStore, err)
+		}
+		if used {
+			return zero, ErrUsed
+		}
+	}
 	return env.Payload, nil
 }
 
 // Redeem verifies a link and, when a store is configured, atomically consumes
-// it. Without a store it is verify-only and multi-use.
+// it: the first call wins, replays return ErrUsed, store failures fail closed
+// with ErrStore. Without a store it is verify-only and multi-use.
 func (m *Manager[T]) Redeem(ctx context.Context, link string) (T, error) {
 	var zero T
 	env, err := m.verify(ctx, link)
 	if err != nil {
 		return zero, err
 	}
+	if m.store != nil {
+		err := m.store.Set(ctx, m.storeKey(link), []byte{1},
+			cache.WithTTL(m.ttl), cache.WithSetNonExist())
+		switch {
+		case errors.Is(err, cache.ErrExists):
+			return zero, ErrUsed
+		case err != nil:
+			return zero, fmt.Errorf("%w: %w", ErrStore, err)
+		}
+	}
 	return env.Payload, nil
+}
+
+// storeKey derives the single-use claim key. The token hash is globally
+// unique (each token carries a random nonce), so scope is not needed here.
+func (m *Manager[T]) storeKey(link string) string {
+	sum := sha256.Sum256([]byte(link))
+	return "magiclink:" + m.purpose + ":" + base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
 // verify parses the token and maps crypto/token errors to package sentinels.

--- a/auth/magiclink/magiclink.go
+++ b/auth/magiclink/magiclink.go
@@ -100,6 +100,9 @@ func (m *Manager[T]) IssueURL(ctx context.Context, base string, payload T) (stri
 	if err != nil {
 		return "", fmt.Errorf("magiclink: invalid base URL: %w", err)
 	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("magiclink: base URL must be absolute (scheme and host): %q", base)
+	}
 	link, err := m.Issue(ctx, payload)
 	if err != nil {
 		return "", err

--- a/auth/magiclink/magiclink.go
+++ b/auth/magiclink/magiclink.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/dmitrymomot/forge/crypto/keyset"
@@ -25,6 +26,8 @@ type Manager[T any] struct {
 	store   cache.Store
 	scopeFn func(context.Context) (string, error)
 	purpose string
+	baseURL string
+	param   string
 	ttl     time.Duration
 }
 
@@ -39,7 +42,15 @@ func New[T any](key []byte, purpose string, opts ...Option) (*Manager[T], error)
 	if err != nil {
 		return nil, err
 	}
-	return &Manager[T]{codec: codec, store: c.store, scopeFn: c.scopeFn, purpose: purpose, ttl: c.ttl}, nil
+	return &Manager[T]{
+		codec:   codec,
+		store:   c.store,
+		scopeFn: c.scopeFn,
+		purpose: purpose,
+		baseURL: c.baseURL,
+		param:   c.param,
+		ttl:     c.ttl,
+	}, nil
 }
 
 // FromKeyset builds a rotation-aware Manager (signs under the primary key,
@@ -53,7 +64,15 @@ func FromKeyset[T any](ks *keyset.Keyset, purpose string, opts ...Option) (*Mana
 	if err != nil {
 		return nil, err
 	}
-	return &Manager[T]{codec: codec, store: c.store, scopeFn: c.scopeFn, purpose: purpose, ttl: c.ttl}, nil
+	return &Manager[T]{
+		codec:   codec,
+		store:   c.store,
+		scopeFn: c.scopeFn,
+		purpose: purpose,
+		baseURL: c.baseURL,
+		param:   c.param,
+		ttl:     c.ttl,
+	}, nil
 }
 
 // Issue creates a signed link token for payload. With a scope hook configured
@@ -64,6 +83,31 @@ func (m *Manager[T]) Issue(ctx context.Context, payload T) (string, error) {
 		return "", err
 	}
 	return m.codec.Issue(envelope[T]{Payload: payload, Scope: scope})
+}
+
+// IssueURL issues a link token and appends it as a query parameter to base
+// (multi-tenant/white-label callers pass the tenant's base per call). An
+// empty base falls back to WithBaseURL; both empty is an error. Existing
+// query parameters on the base are preserved.
+func (m *Manager[T]) IssueURL(ctx context.Context, base string, payload T) (string, error) {
+	if base == "" {
+		base = m.baseURL
+	}
+	if base == "" {
+		return "", errors.New("magiclink: no base URL")
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("magiclink: invalid base URL: %w", err)
+	}
+	link, err := m.Issue(ctx, payload)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set(m.param, link)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
 }
 
 // Peek verifies a link without consuming it. Serve it on GET so email

--- a/auth/magiclink/magiclink.go
+++ b/auth/magiclink/magiclink.go
@@ -85,6 +85,22 @@ func (m *Manager[T]) Issue(ctx context.Context, payload T) (string, error) {
 	return m.codec.Issue(envelope[T]{Payload: payload, Scope: scope})
 }
 
+// parseAbsoluteURL parses u and requires an absolute URL (both scheme and
+// host present), so a scheme-less base such as "app.example.com/verify" is
+// rejected rather than silently yielding a broken relative link. Shared by
+// WithBaseURL (construction) and IssueURL (per-call base) so the two paths
+// cannot drift apart.
+func parseAbsoluteURL(u string) (*url.URL, error) {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil, fmt.Errorf("magiclink: invalid base URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("magiclink: base URL must be absolute (scheme and host): %q", u)
+	}
+	return parsed, nil
+}
+
 // IssueURL issues a link token and appends it as a query parameter to base
 // (multi-tenant/white-label callers pass the tenant's base per call). An
 // empty base falls back to WithBaseURL; both empty is an error. Existing
@@ -96,12 +112,9 @@ func (m *Manager[T]) IssueURL(ctx context.Context, base string, payload T) (stri
 	if base == "" {
 		return "", errors.New("magiclink: no base URL")
 	}
-	u, err := url.Parse(base)
+	u, err := parseAbsoluteURL(base)
 	if err != nil {
-		return "", fmt.Errorf("magiclink: invalid base URL: %w", err)
-	}
-	if u.Scheme == "" || u.Host == "" {
-		return "", fmt.Errorf("magiclink: base URL must be absolute (scheme and host): %q", base)
+		return "", err
 	}
 	link, err := m.Issue(ctx, payload)
 	if err != nil {

--- a/auth/magiclink/magiclink_test.go
+++ b/auth/magiclink/magiclink_test.go
@@ -3,7 +3,10 @@ package magiclink_test
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +17,7 @@ import (
 	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/crypto/keyset"
 	"github.com/dmitrymomot/forge/crypto/secret"
+	"github.com/dmitrymomot/forge/resilience/cache"
 )
 
 type loginClaims struct {
@@ -154,4 +158,116 @@ func TestFromKeysetRotation(t *testing.T) {
 	got, err := mNew.Redeem(context.Background(), link)
 	require.NoError(t, err)
 	assert.Equal(t, "u_1", got.UserID)
+}
+
+func newMemStore(t *testing.T) cache.Store {
+	t.Helper()
+	s := cache.NewMemoryStore()
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestSingleUseRedeem(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithStore(newMemStore(t)))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	got, err := m.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+
+	_, err = m.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrUsed)
+}
+
+func TestPeekDoesNotConsume(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithStore(newMemStore(t)))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	_, err = m.Peek(context.Background(), link)
+	require.NoError(t, err)
+	_, err = m.Peek(context.Background(), link)
+	require.NoError(t, err, "Peek must be repeatable")
+
+	_, err = m.Redeem(context.Background(), link)
+	require.NoError(t, err, "Redeem must still succeed after Peek")
+
+	_, err = m.Peek(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrUsed, "Peek after Redeem reports used")
+}
+
+func TestConcurrentRedeemSingleWinner(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithStore(newMemStore(t)))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	const n = 32
+	var wins, used atomic.Int32
+	var wg sync.WaitGroup
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := m.Redeem(context.Background(), link)
+			switch {
+			case err == nil:
+				wins.Add(1)
+			case errors.Is(err, magiclink.ErrUsed):
+				used.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), wins.Load(), "exactly one redeem wins")
+	assert.Equal(t, int32(n-1), used.Load(), "all others see ErrUsed")
+}
+
+type failingStore struct{ err error }
+
+func (f failingStore) Get(context.Context, string) ([]byte, error) { return nil, f.err }
+func (f failingStore) Set(context.Context, string, []byte, ...cache.SetOption) error {
+	return f.err
+}
+func (f failingStore) Delete(context.Context, string) error      { return f.err }
+func (f failingStore) Has(context.Context, string) (bool, error) { return false, f.err }
+func (f failingStore) DeletePrefix(context.Context, string) error {
+	return f.err
+}
+func (f failingStore) Close() error { return nil }
+
+func TestStoreFailureFailsClosed(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login",
+		magiclink.WithStore(failingStore{err: errors.New("boom")}))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	_, err = m.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrStore)
+	_, err = m.Peek(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrStore)
+}
+
+func TestJunkRejectedBeforeStore(t *testing.T) {
+	// Signature check precedes store I/O: junk must yield ErrInvalid even
+	// when every store call would fail.
+	m, err := magiclink.New[loginClaims](testKey, "login",
+		magiclink.WithStore(failingStore{err: errors.New("boom")}))
+	require.NoError(t, err)
+
+	_, err = m.Redeem(context.Background(), "garbage.token")
+	assert.ErrorIs(t, err, magiclink.ErrInvalid)
+}
+
+func TestWithStoreNilRejected(t *testing.T) {
+	_, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithStore(nil))
+	require.Error(t, err)
 }

--- a/auth/magiclink/magiclink_test.go
+++ b/auth/magiclink/magiclink_test.go
@@ -424,3 +424,31 @@ func TestURLOptionValidation(t *testing.T) {
 	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithBaseURL("://bad"))
 	require.Error(t, err, "unparsable base URL must be rejected")
 }
+
+func TestIssueURLBadBaseErrors(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+
+	// An unparsable per-call base is used directly (no fallback) and must
+	// surface the url.Parse failure.
+	_, err = m.IssueURL(context.Background(), "://bad", loginClaims{UserID: "u_1"})
+	require.Error(t, err)
+}
+
+func TestIssueURLScopeHookError(t *testing.T) {
+	hookErr := errors.New("no tenant in ctx")
+	m, err := magiclink.New[loginClaims](testKey, "login",
+		magiclink.WithScope(func(ctx context.Context) (string, error) {
+			if v, ok := ctx.Value(tenantKey{}).(string); ok {
+				return v, nil
+			}
+			return "", hookErr
+		}))
+	require.NoError(t, err)
+
+	// IssueURL delegates issuance to Issue, so the scope-hook error must
+	// propagate through IssueURL -> Issue -> resolveScope.
+	_, err = m.IssueURL(context.Background(), "https://app.example.com/verify",
+		loginClaims{UserID: "u_1"})
+	assert.ErrorIs(t, err, hookErr)
+}

--- a/auth/magiclink/magiclink_test.go
+++ b/auth/magiclink/magiclink_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -343,4 +344,83 @@ func TestScopedTokenOnUnscopedManagerRejected(t *testing.T) {
 func TestWithScopeNilRejected(t *testing.T) {
 	_, err := magiclink.New[loginClaims](testKey, "invite", magiclink.WithScope(nil))
 	require.Error(t, err)
+}
+
+func TestIssueURLDefaultBase(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login",
+		magiclink.WithBaseURL("https://app.example.com/auth/verify"))
+	require.NoError(t, err)
+
+	u, err := m.IssueURL(context.Background(), "", loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(u)
+	require.NoError(t, err)
+	assert.Equal(t, "https", parsed.Scheme)
+	assert.Equal(t, "app.example.com", parsed.Host)
+	assert.Equal(t, "/auth/verify", parsed.Path)
+
+	link := parsed.Query().Get("token")
+	require.NotEmpty(t, link)
+	got, err := m.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+}
+
+func TestIssueURLPerCallBaseWins(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "invite",
+		magiclink.WithBaseURL("https://app.example.com/join"))
+	require.NoError(t, err)
+
+	u, err := m.IssueURL(context.Background(), "https://acme.example.com/join",
+		loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(u, "https://acme.example.com/join?token="), u)
+}
+
+func TestIssueURLNoBaseErrors(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+
+	_, err = m.IssueURL(context.Background(), "", loginClaims{UserID: "u_1"})
+	require.Error(t, err)
+}
+
+func TestIssueURLPreservesExistingQuery(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+
+	u, err := m.IssueURL(context.Background(),
+		"https://app.example.com/verify?lang=de", loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(u)
+	require.NoError(t, err)
+	assert.Equal(t, "de", parsed.Query().Get("lang"))
+	assert.NotEmpty(t, parsed.Query().Get("token"))
+}
+
+func TestWithParamRename(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithParam("t"))
+	require.NoError(t, err)
+
+	u, err := m.IssueURL(context.Background(), "https://app.example.com/verify",
+		loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(u)
+	require.NoError(t, err)
+	assert.NotEmpty(t, parsed.Query().Get("t"))
+	assert.Empty(t, parsed.Query().Get("token"))
+}
+
+func TestURLOptionValidation(t *testing.T) {
+	_, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithParam(""))
+	require.Error(t, err, "empty param name must be rejected")
+
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithBaseURL(""))
+	require.Error(t, err, "empty base URL must be rejected")
+
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithBaseURL("://bad"))
+	require.Error(t, err, "unparsable base URL must be rejected")
 }

--- a/auth/magiclink/magiclink_test.go
+++ b/auth/magiclink/magiclink_test.go
@@ -435,6 +435,18 @@ func TestIssueURLBadBaseErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestWithBaseURLRelativeRejected(t *testing.T) {
+	_, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithBaseURL("app.example.com/verify"))
+	require.Error(t, err, "scheme-less base URL must be rejected")
+}
+
+func TestIssueURLRelativeBaseErrors(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+	_, err = m.IssueURL(context.Background(), "app.example.com/verify", loginClaims{UserID: "u_1"})
+	require.Error(t, err, "scheme-less per-call base must be rejected")
+}
+
 func TestIssueURLScopeHookError(t *testing.T) {
 	hookErr := errors.New("no tenant in ctx")
 	m, err := magiclink.New[loginClaims](testKey, "login",

--- a/auth/magiclink/magiclink_test.go
+++ b/auth/magiclink/magiclink_test.go
@@ -269,3 +269,78 @@ func TestWithStoreNilRejected(t *testing.T) {
 	_, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithStore(nil))
 	require.Error(t, err)
 }
+
+type tenantKey struct{}
+
+func tenantCtx(scope string) context.Context {
+	return context.WithValue(context.Background(), tenantKey{}, scope)
+}
+
+func tenantScope(ctx context.Context) (string, error) {
+	v, _ := ctx.Value(tenantKey{}).(string)
+	return v, nil
+}
+
+func TestScopeMatrix(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "invite", magiclink.WithScope(tenantScope))
+	require.NoError(t, err)
+
+	// Global link (issued without tenant in ctx): valid everywhere.
+	global, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+	_, err = m.Redeem(tenantCtx("acme"), global)
+	require.NoError(t, err, "global link redeems inside a tenant")
+	_, err = m.Redeem(context.Background(), global)
+	require.NoError(t, err, "global link redeems globally")
+
+	// Scoped link: valid only in the exact tenant it was issued in.
+	scoped, err := m.Issue(tenantCtx("acme"), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+	_, err = m.Peek(tenantCtx("acme"), scoped)
+	require.NoError(t, err, "Peek applies the same scope rule")
+	_, err = m.Redeem(tenantCtx("acme"), scoped)
+	require.NoError(t, err)
+	_, err = m.Redeem(tenantCtx("globex"), scoped)
+	assert.ErrorIs(t, err, magiclink.ErrScopeMismatch)
+	_, err = m.Redeem(context.Background(), scoped)
+	assert.ErrorIs(t, err, magiclink.ErrScopeMismatch, "scoped link is not global")
+}
+
+func TestScopeHookErrorPropagates(t *testing.T) {
+	hookErr := errors.New("no tenant in ctx")
+	m, err := magiclink.New[loginClaims](testKey, "invite",
+		magiclink.WithScope(func(ctx context.Context) (string, error) {
+			if v, ok := ctx.Value(tenantKey{}).(string); ok {
+				return v, nil
+			}
+			return "", hookErr
+		}))
+	require.NoError(t, err)
+
+	_, err = m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	assert.ErrorIs(t, err, hookErr, "hook error aborts issuance")
+
+	link, err := m.Issue(tenantCtx("acme"), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+	_, err = m.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, hookErr, "hook error aborts redemption")
+}
+
+func TestScopedTokenOnUnscopedManagerRejected(t *testing.T) {
+	scoped, err := magiclink.New[loginClaims](testKey, "invite", magiclink.WithScope(tenantScope))
+	require.NoError(t, err)
+	plain, err := magiclink.New[loginClaims](testKey, "invite")
+	require.NoError(t, err)
+
+	link, err := scoped.Issue(tenantCtx("acme"), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	// Config drift fails closed: no hook means ctx scope is always "".
+	_, err = plain.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrScopeMismatch)
+}
+
+func TestWithScopeNilRejected(t *testing.T) {
+	_, err := magiclink.New[loginClaims](testKey, "invite", magiclink.WithScope(nil))
+	require.Error(t, err)
+}

--- a/auth/magiclink/magiclink_test.go
+++ b/auth/magiclink/magiclink_test.go
@@ -212,9 +212,7 @@ func TestConcurrentRedeemSingleWinner(t *testing.T) {
 	var wins, used atomic.Int32
 	var wg sync.WaitGroup
 	for range n {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_, err := m.Redeem(context.Background(), link)
 			switch {
 			case err == nil:
@@ -222,7 +220,7 @@ func TestConcurrentRedeemSingleWinner(t *testing.T) {
 			case errors.Is(err, magiclink.ErrUsed):
 				used.Add(1)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	assert.Equal(t, int32(1), wins.Load(), "exactly one redeem wins")

--- a/auth/magiclink/magiclink_test.go
+++ b/auth/magiclink/magiclink_test.go
@@ -464,3 +464,143 @@ func TestIssueURLScopeHookError(t *testing.T) {
 		loginClaims{UserID: "u_1"})
 	assert.ErrorIs(t, err, hookErr)
 }
+
+// ttlSpyStore records the TTL passed to Set so tests can assert the single-use
+// claim is sized to the link's remaining lifetime. Set always succeeds.
+type ttlSpyStore struct {
+	mu      sync.Mutex
+	lastTTL time.Duration
+}
+
+func (s *ttlSpyStore) Get(context.Context, string) ([]byte, error) { return nil, cache.ErrNotFound }
+func (s *ttlSpyStore) Set(_ context.Context, _ string, _ []byte, opts ...cache.SetOption) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastTTL = cache.ApplySetOptions(opts...).TTL
+	return nil
+}
+func (s *ttlSpyStore) Delete(context.Context, string) error       { return nil }
+func (s *ttlSpyStore) Has(context.Context, string) (bool, error)  { return false, nil }
+func (s *ttlSpyStore) DeletePrefix(context.Context, string) error { return nil }
+func (s *ttlSpyStore) Close() error                               { return nil }
+
+func TestRedeemClaimTTLTracksRemainingLifetime(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	spy := &ttlSpyStore{}
+	m, err := magiclink.New[loginClaims](testKey, "login",
+		magiclink.WithTTL(15*time.Minute), magiclink.WithClock(clk), magiclink.WithStore(spy))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	clk.Advance(10 * time.Minute) // 5m of the 15m lifetime remains
+
+	_, err = m.Redeem(context.Background(), link)
+	require.NoError(t, err)
+
+	spy.mu.Lock()
+	got := spy.lastTTL
+	spy.mu.Unlock()
+	// The claim must track the remaining ~5m (plus a small grace), far below
+	// the full 15m, and stay positive so it never becomes a never-expiring key.
+	assert.Positive(t, got)
+	assert.Greater(t, got, 5*time.Minute, "claim outlives the link's remaining lifetime")
+	assert.Less(t, got, 6*time.Minute, "claim tracks remaining lifetime, not the full TTL")
+}
+
+func TestRedeemClaimTTLFallsBackWithoutExp(t *testing.T) {
+	// A token issued by a store-less manager carries no Exp; redeeming it on a
+	// single-use manager must fall back to the full TTL — a safe claim that
+	// always outlives the link — never a non-positive (never-expiring) TTL.
+	stateless, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+	link, err := stateless.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	spy := &ttlSpyStore{}
+	single, err := magiclink.New[loginClaims](testKey, "login",
+		magiclink.WithTTL(15*time.Minute), magiclink.WithStore(spy))
+	require.NoError(t, err)
+
+	_, err = single.Redeem(context.Background(), link)
+	require.NoError(t, err)
+
+	spy.mu.Lock()
+	got := spy.lastTTL
+	spy.mu.Unlock()
+	assert.Equal(t, 15*time.Minute, got, "claim falls back to full TTL when Exp is absent")
+}
+
+func TestDefaultTokenLengthCap(t *testing.T) {
+	// A VALID but oversized token (large payload) must be rejected by the
+	// default 8192-byte cap before decode — this distinguishes cap-rejection
+	// from a mere malformed-input rejection.
+	big := loginClaims{UserID: strings.Repeat("x", 9000)}
+	lax, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithMaxTokenLength(1<<20))
+	require.NoError(t, err)
+	link, err := lax.Issue(context.Background(), big)
+	require.NoError(t, err)
+	require.Greater(t, len(link), 8192, "payload forces the token over the default cap")
+
+	// The lax manager accepts its own valid token...
+	got, err := lax.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, big.UserID, got.UserID)
+
+	// ...but a default-cap manager rejects the same valid token purely on length.
+	def, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+	_, err = def.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrInvalid)
+	_, err = def.Peek(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrInvalid)
+}
+
+func TestSingleUseHoldsUntilTokenExpiry(t *testing.T) {
+	// End-to-end guard for the single-use guarantee across the claimTTL change:
+	// a redeemed link must stay ErrUsed for a replay right up to token expiry
+	// (the claim must outlive the token's verifiable window), then ErrExpired.
+	clk := clock.NewMock(time.Now())
+	store := cache.NewMemoryStore(cache.WithClock(clk))
+	t.Cleanup(func() { _ = store.Close() })
+	m, err := magiclink.New[loginClaims](testKey, "login",
+		magiclink.WithTTL(time.Minute), magiclink.WithClock(clk), magiclink.WithStore(store))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	_, err = m.Redeem(context.Background(), link)
+	require.NoError(t, err)
+
+	// One second before expiry the token still verifies, so the claim must
+	// still block the replay — no double-redeem window.
+	clk.Advance(59 * time.Second)
+	_, err = m.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrUsed)
+
+	// Past expiry, verify rejects the link before the store is even consulted.
+	clk.Advance(2 * time.Second)
+	_, err = m.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrExpired)
+}
+
+func TestWithMaxTokenLength(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithMaxTokenLength(16))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+	require.Greater(t, len(link), 16, "a real token exceeds the tiny cap")
+
+	_, err = m.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrInvalid, "over-cap link rejected before decode")
+}
+
+func TestWithMaxTokenLengthInvalid(t *testing.T) {
+	_, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithMaxTokenLength(0))
+	require.Error(t, err, "zero max length must be rejected")
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithMaxTokenLength(-1))
+	require.Error(t, err, "negative max length must be rejected")
+}

--- a/auth/magiclink/magiclink_test.go
+++ b/auth/magiclink/magiclink_test.go
@@ -1,0 +1,157 @@
+package magiclink_test
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/magiclink"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+	"github.com/dmitrymomot/forge/crypto/secret"
+)
+
+type loginClaims struct {
+	UserID string `json:"uid"`
+}
+
+var testKey = []byte("0123456789abcdef0123456789abcdef")
+
+func TestNewValidation(t *testing.T) {
+	_, err := magiclink.New[loginClaims](testKey, "")
+	require.Error(t, err, "empty purpose must be rejected")
+
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithTTL(0))
+	require.Error(t, err, "zero TTL must be rejected")
+
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithTTL(-time.Minute))
+	require.Error(t, err, "negative TTL must be rejected")
+
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithClock(nil))
+	require.Error(t, err, "nil clock must be rejected")
+
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithEncrypt(nil))
+	require.Error(t, err, "nil box must be rejected")
+
+	_, err = magiclink.New[loginClaims](nil, "login")
+	require.Error(t, err, "empty key must be rejected")
+}
+
+func TestStatelessRoundTrip(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	got, err := m.Peek(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+
+	// Stateless Redeem is verify-only and multi-use by design.
+	got, err = m.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+
+	got, err = m.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+}
+
+func TestExpired(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	m, err := magiclink.New[loginClaims](testKey, "login",
+		magiclink.WithTTL(15*time.Minute), magiclink.WithClock(clk))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	clk.Advance(16 * time.Minute)
+
+	_, err = m.Peek(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrExpired)
+	_, err = m.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrExpired)
+}
+
+func TestInvalidTokens(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	// Tampered body: flip a character in the first segment.
+	tampered := "A" + link[1:]
+	if tampered == link {
+		tampered = "B" + link[1:]
+	}
+	for _, bad := range []string{"", "garbage", "a.b", tampered} {
+		_, err = m.Redeem(context.Background(), bad)
+		assert.ErrorIs(t, err, magiclink.ErrInvalid, "input %q", bad)
+	}
+}
+
+func TestCrossPurposeRejected(t *testing.T) {
+	login, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+	unsub, err := magiclink.New[loginClaims](testKey, "unsubscribe")
+	require.NoError(t, err)
+
+	link, err := login.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	_, err = unsub.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrInvalid)
+}
+
+func TestEncryptedPayloadHidden(t *testing.T) {
+	box, err := secret.New(testKey)
+	require.NoError(t, err)
+	m, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithEncrypt(box))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	// Without encryption the base64 body decodes to plaintext JSON
+	// containing the payload; with WithEncrypt it must not.
+	body, _, ok := strings.Cut(link, ".")
+	require.True(t, ok)
+	raw, err := base64.RawURLEncoding.DecodeString(body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "u_1")
+
+	got, err := m.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+}
+
+func TestFromKeysetRotation(t *testing.T) {
+	old, err := keyset.New(keyset.WithPrimary(1, testKey))
+	require.NoError(t, err)
+	mOld, err := magiclink.FromKeyset[loginClaims](old, "login")
+	require.NoError(t, err)
+
+	link, err := mOld.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	rotated, err := keyset.New(
+		keyset.WithPrimary(2, []byte("fedcba9876543210fedcba9876543210")),
+		keyset.WithRetired(1, testKey),
+	)
+	require.NoError(t, err)
+	mNew, err := magiclink.FromKeyset[loginClaims](rotated, "login")
+	require.NoError(t, err)
+
+	// Link signed under the retired key still verifies after rotation.
+	got, err := mNew.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+}

--- a/auth/magiclink/options.go
+++ b/auth/magiclink/options.go
@@ -3,8 +3,6 @@ package magiclink
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/dmitrymomot/forge/core/clock"
@@ -126,13 +124,8 @@ func WithBaseURL(u string) Option {
 			c.errs = append(c.errs, errors.New("magiclink: empty base URL"))
 			return
 		}
-		parsed, err := url.Parse(u)
-		if err != nil {
-			c.errs = append(c.errs, fmt.Errorf("magiclink: invalid base URL: %w", err))
-			return
-		}
-		if parsed.Scheme == "" || parsed.Host == "" {
-			c.errs = append(c.errs, fmt.Errorf("magiclink: base URL must be absolute (scheme and host): %q", u))
+		if _, err := parseAbsoluteURL(u); err != nil {
+			c.errs = append(c.errs, err)
 			return
 		}
 		c.baseURL = u

--- a/auth/magiclink/options.go
+++ b/auth/magiclink/options.go
@@ -1,0 +1,78 @@
+package magiclink
+
+import (
+	"errors"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/crypto/secret"
+	"github.com/dmitrymomot/forge/crypto/token"
+)
+
+type config struct {
+	clk  clock.Clock
+	box  *secret.Box
+	errs []error
+	ttl  time.Duration
+}
+
+// Option configures New/FromKeyset.
+type Option func(*config)
+
+func newConfig(purpose string, opts ...Option) (*config, error) {
+	c := &config{clk: clock.System(), ttl: 15 * time.Minute}
+	for _, o := range opts {
+		o(c)
+	}
+	if purpose == "" {
+		c.errs = append(c.errs, errors.New("magiclink: empty purpose"))
+	}
+	if c.ttl <= 0 {
+		c.errs = append(c.errs, errors.New("magiclink: ttl must be positive"))
+	}
+	if len(c.errs) > 0 {
+		return nil, errors.Join(c.errs...)
+	}
+	return c, nil
+}
+
+// codecOptions translates the resolved config into crypto/token options.
+func (c *config) codecOptions(purpose string) []token.Option {
+	opts := []token.Option{
+		token.WithTTL(c.ttl),
+		token.WithPurpose(purpose),
+		token.WithClock(c.clk),
+	}
+	if c.box != nil {
+		opts = append(opts, token.WithEncrypt(c.box))
+	}
+	return opts
+}
+
+// WithTTL sets the link lifetime (default 15m). Links always expire: a
+// non-positive d is a constructor error.
+func WithTTL(d time.Duration) Option { return func(c *config) { c.ttl = d } }
+
+// WithClock sets the time source (default clock.System()). A nil clock is
+// rejected.
+func WithClock(ck clock.Clock) Option {
+	return func(c *config) {
+		if ck == nil {
+			c.errs = append(c.errs, errors.New("magiclink: nil clock"))
+			return
+		}
+		c.clk = ck
+	}
+}
+
+// WithEncrypt encrypts the payload (not just signs it), hiding PII from the
+// URL. A nil box is rejected.
+func WithEncrypt(box *secret.Box) Option {
+	return func(c *config) {
+		if box == nil {
+			c.errs = append(c.errs, errors.New("magiclink: nil box"))
+			return
+		}
+		c.box = box
+	}
+}

--- a/auth/magiclink/options.go
+++ b/auth/magiclink/options.go
@@ -1,6 +1,7 @@
 package magiclink
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -11,11 +12,12 @@ import (
 )
 
 type config struct {
-	clk   clock.Clock
-	store cache.Store
-	box   *secret.Box
-	errs  []error
-	ttl   time.Duration
+	clk     clock.Clock
+	store   cache.Store
+	box     *secret.Box
+	scopeFn func(context.Context) (string, error)
+	errs    []error
+	ttl     time.Duration
 }
 
 // Option configures New/FromKeyset.
@@ -90,5 +92,21 @@ func WithStore(s cache.Store) Option {
 			return
 		}
 		c.store = s
+	}
+}
+
+// WithScope binds links to a tenant scope resolved from ctx (forge-wide
+// multi-tenancy hook). Issue stamps the resolved scope into the token;
+// Peek/Redeem recompute it and fail closed on mismatch. An empty resolved
+// scope means a global link, valid in any tenant context; a hook that wants
+// to forbid global issuance returns an error when ctx lacks a tenant. A nil
+// hook is rejected.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) {
+		if fn == nil {
+			c.errs = append(c.errs, errors.New("magiclink: nil scope hook"))
+			return
+		}
+		c.scopeFn = fn
 	}
 }

--- a/auth/magiclink/options.go
+++ b/auth/magiclink/options.go
@@ -11,6 +11,12 @@ import (
 	"github.com/dmitrymomot/forge/resilience/cache"
 )
 
+// defaultMaxTokenLength caps accepted link length before any decode/verify
+// work, as defense-in-depth against oversized-input CPU abuse. It is generous
+// — a magic link must fit in a URL, which servers cap well below this — while
+// still bounding a forgotten HTTP-layer limit. Tune with WithMaxTokenLength.
+const defaultMaxTokenLength = 8192
+
 type config struct {
 	clk     clock.Clock
 	store   cache.Store
@@ -20,13 +26,14 @@ type config struct {
 	param   string
 	errs    []error
 	ttl     time.Duration
+	maxLen  int
 }
 
 // Option configures New/FromKeyset.
 type Option func(*config)
 
 func newConfig(purpose string, opts ...Option) (*config, error) {
-	c := &config{clk: clock.System(), ttl: 15 * time.Minute, param: "token"}
+	c := &config{clk: clock.System(), ttl: 15 * time.Minute, param: "token", maxLen: defaultMaxTokenLength}
 	for _, o := range opts {
 		o(c)
 	}
@@ -129,6 +136,20 @@ func WithBaseURL(u string) Option {
 			return
 		}
 		c.baseURL = u
+	}
+}
+
+// WithMaxTokenLength caps the accepted link length (default 8192 bytes); Peek
+// and Redeem reject longer input with ErrInvalid before any base64/JSON/HMAC
+// work — defense-in-depth against oversized-input CPU abuse on endpoints that
+// forgot an HTTP-layer size limit. n must be positive.
+func WithMaxTokenLength(n int) Option {
+	return func(c *config) {
+		if n <= 0 {
+			c.errs = append(c.errs, errors.New("magiclink: max token length must be positive"))
+			return
+		}
+		c.maxLen = n
 	}
 }
 

--- a/auth/magiclink/options.go
+++ b/auth/magiclink/options.go
@@ -7,13 +7,15 @@ import (
 	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/crypto/secret"
 	"github.com/dmitrymomot/forge/crypto/token"
+	"github.com/dmitrymomot/forge/resilience/cache"
 )
 
 type config struct {
-	clk  clock.Clock
-	box  *secret.Box
-	errs []error
-	ttl  time.Duration
+	clk   clock.Clock
+	store cache.Store
+	box   *secret.Box
+	errs  []error
+	ttl   time.Duration
 }
 
 // Option configures New/FromKeyset.
@@ -74,5 +76,19 @@ func WithEncrypt(box *secret.Box) Option {
 			return
 		}
 		c.box = box
+	}
+}
+
+// WithStore enables single-use redemption: Redeem atomically claims each link
+// and returns ErrUsed on replay. A nil store is rejected. The bundled LRU
+// memory store can evict live keys; production single-use needs cache/redis
+// or another durable Store.
+func WithStore(s cache.Store) Option {
+	return func(c *config) {
+		if s == nil {
+			c.errs = append(c.errs, errors.New("magiclink: nil store"))
+			return
+		}
+		c.store = s
 	}
 }

--- a/auth/magiclink/options.go
+++ b/auth/magiclink/options.go
@@ -3,6 +3,8 @@ package magiclink
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/dmitrymomot/forge/core/clock"
@@ -16,6 +18,8 @@ type config struct {
 	store   cache.Store
 	box     *secret.Box
 	scopeFn func(context.Context) (string, error)
+	baseURL string
+	param   string
 	errs    []error
 	ttl     time.Duration
 }
@@ -24,7 +28,7 @@ type config struct {
 type Option func(*config)
 
 func newConfig(purpose string, opts ...Option) (*config, error) {
-	c := &config{clk: clock.System(), ttl: 15 * time.Minute}
+	c := &config{clk: clock.System(), ttl: 15 * time.Minute, param: "token"}
 	for _, o := range opts {
 		o(c)
 	}
@@ -108,5 +112,34 @@ func WithScope(fn func(context.Context) (string, error)) Option {
 			return
 		}
 		c.scopeFn = fn
+	}
+}
+
+// WithBaseURL sets the default base used by IssueURL when its base argument
+// is empty — the single-domain convenience. Must be a non-empty, parsable
+// URL.
+func WithBaseURL(u string) Option {
+	return func(c *config) {
+		if u == "" {
+			c.errs = append(c.errs, errors.New("magiclink: empty base URL"))
+			return
+		}
+		if _, err := url.Parse(u); err != nil {
+			c.errs = append(c.errs, fmt.Errorf("magiclink: invalid base URL: %w", err))
+			return
+		}
+		c.baseURL = u
+	}
+}
+
+// WithParam sets the query parameter name IssueURL appends the token under
+// (default "token"). Empty is rejected.
+func WithParam(name string) Option {
+	return func(c *config) {
+		if name == "" {
+			c.errs = append(c.errs, errors.New("magiclink: empty param name"))
+			return
+		}
+		c.param = name
 	}
 }

--- a/auth/magiclink/options.go
+++ b/auth/magiclink/options.go
@@ -86,9 +86,11 @@ func WithEncrypt(box *secret.Box) Option {
 }
 
 // WithStore enables single-use redemption: Redeem atomically claims each link
-// and returns ErrUsed on replay. A nil store is rejected. The bundled LRU
-// memory store can evict live keys; production single-use needs cache/redis
-// or another durable Store.
+// and returns ErrUsed on replay. A nil store is rejected. The bundled memory
+// store can evict live keys, and reclaims expired one-time claims only when
+// built with cache.WithCleanupInterval (lazy expiry never revisits a
+// redeemed key); production single-use should use cache/redis or another
+// durable Store.
 func WithStore(s cache.Store) Option {
 	return func(c *config) {
 		if s == nil {
@@ -116,16 +118,21 @@ func WithScope(fn func(context.Context) (string, error)) Option {
 }
 
 // WithBaseURL sets the default base used by IssueURL when its base argument
-// is empty — the single-domain convenience. Must be a non-empty, parsable
-// URL.
+// is empty — the single-domain convenience. Must be a non-empty, parsable,
+// absolute URL (scheme and host).
 func WithBaseURL(u string) Option {
 	return func(c *config) {
 		if u == "" {
 			c.errs = append(c.errs, errors.New("magiclink: empty base URL"))
 			return
 		}
-		if _, err := url.Parse(u); err != nil {
+		parsed, err := url.Parse(u)
+		if err != nil {
 			c.errs = append(c.errs, fmt.Errorf("magiclink: invalid base URL: %w", err))
+			return
+		}
+		if parsed.Scheme == "" || parsed.Host == "" {
+			c.errs = append(c.errs, fmt.Errorf("magiclink: base URL must be absolute (scheme and host): %q", u))
 			return
 		}
 		c.baseURL = u

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -676,17 +676,6 @@ Deps: `core/random`, `crypto/consttime`; `auth/guard` (planned).
 
 ---
 
-**auth/magiclink**
-
-Signed, TTL'd, single-use links over `crypto/token`: passwordless login,
-team invites (role/tenant claims as a documented example), verify and
-unsubscribe links. Stateless by default; `WithStore` for single-use
-redemption. Does not send email.
-
-Deps: `crypto/token`, `resilience/cache`.
-
----
-
 **auth/oauthclient**
 
 OAuth2/OIDC client: auth-code + PKCE, state, token exchange,

--- a/docs/superpowers/plans/2026-07-13-auth-magiclink.md
+++ b/docs/superpowers/plans/2026-07-13-auth-magiclink.md
@@ -1,0 +1,1263 @@
+# auth/magiclink Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `auth/magiclink` — signed, TTL'd, optionally single-use magic links (passwordless login, invites, verify/unsubscribe) over `crypto/token` and the `resilience/cache.Store` seam.
+
+**Architecture:** A thin generic `Manager[T]` wraps the consumer payload in an internal envelope, delegates sign/encrypt/TTL/purpose to `token.Codec[envelope[T]]`, and adds single-use redemption (atomic `SetNX`), tenant-scope binding (fail-closed hook), and URL construction. No HTTP surface. Spec: `docs/superpowers/specs/2026-07-13-auth-magiclink-design.md`.
+
+**Tech Stack:** Go 1.26, `crypto/token`, `crypto/keyset`, `crypto/secret`, `core/clock`, `resilience/cache` (Store seam only), testify.
+
+## Global Constraints
+
+- Work ONLY in the current branch (`dm/wonderful-yonath-6b5184`); never switch.
+- All files live in `auth/magiclink/` — single package, no subpackages.
+- Black-box tests only: test files declare `package magiclink_test`.
+- After changing files run `just fmt ./auth/magiclink` (package-path form — the single-file form trips a betteralign quirk). Run `just lint` at the end of the final task.
+- Test command: `just test ./auth/magiclink` (runs with `-race -cover`).
+- Runtime errors must be single-line: wrap with `fmt.Errorf("%w: %w", Sentinel, err)`, never `errors.Join` (Join is newline-separated; it is only acceptable for constructor option-error collection, mirroring `crypto/token`).
+- Go 1.26 idioms: `for range n` loops, `b.Loop()` in benchmarks (modernize in `just lint` enforces both).
+- No Claude/AI attribution in any commit message.
+- Struct fields are added to `Manager`/`config` only in the task that first reads them (the `unused` linter flags never-read unexported fields).
+- Note: `ctx` params on `Issue`/`Peek`/`Redeem` are unused until Task 3 wires the scope hook. Default golangci linters do not flag unused params — keep the signatures as written; do not underscore them.
+
+---
+
+### Task 1: Errors, options, constructors, stateless core
+
+**Files:**
+- Create: `auth/magiclink/errors.go`
+- Create: `auth/magiclink/options.go`
+- Create: `auth/magiclink/magiclink.go`
+- Create: `auth/magiclink/magiclink_test.go`
+
+**Interfaces:**
+- Consumes: `token.New[T](key, opts...)`, `token.FromKeyset[T](ks, opts...)`, `token.WithTTL/WithPurpose/WithClock/WithEncrypt`, `token.ErrExpired`, `clock.Clock`, `clock.System()`, `secret.Box`, `keyset.Keyset`.
+- Produces (later tasks rely on these exact signatures):
+  - `func New[T any](key []byte, purpose string, opts ...Option) (*Manager[T], error)`
+  - `func FromKeyset[T any](ks *keyset.Keyset, purpose string, opts ...Option) (*Manager[T], error)`
+  - `func (m *Manager[T]) Issue(ctx context.Context, payload T) (string, error)`
+  - `func (m *Manager[T]) Peek(ctx context.Context, link string) (T, error)`
+  - `func (m *Manager[T]) Redeem(ctx context.Context, link string) (T, error)`
+  - `func (m *Manager[T]) verify(ctx context.Context, link string) (envelope[T], error)` (unexported, extended by Tasks 2–3)
+  - `type Option func(*config)`; `newConfig(purpose string, opts ...Option) (*config, error)` with fields `clk`, `box`, `ttl`, `errs`
+  - Sentinels: `ErrInvalid`, `ErrExpired`, `ErrUsed`, `ErrScopeMismatch`, `ErrStore`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `auth/magiclink/magiclink_test.go`:
+
+```go
+package magiclink_test
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/magiclink"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+	"github.com/dmitrymomot/forge/crypto/secret"
+)
+
+type loginClaims struct {
+	UserID string `json:"uid"`
+}
+
+var testKey = []byte("0123456789abcdef0123456789abcdef")
+
+func TestNewValidation(t *testing.T) {
+	_, err := magiclink.New[loginClaims](testKey, "")
+	require.Error(t, err, "empty purpose must be rejected")
+
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithTTL(0))
+	require.Error(t, err, "zero TTL must be rejected")
+
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithTTL(-time.Minute))
+	require.Error(t, err, "negative TTL must be rejected")
+
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithClock(nil))
+	require.Error(t, err, "nil clock must be rejected")
+
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithEncrypt(nil))
+	require.Error(t, err, "nil box must be rejected")
+
+	_, err = magiclink.New[loginClaims](nil, "login")
+	require.Error(t, err, "empty key must be rejected")
+}
+
+func TestStatelessRoundTrip(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	got, err := m.Peek(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+
+	// Stateless Redeem is verify-only and multi-use by design.
+	got, err = m.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+
+	got, err = m.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+}
+
+func TestExpired(t *testing.T) {
+	clk := clock.NewMock(time.Now())
+	m, err := magiclink.New[loginClaims](testKey, "login",
+		magiclink.WithTTL(15*time.Minute), magiclink.WithClock(clk))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	clk.Advance(16 * time.Minute)
+
+	_, err = m.Peek(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrExpired)
+	_, err = m.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrExpired)
+}
+
+func TestInvalidTokens(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	// Tampered body: flip a character in the first segment.
+	tampered := "A" + link[1:]
+	if tampered == link {
+		tampered = "B" + link[1:]
+	}
+	for _, bad := range []string{"", "garbage", "a.b", tampered} {
+		_, err = m.Redeem(context.Background(), bad)
+		assert.ErrorIs(t, err, magiclink.ErrInvalid, "input %q", bad)
+	}
+}
+
+func TestCrossPurposeRejected(t *testing.T) {
+	login, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+	unsub, err := magiclink.New[loginClaims](testKey, "unsubscribe")
+	require.NoError(t, err)
+
+	link, err := login.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	_, err = unsub.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrInvalid)
+}
+
+func TestEncryptedPayloadHidden(t *testing.T) {
+	box, err := secret.New(testKey)
+	require.NoError(t, err)
+	m, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithEncrypt(box))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	// Without encryption the base64 body decodes to plaintext JSON
+	// containing the payload; with WithEncrypt it must not.
+	body, _, ok := strings.Cut(link, ".")
+	require.True(t, ok)
+	raw, err := base64.RawURLEncoding.DecodeString(body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "u_1")
+
+	got, err := m.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+}
+
+func TestFromKeysetRotation(t *testing.T) {
+	old, err := keyset.New(keyset.WithPrimary(1, testKey))
+	require.NoError(t, err)
+	mOld, err := magiclink.FromKeyset[loginClaims](old, "login")
+	require.NoError(t, err)
+
+	link, err := mOld.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	rotated, err := keyset.New(
+		keyset.WithPrimary(2, []byte("fedcba9876543210fedcba9876543210")),
+		keyset.WithRetired(1, testKey),
+	)
+	require.NoError(t, err)
+	mNew, err := magiclink.FromKeyset[loginClaims](rotated, "login")
+	require.NoError(t, err)
+
+	// Link signed under the retired key still verifies after rotation.
+	got, err := mNew.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `just test ./auth/magiclink`
+Expected: FAIL — compile error (`package magiclink` does not exist yet).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `auth/magiclink/errors.go`:
+
+```go
+package magiclink
+
+import "errors"
+
+// Sentinel errors returned by Peek and Redeem. All are errors.Is-matchable;
+// runtime wrapping keeps the underlying cause inspectable for logs.
+var (
+	// ErrInvalid is returned when a link is malformed, its signature does not
+	// verify, or it was issued for a different purpose.
+	ErrInvalid = errors.New("magiclink: invalid link")
+	// ErrExpired is returned when the link's TTL has passed.
+	ErrExpired = errors.New("magiclink: link expired")
+	// ErrUsed is returned when a single-use link has already been redeemed.
+	ErrUsed = errors.New("magiclink: link already used")
+	// ErrScopeMismatch is returned when a scoped link is verified outside the
+	// tenant scope it was issued in.
+	ErrScopeMismatch = errors.New("magiclink: scope mismatch")
+	// ErrStore is returned when the single-use store fails; redemption fails
+	// closed.
+	ErrStore = errors.New("magiclink: store operation failed")
+)
+```
+
+Create `auth/magiclink/options.go`:
+
+```go
+package magiclink
+
+import (
+	"errors"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/crypto/secret"
+	"github.com/dmitrymomot/forge/crypto/token"
+)
+
+type config struct {
+	clk  clock.Clock
+	box  *secret.Box
+	errs []error
+	ttl  time.Duration
+}
+
+// Option configures New/FromKeyset.
+type Option func(*config)
+
+func newConfig(purpose string, opts ...Option) (*config, error) {
+	c := &config{clk: clock.System(), ttl: 15 * time.Minute}
+	for _, o := range opts {
+		o(c)
+	}
+	if purpose == "" {
+		c.errs = append(c.errs, errors.New("magiclink: empty purpose"))
+	}
+	if c.ttl <= 0 {
+		c.errs = append(c.errs, errors.New("magiclink: ttl must be positive"))
+	}
+	if len(c.errs) > 0 {
+		return nil, errors.Join(c.errs...)
+	}
+	return c, nil
+}
+
+// codecOptions translates the resolved config into crypto/token options.
+func (c *config) codecOptions(purpose string) []token.Option {
+	opts := []token.Option{
+		token.WithTTL(c.ttl),
+		token.WithPurpose(purpose),
+		token.WithClock(c.clk),
+	}
+	if c.box != nil {
+		opts = append(opts, token.WithEncrypt(c.box))
+	}
+	return opts
+}
+
+// WithTTL sets the link lifetime (default 15m). Links always expire: a
+// non-positive d is a constructor error.
+func WithTTL(d time.Duration) Option { return func(c *config) { c.ttl = d } }
+
+// WithClock sets the time source (default clock.System()). A nil clock is
+// rejected.
+func WithClock(ck clock.Clock) Option {
+	return func(c *config) {
+		if ck == nil {
+			c.errs = append(c.errs, errors.New("magiclink: nil clock"))
+			return
+		}
+		c.clk = ck
+	}
+}
+
+// WithEncrypt encrypts the payload (not just signs it), hiding PII from the
+// URL. A nil box is rejected.
+func WithEncrypt(box *secret.Box) Option {
+	return func(c *config) {
+		if box == nil {
+			c.errs = append(c.errs, errors.New("magiclink: nil box"))
+			return
+		}
+		c.box = box
+	}
+}
+```
+
+Create `auth/magiclink/magiclink.go`:
+
+```go
+package magiclink
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/crypto/keyset"
+	"github.com/dmitrymomot/forge/crypto/token"
+)
+
+// envelope wraps the consumer payload inside the signed token.
+type envelope[T any] struct {
+	Payload T `json:"pld"`
+}
+
+// Manager issues and redeems magic-link tokens carrying a payload of type T.
+type Manager[T any] struct {
+	codec *token.Codec[envelope[T]]
+}
+
+// New builds a single-key Manager. Purpose is required: two managers with the
+// same key but different purposes never accept each other's links.
+func New[T any](key []byte, purpose string, opts ...Option) (*Manager[T], error) {
+	c, err := newConfig(purpose, opts...)
+	if err != nil {
+		return nil, err
+	}
+	codec, err := token.New[envelope[T]](key, c.codecOptions(purpose)...)
+	if err != nil {
+		return nil, err
+	}
+	return &Manager[T]{codec: codec}, nil
+}
+
+// FromKeyset builds a rotation-aware Manager (signs under the primary key,
+// verifies links signed under any version).
+func FromKeyset[T any](ks *keyset.Keyset, purpose string, opts ...Option) (*Manager[T], error) {
+	c, err := newConfig(purpose, opts...)
+	if err != nil {
+		return nil, err
+	}
+	codec, err := token.FromKeyset[envelope[T]](ks, c.codecOptions(purpose)...)
+	if err != nil {
+		return nil, err
+	}
+	return &Manager[T]{codec: codec}, nil
+}
+
+// Issue creates a signed link token for payload.
+func (m *Manager[T]) Issue(ctx context.Context, payload T) (string, error) {
+	return m.codec.Issue(envelope[T]{Payload: payload})
+}
+
+// Peek verifies a link without consuming it. Serve it on GET so email
+// scanners that prefetch links cannot burn them.
+func (m *Manager[T]) Peek(ctx context.Context, link string) (T, error) {
+	var zero T
+	env, err := m.verify(ctx, link)
+	if err != nil {
+		return zero, err
+	}
+	return env.Payload, nil
+}
+
+// Redeem verifies a link and, when a store is configured, atomically consumes
+// it. Without a store it is verify-only and multi-use.
+func (m *Manager[T]) Redeem(ctx context.Context, link string) (T, error) {
+	var zero T
+	env, err := m.verify(ctx, link)
+	if err != nil {
+		return zero, err
+	}
+	return env.Payload, nil
+}
+
+// verify parses the token and maps crypto/token errors to package sentinels.
+// Signature verification runs before any store I/O.
+func (m *Manager[T]) verify(ctx context.Context, link string) (envelope[T], error) {
+	env, err := m.codec.Parse(link)
+	if err != nil {
+		return envelope[T]{}, mapTokenErr(err)
+	}
+	return env, nil
+}
+
+func mapTokenErr(err error) error {
+	if errors.Is(err, token.ErrExpired) {
+		return fmt.Errorf("%w: %w", ErrExpired, err)
+	}
+	return fmt.Errorf("%w: %w", ErrInvalid, err)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `just test ./auth/magiclink`
+Expected: PASS (all 7 tests).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/magiclink
+git add auth/magiclink/
+git commit -m "feat(magiclink): stateless issue/peek/redeem core over crypto/token"
+```
+
+---
+
+### Task 2: Single-use redemption (WithStore)
+
+**Files:**
+- Modify: `auth/magiclink/options.go` (add `store` field + `WithStore`)
+- Modify: `auth/magiclink/magiclink.go` (Manager fields, storeKey, Peek/Redeem store logic)
+- Modify: `auth/magiclink/magiclink_test.go` (append tests)
+
+**Interfaces:**
+- Consumes: Task 1's `Manager[T]`, `verify`, sentinels; `cache.Store`, `cache.WithTTL`, `cache.WithSetNonExist`, `cache.ErrExists`, `cache.NewMemoryStore`.
+- Produces:
+  - `WithStore(s cache.Store) Option`
+  - `func (m *Manager[T]) storeKey(link string) string` (unexported) — key format `magiclink:<purpose>:<base64url(sha256(link))>`
+  - `Manager` gains fields `store cache.Store`, `purpose string`, `ttl time.Duration` (set in both constructors).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `auth/magiclink/magiclink_test.go` (add imports `errors`, `sync`, `sync/atomic`, and `github.com/dmitrymomot/forge/resilience/cache`):
+
+```go
+func newMemStore(t *testing.T) cache.Store {
+	t.Helper()
+	s := cache.NewMemoryStore()
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestSingleUseRedeem(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithStore(newMemStore(t)))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	got, err := m.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+
+	_, err = m.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrUsed)
+}
+
+func TestPeekDoesNotConsume(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithStore(newMemStore(t)))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	_, err = m.Peek(context.Background(), link)
+	require.NoError(t, err)
+	_, err = m.Peek(context.Background(), link)
+	require.NoError(t, err, "Peek must be repeatable")
+
+	_, err = m.Redeem(context.Background(), link)
+	require.NoError(t, err, "Redeem must still succeed after Peek")
+
+	_, err = m.Peek(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrUsed, "Peek after Redeem reports used")
+}
+
+func TestConcurrentRedeemSingleWinner(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithStore(newMemStore(t)))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	const n = 32
+	var wins, used atomic.Int32
+	var wg sync.WaitGroup
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := m.Redeem(context.Background(), link)
+			switch {
+			case err == nil:
+				wins.Add(1)
+			case errors.Is(err, magiclink.ErrUsed):
+				used.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), wins.Load(), "exactly one redeem wins")
+	assert.Equal(t, int32(n-1), used.Load(), "all others see ErrUsed")
+}
+
+type failingStore struct{ err error }
+
+func (f failingStore) Get(context.Context, string) ([]byte, error) { return nil, f.err }
+func (f failingStore) Set(context.Context, string, []byte, ...cache.SetOption) error {
+	return f.err
+}
+func (f failingStore) Delete(context.Context, string) error      { return f.err }
+func (f failingStore) Has(context.Context, string) (bool, error) { return false, f.err }
+func (f failingStore) DeletePrefix(context.Context, string) error {
+	return f.err
+}
+func (f failingStore) Close() error { return nil }
+
+func TestStoreFailureFailsClosed(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login",
+		magiclink.WithStore(failingStore{err: errors.New("boom")}))
+	require.NoError(t, err)
+
+	link, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	_, err = m.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrStore)
+	_, err = m.Peek(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrStore)
+}
+
+func TestJunkRejectedBeforeStore(t *testing.T) {
+	// Signature check precedes store I/O: junk must yield ErrInvalid even
+	// when every store call would fail.
+	m, err := magiclink.New[loginClaims](testKey, "login",
+		magiclink.WithStore(failingStore{err: errors.New("boom")}))
+	require.NoError(t, err)
+
+	_, err = m.Redeem(context.Background(), "garbage.token")
+	assert.ErrorIs(t, err, magiclink.ErrInvalid)
+}
+
+func TestWithStoreNilRejected(t *testing.T) {
+	_, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithStore(nil))
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `just test ./auth/magiclink`
+Expected: FAIL — compile error: `undefined: magiclink.WithStore`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `auth/magiclink/options.go`: add `store cache.Store` to `config`, add the import `"github.com/dmitrymomot/forge/resilience/cache"`, and append:
+
+```go
+// WithStore enables single-use redemption: Redeem atomically claims each link
+// and returns ErrUsed on replay. A nil store is rejected. The bundled LRU
+// memory store can evict live keys; production single-use needs cache/redis
+// or another durable Store.
+func WithStore(s cache.Store) Option {
+	return func(c *config) {
+		if s == nil {
+			c.errs = append(c.errs, errors.New("magiclink: nil store"))
+			return
+		}
+		c.store = s
+	}
+}
+```
+
+In `auth/magiclink/magiclink.go`: add imports `"crypto/sha256"`, `"encoding/base64"`, `"time"`, `"github.com/dmitrymomot/forge/resilience/cache"`. Extend the Manager struct and both constructors:
+
+```go
+// Manager issues and redeems magic-link tokens carrying a payload of type T.
+type Manager[T any] struct {
+	codec   *token.Codec[envelope[T]]
+	store   cache.Store
+	purpose string
+	ttl     time.Duration
+}
+```
+
+In both `New` and `FromKeyset`, replace the return line with:
+
+```go
+	return &Manager[T]{codec: codec, store: c.store, purpose: purpose, ttl: c.ttl}, nil
+```
+
+Replace `Peek` and `Redeem` bodies and add `storeKey`:
+
+```go
+// Peek verifies a link without consuming it. Serve it on GET so email
+// scanners that prefetch links cannot burn them. With a store configured it
+// reports ErrUsed for already-redeemed links (best-effort; the consuming
+// Redeem is authoritative).
+func (m *Manager[T]) Peek(ctx context.Context, link string) (T, error) {
+	var zero T
+	env, err := m.verify(ctx, link)
+	if err != nil {
+		return zero, err
+	}
+	if m.store != nil {
+		used, err := m.store.Has(ctx, m.storeKey(link))
+		if err != nil {
+			return zero, fmt.Errorf("%w: %w", ErrStore, err)
+		}
+		if used {
+			return zero, ErrUsed
+		}
+	}
+	return env.Payload, nil
+}
+
+// Redeem verifies a link and, when a store is configured, atomically consumes
+// it: the first call wins, replays return ErrUsed, store failures fail closed
+// with ErrStore. Without a store it is verify-only and multi-use.
+func (m *Manager[T]) Redeem(ctx context.Context, link string) (T, error) {
+	var zero T
+	env, err := m.verify(ctx, link)
+	if err != nil {
+		return zero, err
+	}
+	if m.store != nil {
+		err := m.store.Set(ctx, m.storeKey(link), []byte{1},
+			cache.WithTTL(m.ttl), cache.WithSetNonExist())
+		switch {
+		case errors.Is(err, cache.ErrExists):
+			return zero, ErrUsed
+		case err != nil:
+			return zero, fmt.Errorf("%w: %w", ErrStore, err)
+		}
+	}
+	return env.Payload, nil
+}
+
+// storeKey derives the single-use claim key. The token hash is globally
+// unique (each token carries a random nonce), so scope is not needed here.
+func (m *Manager[T]) storeKey(link string) string {
+	sum := sha256.Sum256([]byte(link))
+	return "magiclink:" + m.purpose + ":" + base64.RawURLEncoding.EncodeToString(sum[:])
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `just test ./auth/magiclink`
+Expected: PASS, race-clean (the concurrent test runs under `-race`).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/magiclink
+git add auth/magiclink/
+git commit -m "feat(magiclink): single-use redemption via cache.Store SetNX claim"
+```
+
+---
+
+### Task 3: Tenant scope binding (WithScope)
+
+**Files:**
+- Modify: `auth/magiclink/options.go` (add `scopeFn` + `WithScope`)
+- Modify: `auth/magiclink/magiclink.go` (envelope.Scope, resolveScope, Issue stamping, verify matching)
+- Modify: `auth/magiclink/magiclink_test.go` (append tests)
+
+**Interfaces:**
+- Consumes: Task 1's `verify`, `envelope`; Task 2's Manager shape.
+- Produces:
+  - `WithScope(fn func(context.Context) (string, error)) Option`
+  - `envelope` gains a `Scope string` field with json tag `scp,omitempty`
+  - `func (m *Manager[T]) resolveScope(ctx context.Context) (string, error)` (unexported)
+  - `Manager` gains field `scopeFn func(context.Context) (string, error)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `auth/magiclink/magiclink_test.go`:
+
+```go
+type tenantKey struct{}
+
+func tenantCtx(scope string) context.Context {
+	return context.WithValue(context.Background(), tenantKey{}, scope)
+}
+
+func tenantScope(ctx context.Context) (string, error) {
+	v, _ := ctx.Value(tenantKey{}).(string)
+	return v, nil
+}
+
+func TestScopeMatrix(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "invite", magiclink.WithScope(tenantScope))
+	require.NoError(t, err)
+
+	// Global link (issued without tenant in ctx): valid everywhere.
+	global, err := m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+	_, err = m.Redeem(tenantCtx("acme"), global)
+	require.NoError(t, err, "global link redeems inside a tenant")
+	_, err = m.Redeem(context.Background(), global)
+	require.NoError(t, err, "global link redeems globally")
+
+	// Scoped link: valid only in the exact tenant it was issued in.
+	scoped, err := m.Issue(tenantCtx("acme"), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+	_, err = m.Peek(tenantCtx("acme"), scoped)
+	require.NoError(t, err, "Peek applies the same scope rule")
+	_, err = m.Redeem(tenantCtx("acme"), scoped)
+	require.NoError(t, err)
+	_, err = m.Redeem(tenantCtx("globex"), scoped)
+	assert.ErrorIs(t, err, magiclink.ErrScopeMismatch)
+	_, err = m.Redeem(context.Background(), scoped)
+	assert.ErrorIs(t, err, magiclink.ErrScopeMismatch, "scoped link is not global")
+}
+
+func TestScopeHookErrorPropagates(t *testing.T) {
+	hookErr := errors.New("no tenant in ctx")
+	m, err := magiclink.New[loginClaims](testKey, "invite",
+		magiclink.WithScope(func(ctx context.Context) (string, error) {
+			if v, ok := ctx.Value(tenantKey{}).(string); ok {
+				return v, nil
+			}
+			return "", hookErr
+		}))
+	require.NoError(t, err)
+
+	_, err = m.Issue(context.Background(), loginClaims{UserID: "u_1"})
+	assert.ErrorIs(t, err, hookErr, "hook error aborts issuance")
+
+	link, err := m.Issue(tenantCtx("acme"), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+	_, err = m.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, hookErr, "hook error aborts redemption")
+}
+
+func TestScopedTokenOnUnscopedManagerRejected(t *testing.T) {
+	scoped, err := magiclink.New[loginClaims](testKey, "invite", magiclink.WithScope(tenantScope))
+	require.NoError(t, err)
+	plain, err := magiclink.New[loginClaims](testKey, "invite")
+	require.NoError(t, err)
+
+	link, err := scoped.Issue(tenantCtx("acme"), loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	// Config drift fails closed: no hook means ctx scope is always "".
+	_, err = plain.Redeem(context.Background(), link)
+	assert.ErrorIs(t, err, magiclink.ErrScopeMismatch)
+}
+
+func TestWithScopeNilRejected(t *testing.T) {
+	_, err := magiclink.New[loginClaims](testKey, "invite", magiclink.WithScope(nil))
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `just test ./auth/magiclink`
+Expected: FAIL — compile error: `undefined: magiclink.WithScope`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `auth/magiclink/options.go`: add `scopeFn func(context.Context) (string, error)` to `config`, add the `"context"` import, and append:
+
+```go
+// WithScope binds links to a tenant scope resolved from ctx (forge-wide
+// multi-tenancy hook). Issue stamps the resolved scope into the token;
+// Peek/Redeem recompute it and fail closed on mismatch. An empty resolved
+// scope means a global link, valid in any tenant context; a hook that wants
+// to forbid global issuance returns an error when ctx lacks a tenant. A nil
+// hook is rejected.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) {
+		if fn == nil {
+			c.errs = append(c.errs, errors.New("magiclink: nil scope hook"))
+			return
+		}
+		c.scopeFn = fn
+	}
+}
+```
+
+In `auth/magiclink/magiclink.go`:
+
+Extend envelope:
+
+```go
+// envelope wraps the consumer payload inside the signed token.
+type envelope[T any] struct {
+	Payload T      `json:"pld"`
+	Scope   string `json:"scp,omitempty"`
+}
+```
+
+Add `scopeFn func(context.Context) (string, error)` to the Manager struct, and in both constructors extend the return to include `scopeFn: c.scopeFn`:
+
+```go
+	return &Manager[T]{codec: codec, store: c.store, scopeFn: c.scopeFn, purpose: purpose, ttl: c.ttl}, nil
+```
+
+Replace `Issue` and `verify`, add `resolveScope`:
+
+```go
+// Issue creates a signed link token for payload. With a scope hook configured
+// the resolved scope is stamped into the token; a hook error aborts issuance.
+func (m *Manager[T]) Issue(ctx context.Context, payload T) (string, error) {
+	scope, err := m.resolveScope(ctx)
+	if err != nil {
+		return "", err
+	}
+	return m.codec.Issue(envelope[T]{Payload: payload, Scope: scope})
+}
+
+// verify parses the token, maps crypto/token errors to package sentinels, and
+// enforces scope. Signature verification runs before any store I/O.
+func (m *Manager[T]) verify(ctx context.Context, link string) (envelope[T], error) {
+	env, err := m.codec.Parse(link)
+	if err != nil {
+		return envelope[T]{}, mapTokenErr(err)
+	}
+	scope, err := m.resolveScope(ctx)
+	if err != nil {
+		return envelope[T]{}, err
+	}
+	if env.Scope != "" && env.Scope != scope {
+		return envelope[T]{}, ErrScopeMismatch
+	}
+	return env, nil
+}
+
+func (m *Manager[T]) resolveScope(ctx context.Context) (string, error) {
+	if m.scopeFn == nil {
+		return "", nil
+	}
+	return m.scopeFn(ctx)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `just test ./auth/magiclink`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/magiclink
+git add auth/magiclink/
+git commit -m "feat(magiclink): fail-closed tenant scope binding via WithScope hook"
+```
+
+---
+
+### Task 4: URL construction (IssueURL, WithBaseURL, WithParam)
+
+**Files:**
+- Modify: `auth/magiclink/options.go` (add `baseURL`/`param` + options)
+- Modify: `auth/magiclink/magiclink.go` (Manager fields, IssueURL)
+- Modify: `auth/magiclink/magiclink_test.go` (append tests)
+
+**Interfaces:**
+- Consumes: Task 3's `Issue`.
+- Produces:
+  - `WithBaseURL(u string) Option` (validated at construction), `WithParam(name string) Option` (default `"token"`)
+  - `func (m *Manager[T]) IssueURL(ctx context.Context, base string, payload T) (string, error)` — per-call base wins; empty base falls back to WithBaseURL; both empty is an error.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `auth/magiclink/magiclink_test.go` (add import `net/url`):
+
+```go
+func TestIssueURLDefaultBase(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login",
+		magiclink.WithBaseURL("https://app.example.com/auth/verify"))
+	require.NoError(t, err)
+
+	u, err := m.IssueURL(context.Background(), "", loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(u)
+	require.NoError(t, err)
+	assert.Equal(t, "https", parsed.Scheme)
+	assert.Equal(t, "app.example.com", parsed.Host)
+	assert.Equal(t, "/auth/verify", parsed.Path)
+
+	link := parsed.Query().Get("token")
+	require.NotEmpty(t, link)
+	got, err := m.Redeem(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, "u_1", got.UserID)
+}
+
+func TestIssueURLPerCallBaseWins(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "invite",
+		magiclink.WithBaseURL("https://app.example.com/join"))
+	require.NoError(t, err)
+
+	u, err := m.IssueURL(context.Background(), "https://acme.example.com/join",
+		loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(u, "https://acme.example.com/join?token="), u)
+}
+
+func TestIssueURLNoBaseErrors(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+
+	_, err = m.IssueURL(context.Background(), "", loginClaims{UserID: "u_1"})
+	require.Error(t, err)
+}
+
+func TestIssueURLPreservesExistingQuery(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login")
+	require.NoError(t, err)
+
+	u, err := m.IssueURL(context.Background(),
+		"https://app.example.com/verify?lang=de", loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(u)
+	require.NoError(t, err)
+	assert.Equal(t, "de", parsed.Query().Get("lang"))
+	assert.NotEmpty(t, parsed.Query().Get("token"))
+}
+
+func TestWithParamRename(t *testing.T) {
+	m, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithParam("t"))
+	require.NoError(t, err)
+
+	u, err := m.IssueURL(context.Background(), "https://app.example.com/verify",
+		loginClaims{UserID: "u_1"})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(u)
+	require.NoError(t, err)
+	assert.NotEmpty(t, parsed.Query().Get("t"))
+	assert.Empty(t, parsed.Query().Get("token"))
+}
+
+func TestURLOptionValidation(t *testing.T) {
+	_, err := magiclink.New[loginClaims](testKey, "login", magiclink.WithParam(""))
+	require.Error(t, err, "empty param name must be rejected")
+
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithBaseURL(""))
+	require.Error(t, err, "empty base URL must be rejected")
+
+	_, err = magiclink.New[loginClaims](testKey, "login", magiclink.WithBaseURL("://bad"))
+	require.Error(t, err, "unparsable base URL must be rejected")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `just test ./auth/magiclink`
+Expected: FAIL — compile error: `undefined: magiclink.WithBaseURL`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `auth/magiclink/options.go`: add `baseURL string` and `param string` to `config`, add the `"fmt"` and `"net/url"` imports, initialize `param: "token"` in `newConfig`'s initial struct literal:
+
+```go
+	c := &config{clk: clock.System(), ttl: 15 * time.Minute, param: "token"}
+```
+
+Append options:
+
+```go
+// WithBaseURL sets the default base used by IssueURL when its base argument
+// is empty — the single-domain convenience. Must be a non-empty, parsable
+// URL.
+func WithBaseURL(u string) Option {
+	return func(c *config) {
+		if u == "" {
+			c.errs = append(c.errs, errors.New("magiclink: empty base URL"))
+			return
+		}
+		if _, err := url.Parse(u); err != nil {
+			c.errs = append(c.errs, fmt.Errorf("magiclink: invalid base URL: %w", err))
+			return
+		}
+		c.baseURL = u
+	}
+}
+
+// WithParam sets the query parameter name IssueURL appends the token under
+// (default "token"). Empty is rejected.
+func WithParam(name string) Option {
+	return func(c *config) {
+		if name == "" {
+			c.errs = append(c.errs, errors.New("magiclink: empty param name"))
+			return
+		}
+		c.param = name
+	}
+}
+```
+
+In `auth/magiclink/magiclink.go`: add `"net/url"` import; add `baseURL string` and `param string` fields to Manager; extend both constructors' return:
+
+```go
+	return &Manager[T]{
+		codec:   codec,
+		store:   c.store,
+		scopeFn: c.scopeFn,
+		purpose: purpose,
+		baseURL: c.baseURL,
+		param:   c.param,
+		ttl:     c.ttl,
+	}, nil
+```
+
+Add `IssueURL`:
+
+```go
+// IssueURL issues a link token and appends it as a query parameter to base
+// (multi-tenant/white-label callers pass the tenant's base per call). An
+// empty base falls back to WithBaseURL; both empty is an error. Existing
+// query parameters on the base are preserved.
+func (m *Manager[T]) IssueURL(ctx context.Context, base string, payload T) (string, error) {
+	if base == "" {
+		base = m.baseURL
+	}
+	if base == "" {
+		return "", errors.New("magiclink: no base URL")
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("magiclink: invalid base URL: %w", err)
+	}
+	link, err := m.Issue(ctx, payload)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set(m.param, link)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `just test ./auth/magiclink`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/magiclink
+git add auth/magiclink/
+git commit -m "feat(magiclink): IssueURL with per-call base for white-label domains"
+```
+
+---
+
+### Task 5: doc.go, benchmarks, roadmap entry removal, final verification
+
+**Files:**
+- Create: `auth/magiclink/doc.go`
+- Create: `auth/magiclink/bench_test.go`
+- Modify: `docs/packages.md` (delete the auth/magiclink roadmap entry)
+
+**Interfaces:**
+- Consumes: the complete public API from Tasks 1–4 (`New`, `FromKeyset`, all options, `Issue`, `IssueURL`, `Peek`, `Redeem`, all sentinels) and test fixtures `loginClaims`/`testKey` from `magiclink_test.go`.
+- Produces: nothing new — documentation, benchmarks, and roadmap hygiene.
+
+- [ ] **Step 1: Write doc.go**
+
+Create `auth/magiclink/doc.go`:
+
+```go
+// Package magiclink issues and redeems signed, TTL'd, optionally single-use
+// links: passwordless login, team invites, email verification, and
+// unsubscribe flows. It builds on crypto/token for the token format and adds
+// single-use redemption over the resilience/cache Store seam, tenant-scope
+// binding, and URL construction. It does not send email — delivery is the
+// caller's channel.
+//
+// Stateless by default: without WithStore a link verifies until its TTL
+// expires and may be redeemed repeatedly (fine for unsubscribe and verify
+// flows where replay is harmless). WithStore makes Redeem atomically
+// single-use. The bundled LRU memory store can evict live keys under
+// pressure; production single-use needs cache/redis or another durable
+// Store.
+//
+// Email scanners (Outlook SafeLinks and friends) prefetch links before the
+// user clicks. Serve GET with Peek — it verifies without consuming — and
+// consume with Redeem on an explicit POST:
+//
+//	type LoginClaims struct {
+//		UserID string `json:"uid"`
+//	}
+//
+//	links, err := magiclink.New[LoginClaims](key, "login",
+//		magiclink.WithTTL(15*time.Minute),
+//		magiclink.WithStore(store), // single-use; omit for stateless links
+//		magiclink.WithBaseURL("https://app.example.com/auth/verify"),
+//	)
+//
+//	// Request: build the link and deliver it yourself.
+//	url, err := links.IssueURL(ctx, "", LoginClaims{UserID: "u_1"})
+//
+//	// GET /auth/verify?token=... — show a confirm button, do not consume.
+//	claims, err := links.Peek(r.Context(), r.URL.Query().Get("token"))
+//
+//	// POST /auth/verify — consume; a second redeem returns ErrUsed.
+//	claims, err = links.Redeem(r.Context(), r.FormValue("token"))
+//
+// Errors are matched with errors.Is: ErrInvalid (malformed, bad signature,
+// wrong purpose), ErrExpired, ErrUsed, ErrScopeMismatch, and ErrStore (store
+// failure; redemption fails closed).
+//
+// Multi-tenant apps bind links to a tenant with WithScope: Issue stamps the
+// scope resolved from ctx into the token, Peek/Redeem recompute it and fail
+// closed on mismatch. A link issued with an empty scope is global and
+// redeems in any tenant context — a hook that wants to forbid global
+// issuance returns an error when ctx lacks a tenant. White-label callers
+// pass the tenant's domain as IssueURL's base argument:
+//
+//	invites, err := magiclink.New[InviteClaims](key, "invite",
+//		magiclink.WithStore(store),
+//		magiclink.WithScope(func(ctx context.Context) (string, error) {
+//			return tenant.FromContext(ctx), nil // "" = global link
+//		}),
+//	)
+//	url, err := invites.IssueURL(ctx, "https://acme.example.com/join",
+//		InviteClaims{Email: "new@hire.com", Role: "admin"})
+package magiclink
+```
+
+- [ ] **Step 2: Write benchmarks**
+
+Create `auth/magiclink/bench_test.go`:
+
+```go
+package magiclink_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/magiclink"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+func BenchmarkIssue(b *testing.B) {
+	m, err := magiclink.New[loginClaims](testKey, "bench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := m.Issue(ctx, loginClaims{UserID: "u_1"}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPeek(b *testing.B) {
+	m, err := magiclink.New[loginClaims](testKey, "bench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	link, err := m.Issue(ctx, loginClaims{UserID: "u_1"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := m.Peek(ctx, link); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRedeemSingleUse(b *testing.B) {
+	store := cache.NewMemoryStore()
+	defer func() { _ = store.Close() }()
+	m, err := magiclink.New[loginClaims](testKey, "bench", magiclink.WithStore(store))
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		b.StopTimer()
+		link, err := m.Issue(ctx, loginClaims{UserID: "u_1"})
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		if _, err := m.Redeem(ctx, link); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Run benchmarks**
+
+Run: `just bench ./auth/magiclink`
+Expected: three benchmarks complete with ns/op and allocs/op reported. Record the numbers — they go in the PR description (repo rule: every package ships benchmarks with a post-benchmark optimization pass; before/after numbers in the PR). If allocs/op looks pathological (hundreds per op), investigate before committing; JSON+HMAC costs some allocation, so single-digit-to-low-tens is acceptable here.
+
+- [ ] **Step 4: Delete the roadmap entry**
+
+The catalog lists only unbuilt packages (design.md: "the moment a package ships, delete its entry"). In `docs/packages.md`, delete the **auth/magiclink** block — the heading, body, deps line, and its trailing `---` separator (currently around lines 679–688):
+
+```markdown
+**auth/magiclink**
+
+Signed, TTL'd, single-use links over `crypto/token`: passwordless login,
+team invites (role/tenant claims as a documented example), verify and
+unsubscribe links. Stateless by default; `WithStore` for single-use
+redemption. Does not send email.
+
+Deps: `crypto/token`, `resilience/cache`.
+
+---
+```
+
+Leave the unrelated mention of `magiclink` near line 87 (another package's "Not `magiclink`..." contrast line) untouched.
+
+- [ ] **Step 5: Full verification**
+
+```bash
+just fmt ./auth/magiclink
+just lint
+just test ./auth/magiclink
+```
+
+Expected: fmt clean, lint reports no issues for `auth/magiclink` (pre-existing issues elsewhere in the repo, if any, are out of scope), all tests pass race-clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add auth/magiclink/ docs/packages.md
+git commit -m "docs(magiclink): package docs, benchmarks; drop shipped roadmap entry"
+```

--- a/docs/superpowers/specs/2026-07-13-auth-magiclink-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-magiclink-design.md
@@ -1,0 +1,235 @@
+# auth/magiclink — Design
+
+Signed, TTL'd, single-use links over `crypto/token`: passwordless login, team
+invites, verify and unsubscribe links. Stateless by default; `WithStore`
+enables single-use redemption. Does not send email.
+
+Deps: `crypto/token`, `resilience/cache` (Store seam only — no driver
+imports). Also imported for API types surfaced by pass-through options:
+`crypto/keyset`, `crypto/secret`, `core/clock`.
+
+## Architecture
+
+A thin generic layer over `crypto/token`. The manager wraps the consumer's
+payload in its own envelope `{scope, payload}`, delegates
+sign/encrypt/TTL/purpose enforcement to `token.Codec[envelope[T]]`, and adds
+three things on top:
+
+1. **Single-use redemption** — atomic `SetNX` claim on the
+   `resilience/cache.Store` seam.
+2. **Tenant scope binding** — the forge-wide `WithScope(ctx)` hook pattern,
+   fail-closed.
+3. **URL construction** — optional convenience for turning tokens into
+   drop-in-an-email links.
+
+Rejected alternatives:
+
+- **Self-contained token format** — duplicates `crypto/token`, violates the
+  catalog's pinned deps.
+- **Extending `crypto/token` with jti/scope** — leaks auth concerns into a
+  crypto brick; magiclink's envelope wrapper achieves the same without
+  touching the brick.
+- **HTTP surface (`FromRequest`, handlers, middleware)** — explicitly
+  excluded (user decision). Consumers extract the token themselves
+  (`r.URL.Query().Get("token")`); the two-step flow is a documented recipe,
+  not shipped handlers. Session creation and redirects are consumer domain.
+
+## API surface
+
+```go
+// Purpose is positional and required: two managers with the same key but
+// different flows must never accept each other's tokens. Empty purpose is a
+// constructor error.
+func New[T any](key []byte, purpose string, opts ...Option) (*Manager[T], error)
+func FromKeyset[T any](ks *keyset.Keyset, purpose string, opts ...Option) (*Manager[T], error)
+
+// Options
+WithTTL(d time.Duration)                        // default 15m; d <= 0 is a constructor error
+WithStore(s cache.Store)                        // enables single-use redemption; nil is a constructor error
+WithScope(fn func(context.Context) (string, error)) // tenancy hook; nil is a constructor error
+WithBaseURL(u string)                           // default base for the single-domain case
+WithParam(name string)                          // query param name, default "token"
+WithEncrypt(box *secret.Box)                    // pass-through: hide payload (PII) from the URL
+WithClock(c clock.Clock)                        // pass-through, tests; nil is a constructor error
+
+// Core
+func (m *Manager[T]) Issue(ctx context.Context, payload T) (string, error)
+func (m *Manager[T]) IssueURL(ctx context.Context, base string, payload T) (string, error)
+func (m *Manager[T]) Peek(ctx context.Context, token string) (T, error)   // non-consuming
+func (m *Manager[T]) Redeem(ctx context.Context, token string) (T, error) // consuming
+```
+
+- `Issue` takes `ctx` because the scope hook reads tenant identity from it.
+- `IssueURL`: per-call `base` wins; empty base falls back to `WithBaseURL`;
+  both empty → error. The token is appended as a query parameter via
+  `url.Parse`, preserving any existing query on the base.
+- The envelope is internal and becomes the codec's payload type:
+
+  ```go
+  type envelope[T any] struct {
+      Scope   string `json:"scp,omitempty"`
+      Payload T      `json:"pld"`
+  }
+  ```
+
+## Tenancy — scope binding
+
+Works single- and multi-tenant per the forge-wide rule: optional
+construction-time hook, fail-closed, zero ceremony single-tenant. Payload
+claims (tenant ID, role) are the consumer's data; the scope hook is the
+enforcement boundary — they are orthogonal.
+
+- **Issue**: hook resolves `(scope, error)` from ctx. Error aborts issuance.
+  Empty scope = deliberately global link (a hook that wants to forbid global
+  issuance returns an error when ctx lacks a tenant).
+- **Redeem/Peek**: scope is recomputed from the incoming ctx and matched
+  against the token's stamped scope.
+
+Matching (one rule, no special cases):
+
+| token scope | ctx scope    | result           |
+|-------------|--------------|------------------|
+| `""`        | anything     | valid (global link, usable while switching tenants) |
+| `"acme"`    | `"acme"`     | valid            |
+| `"acme"`    | other / `""` | `ErrScopeMismatch` |
+
+No hook configured means ctx scope is always `""`, so a scoped token hitting
+an unscoped manager is rejected automatically — config drift fails closed.
+
+## Redemption semantics
+
+Verification order (shared by Peek/Redeem): **codec parse first** —
+constant-time signature check, decrypt, expiry, purpose — so junk tokens are
+rejected before any store I/O (cheap HMAC rejection; no store DoS). Then
+scope check. Then store.
+
+- **Redeem** (with store): `SetNX(key, 0x1, TTL=linkTTL)`; `cache.ErrExists`
+  ⇒ `ErrUsed`. Atomicity comes from the store's `SetNX` — two concurrent
+  redeems, exactly one wins, no locks. Any other store error ⇒ `ErrStore`
+  (fail-closed).
+- **Peek**: best-effort `Has(key)` ⇒ `ErrUsed` for the "already used" page;
+  non-atomic is fine because the consuming POST is authoritative. A store
+  error during Peek's Has is also `ErrStore` (fail-closed).
+- **Stateless mode** (no `WithStore`): `Redeem` ≡ verify-only, multi-use by
+  design — documented as suited to unsubscribe/verify flows where replay is
+  harmless.
+- **Store key**: `magiclink:<purpose>:<base64url(sha256(token))>`. Token
+  hash because `crypto/token` does not expose its nonce; the hash is
+  globally unique, so scope is not needed in the key. The entry may outlive
+  the token by up to one TTL — harmless, the token expires first.
+- **Memory-store caveat** (doc.go): the LRU memory store can evict live
+  keys; production single-use needs `cache/redis` or a durable Store.
+
+## TTL policy
+
+Default 15 minutes. TTL is mandatory: `WithTTL(d <= 0)` is a constructor
+error. Never-expiring magic links are a footgun and would leak store
+entries.
+
+## Errors
+
+`errors.Is`-matchable single-line sentinels in `errors.go`:
+
+- `ErrInvalid` — bad signature, malformed, or wrong purpose. Mapped from
+  `crypto/token` errors and joined (`errors.Join`) so the underlying cause
+  stays inspectable for logs without consumers importing `crypto/token`.
+- `ErrExpired` — mapped from `token.ErrExpired`; distinct because the UX
+  differs ("request a new link").
+- `ErrUsed` — single-use claim already taken.
+- `ErrScopeMismatch` — token scope does not match redeem context.
+- `ErrStore` — store failure during Peek/Redeem; fail-closed, consumer
+  treats as 500.
+
+Constructor misuse (empty purpose, non-positive TTL, nil store/hook/clock)
+returns plain errors from `New`/`FromKeyset`, collected via `errors.Join`
+(mirrors `crypto/token`'s option-error pattern).
+
+## Package anatomy
+
+`auth/magiclink`, single package, no subpackages, ~350–450 LOC:
+
+- `doc.go` — runnable example: passwordless login with the two-step
+  scanner-safe recipe (GET → Peek → confirm button; POST → Redeem), the
+  multi-tenant invite variant with `WithScope`, memory-store caveat, "does
+  not send email" statement.
+- `options.go` — `type Option func(*config)`, option errors collected.
+- `errors.go` — sentinels above.
+- `magiclink.go` — Manager, envelope, Issue/IssueURL/Peek/Redeem.
+- `magiclink_test.go` — black-box tests.
+- `bench_test.go` — benchmarks (repo rule).
+
+## Usage example (abridged; full version in doc.go)
+
+```go
+type LoginClaims struct {
+	UserID string `json:"uid"`
+	Email  string `json:"eml"`
+}
+
+links, err := magiclink.New[LoginClaims](cfg.MagicLinkKey, "login",
+	magiclink.WithTTL(15*time.Minute),
+	magiclink.WithStore(redisStore),
+	magiclink.WithBaseURL("https://app.example.com/auth/verify"),
+)
+
+// Request: issue and email the link (sending is the consumer's job).
+url, _ := links.IssueURL(r.Context(), "", LoginClaims{UserID: u.ID, Email: u.Email})
+
+// GET /auth/verify?token=... — Peek verifies without consuming, so email
+// scanners that prefetch the URL cannot burn the link.
+claims, err := links.Peek(r.Context(), r.URL.Query().Get("token"))
+
+// POST /auth/verify — Redeem atomically claims single-use.
+claims, err = links.Redeem(r.Context(), r.FormValue("token"))
+```
+
+Multi-tenant white-label:
+
+```go
+invites, _ := magiclink.New[InviteClaims](key, "invite",
+	magiclink.WithStore(redisStore),
+	magiclink.WithScope(func(ctx context.Context) (string, error) {
+		return tenant.FromContext(ctx), nil // "" when issued from global context
+	}),
+)
+url, _ := invites.IssueURL(ctx, "https://acme.example.com/join",
+	InviteClaims{Email: "new@hire.com", Role: "admin"})
+```
+
+## Testing
+
+Black-box (`package magiclink_test`):
+
+- Issue → Redeem happy path; payload round-trip.
+- Double redeem → `ErrUsed`; concurrent redeem race (N goroutines, exactly
+  one winner).
+- Peek non-consuming (Redeem still succeeds after); Peek after Redeem →
+  `ErrUsed`.
+- Stateless mode: repeated Redeem succeeds.
+- Expiry via `clock.Mock` advance → `ErrExpired`.
+- Cross-purpose rejection: token from manager A fails on manager B →
+  `ErrInvalid`.
+- Tampered token → `ErrInvalid`.
+- Scope matrix: global-in-tenant OK; tenant-in-same-tenant OK;
+  tenant-in-other-tenant → `ErrScopeMismatch`; tenant-in-global →
+  `ErrScopeMismatch`; hook error propagates at issue and at redeem.
+- URL building: per-call base; default base; both empty → error; base with
+  existing query preserved; `WithParam` rename.
+- `WithEncrypt` round-trip.
+- Store failure fail-closed via an erroring `cache.Store` fake →
+  `ErrStore`.
+
+Benchmarks (`bench_test.go`): `Issue`, `Redeem` — allocation-conscious per
+design.md; before/after numbers in the PR.
+
+## Decisions log
+
+| Decision | Choice | Why |
+|----------|--------|-----|
+| URL building | Layered: core = tokens, URL optional with per-call base | White-label needs per-tenant bases; single-domain gets `WithBaseURL` |
+| Tenancy | Payload claims (data) + `WithScope` hook (enforcement) | Forge-wide pattern; consumers can't forget the check |
+| Redemption | `Peek` + `Redeem` | Email scanners prefetch links; two-step recipe is the production-safe default |
+| Stateless `Redeem` | Succeeds, multi-use, documented | Unsubscribe/verify links are legit stateless; ceremony buys nothing |
+| HTTP surface | None | User decision; extraction is one line, flows are consumer domain |
+| Purpose | Required positional arg | Cross-flow token confusion is a security bug, not a config nicety |
+| TTL | Mandatory, default 15m | Never-expiring links are a footgun; store entries must expire |


### PR DESCRIPTION
## auth/magiclink

Signed, TTL'd, optionally single-use magic links — passwordless login, team invites, email verify/unsubscribe — as a thin generic `Manager[T]` over `crypto/token` and the `resilience/cache.Store` seam. Does not send email; delivery is the caller's channel.

### What's included

- **Stateless core** over `crypto/token`: `Issue`/`Peek`/`Redeem`, purpose-bound (cross-purpose links rejected), `WithEncrypt` to hide PII in the URL, keyset-rotation aware via `FromKeyset`. Without a store a link verifies until TTL and is multi-use (fine for unsubscribe/verify).
- **Single-use redemption** (`WithStore`): atomic `SetNX` claim over `cache.Store`; first `Redeem` wins, replays return `ErrUsed`, store failures fail closed with `ErrStore`. Signature verification precedes all store I/O, and the claim TTL tracks the link's remaining lifetime (never shorter than the token's verifiable window) rather than pinning a full TTL.
- **Fail-closed tenant scope** (`WithScope`): the scope resolved from `ctx` is stamped into the *signed* envelope; `Peek`/`Redeem` recompute and reject a mismatch with `ErrScopeMismatch`. Empty scope = global link; config drift (scoped token → hook-less manager) fails closed. Scope is checked before the single-use claim, so a wrong-tenant attempt can't burn the link.
- **URL construction**: `IssueURL` with per-call base for white-label domains (`WithBaseURL` default, `WithParam` for the query key); existing query params preserved; non-absolute bases rejected.
- `doc.go` with usage examples; roadmap entry removed from `docs/packages.md`.

Sentinels (all `errors.Is`-matchable): `ErrInvalid`, `ErrExpired`, `ErrUsed`, `ErrScopeMismatch`, `ErrStore`.

### Design notes

- **Scanner-safe**: serve GET with `Peek` (verifies, does not consume) so email scanners that prefetch links can't burn them; consume with `Redeem` on POST.
- **Defense-in-depth**: `Peek`/`Redeem` reject links over a generous default cap (8192 bytes, tunable via `WithMaxTokenLength`) before any base64/JSON/HMAC work, so a forgotten HTTP-layer size limit can't become cheap CPU abuse.
- Bundled memory store is best-effort for single-use (can evict live keys and needs `cache.WithCleanupInterval` to reclaim one-time claims) — production single-use should use redis or another durable Store; documented on `WithStore`.

### Benchmarks

No optimization pass was warranted — magic-link issue/redeem is an auth flow, not a per-request hot path, and allocations are inherent to JSON+HMAC (repo rule: optimize only proven-hot paths).

```
BenchmarkIssue-14              1423905      835.8 ns/op   1336 B/op   17 allocs/op
BenchmarkPeek-14                552830      2200   ns/op   2256 B/op   34 allocs/op
BenchmarkRedeemSingleUse-14     188766      6391   ns/op   2922 B/op   45 allocs/op
```

(`RedeemSingleUse` B/op rose ~84 bytes for the new expiry stamp in single-use tokens; alloc counts are unchanged.)

### Test plan

- `just test ./auth/magiclink` — race-clean, **98.4%** coverage. Covers: stateless round-trip, expiry, tampered/malformed/cross-purpose rejection, encrypted-payload hiding, keyset rotation, single-use redeem, Peek non-consumption, 32-goroutine concurrent single-winner (under `-race`), fail-closed store errors, junk-before-store, scope matrix (global/scoped/mismatch/drift), scope-hook error propagation, `IssueURL` base fallback/precedence/query-preservation/param-rename, and bad-base + relative-base + scope-hook error paths.
- `just lint` — 0 issues repo-wide (golangci-lint, modernize, betteralign, nilaway).

### Review

Built task-by-task with a spec+quality review after each task and a whole-branch review at the end. The review loop caught and fixed: a `waitgroupgo` modernize miss in a test, an `IssueURL` error-path coverage gap, and three whole-branch findings — most notably `WithBaseURL`/`IssueURL` silently accepting scheme-less relative bases (which produced broken relative magic links), now rejected with tests. Whole-branch verdict: ready to merge, 0 Critical / 0 Important. Post-PR, Claude's review added three nit/minor/informational notes; the duplicated absolute-URL check was factored into a shared `parseAbsoluteURL` helper, the other two deferred with rationale on the threads.
