### PR TITLE
feat(apikey): Stripe-style API keys with Store seam, guard.Verifier, and Postgres driver

### DIFF
--- a/auth/apikey/apikey.go
+++ b/auth/apikey/apikey.go
@@ -1,0 +1,43 @@
+package apikey
+
+import (
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Key is the stored API-key record. It never contains the plaintext
+// secret: Hash is the hex SHA-256 of the full plaintext and Preview its
+// first 12 characters for dashboard display.
+type Key struct {
+	CreatedAt  time.Time
+	ExpiresAt  time.Time         // zero = never expires
+	LastUsedAt time.Time         // zero = never used
+	RevokedAt  time.Time         // zero = active
+	Meta       map[string]string // caller extras, copied into Identity.Meta on verify
+	Hash       string            // hex SHA-256 of the full plaintext key
+	Preview    string            // first 12 plaintext chars — safe to display
+	Name       string            // human label
+	Subject    string            // principal the key acts as — never empty
+	Tenant     string            // owning tenant; empty in single-tenant apps
+	Scopes     []string          // carried into Identity.Scopes; never enforced here
+	ID         id.UUID           // UUIDv7 record id — time-ordered, never secret-derived
+}
+
+// CreateParams describes a key to mint. Subject is required: for personal
+// keys it is the user id; for tenant-wide keys, whatever principal
+// represents the org acting as itself (tenant id or a service-account id).
+type CreateParams struct {
+	ExpiresAt time.Time // zero = never
+	Meta      map[string]string
+	Name      string
+	Subject   string // required
+	Tenant    string // optional; constrained by the WithScope hook when set
+	Scopes    []string
+}
+
+// Filter narrows List results. Zero fields match everything.
+type Filter struct {
+	Subject string
+	Tenant  string
+}

--- a/auth/apikey/apikey.go
+++ b/auth/apikey/apikey.go
@@ -11,17 +11,22 @@ import (
 // first 12 characters for dashboard display.
 type Key struct {
 	CreatedAt  time.Time
-	ExpiresAt  time.Time         // zero = never expires
-	LastUsedAt time.Time         // zero = never used
-	RevokedAt  time.Time         // zero = active
-	Meta       map[string]string // caller extras, copied into Identity.Meta on verify
-	Hash       string            // hex SHA-256 of the full plaintext key
-	Preview    string            // first 12 plaintext chars — safe to display
-	Name       string            // human label
-	Subject    string            // principal the key acts as — never empty
-	Tenant     string            // owning tenant; empty in single-tenant apps
-	Scopes     []string          // carried into Identity.Scopes; never enforced here
-	ID         id.UUID           // UUIDv7 record id — time-ordered, never secret-derived
+	ExpiresAt  time.Time // zero = never expires
+	LastUsedAt time.Time // zero = never used
+	RevokedAt  time.Time // zero = active
+	// Meta holds caller extras, copied into Identity.Meta on verify. The
+	// keys "key_id" and "key_name" are reserved: Verify always sets
+	// Identity.Meta["key_id"] and, when Name is non-empty,
+	// Identity.Meta["key_name"], overriding any stored value under those
+	// same keys.
+	Meta    map[string]string
+	Hash    string   // hex SHA-256 of the full plaintext key
+	Preview string   // first 12 plaintext chars — safe to display
+	Name    string   // human label
+	Subject string   // principal the key acts as — never empty
+	Tenant  string   // owning tenant; empty in single-tenant apps
+	Scopes  []string // carried into Identity.Scopes; never enforced here
+	ID      id.UUID  // UUIDv7 record id — time-ordered, never secret-derived
 }
 
 // CreateParams describes a key to mint. Subject is required: for personal

--- a/auth/apikey/bench_test.go
+++ b/auth/apikey/bench_test.go
@@ -1,0 +1,53 @@
+package apikey_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+)
+
+func BenchmarkCreate(b *testing.B) {
+	mgr := apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("sk_live"))
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, _, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyHit(b *testing.B) {
+	// Touch disabled: measures the steady-state verify path.
+	mgr := apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("sk_live"), apikey.WithTouchInterval(-1))
+	ctx := context.Background()
+	_, plaintext, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Verify(ctx, plaintext); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyMalformedReject(b *testing.B) {
+	// The DoS-relevant path: checksum rejection without store access.
+	// Target: zero allocations.
+	mgr := apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("sk_live"))
+	ctx := context.Background()
+	_, plaintext, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	bad := plaintext[:len(plaintext)-1] + "!"
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Verify(ctx, bad); err == nil {
+			b.Fatal("expected rejection")
+		}
+	}
+}

--- a/auth/apikey/doc.go
+++ b/auth/apikey/doc.go
@@ -1,0 +1,42 @@
+// Package apikey issues, manages, and verifies API keys: Stripe-style
+// prefixed secrets (sk_live_x7Kp…) with a CRC32 checksum that rejects
+// malformed credentials before any store access, SHA-256 hashes at rest,
+// and the plaintext returned exactly once at creation. Management —
+// create/list/revoke/rotate, per-key scopes, optional expiry, throttled
+// last-used-at — runs behind the storage-agnostic Store seam;
+// verification implements guard.Verifier.
+//
+// Personal and tenant-wide keys share one model: Subject is the principal
+// the key acts as — a user id for personal keys, or a tenant or
+// service-account id for keys owned by the org itself — and Tenant
+// optionally pins the owning org.
+//
+//	store := apikey.NewMemoryStore() // pgstore.New(pool) in production
+//	mgr := apikey.New(store, apikey.WithPrefix("sk_live"))
+//
+//	key, plaintext, err := mgr.Create(ctx, apikey.CreateParams{
+//		Subject: "user_42", Tenant: "org_7", Name: "CI deploy",
+//		Scopes:  []string{"deploy:write"},
+//	})
+//	// Show plaintext once; key.Preview ("sk_live_x7Kp") is what
+//	// dashboards keep. Only the SHA-256 of the plaintext is stored.
+//
+//	authn := guard.New(mgr, guard.WithExtractors(guard.BearerHeader(), guard.Header("X-API-Key")))
+//	mux.Handle("POST /api/deploy", authn(deployHandler))
+//
+// Scopes are carried into guard.Identity.Scopes but never enforced here —
+// enforcement belongs to the authorization seam (auth/rbac).
+//
+// Multi-tenant applications confine management operations with WithScope;
+// verification needs no hook because the key record itself resolves the
+// tenant:
+//
+//	mgr := apikey.New(store, apikey.WithScope(func(ctx context.Context) (string, error) {
+//		return tenantFromCtx(ctx), nil // fail-closed: empty or error aborts
+//	}))
+//
+// Rotation overlaps old and new keys so consumers can deploy the new
+// plaintext before the old one dies:
+//
+//	fresh, plaintext, err := mgr.Rotate(ctx, key.ID, 24*time.Hour)
+package apikey

--- a/auth/apikey/errors.go
+++ b/auth/apikey/errors.go
@@ -1,0 +1,38 @@
+package apikey
+
+import "errors"
+
+var (
+	// ErrNotFound is returned by a Store when no record matches, and by
+	// management operations for other tenants' keys under WithScope (so
+	// cross-tenant existence cannot be probed).
+	ErrNotFound = errors.New("apikey: record not found")
+
+	// ErrDuplicate is returned by Store.Create when a record with the same
+	// ID or Hash already exists.
+	ErrDuplicate = errors.New("apikey: duplicate record")
+
+	// ErrMalformedKey rejects credentials failing prefix/length/checksum
+	// validation — decided before any store access.
+	ErrMalformedKey = errors.New("apikey: malformed key")
+
+	// ErrKeyNotFound rejects well-formed credentials with no matching record.
+	ErrKeyNotFound = errors.New("apikey: key not found")
+
+	// ErrKeyRevoked rejects credentials of revoked keys.
+	ErrKeyRevoked = errors.New("apikey: key revoked")
+
+	// ErrKeyExpired rejects credentials of expired keys.
+	ErrKeyExpired = errors.New("apikey: key expired")
+
+	// ErrSubjectRequired rejects CreateParams with an empty Subject.
+	ErrSubjectRequired = errors.New("apikey: subject required")
+
+	// ErrTenantMismatch rejects management calls whose explicit tenant
+	// conflicts with the WithScope-derived tenant.
+	ErrTenantMismatch = errors.New("apikey: tenant mismatch")
+
+	// ErrScope fails management operations closed when the WithScope hook
+	// errors or yields an empty tenant.
+	ErrScope = errors.New("apikey: tenant scope unavailable")
+)

--- a/auth/apikey/fuzz_test.go
+++ b/auth/apikey/fuzz_test.go
@@ -1,0 +1,38 @@
+package apikey_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+)
+
+// FuzzVerify asserts the core property: no input other than the real
+// plaintext ever authenticates, and no input panics the parser.
+func FuzzVerify(f *testing.F) {
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store, apikey.WithPrefix("sk"))
+	_, plaintext, err := mgr.Create(context.Background(), apikey.CreateParams{Subject: "u1"})
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	f.Add(plaintext)
+	f.Add("")
+	f.Add("sk_")
+	f.Add("sk_" + strings.Repeat("a", 49))
+	f.Add(plaintext[:len(plaintext)-1] + "!")
+
+	f.Fuzz(func(t *testing.T, cred string) {
+		identity, err := mgr.Verify(context.Background(), cred)
+		if err == nil {
+			if cred != plaintext {
+				t.Fatalf("accepted forged credential %q", cred)
+			}
+			if identity.Subject != "u1" {
+				t.Fatalf("wrong subject %q", identity.Subject)
+			}
+		}
+	})
+}

--- a/auth/apikey/integration_test.go
+++ b/auth/apikey/integration_test.go
@@ -1,0 +1,65 @@
+package apikey_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+func TestGuardIntegration(t *testing.T) {
+	t.Parallel()
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store, apikey.WithPrefix("sk_live"))
+	ctx := context.Background()
+	k, plaintext, err := mgr.Create(ctx, apikey.CreateParams{Subject: "user_42", Tenant: "org_7"})
+	require.NoError(t, err)
+
+	authn := guard.New(mgr, guard.WithExtractors(guard.BearerHeader(), guard.Header("X-API-Key")))
+	handler := authn(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity := guard.MustFrom(r.Context())
+		w.Header().Set("X-Subject", identity.Subject)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	do := func(mutate func(*http.Request)) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api", nil)
+		mutate(req)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("no credential 401", func(t *testing.T) {
+		rec := do(func(*http.Request) {})
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("bearer 200", func(t *testing.T) {
+		rec := do(func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+plaintext) })
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "user_42", rec.Header().Get("X-Subject"))
+	})
+
+	t.Run("X-API-Key 200", func(t *testing.T) {
+		rec := do(func(r *http.Request) { r.Header.Set("X-API-Key", plaintext) })
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("garbage 401", func(t *testing.T) {
+		rec := do(func(r *http.Request) { r.Header.Set("X-API-Key", "sk_live_garbage") })
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("revoked 401", func(t *testing.T) {
+		require.NoError(t, mgr.Revoke(ctx, k.ID))
+		rec := do(func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+plaintext) })
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+}

--- a/auth/apikey/keygen.go
+++ b/auth/apikey/keygen.go
@@ -27,8 +27,22 @@ func newKey(prefix string) string {
 	b.WriteString(prefix)
 	b.WriteByte('_')
 	b.WriteString(payload)
-	b.WriteString(encodeChecksum(crc32.ChecksumIEEE([]byte(payload))))
+	b.WriteString(encodeChecksum(crc32String(payload)))
 	return b.String()
+}
+
+// crc32String computes the IEEE CRC32 of s without allocating. The
+// []byte(s) conversion crc32.ChecksumIEEE requires escapes to the heap
+// through the hardware-accelerated path, so validKey — the DoS-relevant
+// reject surface — computes the checksum over the string bytes directly
+// via the standard table-driven update. The result is identical to
+// crc32.ChecksumIEEE (same IEEE polynomial).
+func crc32String(s string) uint32 {
+	crc := ^uint32(0)
+	for i := range len(s) {
+		crc = crc32.IEEETable[byte(crc)^s[i]] ^ (crc >> 8)
+	}
+	return ^crc
 }
 
 // encodeChecksum renders v as fixed-width base62, most significant first.
@@ -44,10 +58,11 @@ func encodeChecksum(v uint32) string {
 // validKey reports whether credential is structurally valid for prefix:
 // exact length, prefix match, and payload CRC32 matching the checksum
 // suffix. CRC32 detects any burst error up to 32 bits, so every
-// single-character corruption is caught. The checksum is compared in
-// place (no encodeChecksum string) to keep this reject path
-// allocation-free — it is the DoS-relevant surface that shields the
-// store from credential-stuffing garbage.
+// single-character corruption is caught. The checksum is computed over the
+// string bytes directly (crc32String) and compared in place (no
+// encodeChecksum string) to keep this reject path allocation-free — it is
+// the DoS-relevant surface that shields the store from credential-stuffing
+// garbage.
 func validKey(prefix, credential string) bool {
 	wantLen := len(prefix) + 1 + payloadLen + checksumLen
 	if len(credential) != wantLen {
@@ -57,7 +72,7 @@ func validKey(prefix, credential string) bool {
 		return false
 	}
 	payload := credential[len(prefix)+1 : wantLen-checksumLen]
-	sum := crc32.ChecksumIEEE([]byte(payload))
+	sum := crc32String(payload)
 	suffix := credential[wantLen-checksumLen:]
 	for i := checksumLen - 1; i >= 0; i-- {
 		if suffix[i] != base62[sum%62] {

--- a/auth/apikey/keygen.go
+++ b/auth/apikey/keygen.go
@@ -1,0 +1,91 @@
+package apikey
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash/crc32"
+	"strings"
+
+	"github.com/dmitrymomot/forge/core/random"
+)
+
+const (
+	payloadLen  = 43 // base62 chars ≈ 256 bits of entropy
+	checksumLen = 6  // fixed-width base62 CRC32 (62^6 > 2^32)
+	previewLen  = 12
+)
+
+// base62 is the checksum alphabet. The payload draws from the same 62
+// characters via random.String's default Alphanumeric set.
+const base62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// newKey mints a plaintext key: <prefix>_<payload><checksum>.
+func newKey(prefix string) string {
+	payload := random.String(payloadLen)
+	var b strings.Builder
+	b.Grow(len(prefix) + 1 + payloadLen + checksumLen)
+	b.WriteString(prefix)
+	b.WriteByte('_')
+	b.WriteString(payload)
+	b.WriteString(encodeChecksum(crc32.ChecksumIEEE([]byte(payload))))
+	return b.String()
+}
+
+// encodeChecksum renders v as fixed-width base62, most significant first.
+func encodeChecksum(v uint32) string {
+	var buf [checksumLen]byte
+	for i := checksumLen - 1; i >= 0; i-- {
+		buf[i] = base62[v%62]
+		v /= 62
+	}
+	return string(buf[:])
+}
+
+// validKey reports whether credential is structurally valid for prefix:
+// exact length, prefix match, and payload CRC32 matching the checksum
+// suffix. CRC32 detects any burst error up to 32 bits, so every
+// single-character corruption is caught. The checksum is compared in
+// place (no encodeChecksum string) to keep this reject path
+// allocation-free — it is the DoS-relevant surface that shields the
+// store from credential-stuffing garbage.
+func validKey(prefix, credential string) bool {
+	wantLen := len(prefix) + 1 + payloadLen + checksumLen
+	if len(credential) != wantLen {
+		return false
+	}
+	if credential[:len(prefix)] != prefix || credential[len(prefix)] != '_' {
+		return false
+	}
+	payload := credential[len(prefix)+1 : wantLen-checksumLen]
+	sum := crc32.ChecksumIEEE([]byte(payload))
+	suffix := credential[wantLen-checksumLen:]
+	for i := checksumLen - 1; i >= 0; i-- {
+		if suffix[i] != base62[sum%62] {
+			return false
+		}
+		sum /= 62
+	}
+	return true
+}
+
+// hashKey returns the hex SHA-256 of the full plaintext key — the stored
+// lookup hash. Unsalted is safe: the payload carries ~256 bits of entropy,
+// so preimage search is infeasible.
+func hashKey(credential string) string {
+	sum := sha256.Sum256([]byte(credential))
+	return hex.EncodeToString(sum[:])
+}
+
+// validPrefix reports whether p is non-empty [a-z0-9_]+.
+func validPrefix(p string) bool {
+	if p == "" {
+		return false
+	}
+	for i := range len(p) {
+		c := p[i]
+		if c != '_' && (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}

--- a/auth/apikey/manager.go
+++ b/auth/apikey/manager.go
@@ -39,6 +39,10 @@ func (m *Manager) Create(ctx context.Context, p CreateParams) (Key, string, erro
 	if p.Subject == "" {
 		return Key{}, "", ErrSubjectRequired
 	}
+	tenant, err := m.scoped(ctx, p.Tenant)
+	if err != nil {
+		return Key{}, "", err
+	}
 	plaintext := newKey(m.cfg.prefix)
 	k := Key{
 		ID:        id.NewUUID(),
@@ -46,7 +50,7 @@ func (m *Manager) Create(ctx context.Context, p CreateParams) (Key, string, erro
 		Preview:   plaintext[:previewLen],
 		Name:      p.Name,
 		Subject:   p.Subject,
-		Tenant:    p.Tenant,
+		Tenant:    tenant,
 		Scopes:    slices.Clone(p.Scopes),
 		Meta:      maps.Clone(p.Meta),
 		CreatedAt: time.Now().UTC(),
@@ -56,4 +60,95 @@ func (m *Manager) Create(ctx context.Context, p CreateParams) (Key, string, erro
 		return Key{}, "", fmt.Errorf("apikey: create: %w", err)
 	}
 	return k, plaintext, nil
+}
+
+// scoped resolves the tenant a management operation is confined to. With
+// no WithScope hook it passes the requested tenant through. Fail-closed:
+// hook errors and empty scoped tenants abort the operation with ErrScope;
+// an explicit requested tenant must be empty or equal to the scoped one.
+func (m *Manager) scoped(ctx context.Context, requested string) (string, error) {
+	if m.cfg.scope == nil {
+		return requested, nil
+	}
+	t, err := m.cfg.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrScope, err)
+	}
+	if t == "" {
+		return "", ErrScope
+	}
+	if requested != "" && requested != t {
+		return "", ErrTenantMismatch
+	}
+	return t, nil
+}
+
+// Get returns one key record. With WithScope configured, other tenants'
+// keys read as ErrNotFound so existence cannot be probed across tenants.
+func (m *Manager) Get(ctx context.Context, keyID id.UUID) (Key, error) {
+	tenant, err := m.scoped(ctx, "")
+	if err != nil {
+		return Key{}, err
+	}
+	k, err := m.store.Get(ctx, keyID)
+	if err != nil {
+		return Key{}, err
+	}
+	if m.cfg.scope != nil && k.Tenant != tenant {
+		return Key{}, ErrNotFound
+	}
+	return k, nil
+}
+
+// List returns keys matching f, newest first. With WithScope configured
+// the filter is confined to the scoped tenant.
+func (m *Manager) List(ctx context.Context, f Filter) ([]Key, error) {
+	tenant, err := m.scoped(ctx, f.Tenant)
+	if err != nil {
+		return nil, err
+	}
+	f.Tenant = tenant
+	return m.store.List(ctx, f)
+}
+
+// Revoke permanently disables a key. Revocation is terminal — a revoked
+// key cannot be un-revoked or rotated.
+func (m *Manager) Revoke(ctx context.Context, keyID id.UUID) error {
+	if _, err := m.Get(ctx, keyID); err != nil {
+		return err
+	}
+	return m.store.Revoke(ctx, keyID, time.Now().UTC())
+}
+
+// Rotate mints a replacement inheriting the old key's Subject, Tenant,
+// Scopes, Name, and Meta (not its expiry), and expires the old key after
+// grace (zero = immediate cutover). Both keys verify during the grace
+// window. The replacement is created before the old key is expired so a
+// failure cannot leave the caller without a working key.
+func (m *Manager) Rotate(ctx context.Context, keyID id.UUID, grace time.Duration) (Key, string, error) {
+	old, err := m.Get(ctx, keyID)
+	if err != nil {
+		return Key{}, "", err
+	}
+	now := time.Now().UTC()
+	if !old.RevokedAt.IsZero() {
+		return Key{}, "", ErrKeyRevoked
+	}
+	if !old.ExpiresAt.IsZero() && !old.ExpiresAt.After(now) {
+		return Key{}, "", ErrKeyExpired
+	}
+	replacement, plaintext, err := m.Create(ctx, CreateParams{
+		Name:    old.Name,
+		Subject: old.Subject,
+		Tenant:  old.Tenant,
+		Scopes:  old.Scopes,
+		Meta:    old.Meta,
+	})
+	if err != nil {
+		return Key{}, "", err
+	}
+	if err := m.store.Expire(ctx, old.ID, now.Add(grace)); err != nil {
+		return Key{}, "", fmt.Errorf("apikey: rotate: %w", err)
+	}
+	return replacement, plaintext, nil
 }

--- a/auth/apikey/manager.go
+++ b/auth/apikey/manager.go
@@ -148,6 +148,12 @@ func (m *Manager) Rotate(ctx context.Context, keyID id.UUID, grace time.Duration
 		return Key{}, "", err
 	}
 	if err := m.store.Expire(ctx, old.ID, now.Add(grace)); err != nil {
+		// The replacement is already persisted and its plaintext was never
+		// returned to the caller, so leaving it active would strand a live,
+		// unreferenceable key. Best-effort revoke it — the old key stays
+		// valid, so the caller keeps a working credential — before
+		// surfacing the failure.
+		_ = m.store.Revoke(ctx, replacement.ID, now)
 		return Key{}, "", fmt.Errorf("apikey: rotate: %w", err)
 	}
 	return replacement, plaintext, nil

--- a/auth/apikey/manager.go
+++ b/auth/apikey/manager.go
@@ -1,0 +1,59 @@
+package apikey
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Manager issues, manages, and verifies API keys over a Store. It
+// implements guard.Verifier. Safe for concurrent use.
+type Manager struct {
+	store Store
+	cfg   config
+}
+
+// New builds a Manager. It panics on a nil store or an invalid prefix —
+// wiring bugs caught at startup, like guard.New's nil-verifier panic.
+func New(store Store, opts ...Option) *Manager {
+	if store == nil {
+		panic("apikey: nil store")
+	}
+	cfg := config{prefix: "key", touchInterval: time.Minute}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if !validPrefix(cfg.prefix) {
+		panic(fmt.Sprintf("apikey: invalid prefix %q", cfg.prefix))
+	}
+	return &Manager{store: store, cfg: cfg}
+}
+
+// Create mints a key for p, returning the stored record and the plaintext.
+// The plaintext is shown exactly once — only its hash is persisted.
+func (m *Manager) Create(ctx context.Context, p CreateParams) (Key, string, error) {
+	if p.Subject == "" {
+		return Key{}, "", ErrSubjectRequired
+	}
+	plaintext := newKey(m.cfg.prefix)
+	k := Key{
+		ID:        id.NewUUID(),
+		Hash:      hashKey(plaintext),
+		Preview:   plaintext[:previewLen],
+		Name:      p.Name,
+		Subject:   p.Subject,
+		Tenant:    p.Tenant,
+		Scopes:    slices.Clone(p.Scopes),
+		Meta:      maps.Clone(p.Meta),
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: p.ExpiresAt,
+	}
+	if err := m.store.Create(ctx, k); err != nil {
+		return Key{}, "", fmt.Errorf("apikey: create: %w", err)
+	}
+	return k, plaintext, nil
+}

--- a/auth/apikey/manager_test.go
+++ b/auth/apikey/manager_test.go
@@ -2,6 +2,7 @@ package apikey_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -154,4 +155,53 @@ func TestRotate_DeadKeysRejected(t *testing.T) {
 	require.NoError(t, store.Expire(ctx, expired.ID, time.Now().UTC().Add(-time.Minute)))
 	_, _, err = mgr.Rotate(ctx, expired.ID, time.Hour)
 	assert.ErrorIs(t, err, apikey.ErrKeyExpired)
+}
+
+// errExpireBoom is a sentinel returned by expireFailStore.Expire, used to
+// prove Rotate compensates for the failure rather than stranding a live,
+// unreferenceable replacement key.
+var errExpireBoom = errors.New("expire boom")
+
+// expireFailStore wraps a real Store, always failing Expire, and records
+// the id passed to Revoke so the test can prove Rotate compensates the
+// freshly-minted replacement — never the old key, which must stay valid.
+type expireFailStore struct {
+	apikey.Store
+	revokedID id.UUID
+}
+
+func (s *expireFailStore) Expire(context.Context, id.UUID, time.Time) error {
+	return errExpireBoom
+}
+
+func (s *expireFailStore) Revoke(ctx context.Context, keyID id.UUID, at time.Time) error {
+	s.revokedID = keyID
+	return s.Store.Revoke(ctx, keyID, at)
+}
+
+func TestRotate_ExpireFailureRevokesReplacement(t *testing.T) {
+	t.Parallel()
+	mem := apikey.NewMemoryStore()
+	fake := &expireFailStore{Store: mem}
+	mgr := apikey.New(fake)
+	ctx := context.Background()
+
+	old, oldPlain, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+
+	_, _, err = mgr.Rotate(ctx, old.ID, time.Hour)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errExpireBoom)
+
+	// Availability: the old key is untouched and still verifies.
+	_, err = mgr.Verify(ctx, oldPlain)
+	require.NoError(t, err)
+
+	// Compensation ran on the replacement's id, not the old key's.
+	require.False(t, fake.revokedID.IsZero())
+	assert.NotEqual(t, old.ID, fake.revokedID)
+
+	replacement, err := mem.Get(ctx, fake.revokedID)
+	require.NoError(t, err)
+	assert.False(t, replacement.RevokedAt.IsZero())
 }

--- a/auth/apikey/manager_test.go
+++ b/auth/apikey/manager_test.go
@@ -1,0 +1,61 @@
+package apikey_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+)
+
+func TestNew_Panics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { apikey.New(nil) })
+	assert.Panics(t, func() { apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("")) })
+	assert.Panics(t, func() { apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("SK-Live")) })
+}
+
+func TestCreate_KeyAnatomy(t *testing.T) {
+	t.Parallel()
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store, apikey.WithPrefix("sk_live"))
+
+	k, plaintext, err := mgr.Create(context.Background(), apikey.CreateParams{
+		Subject: "user_42", Tenant: "org_7", Name: "CI deploy", Scopes: []string{"deploy:write"},
+	})
+	require.NoError(t, err)
+
+	// <prefix>_<43 payload><6 checksum>
+	assert.Len(t, plaintext, len("sk_live")+1+43+6)
+	assert.True(t, strings.HasPrefix(plaintext, "sk_live_"))
+	for _, c := range plaintext[len("sk_live_"):] {
+		assert.Contains(t, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", string(c))
+	}
+	assert.Equal(t, plaintext[:12], k.Preview)
+	assert.NotContains(t, k.Hash, plaintext[8:20]) // hash, not plaintext, at rest
+	assert.False(t, k.ID.IsZero())
+	assert.False(t, k.CreatedAt.IsZero())
+
+	stored, err := store.Get(context.Background(), k.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "user_42", stored.Subject)
+	assert.Equal(t, "org_7", stored.Tenant)
+}
+
+func TestCreate_SubjectRequired(t *testing.T) {
+	t.Parallel()
+	mgr := apikey.New(apikey.NewMemoryStore())
+	_, _, err := mgr.Create(context.Background(), apikey.CreateParams{})
+	assert.ErrorIs(t, err, apikey.ErrSubjectRequired)
+}
+
+func TestCreate_DefaultPrefix(t *testing.T) {
+	t.Parallel()
+	mgr := apikey.New(apikey.NewMemoryStore())
+	_, plaintext, err := mgr.Create(context.Background(), apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(plaintext, "key_"))
+}

--- a/auth/apikey/manager_test.go
+++ b/auth/apikey/manager_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dmitrymomot/forge/auth/apikey"
+	"github.com/dmitrymomot/forge/core/id"
 )
 
 func TestNew_Panics(t *testing.T) {
@@ -58,4 +60,98 @@ func TestCreate_DefaultPrefix(t *testing.T) {
 	_, plaintext, err := mgr.Create(context.Background(), apikey.CreateParams{Subject: "u1"})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(plaintext, "key_"))
+}
+
+func TestGetRevoke(t *testing.T) {
+	t.Parallel()
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store)
+	ctx := context.Background()
+	k, plaintext, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+
+	got, err := mgr.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "u1", got.Subject)
+
+	require.NoError(t, mgr.Revoke(ctx, k.ID))
+	got, err = mgr.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.False(t, got.RevokedAt.IsZero())
+
+	_, err = mgr.Verify(ctx, plaintext)
+	assert.ErrorIs(t, err, apikey.ErrKeyRevoked)
+
+	assert.ErrorIs(t, mgr.Revoke(ctx, id.UUID{15: 9}), apikey.ErrNotFound)
+}
+
+func TestRotate(t *testing.T) {
+	t.Parallel()
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store, apikey.WithPrefix("sk_live"))
+	ctx := context.Background()
+	old, oldPlain, err := mgr.Create(ctx, apikey.CreateParams{
+		Subject: "u1", Tenant: "t1", Name: "prod", Scopes: []string{"a"}, Meta: map[string]string{"m": "1"},
+	})
+	require.NoError(t, err)
+
+	grace := time.Hour
+	before := time.Now().UTC()
+	fresh, freshPlain, err := mgr.Rotate(ctx, old.ID, grace)
+	require.NoError(t, err)
+
+	// Inheritance.
+	assert.Equal(t, old.Subject, fresh.Subject)
+	assert.Equal(t, old.Tenant, fresh.Tenant)
+	assert.Equal(t, old.Name, fresh.Name)
+	assert.Equal(t, old.Scopes, fresh.Scopes)
+	assert.Equal(t, old.Meta, fresh.Meta)
+	assert.NotEqual(t, old.ID, fresh.ID)
+	assert.NotEqual(t, oldPlain, freshPlain)
+
+	// Overlap: both verify during grace.
+	_, err = mgr.Verify(ctx, oldPlain)
+	require.NoError(t, err)
+	_, err = mgr.Verify(ctx, freshPlain)
+	require.NoError(t, err)
+
+	// Old key's expiry ≈ now+grace.
+	oldStored, err := mgr.Get(ctx, old.ID)
+	require.NoError(t, err)
+	assert.WithinDuration(t, before.Add(grace), oldStored.ExpiresAt, 5*time.Second)
+}
+
+func TestRotate_ZeroGraceCutsOver(t *testing.T) {
+	t.Parallel()
+	mgr := apikey.New(apikey.NewMemoryStore())
+	ctx := context.Background()
+	old, oldPlain, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+
+	_, freshPlain, err := mgr.Rotate(ctx, old.ID, 0)
+	require.NoError(t, err)
+
+	_, err = mgr.Verify(ctx, oldPlain)
+	assert.ErrorIs(t, err, apikey.ErrKeyExpired)
+	_, err = mgr.Verify(ctx, freshPlain)
+	assert.NoError(t, err)
+}
+
+func TestRotate_DeadKeysRejected(t *testing.T) {
+	t.Parallel()
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store)
+	ctx := context.Background()
+
+	revoked, _, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+	require.NoError(t, mgr.Revoke(ctx, revoked.ID))
+	_, _, err = mgr.Rotate(ctx, revoked.ID, time.Hour)
+	assert.ErrorIs(t, err, apikey.ErrKeyRevoked)
+
+	expired, _, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u2"})
+	require.NoError(t, err)
+	require.NoError(t, store.Expire(ctx, expired.ID, time.Now().UTC().Add(-time.Minute)))
+	_, _, err = mgr.Rotate(ctx, expired.ID, time.Hour)
+	assert.ErrorIs(t, err, apikey.ErrKeyExpired)
 }

--- a/auth/apikey/memory.go
+++ b/auth/apikey/memory.go
@@ -1,0 +1,112 @@
+package apikey
+
+import (
+	"bytes"
+	"context"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+type memoryStore struct {
+	byID   map[id.UUID]Key
+	byHash map[string]id.UUID
+	mu     sync.RWMutex
+}
+
+// NewMemoryStore returns an in-memory Store for tests and development.
+func NewMemoryStore() Store {
+	return &memoryStore{
+		byID:   make(map[id.UUID]Key),
+		byHash: make(map[string]id.UUID),
+	}
+}
+
+// cloneKey copies the record's reference fields so callers cannot mutate
+// stored state through shared slices/maps (and vice versa).
+func cloneKey(k Key) Key {
+	k.Scopes = slices.Clone(k.Scopes)
+	k.Meta = maps.Clone(k.Meta)
+	return k
+}
+
+func (s *memoryStore) Create(_ context.Context, k Key) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.byID[k.ID]; ok {
+		return ErrDuplicate
+	}
+	if _, ok := s.byHash[k.Hash]; ok {
+		return ErrDuplicate
+	}
+	s.byID[k.ID] = cloneKey(k)
+	s.byHash[k.Hash] = k.ID
+	return nil
+}
+
+func (s *memoryStore) Get(_ context.Context, keyID id.UUID) (Key, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	k, ok := s.byID[keyID]
+	if !ok {
+		return Key{}, ErrNotFound
+	}
+	return cloneKey(k), nil
+}
+
+func (s *memoryStore) GetByHash(_ context.Context, hash string) (Key, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	keyID, ok := s.byHash[hash]
+	if !ok {
+		return Key{}, ErrNotFound
+	}
+	return cloneKey(s.byID[keyID]), nil
+}
+
+func (s *memoryStore) List(_ context.Context, f Filter) ([]Key, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Key, 0, len(s.byID))
+	for _, k := range s.byID {
+		if f.Subject != "" && k.Subject != f.Subject {
+			continue
+		}
+		if f.Tenant != "" && k.Tenant != f.Tenant {
+			continue
+		}
+		out = append(out, cloneKey(k))
+	}
+	// UUIDv7 ids are time-ordered, so byte-descending is newest first.
+	slices.SortFunc(out, func(a, b Key) int {
+		return bytes.Compare(b.ID[:], a.ID[:])
+	})
+	return out, nil
+}
+
+func (s *memoryStore) Revoke(_ context.Context, keyID id.UUID, at time.Time) error {
+	return s.update(keyID, func(k *Key) { k.RevokedAt = at })
+}
+
+func (s *memoryStore) Expire(_ context.Context, keyID id.UUID, at time.Time) error {
+	return s.update(keyID, func(k *Key) { k.ExpiresAt = at })
+}
+
+func (s *memoryStore) Touch(_ context.Context, keyID id.UUID, at time.Time) error {
+	return s.update(keyID, func(k *Key) { k.LastUsedAt = at })
+}
+
+func (s *memoryStore) update(keyID id.UUID, fn func(*Key)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k, ok := s.byID[keyID]
+	if !ok {
+		return ErrNotFound
+	}
+	fn(&k)
+	s.byID[keyID] = k
+	return nil
+}

--- a/auth/apikey/memory.go
+++ b/auth/apikey/memory.go
@@ -26,10 +26,19 @@ func NewMemoryStore() Store {
 }
 
 // cloneKey copies the record's reference fields so callers cannot mutate
-// stored state through shared slices/maps (and vice versa).
+// stored state through shared slices/maps (and vice versa). Nil Scopes and
+// Meta are normalized to non-nil empty values so this store matches the
+// pgstore driver, which persists them as empty text[]/jsonb: callers see the
+// same non-nil empties whichever Store backs the Manager.
 func cloneKey(k Key) Key {
 	k.Scopes = slices.Clone(k.Scopes)
+	if k.Scopes == nil {
+		k.Scopes = []string{}
+	}
 	k.Meta = maps.Clone(k.Meta)
+	if k.Meta == nil {
+		k.Meta = map[string]string{}
+	}
 	return k
 }
 

--- a/auth/apikey/options.go
+++ b/auth/apikey/options.go
@@ -1,0 +1,40 @@
+package apikey
+
+import (
+	"context"
+	"time"
+)
+
+type config struct {
+	scope         func(context.Context) (string, error)
+	prefix        string
+	touchInterval time.Duration
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithPrefix sets the key prefix (default "key"); keys read
+// <prefix>_<payload><checksum>. The prefix must match [a-z0-9_]+.
+// Environments are separate issuers: run one Manager with "sk_live" and
+// another with "sk_test".
+func WithPrefix(p string) Option {
+	return func(c *config) { c.prefix = p }
+}
+
+// WithScope derives the tenant from context for every management
+// operation: Create stamps it, List is confined to it, and
+// Get/Revoke/Rotate report ErrNotFound for other tenants' keys.
+// Fail-closed: a hook error or empty tenant fails the operation with
+// ErrScope. Verify is unaffected — the key record itself carries the
+// tenant. A nil fn leaves the manager unscoped.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) { c.scope = fn }
+}
+
+// WithTouchInterval throttles last-used-at writes: Verify touches the
+// record only when LastUsedAt is staler than d (default 60s). Zero
+// touches on every request; negative disables tracking.
+func WithTouchInterval(d time.Duration) Option {
+	return func(c *config) { c.touchInterval = d }
+}

--- a/auth/apikey/pgstore/doc.go
+++ b/auth/apikey/pgstore/doc.go
@@ -1,0 +1,10 @@
+// Package pgstore is the Postgres apikey.Store driver over pgx. The DDL
+// (forge_api_keys) ships as an embedded goose migration in Migrations;
+// apply it via data/migration under its own version table before first
+// use:
+//
+//	_ = migration.New(pgstore.Migrations, migration.WithTable("forge_apikey_schema")).Up(ctx, db)
+//
+// GetByHash — the verification hot path — is a single point lookup on the
+// unique hash index. Zero time.Time fields map to SQL NULL and back.
+package pgstore

--- a/auth/apikey/pgstore/migrations/00001_create_forge_api_keys.sql
+++ b/auth/apikey/pgstore/migrations/00001_create_forge_api_keys.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+CREATE TABLE forge_api_keys (
+    id           uuid PRIMARY KEY,
+    hash         text NOT NULL UNIQUE,
+    preview      text NOT NULL,
+    name         text NOT NULL DEFAULT '',
+    subject      text NOT NULL,
+    tenant       text NOT NULL DEFAULT '',
+    scopes       text[] NOT NULL DEFAULT '{}',
+    meta         jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at   timestamptz NOT NULL,
+    expires_at   timestamptz,
+    last_used_at timestamptz,
+    revoked_at   timestamptz
+);
+
+CREATE INDEX forge_api_keys_list_idx ON forge_api_keys (tenant, subject, id DESC);
+
+-- +goose Down
+DROP TABLE forge_api_keys;

--- a/auth/apikey/pgstore/pgstore.go
+++ b/auth/apikey/pgstore/pgstore.go
@@ -1,0 +1,167 @@
+package pgstore
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"io/fs"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_api_keys, rooted so
+// its .sql files sit at fsys root (data/migration.New globs fsys's root,
+// not subdirectories). Apply via data/migration under its own version
+// table ("forge_apikey_schema").
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// Store is the Postgres implementation of apikey.Store. The pool's
+// lifecycle is the caller's.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+var _ apikey.Store = (*Store)(nil)
+
+// New builds a Postgres apikey Store. Apply Migrations first.
+func New(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const cols = `id, hash, preview, name, subject, tenant, scopes, meta, created_at, expires_at, last_used_at, revoked_at`
+
+const createSQL = `
+INSERT INTO forge_api_keys (` + cols + `)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`
+
+// Create inserts k. A colliding id or hash yields apikey.ErrDuplicate.
+func (s *Store) Create(ctx context.Context, k apikey.Key) error {
+	scopes := k.Scopes
+	if scopes == nil {
+		scopes = []string{}
+	}
+	meta := k.Meta
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	_, err := s.pool.Exec(ctx, createSQL,
+		k.ID, k.Hash, k.Preview, k.Name, k.Subject, k.Tenant, scopes, meta,
+		k.CreatedAt, nullTime(k.ExpiresAt), nullTime(k.LastUsedAt), nullTime(k.RevokedAt))
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
+		return apikey.ErrDuplicate
+	}
+	return err
+}
+
+// Get returns the record for keyID, or apikey.ErrNotFound.
+func (s *Store) Get(ctx context.Context, keyID id.UUID) (apikey.Key, error) {
+	return scanKey(s.pool.QueryRow(ctx, `SELECT `+cols+` FROM forge_api_keys WHERE id = $1`, keyID))
+}
+
+// GetByHash returns the record whose hash matches, or apikey.ErrNotFound.
+// This is the verification hot path: one point lookup on the unique index.
+func (s *Store) GetByHash(ctx context.Context, hash string) (apikey.Key, error) {
+	return scanKey(s.pool.QueryRow(ctx, `SELECT `+cols+` FROM forge_api_keys WHERE hash = $1`, hash))
+}
+
+// List returns records matching f, newest first (UUIDv7 ids are
+// time-ordered, so id DESC is creation order).
+func (s *Store) List(ctx context.Context, f apikey.Filter) ([]apikey.Key, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+cols+` FROM forge_api_keys
+		 WHERE ($1 = '' OR tenant = $1) AND ($2 = '' OR subject = $2)
+		 ORDER BY id DESC`, f.Tenant, f.Subject)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []apikey.Key
+	for rows.Next() {
+		k, err := scanKey(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, k)
+	}
+	return out, rows.Err()
+}
+
+// Revoke sets revoked_at, or returns apikey.ErrNotFound.
+func (s *Store) Revoke(ctx context.Context, keyID id.UUID, at time.Time) error {
+	return s.setTime(ctx, `UPDATE forge_api_keys SET revoked_at = $2 WHERE id = $1`, keyID, at)
+}
+
+// Expire sets expires_at (rotation grace), or returns apikey.ErrNotFound.
+func (s *Store) Expire(ctx context.Context, keyID id.UUID, at time.Time) error {
+	return s.setTime(ctx, `UPDATE forge_api_keys SET expires_at = $2 WHERE id = $1`, keyID, at)
+}
+
+// Touch sets last_used_at, or returns apikey.ErrNotFound.
+func (s *Store) Touch(ctx context.Context, keyID id.UUID, at time.Time) error {
+	return s.setTime(ctx, `UPDATE forge_api_keys SET last_used_at = $2 WHERE id = $1`, keyID, at)
+}
+
+func (s *Store) setTime(ctx context.Context, sql string, keyID id.UUID, at time.Time) error {
+	tag, err := s.pool.Exec(ctx, sql, keyID, at)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return apikey.ErrNotFound
+	}
+	return nil
+}
+
+// row is satisfied by both pgx.Row and pgx.Rows.
+type row interface{ Scan(dest ...any) error }
+
+func scanKey(r row) (apikey.Key, error) {
+	var k apikey.Key
+	var exp, lu, rv *time.Time
+	err := r.Scan(&k.ID, &k.Hash, &k.Preview, &k.Name, &k.Subject, &k.Tenant,
+		&k.Scopes, &k.Meta, &k.CreatedAt, &exp, &lu, &rv)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return apikey.Key{}, apikey.ErrNotFound
+	}
+	if err != nil {
+		return apikey.Key{}, err
+	}
+	k.ExpiresAt = deref(exp)
+	k.LastUsedAt = deref(lu)
+	k.RevokedAt = deref(rv)
+	return k, nil
+}
+
+// deref maps SQL NULL back to the zero time.
+func deref(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
+// nullTime maps the zero time to SQL NULL.
+func nullTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}

--- a/auth/apikey/pgstore/pgstore.go
+++ b/auth/apikey/pgstore/pgstore.go
@@ -93,7 +93,9 @@ func (s *Store) List(ctx context.Context, f apikey.Filter) ([]apikey.Key, error)
 		return nil, err
 	}
 	defer rows.Close()
-	var out []apikey.Key
+	// Non-nil empty (not nil) on zero rows, matching the memory store so
+	// callers see identical List results whichever Store backs the Manager.
+	out := []apikey.Key{}
 	for rows.Next() {
 		k, err := scanKey(rows)
 		if err != nil {

--- a/auth/apikey/pgstore/pgstore_test.go
+++ b/auth/apikey/pgstore/pgstore_test.go
@@ -90,6 +90,16 @@ func TestPg_NotFound(t *testing.T) {
 	assert.ErrorIs(t, s.Touch(ctx, id.NewUUID(), time.Now()), apikey.ErrNotFound)
 }
 
+// TestPg_ListEmptyNonNil pins parity with the memory store: a List with no
+// matches returns a non-nil empty slice, never nil.
+func TestPg_ListEmptyNonNil(t *testing.T) {
+	s := newStore(t)
+	none, err := s.List(context.Background(), apikey.Filter{Tenant: "tenant-" + id.NewUUID().String()})
+	require.NoError(t, err)
+	assert.NotNil(t, none)
+	assert.Empty(t, none)
+}
+
 func TestPg_DuplicateHash(t *testing.T) {
 	s := newStore(t)
 	ctx := context.Background()

--- a/auth/apikey/pgstore/pgstore_test.go
+++ b/auth/apikey/pgstore/pgstore_test.go
@@ -1,0 +1,173 @@
+package pgstore_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+	"github.com/dmitrymomot/forge/auth/apikey/pgstore"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+)
+
+var _ apikey.Store = (*pgstore.Store)(nil)
+
+func newStore(t *testing.T) *pgstore.Store {
+	t.Helper()
+	dsn := os.Getenv("FORGE_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("set FORGE_TEST_POSTGRES_DSN")
+	}
+	cfg := postgres.DefaultConfig()
+	cfg.URL = dsn
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgstore.Migrations, migration.WithTable("forge_apikey_schema")).Up(context.Background(), db))
+	return pgstore.New(pool)
+}
+
+// mkKey builds a record whose hash/subject/tenant are unique per call:
+// the table persists across test runs, so deterministic values would
+// collide on the unique hash index or inflate List counts on re-runs.
+func mkKey(t *testing.T) apikey.Key {
+	t.Helper()
+	uid := id.NewUUID()
+	return apikey.Key{
+		ID:        uid,
+		Hash:      "hash-" + uid.String(),
+		Preview:   "key_preview1",
+		Name:      "key-" + t.Name(),
+		Subject:   "subj-" + uid.String(),
+		Tenant:    "tenant-" + uid.String(),
+		Scopes:    []string{"read", "write"},
+		Meta:      map[string]string{"env": "prod"},
+		CreatedAt: time.Now().UTC(),
+	}
+}
+
+func TestPg_CreateGetRoundTrip(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	k := mkKey(t)
+	k.ExpiresAt = time.Now().UTC().Add(time.Hour).Truncate(time.Millisecond)
+	require.NoError(t, s.Create(ctx, k))
+
+	got, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.Equal(t, k.ID, got.ID)
+	assert.Equal(t, k.Hash, got.Hash)
+	assert.Equal(t, k.Scopes, got.Scopes)
+	assert.Equal(t, k.Meta, got.Meta)
+	assert.True(t, got.ExpiresAt.Equal(k.ExpiresAt))
+	// NULL ⇔ zero-time mapping.
+	assert.True(t, got.LastUsedAt.IsZero())
+	assert.True(t, got.RevokedAt.IsZero())
+
+	byHash, err := s.GetByHash(ctx, k.Hash)
+	require.NoError(t, err)
+	assert.Equal(t, k.ID, byHash.ID)
+}
+
+func TestPg_NotFound(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	_, err := s.Get(ctx, id.NewUUID())
+	assert.ErrorIs(t, err, apikey.ErrNotFound)
+	_, err = s.GetByHash(ctx, "missing-"+id.NewUUID().String())
+	assert.ErrorIs(t, err, apikey.ErrNotFound)
+	assert.ErrorIs(t, s.Revoke(ctx, id.NewUUID(), time.Now()), apikey.ErrNotFound)
+	assert.ErrorIs(t, s.Expire(ctx, id.NewUUID(), time.Now()), apikey.ErrNotFound)
+	assert.ErrorIs(t, s.Touch(ctx, id.NewUUID(), time.Now()), apikey.ErrNotFound)
+}
+
+func TestPg_DuplicateHash(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	k := mkKey(t)
+	require.NoError(t, s.Create(ctx, k))
+
+	dup := mkKey(t)
+	dup.Hash = k.Hash
+	assert.ErrorIs(t, s.Create(ctx, dup), apikey.ErrDuplicate)
+
+	dupID := mkKey(t)
+	dupID.ID = k.ID
+	assert.ErrorIs(t, s.Create(ctx, dupID), apikey.ErrDuplicate)
+}
+
+func TestPg_ListFilterAndOrder(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	k1, k2 := mkKey(t), mkKey(t)
+	k2.Tenant = k1.Tenant
+	// Deterministic id ordering: id.NewUUID() is NOT monotonic within one
+	// millisecond, so same-ms ids sort randomly and would flake this test.
+	// Share one id and vary only the last byte: k2 > k1 by construction.
+	k2.ID = k1.ID
+	k1.ID[15], k2.ID[15] = 0x01, 0x02
+	require.NoError(t, s.Create(ctx, k1))
+	require.NoError(t, s.Create(ctx, k2))
+
+	all, err := s.List(ctx, apikey.Filter{Tenant: k1.Tenant})
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+	// Newest first = descending id bytes.
+	assert.Equal(t, k2.ID, all[0].ID)
+
+	one, err := s.List(ctx, apikey.Filter{Tenant: k1.Tenant, Subject: k1.Subject})
+	require.NoError(t, err)
+	require.Len(t, one, 1)
+	assert.Equal(t, k1.ID, one[0].ID)
+}
+
+func TestPg_Mutators(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	k := mkKey(t)
+	require.NoError(t, s.Create(ctx, k))
+	at := time.Now().UTC().Truncate(time.Millisecond)
+
+	require.NoError(t, s.Revoke(ctx, k.ID, at))
+	require.NoError(t, s.Expire(ctx, k.ID, at.Add(time.Hour)))
+	require.NoError(t, s.Touch(ctx, k.ID, at.Add(time.Minute)))
+
+	got, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.True(t, got.RevokedAt.Equal(at))
+	assert.True(t, got.ExpiresAt.Equal(at.Add(time.Hour)))
+	assert.True(t, got.LastUsedAt.Equal(at.Add(time.Minute)))
+}
+
+func TestPg_ManagerEndToEnd(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	mgr := apikey.New(s, apikey.WithPrefix("sk_pg"))
+
+	k, plaintext, err := mgr.Create(ctx, apikey.CreateParams{Subject: t.Name() + "-u", Tenant: t.Name() + "-t"})
+	require.NoError(t, err)
+
+	identity, err := mgr.Verify(ctx, plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, t.Name()+"-u", identity.Subject)
+
+	fresh, freshPlain, err := mgr.Rotate(ctx, k.ID, time.Hour)
+	require.NoError(t, err)
+	_, err = mgr.Verify(ctx, plaintext) // old still inside grace
+	require.NoError(t, err)
+	_, err = mgr.Verify(ctx, freshPlain)
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.Revoke(ctx, fresh.ID))
+	_, err = mgr.Verify(ctx, freshPlain)
+	assert.ErrorIs(t, err, apikey.ErrKeyRevoked)
+}

--- a/auth/apikey/scope_test.go
+++ b/auth/apikey/scope_test.go
@@ -1,0 +1,97 @@
+package apikey_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+)
+
+type tenantCtxKey struct{}
+
+func scopeHook(ctx context.Context) (string, error) {
+	t, _ := ctx.Value(tenantCtxKey{}).(string)
+	return t, nil
+}
+
+func tenantCtx(tenant string) context.Context {
+	return context.WithValue(context.Background(), tenantCtxKey{}, tenant)
+}
+
+func newScoped(t *testing.T) *apikey.Manager {
+	t.Helper()
+	return apikey.New(apikey.NewMemoryStore(), apikey.WithScope(scopeHook))
+}
+
+func TestScope_CreateStampsTenant(t *testing.T) {
+	t.Parallel()
+	mgr := newScoped(t)
+
+	k, _, err := mgr.Create(tenantCtx("t1"), apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+	assert.Equal(t, "t1", k.Tenant)
+
+	// Matching explicit tenant is fine; conflicting one is not.
+	_, _, err = mgr.Create(tenantCtx("t1"), apikey.CreateParams{Subject: "u1", Tenant: "t1"})
+	assert.NoError(t, err)
+	_, _, err = mgr.Create(tenantCtx("t1"), apikey.CreateParams{Subject: "u1", Tenant: "t2"})
+	assert.ErrorIs(t, err, apikey.ErrTenantMismatch)
+}
+
+func TestScope_FailClosed(t *testing.T) {
+	t.Parallel()
+	// Empty tenant from the hook.
+	mgr := newScoped(t)
+	_, _, err := mgr.Create(context.Background(), apikey.CreateParams{Subject: "u1"})
+	assert.ErrorIs(t, err, apikey.ErrScope)
+	_, err = mgr.List(context.Background(), apikey.Filter{})
+	assert.ErrorIs(t, err, apikey.ErrScope)
+
+	// Hook error.
+	boom := errors.New("boom")
+	failing := apikey.New(apikey.NewMemoryStore(), apikey.WithScope(
+		func(context.Context) (string, error) { return "", boom }))
+	_, _, err = failing.Create(context.Background(), apikey.CreateParams{Subject: "u1"})
+	assert.ErrorIs(t, err, apikey.ErrScope)
+	assert.ErrorIs(t, err, boom)
+}
+
+func TestScope_CrossTenantReadsAsNotFound(t *testing.T) {
+	t.Parallel()
+	mgr := newScoped(t)
+	k, _, err := mgr.Create(tenantCtx("t1"), apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+
+	_, err = mgr.Get(tenantCtx("t2"), k.ID)
+	assert.ErrorIs(t, err, apikey.ErrNotFound)
+	assert.ErrorIs(t, mgr.Revoke(tenantCtx("t2"), k.ID), apikey.ErrNotFound)
+	_, _, err = mgr.Rotate(tenantCtx("t2"), k.ID, time.Hour)
+	assert.ErrorIs(t, err, apikey.ErrNotFound)
+
+	// Same tenant still works.
+	_, err = mgr.Get(tenantCtx("t1"), k.ID)
+	assert.NoError(t, err)
+}
+
+func TestScope_ListConfined(t *testing.T) {
+	t.Parallel()
+	mgr := newScoped(t)
+	_, _, err := mgr.Create(tenantCtx("t1"), apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+	_, _, err = mgr.Create(tenantCtx("t2"), apikey.CreateParams{Subject: "u2"})
+	require.NoError(t, err)
+
+	keys, err := mgr.List(tenantCtx("t1"), apikey.Filter{})
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "t1", keys[0].Tenant)
+
+	// A conflicting explicit filter tenant is rejected, not silently overridden.
+	_, err = mgr.List(tenantCtx("t1"), apikey.Filter{Tenant: "t2"})
+	assert.ErrorIs(t, err, apikey.ErrTenantMismatch)
+}

--- a/auth/apikey/store.go
+++ b/auth/apikey/store.go
@@ -10,6 +10,9 @@ import (
 // Store persists Key records. Implementations must be safe for concurrent
 // use. Create fails with ErrDuplicate when a record with the same ID or
 // Hash exists; lookups and mutators return ErrNotFound for unknown ids.
+// Implementations may normalize nil and empty Scopes/Meta (and a nil vs.
+// empty List result) in either direction; callers must not depend on
+// which form is returned.
 type Store interface {
 	Create(ctx context.Context, k Key) error
 	Get(ctx context.Context, keyID id.UUID) (Key, error)

--- a/auth/apikey/store.go
+++ b/auth/apikey/store.go
@@ -1,0 +1,25 @@
+package apikey
+
+import (
+	"context"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Store persists Key records. Implementations must be safe for concurrent
+// use. Create fails with ErrDuplicate when a record with the same ID or
+// Hash exists; lookups and mutators return ErrNotFound for unknown ids.
+type Store interface {
+	Create(ctx context.Context, k Key) error
+	Get(ctx context.Context, keyID id.UUID) (Key, error)
+	// GetByHash is the verification path: one point lookup by the hex
+	// SHA-256 of the presented plaintext.
+	GetByHash(ctx context.Context, hash string) (Key, error)
+	// List returns records matching f, newest first (UUIDv7 id order;
+	// ties within one millisecond are unordered).
+	List(ctx context.Context, f Filter) ([]Key, error)
+	Revoke(ctx context.Context, keyID id.UUID, at time.Time) error
+	Expire(ctx context.Context, keyID id.UUID, at time.Time) error
+	Touch(ctx context.Context, keyID id.UUID, at time.Time) error
+}

--- a/auth/apikey/store_test.go
+++ b/auth/apikey/store_test.go
@@ -133,3 +133,47 @@ func TestMemoryStore_CloneIsolation(t *testing.T) {
 	assert.Equal(t, "v", got2.Meta["k"])
 	assert.Equal(t, "read", got2.Scopes[0])
 }
+
+// TestMemoryStore_NilScopesMetaNormalized pins parity with the pgstore
+// driver: nil Scopes/Meta are stored and returned as non-nil empties, and a
+// List with no matches returns a non-nil empty slice — so callers see
+// identical shapes whichever Store backs the Manager.
+func TestMemoryStore_NilScopesMetaNormalized(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+	k := apikey.Key{
+		ID:        id.UUID{15: 1},
+		Hash:      "h1",
+		Preview:   "key_preview1",
+		Subject:   "u1",
+		Scopes:    nil, // caller passed nil …
+		Meta:      nil, // … for both reference fields
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, s.Create(ctx, k))
+
+	got, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, got.Scopes)
+	assert.Empty(t, got.Scopes)
+	assert.NotNil(t, got.Meta)
+	assert.Empty(t, got.Meta)
+
+	byHash, err := s.GetByHash(ctx, "h1")
+	require.NoError(t, err)
+	assert.NotNil(t, byHash.Scopes)
+	assert.NotNil(t, byHash.Meta)
+
+	listed, err := s.List(ctx, apikey.Filter{Subject: "u1"})
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.NotNil(t, listed[0].Scopes)
+	assert.NotNil(t, listed[0].Meta)
+
+	// No matches → non-nil empty slice, never nil.
+	none, err := s.List(ctx, apikey.Filter{Subject: "nobody"})
+	require.NoError(t, err)
+	assert.NotNil(t, none)
+	assert.Empty(t, none)
+}

--- a/auth/apikey/store_test.go
+++ b/auth/apikey/store_test.go
@@ -1,0 +1,135 @@
+package apikey_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// mkKey builds a record with a handcrafted ID so ordering tests are
+// deterministic (UUIDv7 ids from the same millisecond have random tails).
+func mkKey(b byte, hash, subject, tenant string) apikey.Key {
+	return apikey.Key{
+		ID:        id.UUID{15: b}, // last byte varies → byte-ascending = ascending b
+		Hash:      hash,
+		Preview:   "key_preview1",
+		Subject:   subject,
+		Tenant:    tenant,
+		Scopes:    []string{"read"},
+		Meta:      map[string]string{"k": "v"},
+		CreatedAt: time.Now().UTC(),
+	}
+}
+
+func TestMemoryStore_CreateGet(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+	k := mkKey(1, "h1", "u1", "t1")
+
+	require.NoError(t, s.Create(ctx, k))
+
+	got, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.Equal(t, k.Subject, got.Subject)
+	assert.Equal(t, k.Hash, got.Hash)
+
+	byHash, err := s.GetByHash(ctx, "h1")
+	require.NoError(t, err)
+	assert.Equal(t, k.ID, byHash.ID)
+}
+
+func TestMemoryStore_NotFound(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+
+	_, err := s.Get(ctx, id.UUID{15: 9})
+	assert.ErrorIs(t, err, apikey.ErrNotFound)
+	_, err = s.GetByHash(ctx, "missing")
+	assert.ErrorIs(t, err, apikey.ErrNotFound)
+	assert.ErrorIs(t, s.Revoke(ctx, id.UUID{15: 9}, time.Now()), apikey.ErrNotFound)
+	assert.ErrorIs(t, s.Expire(ctx, id.UUID{15: 9}, time.Now()), apikey.ErrNotFound)
+	assert.ErrorIs(t, s.Touch(ctx, id.UUID{15: 9}, time.Now()), apikey.ErrNotFound)
+}
+
+func TestMemoryStore_Duplicate(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+	require.NoError(t, s.Create(ctx, mkKey(1, "h1", "u1", "")))
+
+	assert.ErrorIs(t, s.Create(ctx, mkKey(1, "h-other", "u1", "")), apikey.ErrDuplicate) // same ID
+	assert.ErrorIs(t, s.Create(ctx, mkKey(2, "h1", "u1", "")), apikey.ErrDuplicate)      // same hash
+}
+
+func TestMemoryStore_ListFilterAndOrder(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+	require.NoError(t, s.Create(ctx, mkKey(1, "h1", "u1", "t1")))
+	require.NoError(t, s.Create(ctx, mkKey(2, "h2", "u2", "t1")))
+	require.NoError(t, s.Create(ctx, mkKey(3, "h3", "u1", "t2")))
+
+	all, err := s.List(ctx, apikey.Filter{})
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+	// Newest first = descending ID bytes.
+	assert.Equal(t, id.UUID{15: 3}, all[0].ID)
+	assert.Equal(t, id.UUID{15: 1}, all[2].ID)
+
+	t1, err := s.List(ctx, apikey.Filter{Tenant: "t1"})
+	require.NoError(t, err)
+	assert.Len(t, t1, 2)
+
+	u1t1, err := s.List(ctx, apikey.Filter{Subject: "u1", Tenant: "t1"})
+	require.NoError(t, err)
+	require.Len(t, u1t1, 1)
+	assert.Equal(t, id.UUID{15: 1}, u1t1[0].ID)
+}
+
+func TestMemoryStore_Mutators(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+	k := mkKey(1, "h1", "u1", "")
+	require.NoError(t, s.Create(ctx, k))
+	at := time.Now().UTC().Truncate(time.Second)
+
+	require.NoError(t, s.Revoke(ctx, k.ID, at))
+	require.NoError(t, s.Expire(ctx, k.ID, at.Add(time.Hour)))
+	require.NoError(t, s.Touch(ctx, k.ID, at.Add(time.Minute)))
+
+	got, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.True(t, got.RevokedAt.Equal(at))
+	assert.True(t, got.ExpiresAt.Equal(at.Add(time.Hour)))
+	assert.True(t, got.LastUsedAt.Equal(at.Add(time.Minute)))
+}
+
+func TestMemoryStore_CloneIsolation(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+	k := mkKey(1, "h1", "u1", "")
+	require.NoError(t, s.Create(ctx, k))
+
+	// Mutating the caller's copy or a returned copy must not affect storage.
+	k.Meta["k"] = "mutated"
+	got1, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "v", got1.Meta["k"])
+
+	got1.Meta["k"] = "mutated-again"
+	got1.Scopes[0] = "write"
+	got2, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "v", got2.Meta["k"])
+	assert.Equal(t, "read", got2.Scopes[0])
+}

--- a/auth/apikey/storeerr_test.go
+++ b/auth/apikey/storeerr_test.go
@@ -1,0 +1,64 @@
+package apikey_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// errStoreBoom is a sentinel returned by boomStore to prove Verify/Create
+// wrap unexpected store errors with %w instead of swallowing them.
+var errStoreBoom = errors.New("boom")
+
+// boomStore implements apikey.Store, returning errStoreBoom from
+// GetByHash and Create; the other methods are never exercised by these
+// tests and return zero values.
+type boomStore struct{}
+
+func (boomStore) Create(context.Context, apikey.Key) error { return errStoreBoom }
+
+func (boomStore) Get(context.Context, id.UUID) (apikey.Key, error) {
+	return apikey.Key{}, errStoreBoom
+}
+
+func (boomStore) GetByHash(context.Context, string) (apikey.Key, error) {
+	return apikey.Key{}, errStoreBoom
+}
+
+func (boomStore) List(context.Context, apikey.Filter) ([]apikey.Key, error) {
+	return nil, errStoreBoom
+}
+
+func (boomStore) Revoke(context.Context, id.UUID, time.Time) error { return errStoreBoom }
+func (boomStore) Expire(context.Context, id.UUID, time.Time) error { return errStoreBoom }
+func (boomStore) Touch(context.Context, id.UUID, time.Time) error  { return errStoreBoom }
+
+func TestCreate_StoreErrorWrapped(t *testing.T) {
+	t.Parallel()
+	mgr := apikey.New(boomStore{})
+	_, _, err := mgr.Create(context.Background(), apikey.CreateParams{Subject: "u1"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errStoreBoom)
+}
+
+func TestVerify_StoreErrorWrapped(t *testing.T) {
+	t.Parallel()
+	// Mint a structurally-valid plaintext from a real memory-store manager
+	// sharing the same prefix — validKey only checks prefix/length/checksum,
+	// so it satisfies boomStore's manager too and reaches GetByHash.
+	memMgr := apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("sk_live"))
+	_, plaintext, err := memMgr.Create(context.Background(), apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+
+	mgr := apikey.New(boomStore{}, apikey.WithPrefix("sk_live"))
+	_, err = mgr.Verify(context.Background(), plaintext)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errStoreBoom)
+}

--- a/auth/apikey/verify.go
+++ b/auth/apikey/verify.go
@@ -1,0 +1,65 @@
+package apikey
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+	"github.com/dmitrymomot/forge/crypto/consttime"
+)
+
+var _ guard.Verifier = (*Manager)(nil)
+
+// Verify implements guard.Verifier: it resolves a plaintext credential to
+// the identity of the key's Subject. Malformed credentials (wrong prefix,
+// length, or checksum) are rejected before any store access. Under
+// guard.New every error collapses to an opaque 401; the sentinels serve
+// metrics and direct callers.
+func (m *Manager) Verify(ctx context.Context, credential string) (guard.Identity, error) {
+	if !validKey(m.cfg.prefix, credential) {
+		return guard.Identity{}, ErrMalformedKey
+	}
+	h := hashKey(credential)
+	k, err := m.store.GetByHash(ctx, h)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return guard.Identity{}, ErrKeyNotFound
+		}
+		return guard.Identity{}, fmt.Errorf("apikey: verify: %w", err)
+	}
+	// Defense-in-depth: a buggy store returning the wrong record (or a
+	// corrupt subject-less row) must not authenticate.
+	if !consttime.StringEqual(k.Hash, h) || k.Subject == "" {
+		return guard.Identity{}, ErrKeyNotFound
+	}
+	if !k.RevokedAt.IsZero() {
+		return guard.Identity{}, ErrKeyRevoked
+	}
+	now := time.Now().UTC()
+	if !k.ExpiresAt.IsZero() && !k.ExpiresAt.After(now) {
+		return guard.Identity{}, ErrKeyExpired
+	}
+	if m.cfg.touchInterval >= 0 && (k.LastUsedAt.IsZero() || now.Sub(k.LastUsedAt) >= m.cfg.touchInterval) {
+		// Best-effort by design: a failed touch must not fail authentication.
+		_ = m.store.Touch(ctx, k.ID, now)
+	}
+	meta := maps.Clone(k.Meta)
+	if meta == nil {
+		meta = make(map[string]string, 2)
+	}
+	meta["key_id"] = k.ID.String()
+	if k.Name != "" {
+		meta["key_name"] = k.Name
+	}
+	return guard.Identity{
+		Subject: k.Subject,
+		Tenant:  k.Tenant,
+		Scopes:  slices.Clone(k.Scopes),
+		Method:  guard.MethodAPIKey,
+		Meta:    meta,
+	}, nil
+}

--- a/auth/apikey/verify_test.go
+++ b/auth/apikey/verify_test.go
@@ -1,0 +1,194 @@
+package apikey_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+// issue returns a manager over its own memory store plus one minted key.
+func issue(t *testing.T, opts ...apikey.Option) (*apikey.Manager, apikey.Store, apikey.Key, string) {
+	t.Helper()
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store, append([]apikey.Option{apikey.WithPrefix("sk_live")}, opts...)...)
+	k, plaintext, err := mgr.Create(context.Background(), apikey.CreateParams{
+		Subject: "user_42", Tenant: "org_7", Name: "CI deploy",
+		Scopes: []string{"deploy:write"}, Meta: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+	return mgr, store, k, plaintext
+}
+
+// tamper flips the final checksum character to a different base62 char.
+func tamper(s string) string {
+	last := s[len(s)-1]
+	repl := byte('a')
+	if last == 'a' {
+		repl = 'b'
+	}
+	return s[:len(s)-1] + string(repl)
+}
+
+func TestVerify_OK(t *testing.T) {
+	t.Parallel()
+	mgr, _, k, plaintext := issue(t)
+
+	identity, err := mgr.Verify(context.Background(), plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, "user_42", identity.Subject)
+	assert.Equal(t, "org_7", identity.Tenant)
+	assert.Equal(t, guard.MethodAPIKey, identity.Method)
+	assert.Equal(t, []string{"deploy:write"}, identity.Scopes)
+	assert.Equal(t, k.ID.String(), identity.Meta["key_id"])
+	assert.Equal(t, "CI deploy", identity.Meta["key_name"])
+	assert.Equal(t, "prod", identity.Meta["env"])
+}
+
+func TestVerify_Malformed(t *testing.T) {
+	t.Parallel()
+	mgr, _, _, plaintext := issue(t)
+	ctx := context.Background()
+
+	for name, cred := range map[string]string{
+		"empty":        "",
+		"prefix only":  "sk_live_",
+		"truncated":    plaintext[:len(plaintext)-1],
+		"bad checksum": tamper(plaintext),
+		"wrong prefix": "sk_test" + plaintext[len("sk_live"):],
+	} {
+		_, err := mgr.Verify(ctx, cred)
+		assert.ErrorIs(t, err, apikey.ErrMalformedKey, name)
+	}
+}
+
+func TestVerify_UnknownKey(t *testing.T) {
+	t.Parallel()
+	mgr, _, _, _ := issue(t)
+	// A second issuer with the same prefix mints a structurally valid key
+	// that the first store has never seen.
+	other := apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("sk_live"))
+	_, foreign, err := other.Create(context.Background(), apikey.CreateParams{Subject: "u9"})
+	require.NoError(t, err)
+
+	_, err = mgr.Verify(context.Background(), foreign)
+	assert.ErrorIs(t, err, apikey.ErrKeyNotFound)
+}
+
+func TestVerify_Revoked(t *testing.T) {
+	t.Parallel()
+	mgr, store, k, plaintext := issue(t)
+	require.NoError(t, store.Revoke(context.Background(), k.ID, time.Now().UTC()))
+
+	_, err := mgr.Verify(context.Background(), plaintext)
+	assert.ErrorIs(t, err, apikey.ErrKeyRevoked)
+}
+
+func TestVerify_Expired(t *testing.T) {
+	t.Parallel()
+	mgr, store, k, plaintext := issue(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Expire(ctx, k.ID, time.Now().UTC().Add(time.Hour)))
+	_, err := mgr.Verify(ctx, plaintext) // future expiry still verifies
+	require.NoError(t, err)
+
+	require.NoError(t, store.Expire(ctx, k.ID, time.Now().UTC().Add(-time.Second)))
+	_, err = mgr.Verify(ctx, plaintext)
+	assert.ErrorIs(t, err, apikey.ErrKeyExpired)
+}
+
+func TestVerify_EmptySubjectRecordRejected(t *testing.T) {
+	t.Parallel()
+	// A corrupt record (empty Subject) seeded directly into the store must
+	// not authenticate, even though guard would also catch it.
+	_, _, k, plaintext := issue(t)
+	ctx := context.Background()
+
+	corrupt := k
+	corrupt.Subject = ""
+	store := apikey.NewMemoryStore()
+	require.NoError(t, store.Create(ctx, corrupt))
+	mgr := apikey.New(store, apikey.WithPrefix("sk_live"))
+
+	_, err := mgr.Verify(ctx, plaintext)
+	assert.ErrorIs(t, err, apikey.ErrKeyNotFound)
+}
+
+func TestVerify_TouchThrottling(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("default touches never-used key once", func(t *testing.T) {
+		t.Parallel()
+		mgr, store, k, plaintext := issue(t)
+		_, err := mgr.Verify(ctx, plaintext)
+		require.NoError(t, err)
+		got, err := store.Get(ctx, k.ID)
+		require.NoError(t, err)
+		first := got.LastUsedAt
+		assert.False(t, first.IsZero())
+
+		// Immediately re-verify: fresher than 60s → untouched.
+		_, err = mgr.Verify(ctx, plaintext)
+		require.NoError(t, err)
+		got, err = store.Get(ctx, k.ID)
+		require.NoError(t, err)
+		assert.True(t, got.LastUsedAt.Equal(first))
+	})
+
+	t.Run("stale record is touched", func(t *testing.T) {
+		t.Parallel()
+		mgr, store, k, plaintext := issue(t)
+		old := time.Now().UTC().Add(-2 * time.Minute)
+		require.NoError(t, store.Touch(ctx, k.ID, old))
+		_, err := mgr.Verify(ctx, plaintext)
+		require.NoError(t, err)
+		got, err := store.Get(ctx, k.ID)
+		require.NoError(t, err)
+		assert.True(t, got.LastUsedAt.After(old))
+	})
+
+	t.Run("negative interval disables tracking", func(t *testing.T) {
+		t.Parallel()
+		mgr, store, k, plaintext := issue(t, apikey.WithTouchInterval(-1))
+		_, err := mgr.Verify(ctx, plaintext)
+		require.NoError(t, err)
+		got, err := store.Get(ctx, k.ID)
+		require.NoError(t, err)
+		assert.True(t, got.LastUsedAt.IsZero())
+	})
+
+	t.Run("zero interval touches every request", func(t *testing.T) {
+		t.Parallel()
+		mgr, store, k, plaintext := issue(t, apikey.WithTouchInterval(0))
+		recent := time.Now().UTC().Add(-time.Second)
+		require.NoError(t, store.Touch(ctx, k.ID, recent))
+		_, err := mgr.Verify(ctx, plaintext)
+		require.NoError(t, err)
+		got, err := store.Get(ctx, k.ID)
+		require.NoError(t, err)
+		assert.True(t, got.LastUsedAt.After(recent))
+	})
+}
+
+func TestVerify_IdentityMetaIsolated(t *testing.T) {
+	t.Parallel()
+	mgr, _, _, plaintext := issue(t)
+	ctx := context.Background()
+
+	id1, err := mgr.Verify(ctx, plaintext)
+	require.NoError(t, err)
+	id1.Meta["env"] = "mutated"
+	id1.Scopes[0] = "mutated"
+
+	id2, err := mgr.Verify(ctx, plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, "prod", id2.Meta["env"])
+	assert.Equal(t, "deploy:write", id2.Scopes[0])
+}

--- a/auth/apikey/verify_test.go
+++ b/auth/apikey/verify_test.go
@@ -177,6 +177,30 @@ func TestVerify_TouchThrottling(t *testing.T) {
 	})
 }
 
+func TestVerify_ReservedMetaKeysOverridden(t *testing.T) {
+	t.Parallel()
+	// key_id and key_name are reserved: Verify must always set them from
+	// the record's own ID/Name, overriding any attacker-supplied values
+	// stashed in stored Meta under those same keys.
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store, apikey.WithPrefix("sk_live"))
+	ctx := context.Background()
+
+	k, plaintext, err := mgr.Create(ctx, apikey.CreateParams{
+		Subject: "user_42",
+		Name:    "CI deploy",
+		Meta:    map[string]string{"key_id": "spoofed", "key_name": "spoofed"},
+	})
+	require.NoError(t, err)
+
+	identity, err := mgr.Verify(ctx, plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, k.ID.String(), identity.Meta["key_id"])
+	assert.NotEqual(t, "spoofed", identity.Meta["key_id"])
+	assert.Equal(t, "CI deploy", identity.Meta["key_name"])
+	assert.NotEqual(t, "spoofed", identity.Meta["key_name"])
+}
+
 func TestVerify_IdentityMetaIsolated(t *testing.T) {
 	t.Parallel()
 	mgr, _, _, plaintext := issue(t)

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -651,19 +651,6 @@ Deps: `core/random`, `crypto/digest`.
 
 ---
 
-**auth/apikey**
-
-The full API-key product for tenant- or user-owned keys: Stripe-style
-prefixed keys (`sk_live_…`) with checksum for cheap rejection, hash stored,
-plaintext shown once — plus management (create/list/revoke/rotate, per-key
-scopes, optional expiry, last-used-at tracking) behind a storage-agnostic
-Store, and request verification as a `guard.Verifier` (constant-time, key →
-identity/tenant resolution).
-
-Deps: `core/random`, `crypto/consttime`, `auth/guard`.
-
----
-
 **auth/magiclink**
 
 Signed, TTL'd, single-use links over `crypto/token`: passwordless login,

--- a/docs/superpowers/plans/2026-07-13-auth-apikey.md
+++ b/docs/superpowers/plans/2026-07-13-auth-apikey.md
@@ -1,0 +1,2091 @@
+# auth/apikey Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `auth/apikey` — Stripe-style API keys (issue/manage/verify) behind a storage-agnostic Store, implementing `guard.Verifier`, plus the `pgstore` Postgres driver.
+
+**Architecture:** One core package: `Manager` owns management (Create/Get/List/Revoke/Rotate) and verification (`Verify` implements `guard.Verifier` directly). Keys are `<prefix>_<43 base62 chars><6-char CRC32>`; only the hex SHA-256 of the full plaintext is stored, and malformed credentials are rejected by checksum before any store access. State lives behind a 7-method `Store` seam with an in-package memory store and a pgx driver subpackage.
+
+**Tech Stack:** Go 1.26, `auth/guard`, `core/id` (UUIDv7), `core/random`, `crypto/consttime`, stdlib `crypto/sha256` + `hash/crc32`; driver: pgx v5 + goose migration via `data/migration`.
+
+**Spec:** `docs/superpowers/specs/2026-07-13-auth-apikey-design.md`
+
+## Global Constraints
+
+- Work ONLY in the current branch; never switch.
+- After changing files: `just fmt ./auth/apikey/...` (package-path form — single-file form trips a spurious betteralign "undefined").
+- After each task: `just lint` (runs modernize/betteralign/nilaway) must pass.
+- Tests: black-box only (`package apikey_test` / `package pgstore_test`). Use `httptest.NewRequest`, never `http.NewRequest` with `_` (nilaway).
+- No C-style ascending loops — `for i := range n` (descending loops are fine).
+- Sentinel errors: single-line `errors.New("apikey: ...")`, `errors.Is`-matchable.
+- Never add Claude/AI attribution to commits.
+- Every forge package ships `bench_test.go` (repo rule).
+
+---
+
+### Task 1: Record types, errors, Store seam, memory store
+
+**Files:**
+- Create: `auth/apikey/apikey.go` (Key, CreateParams, Filter)
+- Create: `auth/apikey/errors.go`
+- Create: `auth/apikey/store.go` (Store interface)
+- Create: `auth/apikey/memory.go` (NewMemoryStore)
+- Test: `auth/apikey/store_test.go`
+
+**Interfaces:**
+- Consumes: `core/id` (`id.UUID` = `[16]byte`, `id.NewUUID()`).
+- Produces (later tasks rely on exactly these):
+  - `type Key struct { Meta map[string]string; Scopes []string; Hash, Preview, Name, Subject, Tenant string; ID id.UUID; CreatedAt, ExpiresAt, LastUsedAt, RevokedAt time.Time }`
+  - `type CreateParams struct { Meta map[string]string; Scopes []string; Name, Subject, Tenant string; ExpiresAt time.Time }`
+  - `type Filter struct { Subject, Tenant string }`
+  - `type Store interface { Create(ctx, Key) error; Get(ctx, id.UUID) (Key, error); GetByHash(ctx, string) (Key, error); List(ctx, Filter) ([]Key, error); Revoke(ctx, id.UUID, time.Time) error; Expire(ctx, id.UUID, time.Time) error; Touch(ctx, id.UUID, time.Time) error }`
+  - `func NewMemoryStore() Store`
+  - Sentinels: `ErrNotFound, ErrDuplicate, ErrMalformedKey, ErrKeyNotFound, ErrKeyRevoked, ErrKeyExpired, ErrSubjectRequired, ErrTenantMismatch, ErrScope`
+
+- [ ] **Step 1: Write the failing store contract test**
+
+`auth/apikey/store_test.go`:
+
+```go
+package apikey_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// mkKey builds a record with a handcrafted ID so ordering tests are
+// deterministic (UUIDv7 ids from the same millisecond have random tails).
+func mkKey(b byte, hash, subject, tenant string) apikey.Key {
+	return apikey.Key{
+		ID:        id.UUID{15: b}, // last byte varies → byte-ascending = ascending b
+		Hash:      hash,
+		Preview:   "key_preview1",
+		Subject:   subject,
+		Tenant:    tenant,
+		Scopes:    []string{"read"},
+		Meta:      map[string]string{"k": "v"},
+		CreatedAt: time.Now().UTC(),
+	}
+}
+
+func TestMemoryStore_CreateGet(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+	k := mkKey(1, "h1", "u1", "t1")
+
+	require.NoError(t, s.Create(ctx, k))
+
+	got, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.Equal(t, k.Subject, got.Subject)
+	assert.Equal(t, k.Hash, got.Hash)
+
+	byHash, err := s.GetByHash(ctx, "h1")
+	require.NoError(t, err)
+	assert.Equal(t, k.ID, byHash.ID)
+}
+
+func TestMemoryStore_NotFound(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+
+	_, err := s.Get(ctx, id.UUID{15: 9})
+	assert.ErrorIs(t, err, apikey.ErrNotFound)
+	_, err = s.GetByHash(ctx, "missing")
+	assert.ErrorIs(t, err, apikey.ErrNotFound)
+	assert.ErrorIs(t, s.Revoke(ctx, id.UUID{15: 9}, time.Now()), apikey.ErrNotFound)
+	assert.ErrorIs(t, s.Expire(ctx, id.UUID{15: 9}, time.Now()), apikey.ErrNotFound)
+	assert.ErrorIs(t, s.Touch(ctx, id.UUID{15: 9}, time.Now()), apikey.ErrNotFound)
+}
+
+func TestMemoryStore_Duplicate(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+	require.NoError(t, s.Create(ctx, mkKey(1, "h1", "u1", "")))
+
+	assert.ErrorIs(t, s.Create(ctx, mkKey(1, "h-other", "u1", "")), apikey.ErrDuplicate) // same ID
+	assert.ErrorIs(t, s.Create(ctx, mkKey(2, "h1", "u1", "")), apikey.ErrDuplicate)      // same hash
+}
+
+func TestMemoryStore_ListFilterAndOrder(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+	require.NoError(t, s.Create(ctx, mkKey(1, "h1", "u1", "t1")))
+	require.NoError(t, s.Create(ctx, mkKey(2, "h2", "u2", "t1")))
+	require.NoError(t, s.Create(ctx, mkKey(3, "h3", "u1", "t2")))
+
+	all, err := s.List(ctx, apikey.Filter{})
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+	// Newest first = descending ID bytes.
+	assert.Equal(t, id.UUID{15: 3}, all[0].ID)
+	assert.Equal(t, id.UUID{15: 1}, all[2].ID)
+
+	t1, err := s.List(ctx, apikey.Filter{Tenant: "t1"})
+	require.NoError(t, err)
+	assert.Len(t, t1, 2)
+
+	u1t1, err := s.List(ctx, apikey.Filter{Subject: "u1", Tenant: "t1"})
+	require.NoError(t, err)
+	require.Len(t, u1t1, 1)
+	assert.Equal(t, id.UUID{15: 1}, u1t1[0].ID)
+}
+
+func TestMemoryStore_Mutators(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+	k := mkKey(1, "h1", "u1", "")
+	require.NoError(t, s.Create(ctx, k))
+	at := time.Now().UTC().Truncate(time.Second)
+
+	require.NoError(t, s.Revoke(ctx, k.ID, at))
+	require.NoError(t, s.Expire(ctx, k.ID, at.Add(time.Hour)))
+	require.NoError(t, s.Touch(ctx, k.ID, at.Add(time.Minute)))
+
+	got, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.True(t, got.RevokedAt.Equal(at))
+	assert.True(t, got.ExpiresAt.Equal(at.Add(time.Hour)))
+	assert.True(t, got.LastUsedAt.Equal(at.Add(time.Minute)))
+}
+
+func TestMemoryStore_CloneIsolation(t *testing.T) {
+	t.Parallel()
+	s := apikey.NewMemoryStore()
+	ctx := context.Background()
+	k := mkKey(1, "h1", "u1", "")
+	require.NoError(t, s.Create(ctx, k))
+
+	// Mutating the caller's copy or a returned copy must not affect storage.
+	k.Meta["k"] = "mutated"
+	got1, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "v", got1.Meta["k"])
+
+	got1.Meta["k"] = "mutated-again"
+	got1.Scopes[0] = "write"
+	got2, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "v", got2.Meta["k"])
+	assert.Equal(t, "read", got2.Scopes[0])
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/apikey/`
+Expected: FAIL — compile errors (`undefined: apikey.NewMemoryStore` etc.); the package doesn't exist yet.
+
+- [ ] **Step 3: Implement types, errors, seam, memory store**
+
+`auth/apikey/apikey.go`:
+
+```go
+package apikey
+
+import (
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Key is the stored API-key record. It never contains the plaintext
+// secret: Hash is the hex SHA-256 of the full plaintext and Preview its
+// first 12 characters for dashboard display.
+type Key struct {
+	Meta       map[string]string // caller extras, copied into Identity.Meta on verify
+	Scopes     []string          // carried into Identity.Scopes; never enforced here
+	Hash       string            // hex SHA-256 of the full plaintext key
+	Preview    string            // first 12 plaintext chars — safe to display
+	Name       string            // human label
+	Subject    string            // principal the key acts as — never empty
+	Tenant     string            // owning tenant; empty in single-tenant apps
+	ID         id.UUID           // UUIDv7 record id — time-ordered, never secret-derived
+	CreatedAt  time.Time
+	ExpiresAt  time.Time // zero = never expires
+	LastUsedAt time.Time // zero = never used
+	RevokedAt  time.Time // zero = active
+}
+
+// CreateParams describes a key to mint. Subject is required: for personal
+// keys it is the user id; for tenant-wide keys, whatever principal
+// represents the org acting as itself (tenant id or a service-account id).
+type CreateParams struct {
+	Meta      map[string]string
+	Scopes    []string
+	Name      string
+	Subject   string    // required
+	Tenant    string    // optional; constrained by the WithScope hook when set
+	ExpiresAt time.Time // zero = never
+}
+
+// Filter narrows List results. Zero fields match everything.
+type Filter struct {
+	Subject string
+	Tenant  string
+}
+```
+
+`auth/apikey/errors.go`:
+
+```go
+package apikey
+
+import "errors"
+
+var (
+	// ErrNotFound is returned by a Store when no record matches, and by
+	// management operations for other tenants' keys under WithScope (so
+	// cross-tenant existence cannot be probed).
+	ErrNotFound = errors.New("apikey: record not found")
+
+	// ErrDuplicate is returned by Store.Create when a record with the same
+	// ID or Hash already exists.
+	ErrDuplicate = errors.New("apikey: duplicate record")
+
+	// ErrMalformedKey rejects credentials failing prefix/length/checksum
+	// validation — decided before any store access.
+	ErrMalformedKey = errors.New("apikey: malformed key")
+
+	// ErrKeyNotFound rejects well-formed credentials with no matching record.
+	ErrKeyNotFound = errors.New("apikey: key not found")
+
+	// ErrKeyRevoked rejects credentials of revoked keys.
+	ErrKeyRevoked = errors.New("apikey: key revoked")
+
+	// ErrKeyExpired rejects credentials of expired keys.
+	ErrKeyExpired = errors.New("apikey: key expired")
+
+	// ErrSubjectRequired rejects CreateParams with an empty Subject.
+	ErrSubjectRequired = errors.New("apikey: subject required")
+
+	// ErrTenantMismatch rejects management calls whose explicit tenant
+	// conflicts with the WithScope-derived tenant.
+	ErrTenantMismatch = errors.New("apikey: tenant mismatch")
+
+	// ErrScope fails management operations closed when the WithScope hook
+	// errors or yields an empty tenant.
+	ErrScope = errors.New("apikey: tenant scope unavailable")
+)
+```
+
+`auth/apikey/store.go`:
+
+```go
+package apikey
+
+import (
+	"context"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Store persists Key records. Implementations must be safe for concurrent
+// use. Create fails with ErrDuplicate when a record with the same ID or
+// Hash exists; lookups and mutators return ErrNotFound for unknown ids.
+type Store interface {
+	Create(ctx context.Context, k Key) error
+	Get(ctx context.Context, keyID id.UUID) (Key, error)
+	// GetByHash is the verification path: one point lookup by the hex
+	// SHA-256 of the presented plaintext.
+	GetByHash(ctx context.Context, hash string) (Key, error)
+	// List returns records matching f, newest first (UUIDv7 id order;
+	// ties within one millisecond are unordered).
+	List(ctx context.Context, f Filter) ([]Key, error)
+	Revoke(ctx context.Context, keyID id.UUID, at time.Time) error
+	Expire(ctx context.Context, keyID id.UUID, at time.Time) error
+	Touch(ctx context.Context, keyID id.UUID, at time.Time) error
+}
+```
+
+`auth/apikey/memory.go`:
+
+```go
+package apikey
+
+import (
+	"bytes"
+	"context"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+type memoryStore struct {
+	byID   map[id.UUID]Key
+	byHash map[string]id.UUID
+	mu     sync.RWMutex
+}
+
+// NewMemoryStore returns an in-memory Store for tests and development.
+func NewMemoryStore() Store {
+	return &memoryStore{
+		byID:   make(map[id.UUID]Key),
+		byHash: make(map[string]id.UUID),
+	}
+}
+
+// cloneKey copies the record's reference fields so callers cannot mutate
+// stored state through shared slices/maps (and vice versa).
+func cloneKey(k Key) Key {
+	k.Scopes = slices.Clone(k.Scopes)
+	k.Meta = maps.Clone(k.Meta)
+	return k
+}
+
+func (s *memoryStore) Create(_ context.Context, k Key) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.byID[k.ID]; ok {
+		return ErrDuplicate
+	}
+	if _, ok := s.byHash[k.Hash]; ok {
+		return ErrDuplicate
+	}
+	s.byID[k.ID] = cloneKey(k)
+	s.byHash[k.Hash] = k.ID
+	return nil
+}
+
+func (s *memoryStore) Get(_ context.Context, keyID id.UUID) (Key, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	k, ok := s.byID[keyID]
+	if !ok {
+		return Key{}, ErrNotFound
+	}
+	return cloneKey(k), nil
+}
+
+func (s *memoryStore) GetByHash(_ context.Context, hash string) (Key, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	keyID, ok := s.byHash[hash]
+	if !ok {
+		return Key{}, ErrNotFound
+	}
+	return cloneKey(s.byID[keyID]), nil
+}
+
+func (s *memoryStore) List(_ context.Context, f Filter) ([]Key, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Key, 0, len(s.byID))
+	for _, k := range s.byID {
+		if f.Subject != "" && k.Subject != f.Subject {
+			continue
+		}
+		if f.Tenant != "" && k.Tenant != f.Tenant {
+			continue
+		}
+		out = append(out, cloneKey(k))
+	}
+	// UUIDv7 ids are time-ordered, so byte-descending is newest first.
+	slices.SortFunc(out, func(a, b Key) int {
+		return bytes.Compare(b.ID[:], a.ID[:])
+	})
+	return out, nil
+}
+
+func (s *memoryStore) Revoke(_ context.Context, keyID id.UUID, at time.Time) error {
+	return s.update(keyID, func(k *Key) { k.RevokedAt = at })
+}
+
+func (s *memoryStore) Expire(_ context.Context, keyID id.UUID, at time.Time) error {
+	return s.update(keyID, func(k *Key) { k.ExpiresAt = at })
+}
+
+func (s *memoryStore) Touch(_ context.Context, keyID id.UUID, at time.Time) error {
+	return s.update(keyID, func(k *Key) { k.LastUsedAt = at })
+}
+
+func (s *memoryStore) update(keyID id.UUID, fn func(*Key)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k, ok := s.byID[keyID]
+	if !ok {
+		return ErrNotFound
+	}
+	fn(&k)
+	s.byID[keyID] = k
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests, fmt, verify pass**
+
+Run: `just fmt ./auth/apikey/... && just test ./auth/apikey/`
+Expected: PASS (race + cover on).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add auth/apikey/
+git commit -m "feat(apikey): record types, sentinels, Store seam, memory store"
+```
+
+---
+
+### Task 2: Key generation, Manager construction, Verify
+
+**Files:**
+- Create: `auth/apikey/keygen.go`
+- Create: `auth/apikey/options.go`
+- Create: `auth/apikey/manager.go` (New + Create only)
+- Create: `auth/apikey/verify.go`
+- Test: `auth/apikey/manager_test.go`, `auth/apikey/verify_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's types/sentinels/Store; `random.String(43)` (defaults to the 62-char Alphanumeric set); `consttime.StringEqual(a, b string) bool`; `guard.Identity{Meta, Subject, Tenant, Method, Scopes}`, `guard.MethodAPIKey`, `guard.Verifier`.
+- Produces:
+  - `func New(store Store, opts ...Option) *Manager` — panics on nil store / invalid prefix
+  - `func WithPrefix(p string) Option`, `func WithTouchInterval(d time.Duration) Option`, `func WithScope(fn func(context.Context) (string, error)) Option` (declared here, wired in Task 3)
+  - `func (m *Manager) Create(ctx context.Context, p CreateParams) (Key, string, error)`
+  - `func (m *Manager) Verify(ctx context.Context, credential string) (guard.Identity, error)`
+  - Unexported: `newKey(prefix) string`, `validKey(prefix, credential) bool`, `hashKey(credential) string`, `validPrefix(p) bool`, `previewLen = 12`
+
+- [ ] **Step 1: Write the failing tests**
+
+`auth/apikey/manager_test.go`:
+
+```go
+package apikey_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+)
+
+func TestNew_Panics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { apikey.New(nil) })
+	assert.Panics(t, func() { apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("")) })
+	assert.Panics(t, func() { apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("SK-Live")) })
+}
+
+func TestCreate_KeyAnatomy(t *testing.T) {
+	t.Parallel()
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store, apikey.WithPrefix("sk_live"))
+
+	k, plaintext, err := mgr.Create(context.Background(), apikey.CreateParams{
+		Subject: "user_42", Tenant: "org_7", Name: "CI deploy", Scopes: []string{"deploy:write"},
+	})
+	require.NoError(t, err)
+
+	// <prefix>_<43 payload><6 checksum>
+	assert.Len(t, plaintext, len("sk_live")+1+43+6)
+	assert.True(t, strings.HasPrefix(plaintext, "sk_live_"))
+	for _, c := range plaintext[len("sk_live_"):] {
+		assert.Contains(t, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", string(c))
+	}
+	assert.Equal(t, plaintext[:12], k.Preview)
+	assert.NotContains(t, k.Hash, plaintext[8:20]) // hash, not plaintext, at rest
+	assert.False(t, k.ID.IsZero())
+	assert.False(t, k.CreatedAt.IsZero())
+
+	stored, err := store.Get(context.Background(), k.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "user_42", stored.Subject)
+	assert.Equal(t, "org_7", stored.Tenant)
+}
+
+func TestCreate_SubjectRequired(t *testing.T) {
+	t.Parallel()
+	mgr := apikey.New(apikey.NewMemoryStore())
+	_, _, err := mgr.Create(context.Background(), apikey.CreateParams{})
+	assert.ErrorIs(t, err, apikey.ErrSubjectRequired)
+}
+
+func TestCreate_DefaultPrefix(t *testing.T) {
+	t.Parallel()
+	mgr := apikey.New(apikey.NewMemoryStore())
+	_, plaintext, err := mgr.Create(context.Background(), apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(plaintext, "key_"))
+}
+```
+
+`auth/apikey/verify_test.go`:
+
+```go
+package apikey_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+// issue returns a manager over its own memory store plus one minted key.
+func issue(t *testing.T, opts ...apikey.Option) (*apikey.Manager, apikey.Store, apikey.Key, string) {
+	t.Helper()
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store, append([]apikey.Option{apikey.WithPrefix("sk_live")}, opts...)...)
+	k, plaintext, err := mgr.Create(context.Background(), apikey.CreateParams{
+		Subject: "user_42", Tenant: "org_7", Name: "CI deploy",
+		Scopes: []string{"deploy:write"}, Meta: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+	return mgr, store, k, plaintext
+}
+
+// tamper flips the final checksum character to a different base62 char.
+func tamper(s string) string {
+	last := s[len(s)-1]
+	repl := byte('a')
+	if last == 'a' {
+		repl = 'b'
+	}
+	return s[:len(s)-1] + string(repl)
+}
+
+func TestVerify_OK(t *testing.T) {
+	t.Parallel()
+	mgr, _, k, plaintext := issue(t)
+
+	identity, err := mgr.Verify(context.Background(), plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, "user_42", identity.Subject)
+	assert.Equal(t, "org_7", identity.Tenant)
+	assert.Equal(t, guard.MethodAPIKey, identity.Method)
+	assert.Equal(t, []string{"deploy:write"}, identity.Scopes)
+	assert.Equal(t, k.ID.String(), identity.Meta["key_id"])
+	assert.Equal(t, "CI deploy", identity.Meta["key_name"])
+	assert.Equal(t, "prod", identity.Meta["env"])
+}
+
+func TestVerify_Malformed(t *testing.T) {
+	t.Parallel()
+	mgr, _, _, plaintext := issue(t)
+	ctx := context.Background()
+
+	for name, cred := range map[string]string{
+		"empty":        "",
+		"prefix only":  "sk_live_",
+		"truncated":    plaintext[:len(plaintext)-1],
+		"bad checksum": tamper(plaintext),
+		"wrong prefix": "sk_test" + plaintext[len("sk_live"):],
+	} {
+		_, err := mgr.Verify(ctx, cred)
+		assert.ErrorIs(t, err, apikey.ErrMalformedKey, name)
+	}
+}
+
+func TestVerify_UnknownKey(t *testing.T) {
+	t.Parallel()
+	mgr, _, _, _ := issue(t)
+	// A second issuer with the same prefix mints a structurally valid key
+	// that the first store has never seen.
+	other := apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("sk_live"))
+	_, foreign, err := other.Create(context.Background(), apikey.CreateParams{Subject: "u9"})
+	require.NoError(t, err)
+
+	_, err = mgr.Verify(context.Background(), foreign)
+	assert.ErrorIs(t, err, apikey.ErrKeyNotFound)
+}
+
+func TestVerify_Revoked(t *testing.T) {
+	t.Parallel()
+	mgr, store, k, plaintext := issue(t)
+	require.NoError(t, store.Revoke(context.Background(), k.ID, time.Now().UTC()))
+
+	_, err := mgr.Verify(context.Background(), plaintext)
+	assert.ErrorIs(t, err, apikey.ErrKeyRevoked)
+}
+
+func TestVerify_Expired(t *testing.T) {
+	t.Parallel()
+	mgr, store, k, plaintext := issue(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Expire(ctx, k.ID, time.Now().UTC().Add(time.Hour)))
+	_, err := mgr.Verify(ctx, plaintext) // future expiry still verifies
+	require.NoError(t, err)
+
+	require.NoError(t, store.Expire(ctx, k.ID, time.Now().UTC().Add(-time.Second)))
+	_, err = mgr.Verify(ctx, plaintext)
+	assert.ErrorIs(t, err, apikey.ErrKeyExpired)
+}
+
+func TestVerify_EmptySubjectRecordRejected(t *testing.T) {
+	t.Parallel()
+	// A corrupt record (empty Subject) seeded directly into the store must
+	// not authenticate, even though guard would also catch it.
+	_, _, k, plaintext := issue(t)
+	ctx := context.Background()
+
+	corrupt := k
+	corrupt.Subject = ""
+	store := apikey.NewMemoryStore()
+	require.NoError(t, store.Create(ctx, corrupt))
+	mgr := apikey.New(store, apikey.WithPrefix("sk_live"))
+
+	_, err := mgr.Verify(ctx, plaintext)
+	assert.ErrorIs(t, err, apikey.ErrKeyNotFound)
+}
+
+func TestVerify_TouchThrottling(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("default touches never-used key once", func(t *testing.T) {
+		t.Parallel()
+		mgr, store, k, plaintext := issue(t)
+		_, err := mgr.Verify(ctx, plaintext)
+		require.NoError(t, err)
+		got, err := store.Get(ctx, k.ID)
+		require.NoError(t, err)
+		first := got.LastUsedAt
+		assert.False(t, first.IsZero())
+
+		// Immediately re-verify: fresher than 60s → untouched.
+		_, err = mgr.Verify(ctx, plaintext)
+		require.NoError(t, err)
+		got, err = store.Get(ctx, k.ID)
+		require.NoError(t, err)
+		assert.True(t, got.LastUsedAt.Equal(first))
+	})
+
+	t.Run("stale record is touched", func(t *testing.T) {
+		t.Parallel()
+		mgr, store, k, plaintext := issue(t)
+		old := time.Now().UTC().Add(-2 * time.Minute)
+		require.NoError(t, store.Touch(ctx, k.ID, old))
+		_, err := mgr.Verify(ctx, plaintext)
+		require.NoError(t, err)
+		got, err := store.Get(ctx, k.ID)
+		require.NoError(t, err)
+		assert.True(t, got.LastUsedAt.After(old))
+	})
+
+	t.Run("negative interval disables tracking", func(t *testing.T) {
+		t.Parallel()
+		mgr, store, k, plaintext := issue(t, apikey.WithTouchInterval(-1))
+		_, err := mgr.Verify(ctx, plaintext)
+		require.NoError(t, err)
+		got, err := store.Get(ctx, k.ID)
+		require.NoError(t, err)
+		assert.True(t, got.LastUsedAt.IsZero())
+	})
+
+	t.Run("zero interval touches every request", func(t *testing.T) {
+		t.Parallel()
+		mgr, store, k, plaintext := issue(t, apikey.WithTouchInterval(0))
+		recent := time.Now().UTC().Add(-time.Second)
+		require.NoError(t, store.Touch(ctx, k.ID, recent))
+		_, err := mgr.Verify(ctx, plaintext)
+		require.NoError(t, err)
+		got, err := store.Get(ctx, k.ID)
+		require.NoError(t, err)
+		assert.True(t, got.LastUsedAt.After(recent))
+	})
+}
+
+func TestVerify_IdentityMetaIsolated(t *testing.T) {
+	t.Parallel()
+	mgr, _, _, plaintext := issue(t)
+	ctx := context.Background()
+
+	id1, err := mgr.Verify(ctx, plaintext)
+	require.NoError(t, err)
+	id1.Meta["env"] = "mutated"
+	id1.Scopes[0] = "mutated"
+
+	id2, err := mgr.Verify(ctx, plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, "prod", id2.Meta["env"])
+	assert.Equal(t, "deploy:write", id2.Scopes[0])
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./auth/apikey/`
+Expected: FAIL — `undefined: apikey.New`, `undefined: apikey.WithPrefix`, etc.
+
+- [ ] **Step 3: Implement keygen, options, Manager.New/Create, Verify**
+
+`auth/apikey/keygen.go`:
+
+```go
+package apikey
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash/crc32"
+	"strings"
+
+	"github.com/dmitrymomot/forge/core/random"
+)
+
+const (
+	payloadLen  = 43 // base62 chars ≈ 256 bits of entropy
+	checksumLen = 6  // fixed-width base62 CRC32 (62^6 > 2^32)
+	previewLen  = 12
+)
+
+// base62 is the checksum alphabet. The payload draws from the same 62
+// characters via random.String's default Alphanumeric set.
+const base62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// newKey mints a plaintext key: <prefix>_<payload><checksum>.
+func newKey(prefix string) string {
+	payload := random.String(payloadLen)
+	var b strings.Builder
+	b.Grow(len(prefix) + 1 + payloadLen + checksumLen)
+	b.WriteString(prefix)
+	b.WriteByte('_')
+	b.WriteString(payload)
+	b.WriteString(encodeChecksum(crc32.ChecksumIEEE([]byte(payload))))
+	return b.String()
+}
+
+// encodeChecksum renders v as fixed-width base62, most significant first.
+func encodeChecksum(v uint32) string {
+	var buf [checksumLen]byte
+	for i := checksumLen - 1; i >= 0; i-- {
+		buf[i] = base62[v%62]
+		v /= 62
+	}
+	return string(buf[:])
+}
+
+// validKey reports whether credential is structurally valid for prefix:
+// exact length, prefix match, and payload CRC32 matching the checksum
+// suffix. CRC32 detects any burst error up to 32 bits, so every
+// single-character corruption is caught. The checksum is compared in
+// place (no encodeChecksum string) to keep this reject path
+// allocation-free — it is the DoS-relevant surface that shields the
+// store from credential-stuffing garbage.
+func validKey(prefix, credential string) bool {
+	wantLen := len(prefix) + 1 + payloadLen + checksumLen
+	if len(credential) != wantLen {
+		return false
+	}
+	if credential[:len(prefix)] != prefix || credential[len(prefix)] != '_' {
+		return false
+	}
+	payload := credential[len(prefix)+1 : wantLen-checksumLen]
+	sum := crc32.ChecksumIEEE([]byte(payload))
+	suffix := credential[wantLen-checksumLen:]
+	for i := checksumLen - 1; i >= 0; i-- {
+		if suffix[i] != base62[sum%62] {
+			return false
+		}
+		sum /= 62
+	}
+	return true
+}
+
+// hashKey returns the hex SHA-256 of the full plaintext key — the stored
+// lookup hash. Unsalted is safe: the payload carries ~256 bits of entropy,
+// so preimage search is infeasible.
+func hashKey(credential string) string {
+	sum := sha256.Sum256([]byte(credential))
+	return hex.EncodeToString(sum[:])
+}
+
+// validPrefix reports whether p is non-empty [a-z0-9_]+.
+func validPrefix(p string) bool {
+	if p == "" {
+		return false
+	}
+	for i := range len(p) {
+		c := p[i]
+		if c != '_' && (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}
+```
+
+`auth/apikey/options.go`:
+
+```go
+package apikey
+
+import (
+	"context"
+	"time"
+)
+
+type config struct {
+	scope         func(context.Context) (string, error)
+	prefix        string
+	touchInterval time.Duration
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithPrefix sets the key prefix (default "key"); keys read
+// <prefix>_<payload><checksum>. The prefix must match [a-z0-9_]+.
+// Environments are separate issuers: run one Manager with "sk_live" and
+// another with "sk_test".
+func WithPrefix(p string) Option {
+	return func(c *config) { c.prefix = p }
+}
+
+// WithScope derives the tenant from context for every management
+// operation: Create stamps it, List is confined to it, and
+// Get/Revoke/Rotate report ErrNotFound for other tenants' keys.
+// Fail-closed: a hook error or empty tenant fails the operation with
+// ErrScope. Verify is unaffected — the key record itself carries the
+// tenant. A nil fn leaves the manager unscoped.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) { c.scope = fn }
+}
+
+// WithTouchInterval throttles last-used-at writes: Verify touches the
+// record only when LastUsedAt is staler than d (default 60s). Zero
+// touches on every request; negative disables tracking.
+func WithTouchInterval(d time.Duration) Option {
+	return func(c *config) { c.touchInterval = d }
+}
+```
+
+`auth/apikey/manager.go` (Create's scope-hook wiring lands in Task 3):
+
+```go
+package apikey
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Manager issues, manages, and verifies API keys over a Store. It
+// implements guard.Verifier. Safe for concurrent use.
+type Manager struct {
+	store Store
+	cfg   config
+}
+
+// New builds a Manager. It panics on a nil store or an invalid prefix —
+// wiring bugs caught at startup, like guard.New's nil-verifier panic.
+func New(store Store, opts ...Option) *Manager {
+	if store == nil {
+		panic("apikey: nil store")
+	}
+	cfg := config{prefix: "key", touchInterval: time.Minute}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if !validPrefix(cfg.prefix) {
+		panic(fmt.Sprintf("apikey: invalid prefix %q", cfg.prefix))
+	}
+	return &Manager{store: store, cfg: cfg}
+}
+
+// Create mints a key for p, returning the stored record and the plaintext.
+// The plaintext is shown exactly once — only its hash is persisted.
+func (m *Manager) Create(ctx context.Context, p CreateParams) (Key, string, error) {
+	if p.Subject == "" {
+		return Key{}, "", ErrSubjectRequired
+	}
+	plaintext := newKey(m.cfg.prefix)
+	k := Key{
+		ID:        id.NewUUID(),
+		Hash:      hashKey(plaintext),
+		Preview:   plaintext[:previewLen],
+		Name:      p.Name,
+		Subject:   p.Subject,
+		Tenant:    p.Tenant,
+		Scopes:    slices.Clone(p.Scopes),
+		Meta:      maps.Clone(p.Meta),
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: p.ExpiresAt,
+	}
+	if err := m.store.Create(ctx, k); err != nil {
+		return Key{}, "", fmt.Errorf("apikey: create: %w", err)
+	}
+	return k, plaintext, nil
+}
+```
+
+`auth/apikey/verify.go`:
+
+```go
+package apikey
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+	"github.com/dmitrymomot/forge/crypto/consttime"
+)
+
+var _ guard.Verifier = (*Manager)(nil)
+
+// Verify implements guard.Verifier: it resolves a plaintext credential to
+// the identity of the key's Subject. Malformed credentials (wrong prefix,
+// length, or checksum) are rejected before any store access. Under
+// guard.New every error collapses to an opaque 401; the sentinels serve
+// metrics and direct callers.
+func (m *Manager) Verify(ctx context.Context, credential string) (guard.Identity, error) {
+	if !validKey(m.cfg.prefix, credential) {
+		return guard.Identity{}, ErrMalformedKey
+	}
+	h := hashKey(credential)
+	k, err := m.store.GetByHash(ctx, h)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return guard.Identity{}, ErrKeyNotFound
+		}
+		return guard.Identity{}, fmt.Errorf("apikey: verify: %w", err)
+	}
+	// Defense-in-depth: a buggy store returning the wrong record (or a
+	// corrupt subject-less row) must not authenticate.
+	if !consttime.StringEqual(k.Hash, h) || k.Subject == "" {
+		return guard.Identity{}, ErrKeyNotFound
+	}
+	if !k.RevokedAt.IsZero() {
+		return guard.Identity{}, ErrKeyRevoked
+	}
+	now := time.Now().UTC()
+	if !k.ExpiresAt.IsZero() && !k.ExpiresAt.After(now) {
+		return guard.Identity{}, ErrKeyExpired
+	}
+	if m.cfg.touchInterval >= 0 && (k.LastUsedAt.IsZero() || now.Sub(k.LastUsedAt) >= m.cfg.touchInterval) {
+		// Best-effort by design: a failed touch must not fail authentication.
+		_ = m.store.Touch(ctx, k.ID, now)
+	}
+	meta := maps.Clone(k.Meta)
+	if meta == nil {
+		meta = make(map[string]string, 2)
+	}
+	meta["key_id"] = k.ID.String()
+	if k.Name != "" {
+		meta["key_name"] = k.Name
+	}
+	return guard.Identity{
+		Subject: k.Subject,
+		Tenant:  k.Tenant,
+		Scopes:  slices.Clone(k.Scopes),
+		Method:  guard.MethodAPIKey,
+		Meta:    meta,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run tests, fmt, verify pass**
+
+Run: `just fmt ./auth/apikey/... && just test ./auth/apikey/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add auth/apikey/
+git commit -m "feat(apikey): key generation, Manager, guard.Verifier verification"
+```
+
+---
+
+### Task 3: Management operations and tenant scope hook
+
+**Files:**
+- Modify: `auth/apikey/manager.go` (add scoped helper + Get/List/Revoke/Rotate; wire scope into Create)
+- Test: `auth/apikey/manager_test.go` (append), create `auth/apikey/scope_test.go`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–2.
+- Produces:
+  - `func (m *Manager) Get(ctx context.Context, keyID id.UUID) (Key, error)`
+  - `func (m *Manager) List(ctx context.Context, f Filter) ([]Key, error)`
+  - `func (m *Manager) Revoke(ctx context.Context, keyID id.UUID) error`
+  - `func (m *Manager) Rotate(ctx context.Context, keyID id.UUID, grace time.Duration) (Key, string, error)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `auth/apikey/manager_test.go`:
+
+```go
+func TestGetRevoke(t *testing.T) {
+	t.Parallel()
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store)
+	ctx := context.Background()
+	k, plaintext, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+
+	got, err := mgr.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "u1", got.Subject)
+
+	require.NoError(t, mgr.Revoke(ctx, k.ID))
+	got, err = mgr.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.False(t, got.RevokedAt.IsZero())
+
+	_, err = mgr.Verify(ctx, plaintext)
+	assert.ErrorIs(t, err, apikey.ErrKeyRevoked)
+
+	assert.ErrorIs(t, mgr.Revoke(ctx, id.UUID{15: 9}), apikey.ErrNotFound)
+}
+
+func TestRotate(t *testing.T) {
+	t.Parallel()
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store, apikey.WithPrefix("sk_live"))
+	ctx := context.Background()
+	old, oldPlain, err := mgr.Create(ctx, apikey.CreateParams{
+		Subject: "u1", Tenant: "t1", Name: "prod", Scopes: []string{"a"}, Meta: map[string]string{"m": "1"},
+	})
+	require.NoError(t, err)
+
+	grace := time.Hour
+	before := time.Now().UTC()
+	fresh, freshPlain, err := mgr.Rotate(ctx, old.ID, grace)
+	require.NoError(t, err)
+
+	// Inheritance.
+	assert.Equal(t, old.Subject, fresh.Subject)
+	assert.Equal(t, old.Tenant, fresh.Tenant)
+	assert.Equal(t, old.Name, fresh.Name)
+	assert.Equal(t, old.Scopes, fresh.Scopes)
+	assert.Equal(t, old.Meta, fresh.Meta)
+	assert.NotEqual(t, old.ID, fresh.ID)
+	assert.NotEqual(t, oldPlain, freshPlain)
+
+	// Overlap: both verify during grace.
+	_, err = mgr.Verify(ctx, oldPlain)
+	require.NoError(t, err)
+	_, err = mgr.Verify(ctx, freshPlain)
+	require.NoError(t, err)
+
+	// Old key's expiry ≈ now+grace.
+	oldStored, err := mgr.Get(ctx, old.ID)
+	require.NoError(t, err)
+	assert.WithinDuration(t, before.Add(grace), oldStored.ExpiresAt, 5*time.Second)
+}
+
+func TestRotate_ZeroGraceCutsOver(t *testing.T) {
+	t.Parallel()
+	mgr := apikey.New(apikey.NewMemoryStore())
+	ctx := context.Background()
+	old, oldPlain, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+
+	_, freshPlain, err := mgr.Rotate(ctx, old.ID, 0)
+	require.NoError(t, err)
+
+	_, err = mgr.Verify(ctx, oldPlain)
+	assert.ErrorIs(t, err, apikey.ErrKeyExpired)
+	_, err = mgr.Verify(ctx, freshPlain)
+	assert.NoError(t, err)
+}
+
+func TestRotate_DeadKeysRejected(t *testing.T) {
+	t.Parallel()
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store)
+	ctx := context.Background()
+
+	revoked, _, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+	require.NoError(t, mgr.Revoke(ctx, revoked.ID))
+	_, _, err = mgr.Rotate(ctx, revoked.ID, time.Hour)
+	assert.ErrorIs(t, err, apikey.ErrKeyRevoked)
+
+	expired, _, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u2"})
+	require.NoError(t, err)
+	require.NoError(t, store.Expire(ctx, expired.ID, time.Now().UTC().Add(-time.Minute)))
+	_, _, err = mgr.Rotate(ctx, expired.ID, time.Hour)
+	assert.ErrorIs(t, err, apikey.ErrKeyExpired)
+}
+```
+
+Add `"time"` and `"github.com/dmitrymomot/forge/core/id"` to `manager_test.go` imports.
+
+Create `auth/apikey/scope_test.go`:
+
+```go
+package apikey_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+)
+
+type tenantCtxKey struct{}
+
+func scopeHook(ctx context.Context) (string, error) {
+	t, _ := ctx.Value(tenantCtxKey{}).(string)
+	return t, nil
+}
+
+func tenantCtx(tenant string) context.Context {
+	return context.WithValue(context.Background(), tenantCtxKey{}, tenant)
+}
+
+func newScoped(t *testing.T) *apikey.Manager {
+	t.Helper()
+	return apikey.New(apikey.NewMemoryStore(), apikey.WithScope(scopeHook))
+}
+
+func TestScope_CreateStampsTenant(t *testing.T) {
+	t.Parallel()
+	mgr := newScoped(t)
+
+	k, _, err := mgr.Create(tenantCtx("t1"), apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+	assert.Equal(t, "t1", k.Tenant)
+
+	// Matching explicit tenant is fine; conflicting one is not.
+	_, _, err = mgr.Create(tenantCtx("t1"), apikey.CreateParams{Subject: "u1", Tenant: "t1"})
+	assert.NoError(t, err)
+	_, _, err = mgr.Create(tenantCtx("t1"), apikey.CreateParams{Subject: "u1", Tenant: "t2"})
+	assert.ErrorIs(t, err, apikey.ErrTenantMismatch)
+}
+
+func TestScope_FailClosed(t *testing.T) {
+	t.Parallel()
+	// Empty tenant from the hook.
+	mgr := newScoped(t)
+	_, _, err := mgr.Create(context.Background(), apikey.CreateParams{Subject: "u1"})
+	assert.ErrorIs(t, err, apikey.ErrScope)
+	_, err = mgr.List(context.Background(), apikey.Filter{})
+	assert.ErrorIs(t, err, apikey.ErrScope)
+
+	// Hook error.
+	boom := errors.New("boom")
+	failing := apikey.New(apikey.NewMemoryStore(), apikey.WithScope(
+		func(context.Context) (string, error) { return "", boom }))
+	_, _, err = failing.Create(context.Background(), apikey.CreateParams{Subject: "u1"})
+	assert.ErrorIs(t, err, apikey.ErrScope)
+	assert.ErrorIs(t, err, boom)
+}
+
+func TestScope_CrossTenantReadsAsNotFound(t *testing.T) {
+	t.Parallel()
+	mgr := newScoped(t)
+	k, _, err := mgr.Create(tenantCtx("t1"), apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+
+	_, err = mgr.Get(tenantCtx("t2"), k.ID)
+	assert.ErrorIs(t, err, apikey.ErrNotFound)
+	assert.ErrorIs(t, mgr.Revoke(tenantCtx("t2"), k.ID), apikey.ErrNotFound)
+	_, _, err = mgr.Rotate(tenantCtx("t2"), k.ID, time.Hour)
+	assert.ErrorIs(t, err, apikey.ErrNotFound)
+
+	// Same tenant still works.
+	_, err = mgr.Get(tenantCtx("t1"), k.ID)
+	assert.NoError(t, err)
+}
+
+func TestScope_ListConfined(t *testing.T) {
+	t.Parallel()
+	mgr := newScoped(t)
+	_, _, err := mgr.Create(tenantCtx("t1"), apikey.CreateParams{Subject: "u1"})
+	require.NoError(t, err)
+	_, _, err = mgr.Create(tenantCtx("t2"), apikey.CreateParams{Subject: "u2"})
+	require.NoError(t, err)
+
+	keys, err := mgr.List(tenantCtx("t1"), apikey.Filter{})
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "t1", keys[0].Tenant)
+
+	// A conflicting explicit filter tenant is rejected, not silently overridden.
+	_, err = mgr.List(tenantCtx("t1"), apikey.Filter{Tenant: "t2"})
+	assert.ErrorIs(t, err, apikey.ErrTenantMismatch)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./auth/apikey/`
+Expected: FAIL — `mgr.Get undefined`, `mgr.Revoke undefined`, etc.
+
+- [ ] **Step 3: Implement management ops + scope wiring**
+
+Append to `auth/apikey/manager.go`, and change `Create`'s tenant line:
+
+In `Create`, replace `Tenant: p.Tenant,` usage: insert before `plaintext := newKey(...)`:
+
+```go
+	tenant, err := m.scoped(ctx, p.Tenant)
+	if err != nil {
+		return Key{}, "", err
+	}
+```
+
+and use `Tenant: tenant,` in the `Key{...}` literal.
+
+Append:
+
+```go
+// scoped resolves the tenant a management operation is confined to. With
+// no WithScope hook it passes the requested tenant through. Fail-closed:
+// hook errors and empty scoped tenants abort the operation with ErrScope;
+// an explicit requested tenant must be empty or equal to the scoped one.
+func (m *Manager) scoped(ctx context.Context, requested string) (string, error) {
+	if m.cfg.scope == nil {
+		return requested, nil
+	}
+	t, err := m.cfg.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrScope, err)
+	}
+	if t == "" {
+		return "", ErrScope
+	}
+	if requested != "" && requested != t {
+		return "", ErrTenantMismatch
+	}
+	return t, nil
+}
+
+// Get returns one key record. With WithScope configured, other tenants'
+// keys read as ErrNotFound so existence cannot be probed across tenants.
+func (m *Manager) Get(ctx context.Context, keyID id.UUID) (Key, error) {
+	tenant, err := m.scoped(ctx, "")
+	if err != nil {
+		return Key{}, err
+	}
+	k, err := m.store.Get(ctx, keyID)
+	if err != nil {
+		return Key{}, err
+	}
+	if m.cfg.scope != nil && k.Tenant != tenant {
+		return Key{}, ErrNotFound
+	}
+	return k, nil
+}
+
+// List returns keys matching f, newest first. With WithScope configured
+// the filter is confined to the scoped tenant.
+func (m *Manager) List(ctx context.Context, f Filter) ([]Key, error) {
+	tenant, err := m.scoped(ctx, f.Tenant)
+	if err != nil {
+		return nil, err
+	}
+	f.Tenant = tenant
+	return m.store.List(ctx, f)
+}
+
+// Revoke permanently disables a key. Revocation is terminal — a revoked
+// key cannot be un-revoked or rotated.
+func (m *Manager) Revoke(ctx context.Context, keyID id.UUID) error {
+	if _, err := m.Get(ctx, keyID); err != nil {
+		return err
+	}
+	return m.store.Revoke(ctx, keyID, time.Now().UTC())
+}
+
+// Rotate mints a replacement inheriting the old key's Subject, Tenant,
+// Scopes, Name, and Meta (not its expiry), and expires the old key after
+// grace (zero = immediate cutover). Both keys verify during the grace
+// window. The replacement is created before the old key is expired so a
+// failure cannot leave the caller without a working key.
+func (m *Manager) Rotate(ctx context.Context, keyID id.UUID, grace time.Duration) (Key, string, error) {
+	old, err := m.Get(ctx, keyID)
+	if err != nil {
+		return Key{}, "", err
+	}
+	now := time.Now().UTC()
+	if !old.RevokedAt.IsZero() {
+		return Key{}, "", ErrKeyRevoked
+	}
+	if !old.ExpiresAt.IsZero() && !old.ExpiresAt.After(now) {
+		return Key{}, "", ErrKeyExpired
+	}
+	replacement, plaintext, err := m.Create(ctx, CreateParams{
+		Name:    old.Name,
+		Subject: old.Subject,
+		Tenant:  old.Tenant,
+		Scopes:  old.Scopes,
+		Meta:    old.Meta,
+	})
+	if err != nil {
+		return Key{}, "", err
+	}
+	if err := m.store.Expire(ctx, old.ID, now.Add(grace)); err != nil {
+		return Key{}, "", fmt.Errorf("apikey: rotate: %w", err)
+	}
+	return replacement, plaintext, nil
+}
+```
+
+- [ ] **Step 4: Run tests, fmt, verify pass**
+
+Run: `just fmt ./auth/apikey/... && just test ./auth/apikey/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add auth/apikey/
+git commit -m "feat(apikey): management ops (Get/List/Revoke/Rotate) and WithScope tenant isolation"
+```
+
+---
+
+### Task 4: guard integration, doc.go, fuzz, benchmarks, catalog cleanup
+
+**Files:**
+- Create: `auth/apikey/doc.go`
+- Create: `auth/apikey/integration_test.go`
+- Create: `auth/apikey/fuzz_test.go`
+- Create: `auth/apikey/bench_test.go`
+- Modify: `docs/packages.md` (delete the `auth/apikey` roadmap entry)
+
+**Interfaces:**
+- Consumes: full Task 1–3 surface; `guard.New(v, ...guard.Option) middleware.Middleware`, `guard.WithExtractors`, `guard.BearerHeader()`, `guard.Header(name)`, `guard.MustFrom(ctx) guard.Identity`.
+- Produces: nothing new — verification, docs, benchmarks.
+
+- [ ] **Step 1: Write the guard integration test**
+
+`auth/apikey/integration_test.go`:
+
+```go
+package apikey_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+func TestGuardIntegration(t *testing.T) {
+	t.Parallel()
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store, apikey.WithPrefix("sk_live"))
+	ctx := context.Background()
+	k, plaintext, err := mgr.Create(ctx, apikey.CreateParams{Subject: "user_42", Tenant: "org_7"})
+	require.NoError(t, err)
+
+	authn := guard.New(mgr, guard.WithExtractors(guard.BearerHeader(), guard.Header("X-API-Key")))
+	handler := authn(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity := guard.MustFrom(r.Context())
+		w.Header().Set("X-Subject", identity.Subject)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	do := func(mutate func(*http.Request)) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api", nil)
+		mutate(req)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("no credential 401", func(t *testing.T) {
+		rec := do(func(*http.Request) {})
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("bearer 200", func(t *testing.T) {
+		rec := do(func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+plaintext) })
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "user_42", rec.Header().Get("X-Subject"))
+	})
+
+	t.Run("X-API-Key 200", func(t *testing.T) {
+		rec := do(func(r *http.Request) { r.Header.Set("X-API-Key", plaintext) })
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("garbage 401", func(t *testing.T) {
+		rec := do(func(r *http.Request) { r.Header.Set("X-API-Key", "sk_live_garbage") })
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("revoked 401", func(t *testing.T) {
+		require.NoError(t, mgr.Revoke(ctx, k.ID))
+		rec := do(func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+plaintext) })
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+}
+```
+
+Note: the revoked subtest mutates shared state — keep the subtests in this order and do NOT mark them `t.Parallel()`.
+
+- [ ] **Step 2: Write the fuzz test**
+
+`auth/apikey/fuzz_test.go`:
+
+```go
+package apikey_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+)
+
+// FuzzVerify asserts the core property: no input other than the real
+// plaintext ever authenticates, and no input panics the parser.
+func FuzzVerify(f *testing.F) {
+	store := apikey.NewMemoryStore()
+	mgr := apikey.New(store, apikey.WithPrefix("sk"))
+	_, plaintext, err := mgr.Create(context.Background(), apikey.CreateParams{Subject: "u1"})
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	f.Add(plaintext)
+	f.Add("")
+	f.Add("sk_")
+	f.Add("sk_" + strings.Repeat("a", 49))
+	f.Add(plaintext[:len(plaintext)-1] + "!")
+
+	f.Fuzz(func(t *testing.T, cred string) {
+		identity, err := mgr.Verify(context.Background(), cred)
+		if err == nil {
+			if cred != plaintext {
+				t.Fatalf("accepted forged credential %q", cred)
+			}
+			if identity.Subject != "u1" {
+				t.Fatalf("wrong subject %q", identity.Subject)
+			}
+		}
+	})
+}
+```
+
+- [ ] **Step 3: Write benchmarks**
+
+`auth/apikey/bench_test.go`:
+
+```go
+package apikey_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+)
+
+func BenchmarkCreate(b *testing.B) {
+	mgr := apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("sk_live"))
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, _, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyHit(b *testing.B) {
+	// Touch disabled: measures the steady-state verify path.
+	mgr := apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("sk_live"), apikey.WithTouchInterval(-1))
+	ctx := context.Background()
+	_, plaintext, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Verify(ctx, plaintext); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyMalformedReject(b *testing.B) {
+	// The DoS-relevant path: checksum rejection without store access.
+	// Target: zero allocations.
+	mgr := apikey.New(apikey.NewMemoryStore(), apikey.WithPrefix("sk_live"))
+	ctx := context.Background()
+	_, plaintext, err := mgr.Create(ctx, apikey.CreateParams{Subject: "u1"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	bad := plaintext[:len(plaintext)-1] + "!"
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Verify(ctx, bad); err == nil {
+			b.Fatal("expected rejection")
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run integration/fuzz/bench**
+
+Run: `just fmt ./auth/apikey/... && just test ./auth/apikey/`
+Expected: PASS.
+
+Run: `go test -run=NONE -fuzz=FuzzVerify -fuzztime=30s ./auth/apikey/`
+Expected: no crashers.
+
+Run: `just bench ./auth/apikey/`
+Expected: benchmarks run; record ns/op + allocs/op for the PR description. `BenchmarkVerifyMalformedReject` should report 0 allocs/op (the `[]byte(payload)` conversion is non-escaping; if allocs appear, run the post-benchmark optimization pass required by repo rules).
+
+- [ ] **Step 5: Write doc.go**
+
+`auth/apikey/doc.go`:
+
+```go
+// Package apikey issues, manages, and verifies API keys: Stripe-style
+// prefixed secrets (sk_live_x7Kp…) with a CRC32 checksum that rejects
+// malformed credentials before any store access, SHA-256 hashes at rest,
+// and the plaintext returned exactly once at creation. Management —
+// create/list/revoke/rotate, per-key scopes, optional expiry, throttled
+// last-used-at — runs behind the storage-agnostic Store seam;
+// verification implements guard.Verifier.
+//
+// Personal and tenant-wide keys share one model: Subject is the principal
+// the key acts as — a user id for personal keys, or a tenant or
+// service-account id for keys owned by the org itself — and Tenant
+// optionally pins the owning org.
+//
+//	store := apikey.NewMemoryStore() // pgstore.New(pool) in production
+//	mgr := apikey.New(store, apikey.WithPrefix("sk_live"))
+//
+//	key, plaintext, err := mgr.Create(ctx, apikey.CreateParams{
+//		Subject: "user_42", Tenant: "org_7", Name: "CI deploy",
+//		Scopes:  []string{"deploy:write"},
+//	})
+//	// Show plaintext once; key.Preview ("sk_live_x7Kp") is what
+//	// dashboards keep. Only the SHA-256 of the plaintext is stored.
+//
+//	authn := guard.New(mgr, guard.WithExtractors(guard.BearerHeader(), guard.Header("X-API-Key")))
+//	mux.Handle("POST /api/deploy", authn(deployHandler))
+//
+// Scopes are carried into guard.Identity.Scopes but never enforced here —
+// enforcement belongs to the authorization seam (auth/rbac).
+//
+// Multi-tenant applications confine management operations with WithScope;
+// verification needs no hook because the key record itself resolves the
+// tenant:
+//
+//	mgr := apikey.New(store, apikey.WithScope(func(ctx context.Context) (string, error) {
+//		return tenantFromCtx(ctx), nil // fail-closed: empty or error aborts
+//	}))
+//
+// Rotation overlaps old and new keys so consumers can deploy the new
+// plaintext before the old one dies:
+//
+//	fresh, plaintext, err := mgr.Rotate(ctx, key.ID, 24*time.Hour)
+package apikey
+```
+
+- [ ] **Step 6: Catalog cleanup**
+
+In `docs/packages.md`: delete the whole `**auth/apikey**` entry (heading, description paragraph, `Deps:` line, and its `---` separator — around line 654). Then check remaining references:
+
+Run: `grep -n "apikey" docs/packages.md`
+Expected: only the `auth/scim` entry's "authenticated via `apikey` or `oauthserver` tokens" prose and the `web/hostrouter` "API-key-derived" prose remain — both describe capabilities, not planned-dep tags; leave them.
+
+- [ ] **Step 7: Lint and commit**
+
+Run: `just lint`
+Expected: clean.
+
+```bash
+git add auth/apikey/ docs/packages.md
+git commit -m "feat(apikey): guard integration test, fuzz, benchmarks, doc.go; drop shipped catalog entry"
+```
+
+---
+
+### Task 5: Postgres driver (auth/apikey/pgstore)
+
+**Files:**
+- Create: `auth/apikey/pgstore/migrations/00001_create_forge_api_keys.sql`
+- Create: `auth/apikey/pgstore/pgstore.go`
+- Create: `auth/apikey/pgstore/doc.go`
+- Test: `auth/apikey/pgstore/pgstore_test.go`
+
+**Interfaces:**
+- Consumes: `apikey.Store` seam + `apikey.Key/Filter` + sentinels (Task 1); `id.UUID` (pgx encodes/decodes `[16]byte`-underlying types as `uuid` natively); `data/migration` (`migration.New(fsys, migration.WithTable(...)).Up(ctx, db)`); `data/postgres` (`postgres.Open`, `postgres.DefaultConfig`) — test-only.
+- Produces: `pgstore.New(pool *pgxpool.Pool) *Store` implementing `apikey.Store`; `pgstore.Migrations fs.FS`.
+
+- [ ] **Step 1: Start ephemeral Postgres for live integration runs**
+
+```bash
+docker run --rm -d --name forge-apikey-pg -e POSTGRES_PASSWORD=forge -e POSTGRES_DB=forge -p 5499:5432 postgres:16-alpine
+export FORGE_TEST_POSTGRES_DSN="postgres://postgres:forge@localhost:5499/forge?sslmode=disable"
+```
+
+Expected: container starts; `docker logs forge-apikey-pg` eventually shows "database system is ready to accept connections". (Stop with `docker stop forge-apikey-pg` at the end of the task.)
+
+- [ ] **Step 2: Write the failing integration test**
+
+`auth/apikey/pgstore/pgstore_test.go` — mirrors the `resilience/lock/pgstore` gating pattern; each test uses `t.Name()`-derived subjects/hashes for isolation on the shared table:
+
+```go
+package pgstore_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+	"github.com/dmitrymomot/forge/auth/apikey/pgstore"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+)
+
+var _ apikey.Store = (*pgstore.Store)(nil)
+
+func newStore(t *testing.T) *pgstore.Store {
+	t.Helper()
+	dsn := os.Getenv("FORGE_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("set FORGE_TEST_POSTGRES_DSN")
+	}
+	cfg := postgres.DefaultConfig()
+	cfg.URL = dsn
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgstore.Migrations, migration.WithTable("forge_apikey_schema")).Up(context.Background(), db))
+	return pgstore.New(pool)
+}
+
+// mkKey builds a record whose hash/subject/tenant are unique per call:
+// the table persists across test runs, so deterministic values would
+// collide on the unique hash index or inflate List counts on re-runs.
+func mkKey(t *testing.T) apikey.Key {
+	t.Helper()
+	uid := id.NewUUID()
+	return apikey.Key{
+		ID:        uid,
+		Hash:      "hash-" + uid.String(),
+		Preview:   "key_preview1",
+		Name:      "key-" + t.Name(),
+		Subject:   "subj-" + uid.String(),
+		Tenant:    "tenant-" + uid.String(),
+		Scopes:    []string{"read", "write"},
+		Meta:      map[string]string{"env": "prod"},
+		CreatedAt: time.Now().UTC(),
+	}
+}
+
+func TestPg_CreateGetRoundTrip(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	k := mkKey(t)
+	k.ExpiresAt = time.Now().UTC().Add(time.Hour).Truncate(time.Millisecond)
+	require.NoError(t, s.Create(ctx, k))
+
+	got, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.Equal(t, k.ID, got.ID)
+	assert.Equal(t, k.Hash, got.Hash)
+	assert.Equal(t, k.Scopes, got.Scopes)
+	assert.Equal(t, k.Meta, got.Meta)
+	assert.True(t, got.ExpiresAt.Equal(k.ExpiresAt))
+	// NULL ⇔ zero-time mapping.
+	assert.True(t, got.LastUsedAt.IsZero())
+	assert.True(t, got.RevokedAt.IsZero())
+
+	byHash, err := s.GetByHash(ctx, k.Hash)
+	require.NoError(t, err)
+	assert.Equal(t, k.ID, byHash.ID)
+}
+
+func TestPg_NotFound(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	_, err := s.Get(ctx, id.NewUUID())
+	assert.ErrorIs(t, err, apikey.ErrNotFound)
+	_, err = s.GetByHash(ctx, "missing-"+id.NewUUID().String())
+	assert.ErrorIs(t, err, apikey.ErrNotFound)
+	assert.ErrorIs(t, s.Revoke(ctx, id.NewUUID(), time.Now()), apikey.ErrNotFound)
+	assert.ErrorIs(t, s.Expire(ctx, id.NewUUID(), time.Now()), apikey.ErrNotFound)
+	assert.ErrorIs(t, s.Touch(ctx, id.NewUUID(), time.Now()), apikey.ErrNotFound)
+}
+
+func TestPg_DuplicateHash(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	k := mkKey(t)
+	require.NoError(t, s.Create(ctx, k))
+
+	dup := mkKey(t)
+	dup.Hash = k.Hash
+	assert.ErrorIs(t, s.Create(ctx, dup), apikey.ErrDuplicate)
+
+	dupID := mkKey(t)
+	dupID.ID = k.ID
+	assert.ErrorIs(t, s.Create(ctx, dupID), apikey.ErrDuplicate)
+}
+
+func TestPg_ListFilterAndOrder(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	k1, k2 := mkKey(t), mkKey(t)
+	k2.Tenant = k1.Tenant
+	// Deterministic id ordering: id.NewUUID() is NOT monotonic within one
+	// millisecond, so same-ms ids sort randomly and would flake this test.
+	// Share one id and vary only the last byte: k2 > k1 by construction.
+	k2.ID = k1.ID
+	k1.ID[15], k2.ID[15] = 0x01, 0x02
+	require.NoError(t, s.Create(ctx, k1))
+	require.NoError(t, s.Create(ctx, k2))
+
+	all, err := s.List(ctx, apikey.Filter{Tenant: k1.Tenant})
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+	// Newest first = descending id bytes.
+	assert.Equal(t, k2.ID, all[0].ID)
+
+	one, err := s.List(ctx, apikey.Filter{Tenant: k1.Tenant, Subject: k1.Subject})
+	require.NoError(t, err)
+	require.Len(t, one, 1)
+	assert.Equal(t, k1.ID, one[0].ID)
+}
+
+func TestPg_Mutators(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	k := mkKey(t)
+	require.NoError(t, s.Create(ctx, k))
+	at := time.Now().UTC().Truncate(time.Millisecond)
+
+	require.NoError(t, s.Revoke(ctx, k.ID, at))
+	require.NoError(t, s.Expire(ctx, k.ID, at.Add(time.Hour)))
+	require.NoError(t, s.Touch(ctx, k.ID, at.Add(time.Minute)))
+
+	got, err := s.Get(ctx, k.ID)
+	require.NoError(t, err)
+	assert.True(t, got.RevokedAt.Equal(at))
+	assert.True(t, got.ExpiresAt.Equal(at.Add(time.Hour)))
+	assert.True(t, got.LastUsedAt.Equal(at.Add(time.Minute)))
+}
+
+func TestPg_ManagerEndToEnd(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	mgr := apikey.New(s, apikey.WithPrefix("sk_pg"))
+
+	k, plaintext, err := mgr.Create(ctx, apikey.CreateParams{Subject: t.Name() + "-u", Tenant: t.Name() + "-t"})
+	require.NoError(t, err)
+
+	identity, err := mgr.Verify(ctx, plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, t.Name()+"-u", identity.Subject)
+
+	fresh, freshPlain, err := mgr.Rotate(ctx, k.ID, time.Hour)
+	require.NoError(t, err)
+	_, err = mgr.Verify(ctx, plaintext) // old still inside grace
+	require.NoError(t, err)
+	_, err = mgr.Verify(ctx, freshPlain)
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.Revoke(ctx, fresh.ID))
+	_, err = mgr.Verify(ctx, freshPlain)
+	assert.ErrorIs(t, err, apikey.ErrKeyRevoked)
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./auth/apikey/pgstore/`
+Expected: FAIL — compile errors (`undefined: pgstore.New`, no package).
+
+- [ ] **Step 4: Implement migration + driver**
+
+`auth/apikey/pgstore/migrations/00001_create_forge_api_keys.sql`:
+
+```sql
+-- +goose Up
+CREATE TABLE forge_api_keys (
+    id           uuid PRIMARY KEY,
+    hash         text NOT NULL UNIQUE,
+    preview      text NOT NULL,
+    name         text NOT NULL DEFAULT '',
+    subject      text NOT NULL,
+    tenant       text NOT NULL DEFAULT '',
+    scopes       text[] NOT NULL DEFAULT '{}',
+    meta         jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at   timestamptz NOT NULL,
+    expires_at   timestamptz,
+    last_used_at timestamptz,
+    revoked_at   timestamptz
+);
+
+CREATE INDEX forge_api_keys_list_idx ON forge_api_keys (tenant, subject, id DESC);
+
+-- +goose Down
+DROP TABLE forge_api_keys;
+```
+
+`auth/apikey/pgstore/doc.go`:
+
+```go
+// Package pgstore is the Postgres apikey.Store driver over pgx. The DDL
+// (forge_api_keys) ships as an embedded goose migration in Migrations;
+// apply it via data/migration under its own version table before first
+// use:
+//
+//	_ = migration.New(pgstore.Migrations, migration.WithTable("forge_apikey_schema")).Up(ctx, db)
+//
+// GetByHash — the verification hot path — is a single point lookup on the
+// unique hash index. Zero time.Time fields map to SQL NULL and back.
+package pgstore
+```
+
+`auth/apikey/pgstore/pgstore.go`:
+
+```go
+package pgstore
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"io/fs"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/auth/apikey"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_api_keys, rooted so
+// its .sql files sit at fsys root (data/migration.New globs fsys's root,
+// not subdirectories). Apply via data/migration under its own version
+// table ("forge_apikey_schema").
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// Store is the Postgres implementation of apikey.Store. The pool's
+// lifecycle is the caller's.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+var _ apikey.Store = (*Store)(nil)
+
+// New builds a Postgres apikey Store. Apply Migrations first.
+func New(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const cols = `id, hash, preview, name, subject, tenant, scopes, meta, created_at, expires_at, last_used_at, revoked_at`
+
+const createSQL = `
+INSERT INTO forge_api_keys (` + cols + `)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`
+
+// Create inserts k. A colliding id or hash yields apikey.ErrDuplicate.
+func (s *Store) Create(ctx context.Context, k apikey.Key) error {
+	scopes := k.Scopes
+	if scopes == nil {
+		scopes = []string{}
+	}
+	meta := k.Meta
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	_, err := s.pool.Exec(ctx, createSQL,
+		k.ID, k.Hash, k.Preview, k.Name, k.Subject, k.Tenant, scopes, meta,
+		k.CreatedAt, nullTime(k.ExpiresAt), nullTime(k.LastUsedAt), nullTime(k.RevokedAt))
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
+		return apikey.ErrDuplicate
+	}
+	return err
+}
+
+// Get returns the record for keyID, or apikey.ErrNotFound.
+func (s *Store) Get(ctx context.Context, keyID id.UUID) (apikey.Key, error) {
+	return scanKey(s.pool.QueryRow(ctx, `SELECT `+cols+` FROM forge_api_keys WHERE id = $1`, keyID))
+}
+
+// GetByHash returns the record whose hash matches, or apikey.ErrNotFound.
+// This is the verification hot path: one point lookup on the unique index.
+func (s *Store) GetByHash(ctx context.Context, hash string) (apikey.Key, error) {
+	return scanKey(s.pool.QueryRow(ctx, `SELECT `+cols+` FROM forge_api_keys WHERE hash = $1`, hash))
+}
+
+// List returns records matching f, newest first (UUIDv7 ids are
+// time-ordered, so id DESC is creation order).
+func (s *Store) List(ctx context.Context, f apikey.Filter) ([]apikey.Key, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+cols+` FROM forge_api_keys
+		 WHERE ($1 = '' OR tenant = $1) AND ($2 = '' OR subject = $2)
+		 ORDER BY id DESC`, f.Tenant, f.Subject)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []apikey.Key
+	for rows.Next() {
+		k, err := scanKey(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, k)
+	}
+	return out, rows.Err()
+}
+
+// Revoke sets revoked_at, or returns apikey.ErrNotFound.
+func (s *Store) Revoke(ctx context.Context, keyID id.UUID, at time.Time) error {
+	return s.setTime(ctx, `UPDATE forge_api_keys SET revoked_at = $2 WHERE id = $1`, keyID, at)
+}
+
+// Expire sets expires_at (rotation grace), or returns apikey.ErrNotFound.
+func (s *Store) Expire(ctx context.Context, keyID id.UUID, at time.Time) error {
+	return s.setTime(ctx, `UPDATE forge_api_keys SET expires_at = $2 WHERE id = $1`, keyID, at)
+}
+
+// Touch sets last_used_at, or returns apikey.ErrNotFound.
+func (s *Store) Touch(ctx context.Context, keyID id.UUID, at time.Time) error {
+	return s.setTime(ctx, `UPDATE forge_api_keys SET last_used_at = $2 WHERE id = $1`, keyID, at)
+}
+
+func (s *Store) setTime(ctx context.Context, sql string, keyID id.UUID, at time.Time) error {
+	tag, err := s.pool.Exec(ctx, sql, keyID, at)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return apikey.ErrNotFound
+	}
+	return nil
+}
+
+// row is satisfied by both pgx.Row and pgx.Rows.
+type row interface{ Scan(dest ...any) error }
+
+func scanKey(r row) (apikey.Key, error) {
+	var k apikey.Key
+	var exp, lu, rv *time.Time
+	err := r.Scan(&k.ID, &k.Hash, &k.Preview, &k.Name, &k.Subject, &k.Tenant,
+		&k.Scopes, &k.Meta, &k.CreatedAt, &exp, &lu, &rv)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return apikey.Key{}, apikey.ErrNotFound
+	}
+	if err != nil {
+		return apikey.Key{}, err
+	}
+	k.ExpiresAt = deref(exp)
+	k.LastUsedAt = deref(lu)
+	k.RevokedAt = deref(rv)
+	return k, nil
+}
+
+// deref maps SQL NULL back to the zero time.
+func deref(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
+// nullTime maps the zero time to SQL NULL.
+func nullTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}
+```
+
+- [ ] **Step 5: Run integration tests live**
+
+Run: `just fmt ./auth/apikey/... && FORGE_TEST_POSTGRES_DSN="postgres://postgres:forge@localhost:5499/forge?sslmode=disable" go test -race ./auth/apikey/pgstore/`
+Expected: PASS (all tests run, none skip).
+
+Also verify the skip path: `go test ./auth/apikey/pgstore/` without the env var → tests skip, exit 0.
+
+- [ ] **Step 6: Lint, stop container, commit**
+
+Run: `just lint`
+Expected: clean.
+
+```bash
+docker stop forge-apikey-pg
+git add auth/apikey/pgstore/
+git commit -m "feat(apikey/pgstore): Postgres Store driver with embedded goose migration"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `just test ./auth/apikey/...` — all green with race detector.
+- [ ] `just lint` — clean.
+- [ ] `just bench ./auth/apikey/` — numbers recorded for the PR description (repo rule: before/after if any optimization pass happened).
+- [ ] `grep -rn "apikey" docs/packages.md` — no stale roadmap entry.
+- [ ] PR flow per CLAUDE.md: create PR → wait for CI → fix failures → address Claude review → repeat until clean. Note: claude-code-review.yml times out silently on big PRs — run a local whole-branch review regardless.

--- a/docs/superpowers/specs/2026-07-13-auth-apikey-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-apikey-design.md
@@ -217,9 +217,10 @@ r.Use(guard.New(mgr, guard.WithExtractors(guard.BearerHeader(), guard.Header("X-
 ## Errors
 
 `errors.go`, single-line `errors.Is`-matchable sentinels: `ErrNotFound`
-(store), `ErrMalformedKey`, `ErrKeyNotFound`, `ErrKeyRevoked`,
-`ErrKeyExpired`, `ErrSubjectRequired`, `ErrTenantMismatch`. Nil store or
-invalid prefix panics at construction.
+and `ErrDuplicate` (store contract), `ErrMalformedKey`, `ErrKeyNotFound`,
+`ErrKeyRevoked`, `ErrKeyExpired`, `ErrSubjectRequired`,
+`ErrTenantMismatch`, and `ErrScope` (fail-closed WithScope hook failure /
+empty tenant). Nil store or invalid prefix panics at construction.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-13-auth-apikey-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-apikey-design.md
@@ -22,12 +22,14 @@ Primary consumers: any service exposing a partner/programmatic API.
 
 ## Placement
 
-`auth/apikey`, single package, no subpackages in this PR. Imports:
-`auth/guard`, `core/id`, `core/random`, `crypto/consttime` (+ stdlib
-`crypto/sha256`, `hash/crc32`). Standard anatomy: `doc.go` (runnable
-example), `apikey.go` (Key/Filter/CreateParams), `keygen.go`,
-`manager.go`, `verify.go`, `store.go` (seam), `memory.go` (in-memory
-store), `options.go`, `errors.go`, black-box tests + `bench_test.go`.
+`auth/apikey` core package plus one driver subpackage
+`auth/apikey/pgstore` (pgx). Core imports: `auth/guard`, `core/id`,
+`core/random`, `crypto/consttime` (+ stdlib `crypto/sha256`,
+`hash/crc32`) — core never imports a driver client. Standard anatomy:
+`doc.go` (runnable example), `apikey.go` (Key/Filter/CreateParams),
+`keygen.go`, `manager.go`, `verify.go`, `store.go` (seam), `memory.go`
+(in-memory store), `options.go`, `errors.go`, black-box tests +
+`bench_test.go`.
 
 When this ships: delete the `auth/apikey` entry from docs/packages.md and
 un-tag the planned-dep references (`auth/scim`); the entry's dep line gains
@@ -135,7 +137,40 @@ type Store interface {
 Targeted mutators instead of a generic `Update`: each is one statement in a
 SQL driver and cannot clobber concurrent writes. `NewMemoryStore()`
 (mutex-guarded map by ID + hash index) ships in-package as the seam-owner
-test double; a `pg` driver subpackage is a follow-up, not this PR.
+test double; the postgres driver ships in this PR (next section).
+
+## Postgres driver (`auth/apikey/pgstore`)
+
+Follows the established pgstore idiom (`resilience/lock/pgstore`):
+`New(pool *pgxpool.Pool) *Store`, embedded goose migration exported as
+`Migrations` (rooted via `fs.Sub` so the .sql files sit at fsys root),
+applied by the consumer through `data/migration` under its own version
+table (`forge_apikey_schema` — never shared, per the migration.Group
+collision rule).
+
+```sql
+CREATE TABLE forge_api_keys (
+    id           uuid PRIMARY KEY,
+    hash         text NOT NULL UNIQUE,
+    preview      text NOT NULL,
+    name         text NOT NULL DEFAULT '',
+    subject      text NOT NULL,
+    tenant       text NOT NULL DEFAULT '',
+    scopes       text[] NOT NULL DEFAULT '{}',
+    meta         jsonb NOT NULL DEFAULT '{}',
+    created_at   timestamptz NOT NULL,
+    expires_at   timestamptz,
+    last_used_at timestamptz,
+    revoked_at   timestamptz
+);
+CREATE INDEX forge_api_keys_list_idx ON forge_api_keys (tenant, subject, id DESC);
+```
+
+Mapping rules: zero `time.Time` ⇔ SQL `NULL` on the three nullable
+columns; `List` orders by `id DESC` (UUIDv7 is time-ordered, so this is
+newest-first straight off the index); `GetByHash` hits the unique hash
+index — the verify hot path is one indexed point lookup. Filter clauses
+are appended only for non-empty `Subject`/`Tenant`.
 
 ## Manager API
 
@@ -195,12 +230,17 @@ expired / empty-subject record); touch throttling via injected stale
 (old+new both verify, old dies after grace); scope-hook enforcement
 including cross-tenant `ErrNotFound` and fail-closed hook errors; guard
 integration end-to-end (401/200 through `guard.New(mgr)`); memory-store
-contract tests. Fuzz: `FuzzVerify` over the parse/checksum path.
+contract tests. The same store contract suite runs against pgstore as
+integration tests, gated on `FORGE_TEST_POSTGRES_DSN` (skip when unset;
+run live against ephemeral docker pg16 during development, as in the
+resilience-bundle flow) — plus pg-specific cases: NULL⇔zero-time
+round-trip, hash-uniqueness violation, `List` ordering/filtering, and
+migration apply. Fuzz: `FuzzVerify` over the parse/checksum path.
 Benchmarks (repo requirement): keygen, `Verify` hit, malformed reject —
 target ~zero allocs on the reject path.
 
 ## Anti-scope
 
-No HTTP management handlers; no scope-enforcement middleware; no SQL driver
-in this PR (memory store only); no encryption-at-rest beyond hashing; no
-per-key rate limiting; no idle-based expiry.
+No HTTP management handlers; no scope-enforcement middleware; no drivers
+beyond pgstore (redis/sqlite not planned); no encryption-at-rest beyond
+hashing; no per-key rate limiting; no idle-based expiry.

--- a/docs/superpowers/specs/2026-07-13-auth-apikey-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-apikey-design.md
@@ -1,0 +1,206 @@
+# auth/apikey — design
+
+Date: 2026-07-13
+Status: approved for planning
+
+## Purpose
+
+The full API-key product for tenant- or user-owned keys: Stripe-style
+prefixed keys with a checksum for cheap rejection, hash stored, plaintext
+shown once — plus management (create/list/revoke/rotate, per-key scopes,
+optional expiry, last-used-at tracking) behind a storage-agnostic `Store`,
+and request verification as a `guard.Verifier`.
+
+Works for both ownership shapes with one model: **personal keys** (`Subject`
+= user id, `Tenant` = the user's org) and **tenant-wide keys** (`Subject` =
+whatever principal represents the org acting as itself — tenant id or a
+service-account id, caller's choice). The package never invents principal
+semantics; it requires a non-empty `Subject` and carries it.
+
+Primary consumers: any service exposing a partner/programmatic API.
+`auth/scim` lists apikey-or-oauthserver as its authentication.
+
+## Placement
+
+`auth/apikey`, single package, no subpackages in this PR. Imports:
+`auth/guard`, `core/id`, `core/random`, `crypto/consttime` (+ stdlib
+`crypto/sha256`, `hash/crc32`). Standard anatomy: `doc.go` (runnable
+example), `apikey.go` (Key/Filter/CreateParams), `keygen.go`,
+`manager.go`, `verify.go`, `store.go` (seam), `memory.go` (in-memory
+store), `options.go`, `errors.go`, black-box tests + `bench_test.go`.
+
+When this ships: delete the `auth/apikey` entry from docs/packages.md and
+un-tag the planned-dep references (`auth/scim`); the entry's dep line gains
+`core/id` (UUIDv7 record ids), decided here.
+
+## Decisions (resolved during brainstorming)
+
+1. **Hash-lookup verification.** Store `SHA-256(full plaintext key)` hex;
+   verify = hash the presented credential, exact-match `GetByHash`,
+   `consttime.StringEqual` on the returned hash as defense-in-depth.
+   Unsalted SHA-256 is safe at 256-bit key entropy (no brute-forceable
+   preimage); no bcrypt/argon2 on the hot path. A split key-id+secret
+   format was rejected — a stored `Preview` field gives the same dashboard
+   UX without parsing complexity.
+2. **Key anatomy** — `<prefix>_<payload><checksum>`:
+   - `prefix`: construction-time (`WithPrefix("sk_live")`, default
+     `"key"`), validated `[a-z0-9_]+`; environments are just differently
+     configured issuers, the package invents no env segment.
+   - `payload`: 43 random base62 chars via `random.String` (~256 bits).
+   - `checksum`: CRC32 (IEEE) of the payload bytes, base62-encoded, fixed
+     6 chars (GitHub's scheme) — malformed/truncated keys are rejected
+     before any store hit, and secret scanners can validate leaks offline.
+   - `Preview` = first 12 plaintext chars, stored for dashboards.
+   - `ID` = `id.NewUUID()` (UUIDv7, time-ordered, SQL-native) — record
+     identity is never derived from the secret. All management ops key on
+     `id.UUID`.
+3. **Plaintext is returned exactly once** — from `Create` and `Rotate`,
+   alongside the stored record. The record's exported `Hash` field is not
+   secret (preimage-resistant digest, useless to authenticate); one shared
+   record type between Manager and Store beats a split public/store type.
+4. **last-used-at = throttled best-effort touch.** `Verify` calls
+   `store.Touch` only when the loaded record's `LastUsedAt` is staler than
+   `WithTouchInterval` (default 60s; `0` = every request, negative =
+   disabled). Touch errors never fail verification (documented
+   best-effort).
+5. **Rotation = graceful roll.** `Rotate(ctx, id, grace)` mints a new key
+   inheriting Subject/Tenant/Scopes/Name/Meta and sets the old key's
+   `ExpiresAt = now+grace` (`0` = immediate cutover). Both keys verify
+   during the grace window. Revoked/expired keys cannot be rotated.
+6. **Scopes are carried, not enforced.** `Create` stores them; `Verify`
+   copies them into `guard.Identity.Scopes`. No `RequireScope` middleware —
+   enforcement belongs to the future shared authz seam (`auth/rbac`,
+   guard's 401-vs-403 split).
+7. **Multi-tenancy via optional `WithScope(func(ctx) (string, error))`**
+   (repo-wide rule), governing management ops only — `Verify` resolves
+   tenant from the key record itself. When set: `Create` stamps the derived
+   tenant (params must leave `Tenant` empty or matching, else
+   `ErrTenantMismatch`); `List` forces `Filter.Tenant`; `Get`/`Revoke`/
+   `Rotate` return `ErrNotFound` on tenant mismatch so cross-tenant probing
+   cannot distinguish "exists elsewhere" from "doesn't exist". Hook error
+   or empty tenant fails the operation (fail-closed). Single-tenant apps
+   skip the option — zero ceremony.
+8. **Subject-level ownership stays with the caller.** `Filter.Subject`
+   makes "list this user's keys" one call; whether a given user may revoke
+   a given key is app authz, decided with the record in hand.
+
+## Types
+
+```go
+// Key is the stored record — never contains the plaintext secret.
+type Key struct {
+    ID         id.UUID           // UUIDv7 record id
+    Hash       string            // hex SHA-256 of the full plaintext key
+    Preview    string            // first 12 plaintext chars, for dashboards
+    Name       string            // human label
+    Subject    string            // principal the key acts as — never empty
+    Tenant     string            // optional tenant
+    Scopes     []string
+    Meta       map[string]string
+    CreatedAt  time.Time
+    ExpiresAt  time.Time         // zero = never expires
+    LastUsedAt time.Time         // zero = never used
+    RevokedAt  time.Time         // zero = active
+}
+
+type CreateParams struct {
+    Name      string
+    Subject   string            // required — ErrSubjectRequired
+    Tenant    string            // optional; constrained by the scope hook
+    Scopes    []string
+    Meta      map[string]string
+    ExpiresAt time.Time         // zero = never
+}
+
+type Filter struct {
+    Subject string // optional: personal keys of one principal
+    Tenant  string // optional; forced by the scope hook when configured
+}
+```
+
+## Store seam
+
+```go
+type Store interface {
+    Create(ctx context.Context, k Key) error                    // unique by ID and Hash
+    Get(ctx context.Context, id id.UUID) (Key, error)           // ErrNotFound
+    GetByHash(ctx context.Context, hash string) (Key, error)    // verify path; ErrNotFound
+    List(ctx context.Context, f Filter) ([]Key, error)          // newest first
+    Revoke(ctx context.Context, id id.UUID, at time.Time) error // sets RevokedAt
+    Expire(ctx context.Context, id id.UUID, at time.Time) error // sets ExpiresAt (rotation grace)
+    Touch(ctx context.Context, id id.UUID, at time.Time) error  // sets LastUsedAt (best-effort)
+}
+```
+
+Targeted mutators instead of a generic `Update`: each is one statement in a
+SQL driver and cannot clobber concurrent writes. `NewMemoryStore()`
+(mutex-guarded map by ID + hash index) ships in-package as the seam-owner
+test double; a `pg` driver subpackage is a follow-up, not this PR.
+
+## Manager API
+
+```go
+func New(store Store, opts ...Option) *Manager
+// New panics on nil store or invalid prefix — wiring bugs, like guard.New.
+// Options: WithPrefix(string), WithScope(func(ctx) (string, error)),
+//          WithTouchInterval(time.Duration)
+
+func (m *Manager) Create(ctx context.Context, p CreateParams) (Key, string, error) // record + plaintext
+func (m *Manager) Get(ctx context.Context, keyID id.UUID) (Key, error)
+func (m *Manager) List(ctx context.Context, f Filter) ([]Key, error)
+func (m *Manager) Revoke(ctx context.Context, keyID id.UUID) error
+func (m *Manager) Rotate(ctx context.Context, keyID id.UUID, grace time.Duration) (Key, string, error)
+func (m *Manager) Verify(ctx context.Context, credential string) (guard.Identity, error)
+```
+
+`Manager` implements `guard.Verifier` directly — no adapter type.
+
+## Verify flow (hot path)
+
+1. **Cheap reject** — prefix mismatch, wrong length, or checksum failure ⇒
+   `ErrMalformedKey`; no store hit, so credential-stuffing garbage never
+   reaches the DB.
+2. `store.GetByHash(ctx, sha256hex(credential))` — miss ⇒ `ErrKeyNotFound`.
+3. `consttime.StringEqual` on the returned hash (defense-in-depth against a
+   buggy store).
+4. `RevokedAt` set ⇒ `ErrKeyRevoked`; `ExpiresAt` passed ⇒ `ErrKeyExpired`.
+5. Throttled best-effort `Touch` (decision 4).
+6. Return `guard.Identity{Subject, Tenant, Scopes, Method: guard.MethodAPIKey,
+   Meta: key.Meta + "key_id"/"key_name"}` — key id in Meta so handlers and
+   audit logs can tell which key authenticated.
+
+Under `guard.New` every verify error collapses to an opaque 401; the
+sentinels exist for metrics and direct callers.
+
+Wiring example (doc.go material):
+
+```go
+mgr := apikey.New(store, apikey.WithPrefix("sk_live"))
+r.Use(guard.New(mgr, guard.WithExtractors(guard.BearerHeader(), guard.Header("X-API-Key"))))
+```
+
+## Errors
+
+`errors.go`, single-line `errors.Is`-matchable sentinels: `ErrNotFound`
+(store), `ErrMalformedKey`, `ErrKeyNotFound`, `ErrKeyRevoked`,
+`ErrKeyExpired`, `ErrSubjectRequired`, `ErrTenantMismatch`. Nil store or
+invalid prefix panics at construction.
+
+## Testing
+
+Black-box (`apikey_test`): key-anatomy round-trip; checksum tamper and
+truncation rejection; verify matrix (ok / malformed / unknown / revoked /
+expired / empty-subject record); touch throttling via injected stale
+`LastUsedAt` (0 / positive / negative intervals); rotation grace overlap
+(old+new both verify, old dies after grace); scope-hook enforcement
+including cross-tenant `ErrNotFound` and fail-closed hook errors; guard
+integration end-to-end (401/200 through `guard.New(mgr)`); memory-store
+contract tests. Fuzz: `FuzzVerify` over the parse/checksum path.
+Benchmarks (repo requirement): keygen, `Verify` hit, malformed reject —
+target ~zero allocs on the reject path.
+
+## Anti-scope
+
+No HTTP management handlers; no scope-enforcement middleware; no SQL driver
+in this PR (memory store only); no encryption-at-rest beyond hashing; no
+per-key rate limiting; no idle-based expiry.


### PR DESCRIPTION
## Summary

`auth/apikey` — Stripe-style API keys (issue / manage / verify) behind a storage-agnostic `Store` seam, implementing `guard.Verifier`, plus a Postgres `pgstore` driver.

Keys are `<prefix>_<43 base62 payload><6-char base62 CRC32 checksum>`. Only the hex SHA-256 of the full plaintext is stored; the plaintext is returned exactly once at creation. Malformed credentials are rejected by checksum **before any store access** — the DoS-relevant surface that shields the store from credential-stuffing garbage.

## What's included

- **`Manager`** — `Create` / `Get` / `List` / `Revoke` / `Rotate` for management, and `Verify` implementing `guard.Verifier` directly. UUIDv7 record ids (time-ordered), constant-time hash compare, fail-closed defense-in-depth (rejects corrupt subject-less records).
- **`Store` seam** — 7-method interface with an in-package memory store (dev/tests) and a pgx driver subpackage.
- **Verification gauntlet** — malformed → `ErrMalformedKey` (pre-store), unknown → `ErrKeyNotFound`, revoked → `ErrKeyRevoked`, expired → `ErrKeyExpired`. Under `guard.New` every error collapses to an opaque 401; sentinels serve metrics/direct callers.
- **Graceful rotation** — replacement minted before the old key is expired (never strands the caller); both keys valid during the grace window; zero grace = immediate cutover.
- **Multi-tenant** — optional `WithScope(ctx)` hook confines management ops to the ctx-derived tenant, fail-closed; cross-tenant reads return `ErrNotFound` (unprobeable). `Verify` needs no hook — the key record carries its own tenant.
- **Throttled last-used-at** — `WithTouchInterval` (default 60s; 0 = every request; negative = disabled); best-effort, a failed touch never fails auth.
- **`pgstore`** — Postgres driver over pgx with an embedded goose migration (`forge_api_keys`); zero `time.Time` ⇔ SQL NULL both directions; `GetByHash` verification path is a single point lookup on the unique hash index.

## Testing

- `just test ./auth/apikey/...` — PASS with `-race`, **98.3%** coverage (core).
- `pgstore` integration tests run **live** against Postgres 16 (6/6 with `-race`); DSN-gated skip when `FORGE_TEST_POSTGRES_DSN` is unset.
- `FuzzVerify` — millions of execs, 0 crashers (no forged input authenticates, no panic).
- `just lint` — clean (vet, build, golangci-lint, nilaway, betteralign, modernize).

## Benchmarks (darwin/arm64)

| Benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| `Create` | 1305 | 942 | 9 |
| `VerifyHit` | 1206 | 1808 | 21 |
| `VerifyMalformedReject` | 65.55 | **0** | **0** |

The malformed-reject path is allocation-free: the checksum is computed over the credential's bytes directly via a string-based table-driven IEEE CRC32 (bit-identical to `crc32.ChecksumIEEE`), eliminating the `[]byte` conversion that otherwise escapes through the hardware-accelerated path — keeping the DoS surface free of per-request heap pressure.

## Notes

- Scopes are carried into `guard.Identity.Scopes` but never enforced here — enforcement belongs to the authorization seam (`auth/rbac`).
- Reserved `Meta` keys `key_id`/`key_name` are set by `Verify` on the returned Identity and override any stored value of the same name (a stored/attacker-influenced `key_id` cannot spoof the real one).
- Removed the shipped `auth/apikey` roadmap entry from `docs/packages.md`.
