### PR TITLE
feat(auth/totp): complete 2FA package — TOTP/HOTP, backup codes, Manager, pgstore

### DIFF
--- a/auth/totp/backup.go
+++ b/auth/totp/backup.go
@@ -1,0 +1,80 @@
+package totp
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+
+	"github.com/dmitrymomot/forge/core/random"
+	"github.com/dmitrymomot/forge/crypto/consttime"
+)
+
+// backupAlphabet is lowercase alphanumeric minus the ambiguous 0/1/i/l/o —
+// backup codes are printed and retyped by hand.
+const backupAlphabet = "abcdefghjkmnpqrstuvwxyz23456789"
+
+// GenerateBackupCodes mints count one-time recovery codes of length random
+// characters each. It returns the display forms (dash-grouped every 5, e.g.
+// "abcde-fghij") to show the user exactly once, and the SHA-256 hashes of
+// the normalized forms to persist. A plain hash suffices: the codes are
+// high-entropy random strings, not human-chosen passwords — hence the
+// length floor of 8 (~40 bits over this alphabet).
+func GenerateBackupCodes(count, length int) (codes []string, hashes [][]byte, err error) {
+	if count < 1 {
+		return nil, nil, fmt.Errorf("totp: backup code count must be >= 1, got %d", count)
+	}
+	if length < 8 {
+		return nil, nil, fmt.Errorf("totp: backup code length must be >= 8, got %d", length)
+	}
+	codes = make([]string, count)
+	hashes = make([][]byte, count)
+	for i := range count {
+		raw := random.String(length, backupAlphabet)
+		codes[i] = formatBackupCode(raw)
+		hashes[i] = hashBackupCode(raw)
+	}
+	return codes, hashes, nil
+}
+
+// VerifyBackupCode reports whether code matches one of hashes, comparing
+// against every entry in constant time (no early exit), and returns the
+// matched index so the caller can consume exactly that hash. Input is
+// normalized first, so case and dash/space grouping don't matter.
+func VerifyBackupCode(code string, hashes [][]byte) (idx int, ok bool) {
+	sum := hashBackupCode(normalizeBackupCode(code))
+	idx = -1
+	for i, h := range hashes {
+		if consttime.BytesEqual(sum, h) && !ok {
+			idx, ok = i, true
+		}
+	}
+	return idx, ok
+}
+
+// formatBackupCode inserts a dash every 5 characters for readability.
+func formatBackupCode(raw string) string {
+	var b strings.Builder
+	b.Grow(len(raw) + len(raw)/5)
+	for i := 0; i < len(raw); i += 5 {
+		if i > 0 {
+			b.WriteByte('-')
+		}
+		end := min(i+5, len(raw))
+		b.WriteString(raw[i:end])
+	}
+	return b.String()
+}
+
+// normalizeBackupCode lowercases and strips dashes and spaces so user
+// typing quirks never fail a valid code. Hashes are always computed over
+// the normalized form.
+func normalizeBackupCode(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.ReplaceAll(s, "-", "")
+	return strings.ReplaceAll(s, " ", "")
+}
+
+func hashBackupCode(normalized string) []byte {
+	sum := sha256.Sum256([]byte(normalized))
+	return sum[:]
+}

--- a/auth/totp/backup_test.go
+++ b/auth/totp/backup_test.go
@@ -1,0 +1,79 @@
+package totp_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+func TestGenerateBackupCodes(t *testing.T) {
+	t.Parallel()
+	codes, hashes, err := totp.GenerateBackupCodes(10, 10)
+	require.NoError(t, err)
+	require.Len(t, codes, 10)
+	require.Len(t, hashes, 10)
+
+	seen := map[string]bool{}
+	for _, c := range codes {
+		assert.Equal(t, "xxxxx-xxxxx", strings.Map(func(r rune) rune {
+			if r == '-' {
+				return '-'
+			}
+			return 'x'
+		}, c), "display format grouped by 5: %q", c)
+		assert.False(t, seen[c], "duplicate code %q", c)
+		seen[c] = true
+		for _, r := range strings.ReplaceAll(c, "-", "") {
+			assert.NotContains(t, "01ilo", string(r), "ambiguous char in %q", c)
+		}
+	}
+	for _, h := range hashes {
+		assert.Len(t, h, 32, "SHA-256 hash")
+	}
+}
+
+func TestGenerateBackupCodes_Validation(t *testing.T) {
+	t.Parallel()
+	_, _, err := totp.GenerateBackupCodes(0, 10)
+	assert.Error(t, err)
+	_, _, err = totp.GenerateBackupCodes(10, 7)
+	assert.Error(t, err, "length floor is 8 — the high-entropy claim needs it")
+}
+
+func TestVerifyBackupCode(t *testing.T) {
+	t.Parallel()
+	codes, hashes, err := totp.GenerateBackupCodes(5, 10)
+	require.NoError(t, err)
+
+	idx, ok := totp.VerifyBackupCode(codes[3], hashes)
+	require.True(t, ok)
+	assert.Equal(t, 3, idx)
+
+	_, ok = totp.VerifyBackupCode("aaaaa-aaaaa", hashes)
+	assert.False(t, ok)
+	_, ok = totp.VerifyBackupCode("", hashes)
+	assert.False(t, ok)
+	_, ok = totp.VerifyBackupCode(codes[0], nil)
+	assert.False(t, ok)
+}
+
+func TestVerifyBackupCode_NormalizationEquivalence(t *testing.T) {
+	t.Parallel()
+	codes, hashes, err := totp.GenerateBackupCodes(1, 10)
+	require.NoError(t, err)
+	variants := []string{
+		strings.ToUpper(codes[0]),              // ABCDE-FGHIJ
+		strings.ReplaceAll(codes[0], "-", ""),  // abcdefghij
+		strings.ReplaceAll(codes[0], "-", " "), // abcde fghij
+		" " + strings.ToUpper(strings.ReplaceAll(codes[0], "-", "")) + " ",
+	}
+	for _, v := range variants {
+		idx, ok := totp.VerifyBackupCode(v, hashes)
+		assert.True(t, ok, "variant %q must verify", v)
+		assert.Equal(t, 0, idx)
+	}
+}

--- a/auth/totp/bench_test.go
+++ b/auth/totp/bench_test.go
@@ -1,0 +1,91 @@
+package totp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+func BenchmarkCode(b *testing.B) {
+	tp, err := totp.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	secret := "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+	at := time.Unix(1_700_000_000, 0)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := tp.Code(secret, at); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerify(b *testing.B) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	tp, err := totp.New(totp.WithClock(clock.NewMock(now)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	secret := "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+	code, err := tp.Code(secret, now)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := tp.Verify(secret, code, time.Time{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkManagerVerify(b *testing.B) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	store := totp.NewMemoryStore()
+	key := []byte("0123456789abcdef0123456789abcdef")
+	mgr, err := totp.NewManager(store, key, totp.WithClock(clock.NewMock(now)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := b.Context()
+	enr, err := mgr.BeginEnroll(ctx, "alice", "alice@acme.com")
+	if err != nil {
+		b.Fatal(err)
+	}
+	tp, err := totp.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	first, err := tp.Code(enr.Secret, now)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, err := mgr.ConfirmEnroll(ctx, "alice", first); err != nil {
+		b.Fatal(err)
+	}
+	// Bench the dominant path: a wrong TOTP code falling through the full
+	// window scan and the backup-hash scan (verify successes mutate state
+	// and cannot repeat in a loop).
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Verify(ctx, "alice", "000000"); err == nil {
+			b.Fatal("expected mismatch")
+		}
+	}
+}
+
+func BenchmarkVerifyBackupCode(b *testing.B) {
+	codes, hashes, err := totp.GenerateBackupCodes(10, 10)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, ok := totp.VerifyBackupCode(codes[9], hashes); !ok {
+			b.Fatal("expected match")
+		}
+	}
+}

--- a/auth/totp/code_test.go
+++ b/auth/totp/code_test.go
@@ -1,0 +1,80 @@
+package totp_test
+
+import (
+	"encoding/base32"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+// RFC 6238 Appendix B reference vectors: 8-digit codes, 30s period.
+// Secrets are the ASCII seed repeated to the hash length.
+func TestCode_RFC6238Vectors(t *testing.T) {
+	t.Parallel()
+	seeds := map[totp.Algorithm]string{
+		totp.SHA1:   "12345678901234567890",
+		totp.SHA256: "12345678901234567890123456789012",
+		totp.SHA512: "1234567890123456789012345678901234567890123456789012345678901234",
+	}
+	vectors := []struct {
+		unix  int64
+		codes map[totp.Algorithm]string
+	}{
+		{59, map[totp.Algorithm]string{totp.SHA1: "94287082", totp.SHA256: "46119246", totp.SHA512: "90693936"}},
+		{1111111109, map[totp.Algorithm]string{totp.SHA1: "07081804", totp.SHA256: "68084774", totp.SHA512: "25091201"}},
+		{1111111111, map[totp.Algorithm]string{totp.SHA1: "14050471", totp.SHA256: "67062674", totp.SHA512: "99943326"}},
+		{1234567890, map[totp.Algorithm]string{totp.SHA1: "89005924", totp.SHA256: "91819424", totp.SHA512: "93441116"}},
+		{2000000000, map[totp.Algorithm]string{totp.SHA1: "69279037", totp.SHA256: "90698825", totp.SHA512: "38618901"}},
+		{20000000000, map[totp.Algorithm]string{totp.SHA1: "65353130", totp.SHA256: "77737706", totp.SHA512: "47863826"}},
+	}
+	for alg, seed := range seeds {
+		tp, err := totp.New(totp.WithAlgorithm(alg), totp.WithDigits(8))
+		require.NoError(t, err)
+		secret := b32(seed)
+		for _, v := range vectors {
+			got, err := tp.Code(secret, time.Unix(v.unix, 0).UTC())
+			require.NoError(t, err)
+			assert.Equal(t, v.codes[alg], got, "alg %s time %d", alg, v.unix)
+		}
+	}
+}
+
+func TestCode_PreEpochRejected(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	_, err = tp.Code(b32(rfc4226Raw), time.Unix(-1, 0))
+	assert.Error(t, err)
+}
+
+func TestGenerateSecret(t *testing.T) {
+	t.Parallel()
+	sizes := map[totp.Algorithm]int{totp.SHA1: 20, totp.SHA256: 32, totp.SHA512: 64}
+	for alg, size := range sizes {
+		tp, err := totp.New(totp.WithAlgorithm(alg))
+		require.NoError(t, err)
+		s, err := tp.GenerateSecret()
+		require.NoError(t, err)
+		raw, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(s)
+		require.NoError(t, err, "secret must be canonical unpadded uppercase base32")
+		assert.Len(t, raw, size)
+
+		s2, err := tp.GenerateSecret()
+		require.NoError(t, err)
+		assert.NotEqual(t, s, s2, "secrets must be random")
+	}
+}
+
+func TestGenerateSecret_RoundTripsThroughCode(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	s, err := tp.GenerateSecret()
+	require.NoError(t, err)
+	_, err = tp.Code(s, time.Unix(59, 0))
+	require.NoError(t, err)
+}

--- a/auth/totp/doc.go
+++ b/auth/totp/doc.go
@@ -108,9 +108,24 @@
 //
 // # Custom stores
 //
-// A Store implementation is four CRUD-ish methods plus two atomic gates.
-// All correctness lives in the gates:
+// A Store implementation is four CRUD-ish methods (Get, Save, Delete,
+// DeleteTenant) plus four atomic gates. All concurrency correctness lives in
+// the gates — each is a single conditional statement that reports, via its
+// bool, whether it won:
 //
+//   - SavePending(tenant, subject, r) must upsert a fresh pending record but
+//     refuse to overwrite a confirmed one, so a BeginEnroll cannot revert an
+//     enrollment a concurrent Confirm just activated. Reference SQL:
+//     INSERT INTO forge_totp (tenant,subject,secret,confirmed,backup_hashes)
+//     VALUES ($1,$2,$3,false,'{}') ON CONFLICT (tenant,subject) DO UPDATE
+//     SET secret=EXCLUDED.secret, confirmed=false, last_used_at=NULL,
+//     backup_hashes='{}' WHERE forge_totp.confirmed=false
+//   - Confirm(tenant, subject, expectedSecret, usedAt, hashes) must activate a
+//     pending record only if it is still pending and its secret is unchanged,
+//     so concurrent confirms resolve to one winner and a confirm never
+//     activates a swapped secret. Reference SQL:
+//     UPDATE forge_totp SET confirmed=true, last_used_at=$3, backup_hashes=$4
+//     WHERE tenant=$1 AND subject=$2 AND confirmed=false AND secret=$5
 //   - MarkUsed(tenant, subject, usedAt) must atomically set LastUsedAt =
 //     usedAt only if the stored value is earlier (or zero), reporting
 //     whether it did. Reference SQL:
@@ -121,7 +136,7 @@
 //     UPDATE forge_totp SET backup_hashes=array_remove(backup_hashes,$3)
 //     WHERE tenant=$1 AND subject=$2 AND $3 = ANY(backup_hashes)
 //
-// Both report false (not an error) when the condition fails, including for
+// All four report false (not an error) when the condition fails, including for
 // absent records. Tenant is compared only by equality; "" is the unscoped
 // namespace.
 //

--- a/auth/totp/doc.go
+++ b/auth/totp/doc.go
@@ -34,7 +34,7 @@
 //	case errors.Is(err, totp.ErrReplayed), errors.Is(err, totp.ErrInvalidCode):
 //		// reject
 //	case err != nil:
-//		// operator problem (store down, wrong key material)
+//		// not enrolled, or an operator problem (store down, wrong key material)
 //	case res.UsedBackupCode && res.BackupRemaining <= 2:
 //		// warn: few backup codes left — offer RegenerateBackupCodes
 //	}
@@ -108,7 +108,7 @@
 //
 // # Custom stores
 //
-// A Store implementation is five CRUD-ish methods plus two atomic gates.
+// A Store implementation is four CRUD-ish methods plus two atomic gates.
 // All correctness lives in the gates:
 //
 //   - MarkUsed(tenant, subject, usedAt) must atomically set LastUsedAt =

--- a/auth/totp/doc.go
+++ b/auth/totp/doc.go
@@ -1,0 +1,133 @@
+// Package totp is the complete 2FA package: RFC 6238 TOTP and RFC 4226
+// HOTP code generation and verification, otpauth:// provisioning URIs,
+// and one-time backup codes — with a Manager that runs the whole
+// enrollment/verification lifecycle over a pluggable Store.
+//
+// Two layers are public. The Manager is the front door: it owns
+// pending-enrollment state, seals TOTP secrets with authenticated
+// encryption (crypto/secret) before they reach any store, stores backup
+// codes only as SHA-256 hashes, and routes replay/race protection through
+// two atomic store operations. The stateless primitives underneath
+// (Verify, Code, GenerateBackupCodes, ...) are the escape hatch for
+// consumers with their own storage discipline.
+//
+// # Usage
+//
+// Construction — encryption is mandatory, the key is 32 bytes (use
+// ManagerFromKeyset for rotation):
+//
+//	store := totp.NewMemoryStore() // or pgstore.New(pool), or your own
+//	mgr, err := totp.NewManager(store, key, totp.WithIssuer("Acme"))
+//
+// Enrollment — show the QR, then prove the authenticator works with its
+// first code; the returned backup codes exist in plaintext exactly once:
+//
+//	enr, err := mgr.BeginEnroll(ctx, user.ID, user.Email)
+//	img, err := qrcode.DataURI(enr.URI) // core/qrcode renders the otpauth URI
+//	// ... user scans and submits their first code ...
+//	backupCodes, err := mgr.ConfirmEnroll(ctx, user.ID, firstCode)
+//
+// Login — one call verifies both TOTP and backup codes, replay-safe:
+//
+//	res, err := mgr.Verify(ctx, user.ID, form.Code)
+//	switch {
+//	case errors.Is(err, totp.ErrReplayed), errors.Is(err, totp.ErrInvalidCode):
+//		// reject
+//	case err != nil:
+//		// operator problem (store down, wrong key material)
+//	case res.UsedBackupCode && res.BackupRemaining <= 2:
+//		// warn: few backup codes left — offer RegenerateBackupCodes
+//	}
+//
+// # Grace period (skip the prompt for a while)
+//
+// Whether to prompt at all is session policy, so it stays in the consumer.
+// User-scoped grace is one line off LastVerified:
+//
+//	last, err := mgr.LastVerified(ctx, user.ID)
+//	if err == nil && time.Since(last) < 12*time.Hour {
+//		// skip the OTP prompt
+//	}
+//
+// Caveat: this is user-global — verifying on one device silences the
+// prompt on every device for the window. Prefer device-scoped trust.
+//
+// # Remember this device (recommended)
+//
+// Device-scoped trust is a signed cookie via crypto/token; the trust
+// window is the token TTL and rotation revokes fleet-wide:
+//
+//	type trusted struct{ UserID string `json:"uid"` }
+//	codec, _ := token.New[trusted](key,
+//		token.WithTTL(30*24*time.Hour), token.WithPurpose("2fa-device"))
+//
+//	// after a successful Verify, when the user opts in:
+//	tok, _ := codec.Issue(trusted{UserID: user.ID})
+//	http.SetCookie(w, &http.Cookie{Name: "2fa_device", Value: tok,
+//		MaxAge: 30 * 24 * 3600, HttpOnly: true, Secure: true,
+//		SameSite: http.SameSiteLaxMode})
+//
+//	// before showing the OTP prompt:
+//	if c, err := r.Cookie("2fa_device"); err == nil {
+//		if got, err := codec.Parse(c.Value); err == nil && got.UserID == user.ID {
+//			// skip the prompt — this browser verified recently
+//		}
+//	}
+//
+// # Multi-tenancy
+//
+// Multi-tenant applications wire tenant isolation once, at construction,
+// with WithScope — never by encoding tenant IDs into subjects:
+//
+//	mgr, err := totp.NewManager(store, key,
+//		totp.WithIssuer("Acme"),
+//		totp.WithScope(func(ctx context.Context) (string, error) {
+//			return tenantFromContext(ctx) // e.g. tenant middleware
+//		}),
+//	)
+//
+// The hook runs inside every operation and fails closed: an error or empty
+// scope aborts with ErrScope instead of falling through to the unscoped
+// namespace. Pick the model by asking where an enrollment belongs:
+//
+//   - Single-tenant: omit WithScope.
+//   - Account-global 2FA (GitHub model — one enrollment serves every
+//     workspace the user belongs to): also omit WithScope; the subject is
+//     the global user ID.
+//   - Per-tenant enrollment (Slack model — identity lives inside the
+//     workspace): wire WithScope to the request's tenant. The same subject
+//     enrolls independently per tenant.
+//   - Platform-level operations while scoped: use a context bound to the
+//     target tenant, or a reserved non-empty sentinel scope (e.g.
+//     "@global") that no tenant ID can collide with.
+//
+// Cleanup: tenant offboarding is DisableTenant under a tenant-bound
+// context. Deleting one user across all tenants is the consumer's
+// membership loop — for each membership, run Disable with that tenant's
+// context; the application owns the membership list, not this package.
+//
+// # Custom stores
+//
+// A Store implementation is five CRUD-ish methods plus two atomic gates.
+// All correctness lives in the gates:
+//
+//   - MarkUsed(tenant, subject, usedAt) must atomically set LastUsedAt =
+//     usedAt only if the stored value is earlier (or zero), reporting
+//     whether it did. Reference SQL:
+//     UPDATE forge_totp SET last_used_at=$3 WHERE tenant=$1 AND subject=$2
+//     AND (last_used_at IS NULL OR last_used_at < $3)
+//   - ConsumeBackup(tenant, subject, hash) must atomically remove hash if
+//     present, reporting whether it did. Reference SQL:
+//     UPDATE forge_totp SET backup_hashes=array_remove(backup_hashes,$3)
+//     WHERE tenant=$1 AND subject=$2 AND $3 = ANY(backup_hashes)
+//
+// Both report false (not an error) when the condition fails, including for
+// absent records. Tenant is compared only by equality; "" is the unscoped
+// namespace.
+//
+// # Rate limiting
+//
+// This package does not count attempts. Six-digit codes survive online
+// brute force only behind a limiter — put auth/lockout (or
+// resilience/ratelimit) in front of Verify.
+package totp

--- a/auth/totp/enroll_race_test.go
+++ b/auth/totp/enroll_race_test.go
@@ -1,0 +1,86 @@
+package totp_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+// TestConfirmEnroll_ConcurrentDoubleSubmit proves the atomic Confirm gate: a
+// double-submitted first code resolves to exactly one winner — only that call
+// stores and returns backup codes, and those are the codes that actually work.
+func TestConfirmEnroll_ConcurrentDoubleSubmit(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store)
+	ctx := t.Context()
+
+	enr, err := m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+	code := codeFor(t, enr, fixedNow)
+
+	const n = 16
+	type outcome struct {
+		codes []string
+		err   error
+	}
+	results := make(chan outcome, n)
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			codes, err := m.ConfirmEnroll(ctx, "alice", code)
+			results <- outcome{codes, err}
+		})
+	}
+	wg.Wait()
+	close(results)
+
+	var winners [][]string
+	already := 0
+	for r := range results {
+		switch {
+		case r.err == nil:
+			winners = append(winners, r.codes)
+		case errors.Is(r.err, totp.ErrAlreadyEnrolled):
+			already++
+		default:
+			t.Fatalf("unexpected error from concurrent ConfirmEnroll: %v", r.err)
+		}
+	}
+	require.Len(t, winners, 1, "exactly one confirm wins")
+	assert.Equal(t, n-1, already, "every loser sees ErrAlreadyEnrolled")
+	assert.Len(t, winners[0], 10)
+
+	// The winner's codes are the ones actually persisted.
+	res, err := m.Verify(ctx, "alice", winners[0][0])
+	require.NoError(t, err)
+	assert.True(t, res.UsedBackupCode)
+}
+
+// TestBeginEnroll_DoesNotClobberConfirmed proves the atomic SavePending gate:
+// once an enrollment is confirmed, BeginEnroll refuses rather than reverting it
+// to pending.
+func TestBeginEnroll_DoesNotClobberConfirmed(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store)
+	ctx := t.Context()
+
+	enr, err := m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+	_, err = m.ConfirmEnroll(ctx, "alice", codeFor(t, enr, fixedNow))
+	require.NoError(t, err)
+
+	_, err = m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	assert.ErrorIs(t, err, totp.ErrAlreadyEnrolled)
+
+	// The confirmed enrollment is intact — still enabled.
+	on, err := m.Enabled(ctx, "alice")
+	require.NoError(t, err)
+	assert.True(t, on)
+}

--- a/auth/totp/errors.go
+++ b/auth/totp/errors.go
@@ -1,0 +1,23 @@
+package totp
+
+import "errors"
+
+var (
+	// ErrInvalidCode reports a code that matches neither the TOTP window
+	// nor any backup code.
+	ErrInvalidCode = errors.New("totp: invalid code")
+	// ErrReplayed reports a TOTP code at or before the last verified step —
+	// or one lost to a concurrent verify of the same step.
+	ErrReplayed = errors.New("totp: code already used")
+	// ErrNotEnrolled reports an operation on a subject without a (confirmed,
+	// where required) enrollment.
+	ErrNotEnrolled = errors.New("totp: not enrolled")
+	// ErrAlreadyEnrolled reports BeginEnroll on a confirmed enrollment;
+	// Disable first to re-enroll.
+	ErrAlreadyEnrolled = errors.New("totp: already enrolled")
+	// ErrNotFound is the Store sentinel for an absent record.
+	ErrNotFound = errors.New("totp: record not found")
+	// ErrScope reports a failed or empty scope resolution (fail-closed),
+	// or DisableTenant on an unscoped Manager.
+	ErrScope = errors.New("totp: scope resolution failed")
+)

--- a/auth/totp/fuzz_test.go
+++ b/auth/totp/fuzz_test.go
@@ -1,0 +1,39 @@
+package totp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+// FuzzVerify asserts Verify never panics on hostile secret/code input —
+// malformed base32 must surface as an error.
+func FuzzVerify(f *testing.F) {
+	f.Add("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ", "123456")
+	f.Add("", "")
+	f.Add("!!!!", "00000000")
+	f.Add("gezd gnbv====", "abcdef")
+	f.Add("A", "999999999999999999")
+	tp, err := totp.New()
+	require.NoError(f, err)
+	f.Fuzz(func(t *testing.T, secret, code string) {
+		_, _ = tp.Verify(secret, code, time.Time{})
+		_, _ = tp.Code(secret, time.Unix(59, 0))
+		_, _ = tp.HOTPCode(secret, 42)
+	})
+}
+
+// FuzzBackupCode asserts normalization/verification never panics and that
+// verification of arbitrary input against arbitrary hash sets is total.
+func FuzzBackupCode(f *testing.F) {
+	f.Add("abcde-fghij", []byte("0123456789abcdef0123456789abcdef"))
+	f.Add("", []byte{})
+	f.Add("ABCDE FGHIJ  ", []byte{1})
+	f.Fuzz(func(t *testing.T, code string, hash []byte) {
+		_, _ = totp.VerifyBackupCode(code, [][]byte{hash})
+		_, _ = totp.VerifyBackupCode(code, nil)
+	})
+}

--- a/auth/totp/hotp_test.go
+++ b/auth/totp/hotp_test.go
@@ -1,0 +1,88 @@
+package totp_test
+
+import (
+	"encoding/base32"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+func b32(raw string) string {
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(raw))
+}
+
+// rfc4226Secret is the RFC 4226 Appendix D shared secret.
+const rfc4226Raw = "12345678901234567890"
+
+// rfc4226Codes are the ten Appendix D reference codes for counters 0..9.
+var rfc4226Codes = []string{
+	"755224", "287082", "359152", "969429", "338314",
+	"254676", "287922", "162583", "399871", "520489",
+}
+
+func TestHOTPCode_RFC4226Vectors(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New() // SHA-1, 6 digits
+	require.NoError(t, err)
+	secret := b32(rfc4226Raw)
+	for counter, want := range rfc4226Codes {
+		got, err := tp.HOTPCode(secret, uint64(counter))
+		require.NoError(t, err)
+		assert.Equal(t, want, got, "counter %d", counter)
+	}
+}
+
+func TestHOTPCode_BadSecret(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	_, err = tp.HOTPCode("not!!base32###", 0)
+	assert.Error(t, err)
+}
+
+func TestHOTPCode_SecretNormalization(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	canonical, err := tp.HOTPCode(b32(rfc4226Raw), 0)
+	require.NoError(t, err)
+	// lowercase, spaces, and trailing padding must decode identically —
+	// users retype secrets by hand.
+	messy := "gezd gnbv gy3t qojq gezd gnbv gy3t qojq==="
+	got, err := tp.HOTPCode(messy, 0)
+	require.NoError(t, err)
+	assert.Equal(t, canonical, got)
+}
+
+func TestVerifyHOTP_MatchAndNextCounter(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	secret := b32(rfc4226Raw)
+
+	// Exact counter.
+	next, err := tp.VerifyHOTP(secret, rfc4226Codes[3], 3, 0)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(4), next)
+
+	// Within lookahead: stored counter 2, client advanced to 5.
+	next, err = tp.VerifyHOTP(secret, rfc4226Codes[5], 2, 4)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(6), next)
+
+	// Beyond lookahead.
+	_, err = tp.VerifyHOTP(secret, rfc4226Codes[9], 2, 4)
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+
+	// Behind the counter (replayed HOTP looks like any other mismatch).
+	_, err = tp.VerifyHOTP(secret, rfc4226Codes[1], 3, 4)
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+
+	// Negative lookahead is caller error, not ErrInvalidCode.
+	_, err = tp.VerifyHOTP(secret, rfc4226Codes[3], 3, -1)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, totp.ErrInvalidCode)
+}

--- a/auth/totp/manager.go
+++ b/auth/totp/manager.go
@@ -186,3 +186,98 @@ func (m *Manager) ConfirmEnroll(ctx context.Context, subject, code string) ([]st
 	}
 	return codes, nil
 }
+
+// Verify checks code for subject: TOTP first (replay-safe — the matched
+// step is atomically claimed in the store), then falls back to one-time
+// backup codes (atomically consumed). One call serves a single "enter your
+// code or a backup code" input. ErrNotEnrolled for absent or unconfirmed
+// records; ErrReplayed when the step was already claimed (including by a
+// concurrent request); ErrInvalidCode otherwise.
+func (m *Manager) Verify(ctx context.Context, subject, code string) (VerifyResult, error) {
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	rec, err := m.record(ctx, tenant, subject)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	if !rec.Confirmed {
+		return VerifyResult{}, ErrNotEnrolled
+	}
+	plain, err := m.openSecret(rec)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+
+	matchedAt, verr := m.t.Verify(plain, code, rec.LastUsedAt)
+	switch {
+	case verr == nil:
+		ok, err := m.store.MarkUsed(ctx, tenant, subject, matchedAt)
+		if err != nil {
+			return VerifyResult{}, fmt.Errorf("totp: store mark used: %w", err)
+		}
+		if !ok {
+			return VerifyResult{}, ErrReplayed
+		}
+		return VerifyResult{}, nil
+	case errors.Is(verr, ErrReplayed):
+		return VerifyResult{}, ErrReplayed
+	}
+
+	// TOTP mismatch — try the backup codes.
+	idx, ok := VerifyBackupCode(code, rec.BackupHashes)
+	if !ok {
+		return VerifyResult{}, ErrInvalidCode
+	}
+	consumed, err := m.store.ConsumeBackup(ctx, tenant, subject, rec.BackupHashes[idx])
+	if err != nil {
+		return VerifyResult{}, fmt.Errorf("totp: store consume backup: %w", err)
+	}
+	if !consumed {
+		// Lost a race: someone spent this code between Get and here.
+		return VerifyResult{}, ErrInvalidCode
+	}
+	return VerifyResult{
+		UsedBackupCode: true,
+		// Count from the snapshot we verified against; a concurrent consume
+		// may make this off by one — it is advisory UI data, not state.
+		BackupRemaining: len(rec.BackupHashes) - 1,
+	}, nil
+}
+
+// Enabled reports whether subject has a confirmed enrollment. Absent and
+// pending both read false — it is a policy query, not an error path.
+func (m *Manager) Enabled(ctx context.Context, subject string) (bool, error) {
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return false, err
+	}
+	rec, err := m.store.Get(ctx, tenant, subject)
+	if errors.Is(err, ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("totp: store get: %w", err)
+	}
+	return rec.Confirmed, nil
+}
+
+// LastVerified returns the step-start time of the last successful TOTP
+// verification — the input to a grace-period check (see doc.go). Zero time
+// with a nil error cannot happen for a confirmed record (ConfirmEnroll
+// stamps the first step); ErrNotEnrolled for absent or pending records.
+func (m *Manager) LastVerified(ctx context.Context, subject string) (time.Time, error) {
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return time.Time{}, err
+	}
+	rec, err := m.record(ctx, tenant, subject)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !rec.Confirmed {
+		return time.Time{}, ErrNotEnrolled
+	}
+	return rec.LastUsedAt, nil
+}

--- a/auth/totp/manager.go
+++ b/auth/totp/manager.go
@@ -281,3 +281,61 @@ func (m *Manager) LastVerified(ctx context.Context, subject string) (time.Time, 
 	}
 	return rec.LastUsedAt, nil
 }
+
+// RegenerateBackupCodes invalidates every outstanding backup code and
+// returns a fresh set — the only time the new codes exist in plaintext.
+// ErrNotEnrolled unless a confirmed enrollment exists.
+func (m *Manager) RegenerateBackupCodes(ctx context.Context, subject string) ([]string, error) {
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := m.record(ctx, tenant, subject)
+	if err != nil {
+		return nil, err
+	}
+	if !rec.Confirmed {
+		return nil, ErrNotEnrolled
+	}
+	codes, hashes, err := GenerateBackupCodes(m.t.cfg.backupCount, m.t.cfg.backupLength)
+	if err != nil {
+		return nil, err
+	}
+	rec.BackupHashes = hashes
+	if err := m.store.Save(ctx, tenant, subject, rec); err != nil {
+		return nil, fmt.Errorf("totp: store save: %w", err)
+	}
+	return codes, nil
+}
+
+// Disable removes the enrollment entirely — secret, backup codes, state.
+// Idempotent: disabling an absent enrollment is a no-op.
+func (m *Manager) Disable(ctx context.Context, subject string) error {
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return err
+	}
+	if err := m.store.Delete(ctx, tenant, subject); err != nil {
+		return fmt.Errorf("totp: store delete: %w", err)
+	}
+	return nil
+}
+
+// DisableTenant bulk-deletes every enrollment in the scope-resolved tenant
+// (offboarding, GDPR erasure) and returns the count. It requires WithScope:
+// an unscoped Manager has no tenant to delete and returns ErrScope.
+// Platform-level jobs run it with a context bound to the target tenant.
+func (m *Manager) DisableTenant(ctx context.Context) (int, error) {
+	if m.t.cfg.scope == nil {
+		return 0, ErrScope
+	}
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return 0, err
+	}
+	n, err := m.store.DeleteTenant(ctx, tenant)
+	if err != nil {
+		return 0, fmt.Errorf("totp: store delete tenant: %w", err)
+	}
+	return n, nil
+}

--- a/auth/totp/manager.go
+++ b/auth/totp/manager.go
@@ -121,6 +121,15 @@ func (m *Manager) openSecret(r *Record) (string, error) {
 // earlier unconfirmed one, so re-showing the QR is safe — and returns the
 // plaintext secret and provisioning URI for the UI. ErrAlreadyEnrolled if a
 // confirmed enrollment exists; Disable first to re-enroll.
+//
+// The ErrAlreadyEnrolled guard is check-then-act, not atomic: a BeginEnroll
+// racing a concurrent ConfirmEnroll for the same subject can read the record
+// while it is still pending and then overwrite the just-confirmed enrollment
+// back to unconfirmed, orphaning the backup codes ConfirmEnroll returned.
+// Enroll and confirm are sequential user actions, so this needs two in-flight
+// requests for one subject at the same instant; serialize per-subject
+// enrollment (or gate on a conditional store write) if that is reachable in
+// your deployment.
 func (m *Manager) BeginEnroll(ctx context.Context, subject, account string) (*Enrollment, error) {
 	if subject == "" {
 		return nil, errors.New("totp: empty subject")

--- a/auth/totp/manager.go
+++ b/auth/totp/manager.go
@@ -122,14 +122,10 @@ func (m *Manager) openSecret(r *Record) (string, error) {
 // plaintext secret and provisioning URI for the UI. ErrAlreadyEnrolled if a
 // confirmed enrollment exists; Disable first to re-enroll.
 //
-// The ErrAlreadyEnrolled guard is check-then-act, not atomic: a BeginEnroll
-// racing a concurrent ConfirmEnroll for the same subject can read the record
-// while it is still pending and then overwrite the just-confirmed enrollment
-// back to unconfirmed, orphaning the backup codes ConfirmEnroll returned.
-// Enroll and confirm are sequential user actions, so this needs two in-flight
-// requests for one subject at the same instant; serialize per-subject
-// enrollment (or gate on a conditional store write) if that is reachable in
-// your deployment.
+// The confirmed-enrollment guard is the atomic Store.SavePending write, not a
+// separate read: a BeginEnroll racing a concurrent ConfirmEnroll for the same
+// subject cannot overwrite the just-confirmed enrollment — SavePending refuses
+// once the record is confirmed and returns ErrAlreadyEnrolled here.
 func (m *Manager) BeginEnroll(ctx context.Context, subject, account string) (*Enrollment, error) {
 	if subject == "" {
 		return nil, errors.New("totp: empty subject")
@@ -137,13 +133,6 @@ func (m *Manager) BeginEnroll(ctx context.Context, subject, account string) (*En
 	tenant, err := m.tenant(ctx)
 	if err != nil {
 		return nil, err
-	}
-	existing, err := m.store.Get(ctx, tenant, subject)
-	switch {
-	case err == nil && existing.Confirmed:
-		return nil, ErrAlreadyEnrolled
-	case err != nil && !errors.Is(err, ErrNotFound):
-		return nil, fmt.Errorf("totp: store get: %w", err)
 	}
 	plain, err := m.t.GenerateSecret()
 	if err != nil {
@@ -153,8 +142,12 @@ func (m *Manager) BeginEnroll(ctx context.Context, subject, account string) (*En
 	if err != nil {
 		return nil, fmt.Errorf("totp: seal secret: %w", err)
 	}
-	if err := m.store.Save(ctx, tenant, subject, &Record{Secret: sealed}); err != nil {
-		return nil, fmt.Errorf("totp: store save: %w", err)
+	ok, err := m.store.SavePending(ctx, tenant, subject, &Record{Secret: sealed})
+	if err != nil {
+		return nil, fmt.Errorf("totp: store save pending: %w", err)
+	}
+	if !ok {
+		return nil, ErrAlreadyEnrolled
 	}
 	return &Enrollment{Secret: plain, URI: m.t.ProvisioningURI(plain, account)}, nil
 }
@@ -163,6 +156,13 @@ func (m *Manager) BeginEnroll(ctx context.Context, subject, account string) (*En
 // first code, activates the record, and returns the one-time backup codes —
 // the only time they exist in plaintext. ErrNotEnrolled without a pending
 // record; ErrInvalidCode leaves the record pending for another attempt.
+//
+// Activation is the atomic Store.Confirm write, gated on the enrollment still
+// being pending with the same secret. So concurrent double-submits of the same
+// first code resolve to exactly one winner — only that call stores and returns
+// backup codes; the losers get ErrAlreadyEnrolled — and a confirm racing a
+// BeginEnroll that swapped the secret never activates a secret the user did
+// not prove.
 func (m *Manager) ConfirmEnroll(ctx context.Context, subject, code string) ([]string, error) {
 	tenant, err := m.tenant(ctx)
 	if err != nil {
@@ -187,11 +187,25 @@ func (m *Manager) ConfirmEnroll(ctx context.Context, subject, code string) ([]st
 	if err != nil {
 		return nil, err
 	}
-	rec.Confirmed = true
-	rec.LastUsedAt = matchedAt
-	rec.BackupHashes = hashes
-	if err := m.store.Save(ctx, tenant, subject, rec); err != nil {
-		return nil, fmt.Errorf("totp: store save: %w", err)
+	ok, err := m.store.Confirm(ctx, tenant, subject, rec.Secret, matchedAt, hashes)
+	if err != nil {
+		return nil, fmt.Errorf("totp: store confirm: %w", err)
+	}
+	if !ok {
+		// Lost the race: a concurrent confirm won, the enrollment was disabled,
+		// or a concurrent BeginEnroll replaced the pending secret. Disambiguate
+		// so the caller sees a truthful terminal error instead of our codes.
+		cur, gerr := m.store.Get(ctx, tenant, subject)
+		switch {
+		case errors.Is(gerr, ErrNotFound):
+			return nil, ErrNotEnrolled
+		case gerr != nil:
+			return nil, fmt.Errorf("totp: store get: %w", gerr)
+		case cur.Confirmed:
+			return nil, ErrAlreadyEnrolled
+		default:
+			return nil, ErrNotEnrolled
+		}
 	}
 	return codes, nil
 }

--- a/auth/totp/manager.go
+++ b/auth/totp/manager.go
@@ -1,0 +1,188 @@
+package totp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/crypto/keyset"
+	"github.com/dmitrymomot/forge/crypto/secret"
+)
+
+// Manager orchestrates the full 2FA lifecycle — enroll, confirm, verify,
+// recover, disable — over a Store. Secrets are sealed with an AEAD box
+// before they reach the store and backup codes are stored as hashes;
+// encryption is mandatory by construction. Safe for concurrent use.
+type Manager struct {
+	t     *TOTP
+	store Store
+	box   *secret.Box
+}
+
+// Enrollment is what BeginEnroll hands the UI: the plaintext secret for
+// manual entry and the otpauth:// URI to render as a QR (core/qrcode's
+// DataURI composes). Neither is persisted in this form.
+type Enrollment struct {
+	Secret string
+	URI    string
+}
+
+// VerifyResult reports which path verified the code.
+type VerifyResult struct {
+	// UsedBackupCode is true when a one-time backup code (now consumed)
+	// matched instead of a TOTP code.
+	UsedBackupCode bool
+	// BackupRemaining is the number of backup codes left after this call;
+	// meaningful only when UsedBackupCode is true.
+	BackupRemaining int
+}
+
+// NewManager builds a Manager sealing secrets with key (32 bytes,
+// AES-256-GCM). Use ManagerFromKeyset for key rotation.
+func NewManager(store Store, key []byte, opts ...Option) (*Manager, error) {
+	box, err := secret.New(key)
+	if err != nil {
+		return nil, fmt.Errorf("totp: %w", err)
+	}
+	return newManager(store, box, opts)
+}
+
+// ManagerFromKeyset builds a Manager whose box encrypts under the keyset's
+// primary key and decrypts under any version — rotation without re-enrolling.
+func ManagerFromKeyset(store Store, ks *keyset.Keyset, opts ...Option) (*Manager, error) {
+	box, err := secret.FromKeyset(ks)
+	if err != nil {
+		return nil, fmt.Errorf("totp: %w", err)
+	}
+	return newManager(store, box, opts)
+}
+
+func newManager(store Store, box *secret.Box, opts []Option) (*Manager, error) {
+	if store == nil {
+		return nil, errors.New("totp: nil store")
+	}
+	t, err := New(opts...)
+	if err != nil {
+		return nil, err
+	}
+	if t.cfg.backupCount < 1 {
+		return nil, fmt.Errorf("totp: backup code count must be >= 1, got %d", t.cfg.backupCount)
+	}
+	if t.cfg.backupLength < 8 {
+		return nil, fmt.Errorf("totp: backup code length must be >= 8, got %d", t.cfg.backupLength)
+	}
+	return &Manager{t: t, store: store, box: box}, nil
+}
+
+// tenant resolves the scope hook, failing closed: with a hook configured, a
+// hook error or empty scope aborts the operation with ErrScope so a scoped
+// operation can never fall through to the unscoped ("") namespace.
+func (m *Manager) tenant(ctx context.Context) (string, error) {
+	if m.t.cfg.scope == nil {
+		return "", nil
+	}
+	s, err := m.t.cfg.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrScope, err)
+	}
+	if s == "" {
+		return "", ErrScope
+	}
+	return s, nil
+}
+
+// record fetches and translates the store sentinel: absent = ErrNotEnrolled
+// at the Manager surface.
+func (m *Manager) record(ctx context.Context, tenant, subject string) (*Record, error) {
+	r, err := m.store.Get(ctx, tenant, subject)
+	if errors.Is(err, ErrNotFound) {
+		return nil, ErrNotEnrolled
+	}
+	if err != nil {
+		return nil, fmt.Errorf("totp: store get: %w", err)
+	}
+	return r, nil
+}
+
+// openSecret unseals a record's secret. Failure means wrong key material —
+// an operator problem surfaced as secret.ErrDecryptFailed, never as
+// ErrInvalidCode.
+func (m *Manager) openSecret(r *Record) (string, error) {
+	plain, err := m.box.Decrypt(r.Secret)
+	if err != nil {
+		return "", fmt.Errorf("totp: unseal secret: %w", err)
+	}
+	return string(plain), nil
+}
+
+// BeginEnroll starts (or restarts) enrollment for subject: it generates a
+// fresh secret, seals it, saves an unconfirmed record — overwriting any
+// earlier unconfirmed one, so re-showing the QR is safe — and returns the
+// plaintext secret and provisioning URI for the UI. ErrAlreadyEnrolled if a
+// confirmed enrollment exists; Disable first to re-enroll.
+func (m *Manager) BeginEnroll(ctx context.Context, subject, account string) (*Enrollment, error) {
+	if subject == "" {
+		return nil, errors.New("totp: empty subject")
+	}
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	existing, err := m.store.Get(ctx, tenant, subject)
+	switch {
+	case err == nil && existing.Confirmed:
+		return nil, ErrAlreadyEnrolled
+	case err != nil && !errors.Is(err, ErrNotFound):
+		return nil, fmt.Errorf("totp: store get: %w", err)
+	}
+	plain, err := m.t.GenerateSecret()
+	if err != nil {
+		return nil, err
+	}
+	sealed, err := m.box.Encrypt([]byte(plain))
+	if err != nil {
+		return nil, fmt.Errorf("totp: seal secret: %w", err)
+	}
+	if err := m.store.Save(ctx, tenant, subject, &Record{Secret: sealed}); err != nil {
+		return nil, fmt.Errorf("totp: store save: %w", err)
+	}
+	return &Enrollment{Secret: plain, URI: m.t.ProvisioningURI(plain, account)}, nil
+}
+
+// ConfirmEnroll proves the authenticator was enrolled by verifying its
+// first code, activates the record, and returns the one-time backup codes —
+// the only time they exist in plaintext. ErrNotEnrolled without a pending
+// record; ErrInvalidCode leaves the record pending for another attempt.
+func (m *Manager) ConfirmEnroll(ctx context.Context, subject, code string) ([]string, error) {
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := m.record(ctx, tenant, subject)
+	if err != nil {
+		return nil, err
+	}
+	if rec.Confirmed {
+		return nil, ErrAlreadyEnrolled
+	}
+	plain, err := m.openSecret(rec)
+	if err != nil {
+		return nil, err
+	}
+	matchedAt, err := m.t.Verify(plain, code, time.Time{})
+	if err != nil {
+		return nil, err
+	}
+	codes, hashes, err := GenerateBackupCodes(m.t.cfg.backupCount, m.t.cfg.backupLength)
+	if err != nil {
+		return nil, err
+	}
+	rec.Confirmed = true
+	rec.LastUsedAt = matchedAt
+	rec.BackupHashes = hashes
+	if err := m.store.Save(ctx, tenant, subject, rec); err != nil {
+		return nil, fmt.Errorf("totp: store save: %w", err)
+	}
+	return codes, nil
+}

--- a/auth/totp/manager_test.go
+++ b/auth/totp/manager_test.go
@@ -1,0 +1,168 @@
+package totp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+var testKey = []byte("0123456789abcdef0123456789abcdef")
+
+// fixedNow pins Manager clocks; individual tests advance via a fresh Manager.
+var fixedNow = time.Unix(1_700_000_000, 0).UTC()
+
+func newManager(t *testing.T, store totp.Store, opts ...totp.Option) *totp.Manager {
+	t.Helper()
+	opts = append([]totp.Option{
+		totp.WithIssuer("Acme"),
+		totp.WithClock(clock.NewMock(fixedNow)),
+	}, opts...)
+	m, err := totp.NewManager(store, testKey, opts...)
+	require.NoError(t, err)
+	return m
+}
+
+// codeFor computes the current valid code for an enrollment's secret.
+func codeFor(t *testing.T, enr *totp.Enrollment, at time.Time) string {
+	t.Helper()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	code, err := tp.Code(enr.Secret, at)
+	require.NoError(t, err)
+	return code
+}
+
+func TestNewManager_Validation(t *testing.T) {
+	t.Parallel()
+	_, err := totp.NewManager(nil, testKey)
+	assert.Error(t, err, "nil store")
+	_, err = totp.NewManager(totp.NewMemoryStore(), []byte("short"))
+	assert.Error(t, err, "bad key size")
+	_, err = totp.NewManager(totp.NewMemoryStore(), testKey, totp.WithBackupCodeCount(0))
+	assert.Error(t, err)
+	_, err = totp.NewManager(totp.NewMemoryStore(), testKey, totp.WithBackupCodeLength(7))
+	assert.Error(t, err)
+}
+
+func TestManagerFromKeyset(t *testing.T) {
+	t.Parallel()
+	ks, err := keyset.New(keyset.WithPrimary(1, testKey))
+	require.NoError(t, err)
+	m, err := totp.ManagerFromKeyset(totp.NewMemoryStore(), ks, totp.WithIssuer("Acme"))
+	require.NoError(t, err)
+	require.NotNil(t, m)
+}
+
+func TestBeginEnroll(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store)
+	ctx := t.Context()
+
+	enr, err := m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+	assert.NotEmpty(t, enr.Secret)
+	assert.Contains(t, enr.URI, "otpauth://totp/")
+	assert.Contains(t, enr.URI, "issuer=Acme")
+
+	// The stored secret is ciphertext, not the plaintext we returned.
+	rec, err := store.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.False(t, rec.Confirmed)
+	assert.NotContains(t, string(rec.Secret), enr.Secret)
+
+	// Re-begin before confirm: idempotent overwrite, fresh secret.
+	enr2, err := m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+	assert.NotEqual(t, enr.Secret, enr2.Secret)
+
+	// Empty subject is caller error.
+	_, err = m.BeginEnroll(ctx, "", "x@acme.com")
+	assert.Error(t, err)
+}
+
+func TestConfirmEnroll(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store)
+	ctx := t.Context()
+
+	// No pending record.
+	_, err := m.ConfirmEnroll(ctx, "alice", "123456")
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+
+	enr, err := m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+
+	// Wrong first code: record stays pending.
+	_, err = m.ConfirmEnroll(ctx, "alice", "000000")
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+	rec, err := store.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.False(t, rec.Confirmed)
+
+	// Correct first code: confirmed, backup codes issued, step persisted.
+	codes, err := m.ConfirmEnroll(ctx, "alice", codeFor(t, enr, fixedNow))
+	require.NoError(t, err)
+	assert.Len(t, codes, 10)
+	rec, err = store.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.True(t, rec.Confirmed)
+	assert.Len(t, rec.BackupHashes, 10)
+	assert.False(t, rec.LastUsedAt.IsZero())
+
+	// BeginEnroll after confirm: refused.
+	_, err = m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	assert.ErrorIs(t, err, totp.ErrAlreadyEnrolled)
+
+	// ConfirmEnroll after confirm: refused.
+	_, err = m.ConfirmEnroll(ctx, "alice", codeFor(t, enr, fixedNow))
+	assert.ErrorIs(t, err, totp.ErrAlreadyEnrolled)
+}
+
+func TestConfirmEnroll_BackupOptionsRespected(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, totp.NewMemoryStore(),
+		totp.WithBackupCodeCount(4), totp.WithBackupCodeLength(15))
+	ctx := t.Context()
+	enr, err := m.BeginEnroll(ctx, "bob", "bob@acme.com")
+	require.NoError(t, err)
+	codes, err := m.ConfirmEnroll(ctx, "bob", codeFor(t, enr, fixedNow))
+	require.NoError(t, err)
+	require.Len(t, codes, 4)
+	assert.Equal(t, "xxxxx-xxxxx-xxxxx", func() string {
+		out := []byte{}
+		for _, r := range codes[0] {
+			if r == '-' {
+				out = append(out, '-')
+			} else {
+				out = append(out, 'x')
+			}
+		}
+		return string(out)
+	}())
+}
+
+func TestManager_WrongKeyDoesNotReadAsBadCode(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m1 := newManager(t, store)
+	ctx := t.Context()
+	enr, err := m1.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+
+	// A manager with different key material cannot decrypt: the error must
+	// NOT be ErrInvalidCode — this is an operator problem, not a user typo.
+	m2, err := totp.NewManager(store, []byte("ffffffffffffffffffffffffffffffff"),
+		totp.WithClock(clock.NewMock(fixedNow)))
+	require.NoError(t, err)
+	_, err = m2.ConfirmEnroll(ctx, "alice", codeFor(t, enr, fixedNow))
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, totp.ErrInvalidCode)
+}

--- a/auth/totp/options.go
+++ b/auth/totp/options.go
@@ -1,0 +1,79 @@
+package totp
+
+import (
+	"context"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type config struct {
+	clk          clock.Clock
+	scope        func(context.Context) (string, error)
+	issuer       string
+	digits       int
+	period       time.Duration
+	algorithm    Algorithm
+	skew         int
+	backupCount  int
+	backupLength int
+}
+
+func defaultConfig() config {
+	return config{
+		digits:       6,
+		period:       30 * time.Second,
+		algorithm:    SHA1,
+		skew:         1,
+		clk:          clock.System(),
+		backupCount:  10,
+		backupLength: 10,
+	}
+}
+
+// Option configures New and NewManager.
+type Option func(*config)
+
+// WithIssuer sets the issuer shown in authenticator apps and embedded in
+// provisioning URIs. Empty (the default) omits the issuer from the URI.
+func WithIssuer(s string) Option { return func(c *config) { c.issuer = s } }
+
+// WithDigits sets the code length: 6 (default) or 8.
+func WithDigits(n int) Option { return func(c *config) { c.digits = n } }
+
+// WithPeriod sets the TOTP time step (default 30s). Whole seconds, >= 1s.
+// Authenticator apps widely assume 30s — change only for closed ecosystems.
+func WithPeriod(d time.Duration) Option { return func(c *config) { c.period = d } }
+
+// WithAlgorithm selects the HMAC hash (default SHA1 — the variant
+// authenticator apps support universally).
+func WithAlgorithm(a Algorithm) Option { return func(c *config) { c.algorithm = a } }
+
+// WithSkew sets clock-drift tolerance in steps either side of now
+// (default 1; 0 = exact step only).
+func WithSkew(n int) Option { return func(c *config) { c.skew = n } }
+
+// WithClock injects a clock for deterministic tests.
+func WithClock(clk clock.Clock) Option {
+	return func(c *config) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+// WithScope derives a tenant from the request context on every Manager
+// operation, so multi-tenant isolation is wired once at construction and no
+// call site can forget it. Fail-closed: a hook error or empty scope aborts
+// the operation with ErrScope. Single-tenant applications omit this option.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) { c.scope = fn }
+}
+
+// WithBackupCodeCount sets how many backup codes ConfirmEnroll and
+// RegenerateBackupCodes hand out (default 10, >= 1).
+func WithBackupCodeCount(n int) Option { return func(c *config) { c.backupCount = n } }
+
+// WithBackupCodeLength sets backup-code length in characters, excluding
+// display dashes (default 10, >= 8).
+func WithBackupCodeLength(n int) Option { return func(c *config) { c.backupLength = n } }

--- a/auth/totp/pgstore/doc.go
+++ b/auth/totp/pgstore/doc.go
@@ -1,0 +1,7 @@
+// Package pgstore is the Postgres implementation of totp.Store: one
+// forge_totp table keyed (tenant, subject), with MarkUsed and
+// ConsumeBackup as single conditional UPDATEs so replay and backup-code
+// races resolve in the database. The DDL ships as an embedded goose
+// migration in Migrations; apply it via data/migration under its own
+// version table (e.g. "forge_totp_schema").
+package pgstore

--- a/auth/totp/pgstore/migrations/00001_totp.sql
+++ b/auth/totp/pgstore/migrations/00001_totp.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+CREATE TABLE forge_totp (
+    tenant        text NOT NULL DEFAULT '',
+    subject       text NOT NULL,
+    secret        bytea NOT NULL,
+    confirmed     boolean NOT NULL DEFAULT false,
+    last_used_at  timestamptz,
+    backup_hashes bytea[] NOT NULL DEFAULT '{}',
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    updated_at    timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant, subject)
+);
+
+-- +goose Down
+DROP TABLE forge_totp;

--- a/auth/totp/pgstore/pgstore.go
+++ b/auth/totp/pgstore/pgstore.go
@@ -82,6 +82,48 @@ func (s *Store) Save(ctx context.Context, tenant, subject string, r *totp.Record
 	return err
 }
 
+// SavePending atomically stores a fresh pending enrollment, refusing to
+// overwrite a confirmed one — the ON CONFLICT DO UPDATE ... WHERE clause makes
+// the guard atomic against a concurrent Confirm, so a racing BeginEnroll
+// cannot revert a just-confirmed enrollment to pending.
+func (s *Store) SavePending(ctx context.Context, tenant, subject string, r *totp.Record) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
+		`INSERT INTO forge_totp (tenant, subject, secret, confirmed, last_used_at, backup_hashes)
+		 VALUES ($1, $2, $3, false, NULL, '{}'::bytea[])
+		 ON CONFLICT (tenant, subject) DO UPDATE SET
+		   secret = EXCLUDED.secret,
+		   confirmed = false,
+		   last_used_at = NULL,
+		   backup_hashes = '{}'::bytea[],
+		   updated_at = now()
+		 WHERE forge_totp.confirmed = false`,
+		tenant, subject, r.Secret)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// Confirm atomically activates a pending enrollment only if it is still
+// pending and its secret is unchanged. The WHERE clause resolves concurrent
+// confirms of the same code — and a racing SavePending that swapped the secret
+// — to exactly one winner, and never activates a secret the user did not prove.
+func (s *Store) Confirm(ctx context.Context, tenant, subject string, expectedSecret []byte, lastUsedAt time.Time, hashes [][]byte) (bool, error) {
+	h := hashes
+	if h == nil {
+		h = [][]byte{}
+	}
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE forge_totp
+		 SET confirmed = true, last_used_at = $3, backup_hashes = $4, updated_at = now()
+		 WHERE tenant = $1 AND subject = $2 AND confirmed = false AND secret = $5`,
+		tenant, subject, lastUsedAt, h, expectedSecret)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
 // Delete removes the record; absent is a no-op.
 func (s *Store) Delete(ctx context.Context, tenant, subject string) error {
 	_, err := s.pool.Exec(ctx,

--- a/auth/totp/pgstore/pgstore.go
+++ b/auth/totp/pgstore/pgstore.go
@@ -148,6 +148,9 @@ func (s *Store) MarkUsed(ctx context.Context, tenant, subject string, usedAt tim
 
 // ConsumeBackup atomically removes hash if present; the ANY guard makes
 // concurrent consumes of the same code resolve to exactly one winner.
+// array_remove strips every occurrence, but backup hashes are SHA-256 of
+// distinct random codes and so are unique — it removes exactly one, matching
+// the memory store's remove-first-match.
 func (s *Store) ConsumeBackup(ctx context.Context, tenant, subject string, hash []byte) (bool, error) {
 	tag, err := s.pool.Exec(ctx,
 		`UPDATE forge_totp SET backup_hashes = array_remove(backup_hashes, $3), updated_at = now()

--- a/auth/totp/pgstore/pgstore.go
+++ b/auth/totp/pgstore/pgstore.go
@@ -1,0 +1,136 @@
+package pgstore
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"io/fs"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_totp, rooted so its
+// .sql files sit at fsys root (data/migration.New globs the fsys root, not
+// subdirectories). Apply via data/migration under its own version table
+// ("forge_totp_schema").
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// Store is the Postgres implementation of totp.Store. The pool's lifecycle
+// is the caller's.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+var _ totp.Store = (*Store)(nil)
+
+// New builds a Postgres totp Store. Apply Migrations first.
+func New(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+// Get returns the record, or totp.ErrNotFound.
+func (s *Store) Get(ctx context.Context, tenant, subject string) (*totp.Record, error) {
+	var r totp.Record
+	var lastUsed *time.Time
+	err := s.pool.QueryRow(ctx,
+		`SELECT secret, confirmed, last_used_at, backup_hashes
+		 FROM forge_totp WHERE tenant = $1 AND subject = $2`,
+		tenant, subject).Scan(&r.Secret, &r.Confirmed, &lastUsed, &r.BackupHashes)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, totp.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if lastUsed != nil {
+		r.LastUsedAt = *lastUsed
+	}
+	return &r, nil
+}
+
+// Save upserts the record (full replace of mutable columns).
+func (s *Store) Save(ctx context.Context, tenant, subject string, r *totp.Record) error {
+	hashes := r.BackupHashes
+	if hashes == nil {
+		hashes = [][]byte{}
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO forge_totp (tenant, subject, secret, confirmed, last_used_at, backup_hashes)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (tenant, subject) DO UPDATE SET
+		   secret = EXCLUDED.secret,
+		   confirmed = EXCLUDED.confirmed,
+		   last_used_at = EXCLUDED.last_used_at,
+		   backup_hashes = EXCLUDED.backup_hashes,
+		   updated_at = now()`,
+		tenant, subject, r.Secret, r.Confirmed, nullTime(r.LastUsedAt), hashes)
+	return err
+}
+
+// Delete removes the record; absent is a no-op.
+func (s *Store) Delete(ctx context.Context, tenant, subject string) error {
+	_, err := s.pool.Exec(ctx,
+		`DELETE FROM forge_totp WHERE tenant = $1 AND subject = $2`, tenant, subject)
+	return err
+}
+
+// MarkUsed atomically advances last_used_at iff the stored value is
+// earlier (or NULL). The condition lives in the WHERE clause, so
+// concurrent verifies of the same step resolve to exactly one winner.
+func (s *Store) MarkUsed(ctx context.Context, tenant, subject string, usedAt time.Time) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE forge_totp SET last_used_at = $3, updated_at = now()
+		 WHERE tenant = $1 AND subject = $2
+		   AND (last_used_at IS NULL OR last_used_at < $3)`,
+		tenant, subject, usedAt)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// ConsumeBackup atomically removes hash if present; the ANY guard makes
+// concurrent consumes of the same code resolve to exactly one winner.
+func (s *Store) ConsumeBackup(ctx context.Context, tenant, subject string, hash []byte) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE forge_totp SET backup_hashes = array_remove(backup_hashes, $3), updated_at = now()
+		 WHERE tenant = $1 AND subject = $2 AND $3 = ANY(backup_hashes)`,
+		tenant, subject, hash)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// DeleteTenant removes every record in tenant — exact match on the leading
+// PK column, no pattern matching.
+func (s *Store) DeleteTenant(ctx context.Context, tenant string) (int, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM forge_totp WHERE tenant = $1`, tenant)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+// nullTime maps the zero time to SQL NULL.
+func nullTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}

--- a/auth/totp/pgstore/pgstore_test.go
+++ b/auth/totp/pgstore/pgstore_test.go
@@ -1,0 +1,190 @@
+package pgstore_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+	"github.com/dmitrymomot/forge/auth/totp/pgstore"
+	"github.com/dmitrymomot/forge/core/random"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+)
+
+var _ totp.Store = (*pgstore.Store)(nil)
+
+func newStore(t *testing.T) *pgstore.Store {
+	t.Helper()
+	dsn := os.Getenv("FORGE_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("set FORGE_TEST_POSTGRES_DSN")
+	}
+	cfg := postgres.DefaultConfig()
+	cfg.URL = dsn
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgstore.Migrations, migration.WithTable("forge_totp_schema")).Up(context.Background(), db))
+	return pgstore.New(pool)
+}
+
+// subj returns a unique subject per call: the table persists across test
+// runs, so deterministic keys would collide on the PK.
+func subj() string { return "subj-" + random.String(12) }
+
+func rec(confirmed bool) *totp.Record {
+	return &totp.Record{
+		Secret:       []byte("ciphertext-bytes"),
+		Confirmed:    confirmed,
+		BackupHashes: [][]byte{{1, 2, 3}, {4, 5, 6}},
+	}
+}
+
+func TestPg_SaveGetRoundTrip(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	sub := subj()
+
+	_, err := s.Get(ctx, "", sub)
+	assert.ErrorIs(t, err, totp.ErrNotFound)
+
+	r := rec(true)
+	r.LastUsedAt = time.Unix(1_700_000_010, 0).UTC() // step-start: whole seconds
+	require.NoError(t, s.Save(ctx, "", sub, r))
+
+	got, err := s.Get(ctx, "", sub)
+	require.NoError(t, err)
+	assert.Equal(t, r.Secret, got.Secret)
+	assert.True(t, got.Confirmed)
+	assert.True(t, got.LastUsedAt.Equal(r.LastUsedAt), "timestamptz round-trip is exact for whole seconds")
+	assert.Equal(t, r.BackupHashes, got.BackupHashes)
+
+	// Upsert: full replace.
+	r2 := rec(false)
+	require.NoError(t, s.Save(ctx, "", sub, r2))
+	got, err = s.Get(ctx, "", sub)
+	require.NoError(t, err)
+	assert.False(t, got.Confirmed)
+	assert.True(t, got.LastUsedAt.IsZero(), "NULL maps back to zero time")
+}
+
+func TestPg_MarkUsed(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	sub := subj()
+	require.NoError(t, s.Save(ctx, "", sub, rec(true)))
+
+	t0 := time.Unix(1_700_000_010, 0).UTC()
+	ok, err := s.MarkUsed(ctx, "", sub, t0)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = s.MarkUsed(ctx, "", sub, t0)
+	require.NoError(t, err)
+	assert.False(t, ok, "same step claimed once")
+
+	ok, err = s.MarkUsed(ctx, "", sub, t0.Add(-30*time.Second))
+	require.NoError(t, err)
+	assert.False(t, ok, "earlier step rejected")
+
+	ok, err = s.MarkUsed(ctx, "", sub, t0.Add(30*time.Second))
+	require.NoError(t, err)
+	assert.True(t, ok, "later step advances")
+
+	ok, err = s.MarkUsed(ctx, "", "ghost-"+sub, t0)
+	require.NoError(t, err)
+	assert.False(t, ok, "absent record: false, nil")
+}
+
+func TestPg_ConsumeBackup(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	sub := subj()
+	require.NoError(t, s.Save(ctx, "", sub, rec(true)))
+
+	ok, err := s.ConsumeBackup(ctx, "", sub, []byte{1, 2, 3})
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = s.ConsumeBackup(ctx, "", sub, []byte{1, 2, 3})
+	require.NoError(t, err)
+	assert.False(t, ok, "single use")
+
+	got, err := s.Get(ctx, "", sub)
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{{4, 5, 6}}, got.BackupHashes)
+}
+
+func TestPg_DeleteAndDeleteTenant(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	tenant := "tenant-" + random.String(12)
+	subA, subB := subj(), subj()
+
+	require.NoError(t, s.Save(ctx, tenant, subA, rec(true)))
+	require.NoError(t, s.Save(ctx, tenant, subB, rec(true)))
+	require.NoError(t, s.Save(ctx, "", subA, rec(true)))
+
+	// Tenant isolation on point reads.
+	_, err := s.Get(ctx, tenant, subA)
+	require.NoError(t, err)
+	_, err = s.Get(ctx, "other-"+tenant, subA)
+	assert.ErrorIs(t, err, totp.ErrNotFound)
+
+	// Delete one record; absent delete is a no-op.
+	require.NoError(t, s.Delete(ctx, tenant, subB))
+	require.NoError(t, s.Delete(ctx, tenant, subB))
+	_, err = s.Get(ctx, tenant, subB)
+	assert.ErrorIs(t, err, totp.ErrNotFound)
+
+	// DeleteTenant removes exactly the tenant's records.
+	n, err := s.DeleteTenant(ctx, tenant)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	_, err = s.Get(ctx, "", subA)
+	assert.NoError(t, err, "unscoped record untouched")
+}
+
+func TestPg_ManagerLifecycleEndToEnd(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	key := []byte("0123456789abcdef0123456789abcdef")
+	mgr, err := totp.NewManager(s, key, totp.WithIssuer("Acme"))
+	require.NoError(t, err)
+	sub := subj()
+
+	enr, err := mgr.BeginEnroll(ctx, sub, sub+"@acme.com")
+	require.NoError(t, err)
+	tp, err := totp.New()
+	require.NoError(t, err)
+	code, err := tp.Code(enr.Secret, time.Now())
+	require.NoError(t, err)
+	backup, err := mgr.ConfirmEnroll(ctx, sub, code)
+	require.NoError(t, err)
+	require.Len(t, backup, 10)
+
+	// TOTP re-use of the confirm step is replayed.
+	_, err = mgr.Verify(ctx, sub, code)
+	assert.ErrorIs(t, err, totp.ErrReplayed)
+
+	// Backup code path works and consumes.
+	res, err := mgr.Verify(ctx, sub, backup[0])
+	require.NoError(t, err)
+	assert.True(t, res.UsedBackupCode)
+	assert.Equal(t, 9, res.BackupRemaining)
+	_, err = mgr.Verify(ctx, sub, backup[0])
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+
+	require.NoError(t, mgr.Disable(ctx, sub))
+	on, err := mgr.Enabled(ctx, sub)
+	require.NoError(t, err)
+	assert.False(t, on)
+}

--- a/auth/totp/pgstore/pgstore_test.go
+++ b/auth/totp/pgstore/pgstore_test.go
@@ -76,6 +76,60 @@ func TestPg_SaveGetRoundTrip(t *testing.T) {
 	assert.True(t, got.LastUsedAt.IsZero(), "NULL maps back to zero time")
 }
 
+func TestPg_SavePendingAndConfirm(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	sub := subj()
+	secret := []byte("sealed-" + sub)
+
+	// SavePending on absent → stores a pending record with no backup codes.
+	ok, err := s.SavePending(ctx, "", sub, &totp.Record{Secret: secret})
+	require.NoError(t, err)
+	assert.True(t, ok)
+	got, err := s.Get(ctx, "", sub)
+	require.NoError(t, err)
+	assert.False(t, got.Confirmed)
+	assert.Equal(t, secret, got.Secret)
+	assert.Empty(t, got.BackupHashes)
+	assert.True(t, got.LastUsedAt.IsZero())
+
+	// SavePending again overwrites the still-pending secret.
+	secret2 := []byte("sealed2-" + sub)
+	ok, err = s.SavePending(ctx, "", sub, &totp.Record{Secret: secret2})
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	// Confirm with the stale secret → refused (a racing SavePending swapped it).
+	at := time.Unix(1_700_000_050, 0).UTC()
+	ok, err = s.Confirm(ctx, "", sub, secret, at, [][]byte{{1}})
+	require.NoError(t, err)
+	assert.False(t, ok, "secret mismatch must not confirm")
+
+	// Confirm with the current secret → activates.
+	ok, err = s.Confirm(ctx, "", sub, secret2, at, [][]byte{{1, 2}, {3, 4}})
+	require.NoError(t, err)
+	assert.True(t, ok)
+	got, err = s.Get(ctx, "", sub)
+	require.NoError(t, err)
+	assert.True(t, got.Confirmed)
+	assert.True(t, got.LastUsedAt.Equal(at))
+	assert.Equal(t, [][]byte{{1, 2}, {3, 4}}, got.BackupHashes)
+
+	// Confirm again → false (already confirmed).
+	ok, err = s.Confirm(ctx, "", sub, secret2, at, [][]byte{{9}})
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// SavePending must refuse to clobber a confirmed enrollment.
+	ok, err = s.SavePending(ctx, "", sub, &totp.Record{Secret: []byte("sealed3")})
+	require.NoError(t, err)
+	assert.False(t, ok)
+	got, err = s.Get(ctx, "", sub)
+	require.NoError(t, err)
+	assert.True(t, got.Confirmed)
+	assert.Equal(t, secret2, got.Secret, "confirmed record untouched")
+}
+
 func TestPg_MarkUsed(t *testing.T) {
 	s := newStore(t)
 	ctx := context.Background()

--- a/auth/totp/secret.go
+++ b/auth/totp/secret.go
@@ -22,7 +22,7 @@ func (t *TOTP) GenerateSecret() (string, error) {
 	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(buf), nil
 }
 
-// ProvisioningURI renders the otpauth:// Key Uri for authenticator-app
+// ProvisioningURI renders the otpauth:// Key URI for authenticator-app
 // enrollment (render it as a QR with core/qrcode's DataURI, or show it for
 // manual entry). The label is Issuer:account (account only when the issuer
 // is empty); issuer, algorithm, digits, and period ride as query params so

--- a/auth/totp/secret.go
+++ b/auth/totp/secret.go
@@ -1,0 +1,19 @@
+package totp
+
+import (
+	"encoding/base32"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/core/random"
+)
+
+// GenerateSecret returns a new shared secret: cryptographically random
+// bytes sized to the configured algorithm's hash length (RFC 4226 §4),
+// encoded as unpadded uppercase base32 for authenticator-app entry.
+func (t *TOTP) GenerateSecret() (string, error) {
+	buf := make([]byte, t.cfg.algorithm.secretSize())
+	if err := random.Read(buf); err != nil {
+		return "", fmt.Errorf("totp: generate secret: %w", err)
+	}
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(buf), nil
+}

--- a/auth/totp/secret.go
+++ b/auth/totp/secret.go
@@ -3,6 +3,9 @@ package totp
 import (
 	"encoding/base32"
 	"fmt"
+	"net/url"
+	"strconv"
+	"time"
 
 	"github.com/dmitrymomot/forge/core/random"
 )
@@ -16,4 +19,23 @@ func (t *TOTP) GenerateSecret() (string, error) {
 		return "", fmt.Errorf("totp: generate secret: %w", err)
 	}
 	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(buf), nil
+}
+
+// ProvisioningURI renders the otpauth:// Key Uri for authenticator-app
+// enrollment (render it as a QR with core/qrcode's DataURI, or show it for
+// manual entry). The label is Issuer:account (account only when the issuer
+// is empty); issuer, algorithm, digits, and period ride as query params so
+// the app enrolls with exactly the parameters Verify checks.
+func (t *TOTP) ProvisioningURI(secret, account string) string {
+	label := url.PathEscape(account)
+	q := url.Values{}
+	q.Set("secret", secret)
+	if t.cfg.issuer != "" {
+		label = url.PathEscape(t.cfg.issuer) + ":" + label
+		q.Set("issuer", t.cfg.issuer)
+	}
+	q.Set("algorithm", t.cfg.algorithm.String())
+	q.Set("digits", strconv.Itoa(t.cfg.digits))
+	q.Set("period", strconv.FormatInt(int64(t.cfg.period/time.Second), 10))
+	return "otpauth://totp/" + label + "?" + q.Encode()
 }

--- a/auth/totp/secret.go
+++ b/auth/totp/secret.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dmitrymomot/forge/core/random"
@@ -27,15 +28,24 @@ func (t *TOTP) GenerateSecret() (string, error) {
 // is empty); issuer, algorithm, digits, and period ride as query params so
 // the app enrolls with exactly the parameters Verify checks.
 func (t *TOTP) ProvisioningURI(secret, account string) string {
-	label := url.PathEscape(account)
+	label := escapeLabelPart(account)
 	q := url.Values{}
 	q.Set("secret", secret)
 	if t.cfg.issuer != "" {
-		label = url.PathEscape(t.cfg.issuer) + ":" + label
+		label = escapeLabelPart(t.cfg.issuer) + ":" + label
 		q.Set("issuer", t.cfg.issuer)
 	}
 	q.Set("algorithm", t.cfg.algorithm.String())
 	q.Set("digits", strconv.Itoa(t.cfg.digits))
 	q.Set("period", strconv.FormatInt(int64(t.cfg.period/time.Second), 10))
 	return "otpauth://totp/" + label + "?" + q.Encode()
+}
+
+// escapeLabelPart path-escapes an otpauth label component and, unlike
+// url.PathEscape, also escapes the colon: a colon inside the issuer or account
+// would otherwise be indistinguishable from the Issuer:account separator that
+// authenticator apps split on. The authoritative issuer= query param still
+// carries the raw value.
+func escapeLabelPart(s string) string {
+	return strings.ReplaceAll(url.PathEscape(s), ":", "%3A")
 }

--- a/auth/totp/store.go
+++ b/auth/totp/store.go
@@ -1,0 +1,135 @@
+package totp
+
+import (
+	"bytes"
+	"context"
+	"slices"
+	"sync"
+	"time"
+)
+
+// Record is one enrollment as the store sees it: the secret is AEAD
+// ciphertext and backup codes are SHA-256 hashes — a store never holds
+// plaintext material.
+type Record struct {
+	LastUsedAt   time.Time // step-start of the last verified TOTP; zero = never
+	Secret       []byte    // crypto/secret.Box ciphertext
+	BackupHashes [][]byte  // SHA-256 of normalized backup codes
+	Confirmed    bool      // false while enrollment is pending first-code proof
+}
+
+// Store persists enrollment records keyed (tenant, subject); tenant "" is
+// the unscoped namespace and stores interpret it only by equality.
+// Implementations must be safe for concurrent use. MarkUsed and
+// ConsumeBackup carry all concurrency correctness — the rest is CRUD.
+type Store interface {
+	// Get returns the record, or ErrNotFound.
+	Get(ctx context.Context, tenant, subject string) (*Record, error)
+	// Save upserts the record (full replace).
+	Save(ctx context.Context, tenant, subject string, r *Record) error
+	// Delete removes the record; absent is a no-op.
+	Delete(ctx context.Context, tenant, subject string) error
+	// MarkUsed atomically sets LastUsedAt=usedAt iff the stored value is
+	// earlier (or zero). false = a concurrent verify already claimed this
+	// or a later step, or the record is gone. The replay/race gate.
+	MarkUsed(ctx context.Context, tenant, subject string, usedAt time.Time) (bool, error)
+	// ConsumeBackup atomically removes hash if present. false = not
+	// present (already spent, never existed, or record gone). The
+	// single-use gate.
+	ConsumeBackup(ctx context.Context, tenant, subject string, hash []byte) (bool, error)
+	// DeleteTenant removes every record in tenant, returning the count.
+	DeleteTenant(ctx context.Context, tenant string) (int, error)
+}
+
+type memKey struct{ tenant, subject string }
+
+type memoryStore struct {
+	recs map[memKey]*Record
+	mu   sync.RWMutex
+}
+
+// NewMemoryStore returns an in-memory Store for tests, development, and
+// single-process apps. State does not survive restarts.
+func NewMemoryStore() Store {
+	return &memoryStore{recs: make(map[memKey]*Record)}
+}
+
+// cloneRecord deep-copies so callers and the store never share slices.
+func cloneRecord(r *Record) *Record {
+	c := &Record{
+		Secret:     slices.Clone(r.Secret),
+		Confirmed:  r.Confirmed,
+		LastUsedAt: r.LastUsedAt,
+	}
+	if r.BackupHashes != nil {
+		c.BackupHashes = make([][]byte, len(r.BackupHashes))
+		for i, h := range r.BackupHashes {
+			c.BackupHashes[i] = slices.Clone(h)
+		}
+	}
+	return c
+}
+
+func (s *memoryStore) Get(_ context.Context, tenant, subject string) (*Record, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.recs[memKey{tenant, subject}]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return cloneRecord(r), nil
+}
+
+func (s *memoryStore) Save(_ context.Context, tenant, subject string, r *Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recs[memKey{tenant, subject}] = cloneRecord(r)
+	return nil
+}
+
+func (s *memoryStore) Delete(_ context.Context, tenant, subject string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.recs, memKey{tenant, subject})
+	return nil
+}
+
+func (s *memoryStore) MarkUsed(_ context.Context, tenant, subject string, usedAt time.Time) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.recs[memKey{tenant, subject}]
+	if !ok || (!r.LastUsedAt.IsZero() && !r.LastUsedAt.Before(usedAt)) {
+		return false, nil
+	}
+	r.LastUsedAt = usedAt
+	return true, nil
+}
+
+func (s *memoryStore) ConsumeBackup(_ context.Context, tenant, subject string, hash []byte) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.recs[memKey{tenant, subject}]
+	if !ok {
+		return false, nil
+	}
+	for i, h := range r.BackupHashes {
+		if bytes.Equal(h, hash) {
+			r.BackupHashes = slices.Delete(r.BackupHashes, i, i+1)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *memoryStore) DeleteTenant(_ context.Context, tenant string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for k := range s.recs {
+		if k.tenant == tenant {
+			delete(s.recs, k)
+			n++
+		}
+	}
+	return n, nil
+}

--- a/auth/totp/store.go
+++ b/auth/totp/store.go
@@ -20,13 +20,31 @@ type Record struct {
 
 // Store persists enrollment records keyed (tenant, subject); tenant "" is
 // the unscoped namespace and stores interpret it only by equality.
-// Implementations must be safe for concurrent use. MarkUsed and
-// ConsumeBackup carry all concurrency correctness — the rest is CRUD.
+// Implementations must be safe for concurrent use. SavePending, Confirm,
+// MarkUsed, and ConsumeBackup carry all concurrency correctness — the rest
+// is CRUD.
 type Store interface {
 	// Get returns the record, or ErrNotFound.
 	Get(ctx context.Context, tenant, subject string) (*Record, error)
-	// Save upserts the record (full replace).
+	// Save upserts the record (full replace). Used for operations on an
+	// already-confirmed record (e.g. regenerating backup codes); enroll and
+	// confirm go through SavePending and Confirm.
 	Save(ctx context.Context, tenant, subject string, r *Record) error
+	// SavePending atomically stores a fresh pending (unconfirmed) enrollment,
+	// overwriting an existing pending one but refusing to overwrite a
+	// confirmed one. false = a confirmed enrollment already exists. This is
+	// the enroll gate: it stops a BeginEnroll from clobbering an enrollment a
+	// concurrent Confirm just activated. Only r.Secret is read; the stored
+	// record is always pending with no backup codes.
+	SavePending(ctx context.Context, tenant, subject string, r *Record) (bool, error)
+	// Confirm atomically activates a pending enrollment — setting Confirmed,
+	// LastUsedAt, and BackupHashes — only if the stored record is still
+	// pending and its Secret still equals expectedSecret. false = no such
+	// pending record (already confirmed, gone, or its secret was replaced by
+	// a concurrent SavePending). This is the confirm gate: concurrent confirms
+	// of the same code resolve to exactly one winner, and a confirm never
+	// activates a secret the user did not prove.
+	Confirm(ctx context.Context, tenant, subject string, expectedSecret []byte, lastUsedAt time.Time, hashes [][]byte) (bool, error)
 	// Delete removes the record; absent is a no-op.
 	Delete(ctx context.Context, tenant, subject string) error
 	// MarkUsed atomically sets LastUsedAt=usedAt iff the stored value is
@@ -55,17 +73,17 @@ func NewMemoryStore() Store {
 }
 
 // cloneRecord deep-copies so callers and the store never share slices.
+// BackupHashes is always non-nil (empty when there are none), matching the
+// pgstore driver's read shape so the two stores are byte-for-byte comparable.
 func cloneRecord(r *Record) *Record {
 	c := &Record{
-		Secret:     slices.Clone(r.Secret),
-		Confirmed:  r.Confirmed,
-		LastUsedAt: r.LastUsedAt,
+		Secret:       slices.Clone(r.Secret),
+		Confirmed:    r.Confirmed,
+		LastUsedAt:   r.LastUsedAt,
+		BackupHashes: make([][]byte, len(r.BackupHashes)),
 	}
-	if r.BackupHashes != nil {
-		c.BackupHashes = make([][]byte, len(r.BackupHashes))
-		for i, h := range r.BackupHashes {
-			c.BackupHashes[i] = slices.Clone(h)
-		}
+	for i, h := range r.BackupHashes {
+		c.BackupHashes[i] = slices.Clone(h)
 	}
 	return c
 }
@@ -85,6 +103,33 @@ func (s *memoryStore) Save(_ context.Context, tenant, subject string, r *Record)
 	defer s.mu.Unlock()
 	s.recs[memKey{tenant, subject}] = cloneRecord(r)
 	return nil
+}
+
+func (s *memoryStore) SavePending(_ context.Context, tenant, subject string, r *Record) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := memKey{tenant, subject}
+	if existing, ok := s.recs[k]; ok && existing.Confirmed {
+		return false, nil
+	}
+	s.recs[k] = &Record{Secret: slices.Clone(r.Secret), BackupHashes: [][]byte{}}
+	return true, nil
+}
+
+func (s *memoryStore) Confirm(_ context.Context, tenant, subject string, expectedSecret []byte, lastUsedAt time.Time, hashes [][]byte) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.recs[memKey{tenant, subject}]
+	if !ok || r.Confirmed || !bytes.Equal(r.Secret, expectedSecret) {
+		return false, nil
+	}
+	r.Confirmed = true
+	r.LastUsedAt = lastUsedAt
+	r.BackupHashes = make([][]byte, len(hashes))
+	for i, h := range hashes {
+		r.BackupHashes[i] = slices.Clone(h)
+	}
+	return true, nil
 }
 
 func (s *memoryStore) Delete(_ context.Context, tenant, subject string) error {

--- a/auth/totp/store_gates_test.go
+++ b/auth/totp/store_gates_test.go
@@ -1,0 +1,116 @@
+package totp_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+func TestMemoryStore_SavePending(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+
+	// Absent → stores a fresh pending record.
+	ok, err := s.SavePending(ctx, "", "alice", &totp.Record{Secret: []byte("s1")})
+	require.NoError(t, err)
+	assert.True(t, ok)
+	got, err := s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.False(t, got.Confirmed)
+	assert.Equal(t, []byte("s1"), got.Secret)
+	assert.Empty(t, got.BackupHashes)
+
+	// Pending → overwrites with a fresh secret, still pending.
+	ok, err = s.SavePending(ctx, "", "alice", &totp.Record{Secret: []byte("s2")})
+	require.NoError(t, err)
+	assert.True(t, ok)
+	got, err = s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("s2"), got.Secret)
+
+	// Confirm it, then SavePending must refuse to clobber the confirmed record.
+	ok, err = s.Confirm(ctx, "", "alice", []byte("s2"), time.Unix(3000, 0), [][]byte{{9}})
+	require.NoError(t, err)
+	require.True(t, ok)
+	ok, err = s.SavePending(ctx, "", "alice", &totp.Record{Secret: []byte("s3")})
+	require.NoError(t, err)
+	assert.False(t, ok, "must not overwrite a confirmed enrollment")
+	got, err = s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.True(t, got.Confirmed)
+	assert.Equal(t, []byte("s2"), got.Secret, "confirmed record untouched")
+}
+
+func TestMemoryStore_Confirm(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+
+	// Absent → false.
+	ok, err := s.Confirm(ctx, "", "alice", []byte("s1"), time.Unix(3000, 0), [][]byte{{1}})
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	ok, err = s.SavePending(ctx, "", "alice", &totp.Record{Secret: []byte("s1")})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Wrong secret → false, stays pending (a racing SavePending swapped it).
+	ok, err = s.Confirm(ctx, "", "alice", []byte("WRONG"), time.Unix(3000, 0), [][]byte{{1}})
+	require.NoError(t, err)
+	assert.False(t, ok)
+	got, err := s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.False(t, got.Confirmed)
+
+	// Right secret → activates with hashes + last-used step.
+	at := time.Unix(3000, 0)
+	ok, err = s.Confirm(ctx, "", "alice", []byte("s1"), at, [][]byte{{1, 2}, {3, 4}})
+	require.NoError(t, err)
+	assert.True(t, ok)
+	got, err = s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.True(t, got.Confirmed)
+	assert.True(t, got.LastUsedAt.Equal(at))
+	assert.Equal(t, [][]byte{{1, 2}, {3, 4}}, got.BackupHashes)
+
+	// Already confirmed → false.
+	ok, err = s.Confirm(ctx, "", "alice", []byte("s1"), at, [][]byte{{9}})
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestMemoryStore_Confirm_ConcurrentSingleWinner(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+	ok, err := s.SavePending(ctx, "", "alice", &totp.Record{Secret: []byte("s1")})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	const n = 32
+	wins := make(chan bool, n)
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			won, err := s.Confirm(ctx, "", "alice", []byte("s1"), time.Unix(3000, 0), [][]byte{{1}})
+			assert.NoError(t, err)
+			wins <- won
+		})
+	}
+	wg.Wait()
+	close(wins)
+	won := 0
+	for ok := range wins {
+		if ok {
+			won++
+		}
+	}
+	assert.Equal(t, 1, won, "exactly one concurrent confirm claims the pending enrollment")
+}

--- a/auth/totp/store_test.go
+++ b/auth/totp/store_test.go
@@ -56,11 +56,11 @@ func TestMemoryStore_DeepCopies(t *testing.T) {
 
 	// Mutating the caller's record after Save must not affect the store.
 	r.Secret[0] = 'X'
-	r.BackupHashes[0][0] = 99 //nolint:nilaway // rec() always seeds non-empty BackupHashes
+	r.BackupHashes[0][0] = 99
 	got, err := s.Get(ctx, "", "alice")
 	require.NoError(t, err)
 	assert.Equal(t, []byte("ciphertext"), got.Secret)
-	assert.Equal(t, byte(1), got.BackupHashes[0][0]) //nolint:nilaway // rec() always seeds non-empty BackupHashes
+	assert.Equal(t, byte(1), got.BackupHashes[0][0])
 
 	// Mutating a Get result must not affect the store either.
 	got.Secret[0] = 'Y'

--- a/auth/totp/store_test.go
+++ b/auth/totp/store_test.go
@@ -56,11 +56,11 @@ func TestMemoryStore_DeepCopies(t *testing.T) {
 
 	// Mutating the caller's record after Save must not affect the store.
 	r.Secret[0] = 'X'
-	r.BackupHashes[0][0] = 99
+	r.BackupHashes[0][0] = 99 //nolint:nilaway // rec() always seeds non-empty BackupHashes
 	got, err := s.Get(ctx, "", "alice")
 	require.NoError(t, err)
 	assert.Equal(t, []byte("ciphertext"), got.Secret)
-	assert.Equal(t, byte(1), got.BackupHashes[0][0])
+	assert.Equal(t, byte(1), got.BackupHashes[0][0]) //nolint:nilaway // rec() always seeds non-empty BackupHashes
 
 	// Mutating a Get result must not affect the store either.
 	got.Secret[0] = 'Y'

--- a/auth/totp/store_test.go
+++ b/auth/totp/store_test.go
@@ -1,0 +1,178 @@
+package totp_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+func rec(confirmed bool) *totp.Record {
+	return &totp.Record{
+		Secret:       []byte("ciphertext"),
+		Confirmed:    confirmed,
+		BackupHashes: [][]byte{{1, 2}, {3, 4}},
+	}
+}
+
+func TestMemoryStore_CRUD(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+
+	_, err := s.Get(ctx, "", "alice")
+	assert.ErrorIs(t, err, totp.ErrNotFound)
+
+	require.NoError(t, s.Save(ctx, "", "alice", rec(false)))
+	got, err := s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.False(t, got.Confirmed)
+	assert.Equal(t, []byte("ciphertext"), got.Secret)
+
+	// Save is a full replace.
+	require.NoError(t, s.Save(ctx, "", "alice", rec(true)))
+	got, err = s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.True(t, got.Confirmed)
+
+	require.NoError(t, s.Delete(ctx, "", "alice"))
+	_, err = s.Get(ctx, "", "alice")
+	assert.ErrorIs(t, err, totp.ErrNotFound)
+
+	// Delete of an absent record is a no-op, not an error.
+	require.NoError(t, s.Delete(ctx, "", "alice"))
+}
+
+func TestMemoryStore_DeepCopies(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+	r := rec(true)
+	require.NoError(t, s.Save(ctx, "", "alice", r))
+
+	// Mutating the caller's record after Save must not affect the store.
+	r.Secret[0] = 'X'
+	r.BackupHashes[0][0] = 99
+	got, err := s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("ciphertext"), got.Secret)
+	assert.Equal(t, byte(1), got.BackupHashes[0][0])
+
+	// Mutating a Get result must not affect the store either.
+	got.Secret[0] = 'Y'
+	again, err := s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("ciphertext"), again.Secret)
+}
+
+func TestMemoryStore_MarkUsed(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+	require.NoError(t, s.Save(ctx, "", "alice", rec(true)))
+
+	t0 := time.Unix(3000, 0)
+	ok, err := s.MarkUsed(ctx, "", "alice", t0)
+	require.NoError(t, err)
+	assert.True(t, ok, "zero LastUsedAt accepts any step")
+
+	ok, err = s.MarkUsed(ctx, "", "alice", t0)
+	require.NoError(t, err)
+	assert.False(t, ok, "same step is claimed exactly once")
+
+	ok, err = s.MarkUsed(ctx, "", "alice", time.Unix(2970, 0))
+	require.NoError(t, err)
+	assert.False(t, ok, "earlier step rejected")
+
+	ok, err = s.MarkUsed(ctx, "", "alice", time.Unix(3030, 0))
+	require.NoError(t, err)
+	assert.True(t, ok, "later step advances")
+
+	ok, err = s.MarkUsed(ctx, "", "ghost", t0)
+	require.NoError(t, err)
+	assert.False(t, ok, "absent record: false, nil (pg driver parity)")
+}
+
+func TestMemoryStore_MarkUsed_ConcurrentSingleWinner(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+	require.NoError(t, s.Save(ctx, "", "alice", rec(true)))
+
+	const n = 32
+	wins := make(chan bool, n)
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			ok, err := s.MarkUsed(ctx, "", "alice", time.Unix(3000, 0))
+			assert.NoError(t, err)
+			wins <- ok
+		})
+	}
+	wg.Wait()
+	close(wins)
+	won := 0
+	for ok := range wins {
+		if ok {
+			won++
+		}
+	}
+	assert.Equal(t, 1, won, "exactly one concurrent verify claims the step")
+}
+
+func TestMemoryStore_ConsumeBackup(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+	require.NoError(t, s.Save(ctx, "", "alice", rec(true)))
+
+	ok, err := s.ConsumeBackup(ctx, "", "alice", []byte{1, 2})
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = s.ConsumeBackup(ctx, "", "alice", []byte{1, 2})
+	require.NoError(t, err)
+	assert.False(t, ok, "single use")
+
+	got, err := s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{{3, 4}}, got.BackupHashes)
+
+	ok, err = s.ConsumeBackup(ctx, "", "ghost", []byte{3, 4})
+	require.NoError(t, err)
+	assert.False(t, ok, "absent record: false, nil")
+}
+
+func TestMemoryStore_TenantIsolationAndDeleteTenant(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+	require.NoError(t, s.Save(ctx, "t1", "alice", rec(true)))
+	require.NoError(t, s.Save(ctx, "t2", "alice", rec(false)))
+	require.NoError(t, s.Save(ctx, "", "alice", rec(true)))
+
+	r1, err := s.Get(ctx, "t1", "alice")
+	require.NoError(t, err)
+	assert.True(t, r1.Confirmed)
+	r2, err := s.Get(ctx, "t2", "alice")
+	require.NoError(t, err)
+	assert.False(t, r2.Confirmed, "same subject, distinct records per tenant")
+
+	n, err := s.DeleteTenant(ctx, "t1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	_, err = s.Get(ctx, "t1", "alice")
+	assert.ErrorIs(t, err, totp.ErrNotFound)
+	_, err = s.Get(ctx, "t2", "alice")
+	assert.NoError(t, err, "other tenants untouched")
+	_, err = s.Get(ctx, "", "alice")
+	assert.NoError(t, err, "unscoped record untouched")
+
+	n, err = s.DeleteTenant(ctx, "t1")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}

--- a/auth/totp/tenancy_test.go
+++ b/auth/totp/tenancy_test.go
@@ -127,7 +127,38 @@ func TestScope_FailClosed(t *testing.T) {
 	mErr := newManager(t, store, totp.WithScope(func(context.Context) (string, error) {
 		return "", boom
 	}))
-	_, err = mErr.Enabled(t.Context(), "alice")
+	ctx := t.Context()
+
+	// All 8 methods must fail closed with ErrScope wrapping boom.
+	_, err = mErr.BeginEnroll(ctx, "alice", "a@acme.com")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	assert.ErrorIs(t, err, boom)
+
+	_, err = mErr.ConfirmEnroll(ctx, "alice", "123456")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	assert.ErrorIs(t, err, boom)
+
+	_, err = mErr.Verify(ctx, "alice", "123456")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	assert.ErrorIs(t, err, boom)
+
+	_, err = mErr.Enabled(ctx, "alice")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	assert.ErrorIs(t, err, boom)
+
+	_, err = mErr.LastVerified(ctx, "alice")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	assert.ErrorIs(t, err, boom)
+
+	_, err = mErr.RegenerateBackupCodes(ctx, "alice")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	assert.ErrorIs(t, err, boom)
+
+	err = mErr.Disable(ctx, "alice")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	assert.ErrorIs(t, err, boom)
+
+	_, err = mErr.DisableTenant(ctx)
 	assert.ErrorIs(t, err, totp.ErrScope)
 	assert.ErrorIs(t, err, boom)
 }

--- a/auth/totp/tenancy_test.go
+++ b/auth/totp/tenancy_test.go
@@ -1,0 +1,174 @@
+package totp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+type tenantCtxKey struct{}
+
+func tenantCtx(t *testing.T, tenant string) context.Context {
+	t.Helper()
+	return context.WithValue(t.Context(), tenantCtxKey{}, tenant)
+}
+
+func scopeHook(ctx context.Context) (string, error) {
+	v, _ := ctx.Value(tenantCtxKey{}).(string)
+	return v, nil
+}
+
+// scopedEnroll enrolls subject under tenant and returns issued backup codes.
+func scopedEnroll(t *testing.T, m *totp.Manager, ctx context.Context, subject string) (*totp.Enrollment, []string) {
+	t.Helper()
+	enr, err := m.BeginEnroll(ctx, subject, subject+"@acme.com")
+	require.NoError(t, err)
+	codes, err := m.ConfirmEnroll(ctx, subject, codeFor(t, enr, fixedNow))
+	require.NoError(t, err)
+	return enr, codes
+}
+
+func TestRegenerateBackupCodes(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m, _, oldCodes := enroll(t, store)
+	ctx := t.Context()
+
+	newCodes, err := m.RegenerateBackupCodes(ctx, "alice")
+	require.NoError(t, err)
+	assert.Len(t, newCodes, 10)
+
+	// Old codes are dead, new ones live.
+	_, err = m.Verify(ctx, "alice", oldCodes[0])
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+	res, err := m.Verify(ctx, "alice", newCodes[0])
+	require.NoError(t, err)
+	assert.True(t, res.UsedBackupCode)
+
+	// Not enrolled / pending → ErrNotEnrolled.
+	_, err = m.RegenerateBackupCodes(ctx, "ghost")
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+}
+
+func TestDisable(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m, enr, _ := enroll(t, store)
+	ctx := t.Context()
+
+	require.NoError(t, m.Disable(ctx, "alice"))
+	on, err := m.Enabled(ctx, "alice")
+	require.NoError(t, err)
+	assert.False(t, on)
+	_, err = m.Verify(ctx, "alice", codeFor(t, enr, fixedNow))
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+
+	// Disable is idempotent; re-enroll works after it.
+	require.NoError(t, m.Disable(ctx, "alice"))
+	_, err = m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+}
+
+func TestScope_IsolatesTenants(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store, totp.WithScope(scopeHook))
+
+	ctxA, ctxB := tenantCtx(t, "tenant-a"), tenantCtx(t, "tenant-b")
+	enrA, _ := scopedEnroll(t, m, ctxA, "alice")
+
+	// Same subject, other tenant: independent lifecycle.
+	on, err := m.Enabled(ctxB, "alice")
+	require.NoError(t, err)
+	assert.False(t, on, "tenant-b sees no enrollment")
+	_, err = m.Verify(ctxB, "alice", codeFor(t, enrA, fixedNow))
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+
+	enrB, _ := scopedEnroll(t, m, ctxB, "alice")
+	assert.NotEqual(t, enrA.Secret, enrB.Secret, "independent secrets per tenant")
+
+	// Disable in one tenant leaves the other intact.
+	require.NoError(t, m.Disable(ctxB, "alice"))
+	on, err = m.Enabled(ctxA, "alice")
+	require.NoError(t, err)
+	assert.True(t, on)
+}
+
+func TestScope_FailClosed(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+
+	// Hook returning empty scope → ErrScope on every method.
+	m := newManager(t, store, totp.WithScope(scopeHook))
+	noTenant := t.Context() // no tenant value in context → hook returns ""
+	_, err := m.BeginEnroll(noTenant, "alice", "a@acme.com")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	_, err = m.ConfirmEnroll(noTenant, "alice", "123456")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	_, err = m.Verify(noTenant, "alice", "123456")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	_, err = m.Enabled(noTenant, "alice")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	_, err = m.LastVerified(noTenant, "alice")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	_, err = m.RegenerateBackupCodes(noTenant, "alice")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	assert.ErrorIs(t, m.Disable(noTenant, "alice"), totp.ErrScope)
+	_, err = m.DisableTenant(noTenant)
+	assert.ErrorIs(t, err, totp.ErrScope)
+
+	// Hook returning an error → ErrScope wrapping it.
+	boom := errors.New("boom")
+	mErr := newManager(t, store, totp.WithScope(func(context.Context) (string, error) {
+		return "", boom
+	}))
+	_, err = mErr.Enabled(t.Context(), "alice")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	assert.ErrorIs(t, err, boom)
+}
+
+func TestScope_UnscopedAndScopedNeverCollide(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	unscoped := newManager(t, store)
+	scoped := newManager(t, store, totp.WithScope(scopeHook))
+
+	enrU, _ := scopedEnroll(t, unscoped, t.Context(), "alice")
+	_ = enrU
+
+	on, err := scoped.Enabled(tenantCtx(t, "tenant-a"), "alice")
+	require.NoError(t, err)
+	assert.False(t, on, "scoped manager cannot see the unscoped record")
+}
+
+func TestDisableTenant(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store, totp.WithScope(scopeHook))
+	ctxA, ctxB := tenantCtx(t, "tenant-a"), tenantCtx(t, "tenant-b")
+
+	scopedEnroll(t, m, ctxA, "alice")
+	scopedEnroll(t, m, ctxA, "bob")
+	scopedEnroll(t, m, ctxB, "alice")
+
+	n, err := m.DisableTenant(ctxA)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	on, err := m.Enabled(ctxA, "alice")
+	require.NoError(t, err)
+	assert.False(t, on)
+	on, err = m.Enabled(ctxB, "alice")
+	require.NoError(t, err)
+	assert.True(t, on, "tenant-b untouched")
+
+	// Unscoped manager has no tenant to delete.
+	unscoped := newManager(t, store)
+	_, err = unscoped.DisableTenant(t.Context())
+	assert.ErrorIs(t, err, totp.ErrScope)
+}

--- a/auth/totp/totp.go
+++ b/auth/totp/totp.go
@@ -195,3 +195,46 @@ func (t *TOTP) Code(secret string, at time.Time) (string, error) {
 	counter := uint64(at.Unix() / t.stepSeconds())
 	return hotp(t.cfg.algorithm.hashFunc(), key, counter, t.cfg.digits), nil
 }
+
+// Verify checks code against every step in [now-skew, now+skew] — all
+// windows evaluated without early exit, compared in constant time — then
+// rejects any match at or before lastUsed's step (ErrReplayed). On success
+// it returns the matched step-start time (UTC, whole seconds): persist it
+// and pass it back as lastUsed on the next call. Zero lastUsed = never
+// verified. ErrInvalidCode when no window matches.
+func (t *TOTP) Verify(secret, code string, lastUsed time.Time) (time.Time, error) {
+	key, err := decodeSecret(secret)
+	if err != nil {
+		return time.Time{}, err
+	}
+	step := t.stepSeconds()
+	cur := t.cfg.clk.Now().Unix() / step
+	last := int64(-1)
+	if !lastUsed.IsZero() {
+		last = lastUsed.Unix() / step
+	}
+
+	matched, replayed := int64(-1), false
+	for off := -t.cfg.skew; off <= t.cfg.skew; off++ {
+		c := cur + int64(off)
+		if c < 0 {
+			continue
+		}
+		if !consttime.StringEqual(hotp(t.cfg.algorithm.hashFunc(), key, uint64(c), t.cfg.digits), code) {
+			continue
+		}
+		if c <= last {
+			replayed = true
+		} else if c > matched {
+			matched = c
+		}
+	}
+	switch {
+	case matched >= 0:
+		return time.Unix(matched*step, 0).UTC(), nil
+	case replayed:
+		return time.Time{}, ErrReplayed
+	default:
+		return time.Time{}, ErrInvalidCode
+	}
+}

--- a/auth/totp/totp.go
+++ b/auth/totp/totp.go
@@ -5,12 +5,18 @@
 package totp
 
 import (
+	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
+	"encoding/base32"
+	"encoding/binary"
 	"fmt"
 	"hash"
+	"strings"
 	"time"
+
+	"github.com/dmitrymomot/forge/crypto/consttime"
 )
 
 // Algorithm selects the HMAC hash for code derivation.
@@ -98,4 +104,78 @@ func (c *config) validateCore() error {
 		return fmt.Errorf("totp: unknown algorithm %d", int(c.algorithm))
 	}
 	return nil
+}
+
+// decodeSecret parses a base32 shared secret leniently: users retype
+// secrets by hand, so lowercase, interior spaces, and trailing padding are
+// all accepted. Never panics on malformed input.
+func decodeSecret(s string) ([]byte, error) {
+	s = strings.ToUpper(strings.ReplaceAll(s, " ", ""))
+	s = strings.TrimRight(s, "=")
+	b, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("totp: decode secret: %w", err)
+	}
+	return b, nil
+}
+
+// hotp computes the RFC 4226 code: HMAC(key, counter) → dynamic truncation
+// → digits decimal digits, zero-padded.
+func hotp(h func() hash.Hash, key []byte, counter uint64, digits int) string {
+	mac := hmac.New(h, key)
+	var msg [8]byte
+	binary.BigEndian.PutUint64(msg[:], counter)
+	mac.Write(msg[:])
+	sum := mac.Sum(nil)
+
+	off := sum[len(sum)-1] & 0x0f
+	v := binary.BigEndian.Uint32(sum[off:off+4]) & 0x7fffffff
+
+	mod := uint32(1_000_000)
+	if digits == 8 {
+		mod = 100_000_000
+	}
+	code := v % mod
+
+	out := make([]byte, digits)
+	for i := digits - 1; i >= 0; i-- {
+		out[i] = '0' + byte(code%10)
+		code /= 10
+	}
+	return string(out)
+}
+
+// HOTPCode computes the RFC 4226 code for counter. Counter state is the
+// caller's; most consumers want time-based Code/Verify instead.
+func (t *TOTP) HOTPCode(secret string, counter uint64) (string, error) {
+	key, err := decodeSecret(secret)
+	if err != nil {
+		return "", err
+	}
+	return hotp(t.cfg.algorithm.hashFunc(), key, counter, t.cfg.digits), nil
+}
+
+// VerifyHOTP checks code against counters counter..counter+lookahead
+// (constant-time, no early exit) and returns the next counter value to
+// persist (matched+1). ErrInvalidCode when nothing matches.
+func (t *TOTP) VerifyHOTP(secret, code string, counter uint64, lookahead int) (uint64, error) {
+	if lookahead < 0 {
+		return 0, fmt.Errorf("totp: negative lookahead %d", lookahead)
+	}
+	key, err := decodeSecret(secret)
+	if err != nil {
+		return 0, err
+	}
+	var next uint64
+	found := false
+	for i := range lookahead + 1 {
+		c := counter + uint64(i)
+		if consttime.StringEqual(hotp(t.cfg.algorithm.hashFunc(), key, c, t.cfg.digits), code) && !found {
+			next, found = c+1, true
+		}
+	}
+	if !found {
+		return 0, ErrInvalidCode
+	}
+	return next, nil
 }

--- a/auth/totp/totp.go
+++ b/auth/totp/totp.go
@@ -197,7 +197,9 @@ func (t *TOTP) Code(secret string, at time.Time) (string, error) {
 // rejects any match at or before lastUsed's step (ErrReplayed). On success
 // it returns the matched step-start time (UTC, whole seconds): persist it
 // and pass it back as lastUsed on the next call. Zero lastUsed = never
-// verified. ErrInvalidCode when no window matches.
+// verified; callers pass back only step-times from prior Verify results,
+// which are always after the Unix epoch. ErrInvalidCode when no window
+// matches.
 func (t *TOTP) Verify(secret, code string, lastUsed time.Time) (time.Time, error) {
 	key, err := decodeSecret(secret)
 	if err != nil {

--- a/auth/totp/totp.go
+++ b/auth/totp/totp.go
@@ -179,3 +179,19 @@ func (t *TOTP) VerifyHOTP(secret, code string, counter uint64, lookahead int) (u
 	}
 	return next, nil
 }
+
+func (t *TOTP) stepSeconds() int64 { return int64(t.cfg.period / time.Second) }
+
+// Code computes the TOTP code for an explicit instant — client side, CLIs,
+// tests. Server-side verification should use Verify.
+func (t *TOTP) Code(secret string, at time.Time) (string, error) {
+	if at.Unix() < 0 {
+		return "", fmt.Errorf("totp: time %s is before the unix epoch", at)
+	}
+	key, err := decodeSecret(secret)
+	if err != nil {
+		return "", err
+	}
+	counter := uint64(at.Unix() / t.stepSeconds())
+	return hotp(t.cfg.algorithm.hashFunc(), key, counter, t.cfg.digits), nil
+}

--- a/auth/totp/totp.go
+++ b/auth/totp/totp.go
@@ -1,7 +1,3 @@
-// Package totp implements RFC 6238 TOTP / RFC 4226 HOTP two-factor
-// authentication: secret generation, skew-window verification with replay
-// rejection, otpauth:// provisioning URIs, one-time backup codes, and a
-// Manager over a tenant-aware Store seam. See doc.go for recipes.
 package totp
 
 import (

--- a/auth/totp/totp.go
+++ b/auth/totp/totp.go
@@ -1,0 +1,101 @@
+// Package totp implements RFC 6238 TOTP / RFC 4226 HOTP two-factor
+// authentication: secret generation, skew-window verification with replay
+// rejection, otpauth:// provisioning URIs, one-time backup codes, and a
+// Manager over a tenant-aware Store seam. See doc.go for recipes.
+package totp
+
+import (
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"fmt"
+	"hash"
+	"time"
+)
+
+// Algorithm selects the HMAC hash for code derivation.
+type Algorithm int
+
+// Supported HMAC algorithms. SHA1 is the authenticator-app default.
+const (
+	SHA1 Algorithm = iota
+	SHA256
+	SHA512
+)
+
+// String returns the otpauth URI parameter form: "SHA1", "SHA256", "SHA512".
+func (a Algorithm) String() string {
+	switch a {
+	case SHA1:
+		return "SHA1"
+	case SHA256:
+		return "SHA256"
+	case SHA512:
+		return "SHA512"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// hashFunc returns the hash constructor for HMAC.
+func (a Algorithm) hashFunc() func() hash.Hash {
+	switch a {
+	case SHA256:
+		return sha256.New
+	case SHA512:
+		return sha512.New
+	default:
+		return sha1.New
+	}
+}
+
+// secretSize is the RFC 4226 §4 recommendation: secret length = hash length.
+func (a Algorithm) secretSize() int {
+	switch a {
+	case SHA256:
+		return 32
+	case SHA512:
+		return 64
+	default:
+		return 20
+	}
+}
+
+func (a Algorithm) valid() bool { return a == SHA1 || a == SHA256 || a == SHA512 }
+
+// TOTP holds validated code-generation parameters. One instance serves both
+// enrollment (ProvisioningURI) and verification, so the parameters an
+// authenticator app was enrolled with can never drift from the ones Verify
+// checks. Safe for concurrent use.
+type TOTP struct {
+	cfg config
+}
+
+// New validates opts and builds a TOTP. Defaults: 6 digits, 30s period,
+// SHA-1, skew ±1.
+func New(opts ...Option) (*TOTP, error) {
+	cfg := defaultConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if err := cfg.validateCore(); err != nil {
+		return nil, err
+	}
+	return &TOTP{cfg: cfg}, nil
+}
+
+func (c *config) validateCore() error {
+	if c.digits != 6 && c.digits != 8 {
+		return fmt.Errorf("totp: digits must be 6 or 8, got %d", c.digits)
+	}
+	if c.period < time.Second || c.period%time.Second != 0 {
+		return fmt.Errorf("totp: period must be whole seconds >= 1s, got %s", c.period)
+	}
+	if c.skew < 0 {
+		return fmt.Errorf("totp: skew must be >= 0, got %d", c.skew)
+	}
+	if !c.algorithm.valid() {
+		return fmt.Errorf("totp: unknown algorithm %d", int(c.algorithm))
+	}
+	return nil
+}

--- a/auth/totp/totp_test.go
+++ b/auth/totp/totp_test.go
@@ -1,0 +1,60 @@
+package totp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+func TestNew_Defaults(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	require.NotNil(t, tp)
+}
+
+func TestNew_InvalidConfig(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		opt  totp.Option
+	}{
+		{"digits 7", totp.WithDigits(7)},
+		{"digits 0", totp.WithDigits(0)},
+		{"period sub-second", totp.WithPeriod(500 * time.Millisecond)},
+		{"period fractional", totp.WithPeriod(30*time.Second + 500*time.Millisecond)},
+		{"period zero", totp.WithPeriod(0)},
+		{"negative skew", totp.WithSkew(-1)},
+		{"unknown algorithm", totp.WithAlgorithm(totp.Algorithm(99))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := totp.New(tt.opt)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestNew_ValidVariants(t *testing.T) {
+	t.Parallel()
+	_, err := totp.New(
+		totp.WithIssuer("Acme"),
+		totp.WithDigits(8),
+		totp.WithPeriod(60*time.Second),
+		totp.WithAlgorithm(totp.SHA512),
+		totp.WithSkew(0),
+	)
+	require.NoError(t, err)
+}
+
+func TestAlgorithm_String(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "SHA1", totp.SHA1.String())
+	assert.Equal(t, "SHA256", totp.SHA256.String())
+	assert.Equal(t, "SHA512", totp.SHA512.String())
+}

--- a/auth/totp/uri_test.go
+++ b/auth/totp/uri_test.go
@@ -1,0 +1,65 @@
+package totp_test
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+func TestProvisioningURI_Full(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New(totp.WithIssuer("Acme Corp"), totp.WithDigits(8),
+		totp.WithPeriod(60*time.Second), totp.WithAlgorithm(totp.SHA256))
+	require.NoError(t, err)
+
+	uri := tp.ProvisioningURI("JBSWY3DPEHPK3PXP", "user+tag@acme.com")
+
+	u, err := url.Parse(uri)
+	require.NoError(t, err)
+	assert.Equal(t, "otpauth", u.Scheme)
+	assert.Equal(t, "totp", u.Host)
+	// Label is Issuer:account, path-escaped; url.Parse unescapes it.
+	assert.Equal(t, "/Acme Corp:user+tag@acme.com", u.Path)
+
+	q := u.Query()
+	assert.Equal(t, "JBSWY3DPEHPK3PXP", q.Get("secret"))
+	assert.Equal(t, "Acme Corp", q.Get("issuer"))
+	assert.Equal(t, "SHA256", q.Get("algorithm"))
+	assert.Equal(t, "8", q.Get("digits"))
+	assert.Equal(t, "60", q.Get("period"))
+}
+
+func TestProvisioningURI_EmptyIssuer(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	uri := tp.ProvisioningURI("JBSWY3DPEHPK3PXP", "user@acme.com")
+
+	u, err := url.Parse(uri)
+	require.NoError(t, err)
+	assert.Equal(t, "/user@acme.com", u.Path, "no issuer prefix in label")
+	assert.False(t, u.Query().Has("issuer"), "issuer param omitted")
+	assert.Equal(t, "30", u.Query().Get("period"))
+	assert.Equal(t, "6", u.Query().Get("digits"))
+	assert.Equal(t, "SHA1", u.Query().Get("algorithm"))
+}
+
+func TestProvisioningURI_EscapesLabel(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New(totp.WithIssuer("Ac/me:Corp"))
+	require.NoError(t, err)
+	uri := tp.ProvisioningURI("JBSWY3DPEHPK3PXP", "a b/c@x.io")
+	// Raw reserved characters must not appear unescaped in the label part.
+	label := strings.TrimPrefix(uri[:strings.Index(uri, "?")], "otpauth://totp/")
+	assert.NotContains(t, label, " ")
+	assert.NotContains(t, label, "/")
+	u, err := url.Parse(uri)
+	require.NoError(t, err)
+	assert.Equal(t, "Ac/me:Corp", u.Query().Get("issuer"))
+}

--- a/auth/totp/uri_test.go
+++ b/auth/totp/uri_test.go
@@ -63,3 +63,17 @@ func TestProvisioningURI_EscapesLabel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Ac/me:Corp", u.Query().Get("issuer"))
 }
+
+func TestProvisioningURI_EscapesColonInLabelParts(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New(totp.WithIssuer("Foo:Bar"))
+	require.NoError(t, err)
+	uri := tp.ProvisioningURI("JBSWY3DPEHPK3PXP", "user:name@x.io")
+	label := strings.TrimPrefix(uri[:strings.Index(uri, "?")], "otpauth://totp/")
+	// Colons inside the issuer and account are escaped, so the label carries
+	// exactly one literal colon — the Issuer:account separator apps split on.
+	assert.Equal(t, 1, strings.Count(label, ":"), "label = %q", label)
+	u, err := url.Parse(uri)
+	require.NoError(t, err)
+	assert.Equal(t, "Foo:Bar", u.Query().Get("issuer"), "raw issuer stays authoritative in the query param")
+}

--- a/auth/totp/verify_manager_test.go
+++ b/auth/totp/verify_manager_test.go
@@ -1,0 +1,168 @@
+package totp_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// enroll provisions a confirmed enrollment and returns the manager,
+// enrollment (for code computation), and issued backup codes.
+func enroll(t *testing.T, store totp.Store, opts ...totp.Option) (*totp.Manager, *totp.Enrollment, []string) {
+	t.Helper()
+	m := newManager(t, store, opts...)
+	ctx := t.Context()
+	enr, err := m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+	backup, err := m.ConfirmEnroll(ctx, "alice", codeFor(t, enr, fixedNow))
+	require.NoError(t, err)
+	return m, enr, backup
+}
+
+func TestManagerVerify_TOTPPath(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	_, enr, _ := enroll(t, store)
+	ctx := t.Context()
+
+	// ConfirmEnroll consumed the fixedNow step; advance one step.
+	later := fixedNow.Add(30 * time.Second)
+	m2, err := totp.NewManager(store, testKey, totp.WithClock(clock.NewMock(later)))
+	require.NoError(t, err)
+
+	res, err := m2.Verify(ctx, "alice", codeFor(t, enr, later))
+	require.NoError(t, err)
+	assert.False(t, res.UsedBackupCode)
+
+	// Same code again: the step is spent.
+	_, err = m2.Verify(ctx, "alice", codeFor(t, enr, later))
+	assert.ErrorIs(t, err, totp.ErrReplayed)
+
+	// Garbage code.
+	_, err = m2.Verify(ctx, "alice", "000000")
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+}
+
+func TestManagerVerify_BackupPath(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m, _, backup := enroll(t, store)
+	ctx := t.Context()
+
+	res, err := m.Verify(ctx, "alice", backup[0])
+	require.NoError(t, err)
+	assert.True(t, res.UsedBackupCode)
+	assert.Equal(t, 9, res.BackupRemaining)
+
+	// Consumed: second use fails.
+	_, err = m.Verify(ctx, "alice", backup[0])
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+
+	// Normalization: uppercase + no dashes still verifies.
+	res, err = m.Verify(ctx, "alice", "  "+stringsUpperNoDash(backup[1])+" ")
+	require.NoError(t, err)
+	assert.True(t, res.UsedBackupCode)
+	assert.Equal(t, 8, res.BackupRemaining)
+}
+
+func stringsUpperNoDash(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := range len(s) {
+		c := s[i]
+		if c == '-' {
+			continue
+		}
+		if 'a' <= c && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func TestManagerVerify_Unenrolled(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store)
+	ctx := t.Context()
+
+	_, err := m.Verify(ctx, "ghost", "123456")
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+
+	// Pending (unconfirmed) enrollment refuses Verify too.
+	_, err = m.BeginEnroll(ctx, "bob", "bob@acme.com")
+	require.NoError(t, err)
+	_, err = m.Verify(ctx, "bob", "123456")
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+}
+
+func TestManagerVerify_ConcurrentSameCode_OneWinner(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	_, enr, _ := enroll(t, store)
+	ctx := t.Context()
+
+	later := fixedNow.Add(60 * time.Second)
+	m2, err := totp.NewManager(store, testKey, totp.WithClock(clock.NewMock(later)))
+	require.NoError(t, err)
+	code := codeFor(t, enr, later)
+
+	const n = 16
+	results := make(chan error, n)
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			_, err := m2.Verify(ctx, "alice", code)
+			results <- err
+		})
+	}
+	wg.Wait()
+	close(results)
+	okCount, replayCount := 0, 0
+	for err := range results {
+		switch {
+		case err == nil:
+			okCount++
+		case assert.ErrorIs(t, err, totp.ErrReplayed):
+			replayCount++
+		}
+	}
+	assert.Equal(t, 1, okCount, "exactly one concurrent verify succeeds")
+	assert.Equal(t, n-1, replayCount)
+}
+
+func TestEnabledAndLastVerified(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store)
+	ctx := t.Context()
+
+	on, err := m.Enabled(ctx, "alice")
+	require.NoError(t, err)
+	assert.False(t, on, "absent: false, nil — a policy query, not an error")
+	_, err = m.LastVerified(ctx, "alice")
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+
+	enr, err := m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+	on, err = m.Enabled(ctx, "alice")
+	require.NoError(t, err)
+	assert.False(t, on, "pending: still false")
+	_, err = m.LastVerified(ctx, "alice")
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled, "pending: not enrolled")
+
+	_, err = m.ConfirmEnroll(ctx, "alice", codeFor(t, enr, fixedNow))
+	require.NoError(t, err)
+	on, err = m.Enabled(ctx, "alice")
+	require.NoError(t, err)
+	assert.True(t, on)
+	last, err := m.LastVerified(ctx, "alice")
+	require.NoError(t, err)
+	assert.False(t, last.IsZero(), "confirm stamped the first verified step")
+}

--- a/auth/totp/verify_test.go
+++ b/auth/totp/verify_test.go
@@ -1,0 +1,119 @@
+package totp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// newVerifier pins the clock to a fixed instant so window math is exact.
+func newVerifier(t *testing.T, at time.Time, opts ...totp.Option) *totp.TOTP {
+	t.Helper()
+	tp, err := totp.New(append(opts, totp.WithClock(clock.NewMock(at)))...)
+	require.NoError(t, err)
+	return tp
+}
+
+func TestVerify_CurrentStep(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_111_111_111, 0).UTC()
+	tp := newVerifier(t, now)
+	secret := b32(rfc4226Raw)
+	code, err := tp.Code(secret, now)
+	require.NoError(t, err)
+
+	matchedAt, err := tp.Verify(secret, code, time.Time{})
+	require.NoError(t, err)
+	// Returned value is the step-start time: lossless counter round-trip.
+	assert.Equal(t, (now.Unix()/30)*30, matchedAt.Unix())
+	assert.Equal(t, int64(0), matchedAt.Unix()%30)
+}
+
+func TestVerify_SkewWindow(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_111_111_111, 0).UTC()
+	secret := b32(rfc4226Raw)
+	tp := newVerifier(t, now) // skew ±1
+
+	for _, offset := range []time.Duration{-30 * time.Second, 30 * time.Second} {
+		code, err := tp.Code(secret, now.Add(offset))
+		require.NoError(t, err)
+		_, err = tp.Verify(secret, code, time.Time{})
+		assert.NoError(t, err, "offset %s within ±1 skew", offset)
+	}
+	for _, offset := range []time.Duration{-60 * time.Second, 60 * time.Second} {
+		code, err := tp.Code(secret, now.Add(offset))
+		require.NoError(t, err)
+		_, err = tp.Verify(secret, code, time.Time{})
+		assert.ErrorIs(t, err, totp.ErrInvalidCode, "offset %s outside ±1 skew", offset)
+	}
+
+	strict := newVerifier(t, now, totp.WithSkew(0))
+	code, err := strict.Code(secret, now.Add(-30*time.Second))
+	require.NoError(t, err)
+	_, err = strict.Verify(secret, code, time.Time{})
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+}
+
+func TestVerify_Replay(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_111_111_111, 0).UTC()
+	tp := newVerifier(t, now)
+	secret := b32(rfc4226Raw)
+	code, err := tp.Code(secret, now)
+	require.NoError(t, err)
+
+	matchedAt, err := tp.Verify(secret, code, time.Time{})
+	require.NoError(t, err)
+
+	// Same code with lastUsed = the returned step: replayed.
+	_, err = tp.Verify(secret, code, matchedAt)
+	assert.ErrorIs(t, err, totp.ErrReplayed)
+
+	// Codes from steps before lastUsed are also replayed, not merely invalid.
+	prev, err := tp.Code(secret, now.Add(-30*time.Second))
+	require.NoError(t, err)
+	_, err = tp.Verify(secret, prev, matchedAt)
+	assert.ErrorIs(t, err, totp.ErrReplayed)
+
+	// A later step still verifies: clock advances one step, same lastUsed.
+	later := newVerifier(t, now.Add(30*time.Second))
+	next, err := later.Code(secret, now.Add(30*time.Second))
+	require.NoError(t, err)
+	nextAt, err := later.Verify(secret, next, matchedAt)
+	require.NoError(t, err)
+	assert.True(t, nextAt.After(matchedAt))
+}
+
+func TestVerify_TimeRoundTripSurvivesStorage(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_111_111_111, 0).UTC()
+	tp := newVerifier(t, now)
+	secret := b32(rfc4226Raw)
+	code, err := tp.Code(secret, now)
+	require.NoError(t, err)
+	matchedAt, err := tp.Verify(secret, code, time.Time{})
+	require.NoError(t, err)
+
+	// Round-tripping through unix seconds (a timestamptz column) preserves
+	// the replay boundary exactly.
+	stored := time.Unix(matchedAt.Unix(), 0)
+	_, err = tp.Verify(secret, code, stored)
+	assert.ErrorIs(t, err, totp.ErrReplayed)
+}
+
+func TestVerify_GarbageInputs(t *testing.T) {
+	t.Parallel()
+	tp := newVerifier(t, time.Unix(1_111_111_111, 0).UTC())
+	_, err := tp.Verify("###", "123456", time.Time{})
+	require.Error(t, err)
+	_, err = tp.Verify(b32(rfc4226Raw), "", time.Time{})
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+	_, err = tp.Verify(b32(rfc4226Raw), "abcdef", time.Time{})
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+}

--- a/auth/totp/verify_test.go
+++ b/auth/totp/verify_test.go
@@ -19,6 +19,20 @@ func newVerifier(t *testing.T, at time.Time, opts ...totp.Option) *totp.TOTP {
 	return tp
 }
 
+// TestWithClock_NilKeepsDefault exercises the WithClock nil-guard: a nil clock
+// must leave the default (system) clock in place, and Verify must still work
+// against it — a code generated for "now" verifies within the default skew.
+func TestWithClock_NilKeepsDefault(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New(totp.WithClock(nil))
+	require.NoError(t, err)
+	secret := b32(rfc4226Raw)
+	code, err := tp.Code(secret, time.Now())
+	require.NoError(t, err)
+	_, err = tp.Verify(secret, code, time.Time{})
+	require.NoError(t, err, "default system clock drives Verify when WithClock(nil)")
+}
+
 func TestVerify_CurrentStep(t *testing.T) {
 	t.Parallel()
 	now := time.Unix(1_111_111_111, 0).UTC()

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -630,17 +630,6 @@ Deps: `resilience/ratelimit`.
 
 ---
 
-**auth/totp**
-
-The complete 2FA package: RFC 6238/4226 TOTP/HOTP secret generation,
-skew-window verify, otpauth:// provisioning URI, and one-time backup codes
-(generate/hash/verify-and-consume, constant-time). QR image rendering
-lights up via `core/qrcode`. Persistence is consumer DB.
-
-Deps: `core/qrcode`, `core/random`, `crypto/consttime`.
-
----
-
 **auth/magiclink**
 
 Signed, TTL'd, single-use links over `crypto/token`: passwordless login,

--- a/docs/superpowers/plans/2026-07-13-auth-totp.md
+++ b/docs/superpowers/plans/2026-07-13-auth-totp.md
@@ -1,0 +1,3403 @@
+# auth/totp Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `auth/totp` — the complete 2FA package: RFC 6238/4226 TOTP/HOTP primitives, otpauth:// provisioning, one-time backup codes, plus a `Manager` over a tenant-aware `Store` seam (memory + Postgres) with mandatory AEAD encryption of secrets at rest.
+
+**Architecture:** Two public layers. Layer 1: stateless RFC math on a `*totp.TOTP` config struct plus package-level backup-code functions. Layer 2: `totp.Manager` orchestrating enroll → confirm → verify over a 6-method `Store` interface keyed `(tenant, subject)`; the TOTP secret is `crypto/secret.Box` ciphertext before it reaches any store, backup codes are stored as SHA-256 hashes, replay/race protection lives in two atomic store methods (`MarkUsed`, `ConsumeBackup`). Tenancy enters only via the canonical fail-closed `WithScope(ctx)` hook.
+
+**Tech Stack:** Go 1.26, stdlib crypto (`hmac`, `sha1/256/512`, `base32`) + forge-internal deps: `core/random`, `core/clock`, `crypto/consttime`, `crypto/secret`, `crypto/keyset`. pgstore: `pgx/v5` via `data/postgres`, goose migrations via `data/migration`.
+
+**Spec:** `docs/superpowers/specs/2026-07-13-auth-totp-design.md` (approved).
+
+## Global Constraints
+
+- Module `github.com/dmitrymomot/forge`; Go 1.26; work ONLY in branch `dm/auth-totp-brainstorming-33a6a1`, never switch.
+- Run `just fmt ./auth/totp/` (and `just fmt ./auth/totp/pgstore/` when it exists) after file changes — package form, NOT single-file form (single-file trips a betteralign bug). Run `just lint` when a task finishes.
+- Tests: `just test ./auth/totp/` (runs `go test -race -cover`). Black-box only — test package is `totp_test` (`pgstore_test` for the driver). Use `t.Context()` for contexts, `testify` `require`/`assert`.
+- Benchmarks REQUIRED (repo rule): `bench_test.go` with `b.ReportAllocs()` + `for b.Loop()`; numbers go in the PR description.
+- Errors: single-line sentinels, `errors.Is`-matchable, message prefix `totp: `.
+- Loops over ints: `for i := range n` (modernize enforces). Use `new(expr)`, not ptr helpers.
+- No Claude/AI attribution in any commit message or PR content.
+- Manager test key (secret.Box needs 32 bytes): `[]byte("0123456789abcdef0123456789abcdef")`.
+- RFC test secrets are built IN TEST CODE via `base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(...)` — never hand-transcribed base32.
+- `docs/design.md` governs style: no reflection, options pattern (`type Option func(*config)`), test doubles live with the seam owner, single-responsibility files.
+
+---
+
+### Task 1: Package skeleton — errors, Algorithm, options, `New` validation
+
+**Files:**
+- Create: `auth/totp/errors.go`
+- Create: `auth/totp/options.go`
+- Create: `auth/totp/totp.go`
+- Test: `auth/totp/totp_test.go`
+
+**Interfaces:**
+- Consumes: `core/clock.Clock`, `clock.System()`.
+- Produces: `totp.New(opts ...Option) (*TOTP, error)`; type `Algorithm` (`totp.SHA1`, `totp.SHA256`, `totp.SHA512`, `String()` → `"SHA1"` etc.); options `WithIssuer(string)`, `WithDigits(int)`, `WithPeriod(time.Duration)`, `WithAlgorithm(Algorithm)`, `WithSkew(int)`, `WithClock(clock.Clock)`, `WithScope(func(context.Context) (string, error))`, `WithBackupCodeCount(int)`, `WithBackupCodeLength(int)`; sentinels `ErrInvalidCode`, `ErrReplayed`, `ErrNotEnrolled`, `ErrAlreadyEnrolled`, `ErrNotFound`, `ErrScope`. Later tasks add methods to `*TOTP` and read `config` fields.
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/totp/totp_test.go`:
+
+```go
+package totp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+func TestNew_Defaults(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	require.NotNil(t, tp)
+}
+
+func TestNew_InvalidConfig(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		opt  totp.Option
+	}{
+		{"digits 7", totp.WithDigits(7)},
+		{"digits 0", totp.WithDigits(0)},
+		{"period sub-second", totp.WithPeriod(500 * time.Millisecond)},
+		{"period fractional", totp.WithPeriod(30*time.Second + 500*time.Millisecond)},
+		{"period zero", totp.WithPeriod(0)},
+		{"negative skew", totp.WithSkew(-1)},
+		{"unknown algorithm", totp.WithAlgorithm(totp.Algorithm(99))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := totp.New(tt.opt)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestNew_ValidVariants(t *testing.T) {
+	t.Parallel()
+	_, err := totp.New(
+		totp.WithIssuer("Acme"),
+		totp.WithDigits(8),
+		totp.WithPeriod(60*time.Second),
+		totp.WithAlgorithm(totp.SHA512),
+		totp.WithSkew(0),
+	)
+	require.NoError(t, err)
+}
+
+func TestAlgorithm_String(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "SHA1", totp.SHA1.String())
+	assert.Equal(t, "SHA256", totp.SHA256.String())
+	assert.Equal(t, "SHA512", totp.SHA512.String())
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/totp/`
+Expected: FAIL — `package github.com/dmitrymomot/forge/auth/totp: no Go files` (or undefined symbols once files exist partially).
+
+- [ ] **Step 3: Write minimal implementation**
+
+`auth/totp/errors.go`:
+
+```go
+package totp
+
+import "errors"
+
+var (
+	// ErrInvalidCode reports a code that matches neither the TOTP window
+	// nor any backup code.
+	ErrInvalidCode = errors.New("totp: invalid code")
+	// ErrReplayed reports a TOTP code at or before the last verified step —
+	// or one lost to a concurrent verify of the same step.
+	ErrReplayed = errors.New("totp: code already used")
+	// ErrNotEnrolled reports an operation on a subject without a (confirmed,
+	// where required) enrollment.
+	ErrNotEnrolled = errors.New("totp: not enrolled")
+	// ErrAlreadyEnrolled reports BeginEnroll on a confirmed enrollment;
+	// Disable first to re-enroll.
+	ErrAlreadyEnrolled = errors.New("totp: already enrolled")
+	// ErrNotFound is the Store sentinel for an absent record.
+	ErrNotFound = errors.New("totp: record not found")
+	// ErrScope reports a failed or empty scope resolution (fail-closed),
+	// or DisableTenant on an unscoped Manager.
+	ErrScope = errors.New("totp: scope resolution failed")
+)
+```
+
+`auth/totp/options.go`:
+
+```go
+package totp
+
+import (
+	"context"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type config struct {
+	issuer       string
+	digits       int
+	period       time.Duration
+	algorithm    Algorithm
+	skew         int
+	clk          clock.Clock
+	scope        func(context.Context) (string, error)
+	backupCount  int
+	backupLength int
+}
+
+func defaultConfig() config {
+	return config{
+		digits:       6,
+		period:       30 * time.Second,
+		algorithm:    SHA1,
+		skew:         1,
+		clk:          clock.System(),
+		backupCount:  10,
+		backupLength: 10,
+	}
+}
+
+// Option configures New and NewManager.
+type Option func(*config)
+
+// WithIssuer sets the issuer shown in authenticator apps and embedded in
+// provisioning URIs. Empty (the default) omits the issuer from the URI.
+func WithIssuer(s string) Option { return func(c *config) { c.issuer = s } }
+
+// WithDigits sets the code length: 6 (default) or 8.
+func WithDigits(n int) Option { return func(c *config) { c.digits = n } }
+
+// WithPeriod sets the TOTP time step (default 30s). Whole seconds, >= 1s.
+// Authenticator apps widely assume 30s — change only for closed ecosystems.
+func WithPeriod(d time.Duration) Option { return func(c *config) { c.period = d } }
+
+// WithAlgorithm selects the HMAC hash (default SHA1 — the variant
+// authenticator apps support universally).
+func WithAlgorithm(a Algorithm) Option { return func(c *config) { c.algorithm = a } }
+
+// WithSkew sets clock-drift tolerance in steps either side of now
+// (default 1; 0 = exact step only).
+func WithSkew(n int) Option { return func(c *config) { c.skew = n } }
+
+// WithClock injects a clock for deterministic tests.
+func WithClock(clk clock.Clock) Option {
+	return func(c *config) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+// WithScope derives a tenant from the request context on every Manager
+// operation, so multi-tenant isolation is wired once at construction and no
+// call site can forget it. Fail-closed: a hook error or empty scope aborts
+// the operation with ErrScope. Single-tenant applications omit this option.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) { c.scope = fn }
+}
+
+// WithBackupCodeCount sets how many backup codes ConfirmEnroll and
+// RegenerateBackupCodes hand out (default 10, >= 1).
+func WithBackupCodeCount(n int) Option { return func(c *config) { c.backupCount = n } }
+
+// WithBackupCodeLength sets backup-code length in characters, excluding
+// display dashes (default 10, >= 8).
+func WithBackupCodeLength(n int) Option { return func(c *config) { c.backupLength = n } }
+```
+
+`auth/totp/totp.go`:
+
+```go
+// Package totp implements RFC 6238 TOTP / RFC 4226 HOTP two-factor
+// authentication: secret generation, skew-window verification with replay
+// rejection, otpauth:// provisioning URIs, one-time backup codes, and a
+// Manager over a tenant-aware Store seam. See doc.go for recipes.
+package totp
+
+import (
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"fmt"
+	"hash"
+	"time"
+)
+
+// Algorithm selects the HMAC hash for code derivation.
+type Algorithm int
+
+// Supported HMAC algorithms. SHA1 is the authenticator-app default.
+const (
+	SHA1 Algorithm = iota
+	SHA256
+	SHA512
+)
+
+// String returns the otpauth URI parameter form: "SHA1", "SHA256", "SHA512".
+func (a Algorithm) String() string {
+	switch a {
+	case SHA1:
+		return "SHA1"
+	case SHA256:
+		return "SHA256"
+	case SHA512:
+		return "SHA512"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// hashFunc returns the hash constructor for HMAC.
+func (a Algorithm) hashFunc() func() hash.Hash {
+	switch a {
+	case SHA256:
+		return sha256.New
+	case SHA512:
+		return sha512.New
+	default:
+		return sha1.New
+	}
+}
+
+// secretSize is the RFC 4226 §4 recommendation: secret length = hash length.
+func (a Algorithm) secretSize() int {
+	switch a {
+	case SHA256:
+		return 32
+	case SHA512:
+		return 64
+	default:
+		return 20
+	}
+}
+
+func (a Algorithm) valid() bool { return a == SHA1 || a == SHA256 || a == SHA512 }
+
+// TOTP holds validated code-generation parameters. One instance serves both
+// enrollment (ProvisioningURI) and verification, so the parameters an
+// authenticator app was enrolled with can never drift from the ones Verify
+// checks. Safe for concurrent use.
+type TOTP struct {
+	cfg config
+}
+
+// New validates opts and builds a TOTP. Defaults: 6 digits, 30s period,
+// SHA-1, skew ±1.
+func New(opts ...Option) (*TOTP, error) {
+	cfg := defaultConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if err := cfg.validateCore(); err != nil {
+		return nil, err
+	}
+	return &TOTP{cfg: cfg}, nil
+}
+
+func (c *config) validateCore() error {
+	if c.digits != 6 && c.digits != 8 {
+		return fmt.Errorf("totp: digits must be 6 or 8, got %d", c.digits)
+	}
+	if c.period < time.Second || c.period%time.Second != 0 {
+		return fmt.Errorf("totp: period must be whole seconds >= 1s, got %s", c.period)
+	}
+	if c.skew < 0 {
+		return fmt.Errorf("totp: skew must be >= 0, got %d", c.skew)
+	}
+	if !c.algorithm.valid() {
+		return fmt.Errorf("totp: unknown algorithm %d", int(c.algorithm))
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./auth/totp/`
+Expected: PASS
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/totp/
+git add auth/totp/
+git commit -m "feat(totp): package skeleton — errors, Algorithm, options, New validation"
+```
+
+---
+
+### Task 2: HOTP core (RFC 4226) — `HOTPCode`, `VerifyHOTP`, secret decoding
+
+**Files:**
+- Modify: `auth/totp/totp.go` (append)
+- Test: `auth/totp/hotp_test.go`
+
+**Interfaces:**
+- Consumes: `config` fields, `Algorithm.hashFunc()` from Task 1; `crypto/consttime.StringEqual`.
+- Produces: `(t *TOTP) HOTPCode(secret string, counter uint64) (string, error)`; `(t *TOTP) VerifyHOTP(secret, code string, counter uint64, lookahead int) (uint64, error)` returning the NEXT counter to store (matched+1); unexported `decodeSecret(string) ([]byte, error)` and `hotp(h func() hash.Hash, key []byte, counter uint64, digits int) string` reused by Tasks 3–4.
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/totp/hotp_test.go`:
+
+```go
+package totp_test
+
+import (
+	"encoding/base32"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+func b32(raw string) string {
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(raw))
+}
+
+// rfc4226Secret is the RFC 4226 Appendix D shared secret.
+const rfc4226Raw = "12345678901234567890"
+
+// rfc4226Codes are the ten Appendix D reference codes for counters 0..9.
+var rfc4226Codes = []string{
+	"755224", "287082", "359152", "969429", "338314",
+	"254676", "287922", "162583", "399871", "520489",
+}
+
+func TestHOTPCode_RFC4226Vectors(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New() // SHA-1, 6 digits
+	require.NoError(t, err)
+	secret := b32(rfc4226Raw)
+	for counter, want := range rfc4226Codes {
+		got, err := tp.HOTPCode(secret, uint64(counter))
+		require.NoError(t, err)
+		assert.Equal(t, want, got, "counter %d", counter)
+	}
+}
+
+func TestHOTPCode_BadSecret(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	_, err = tp.HOTPCode("not!!base32###", 0)
+	assert.Error(t, err)
+}
+
+func TestHOTPCode_SecretNormalization(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	canonical, err := tp.HOTPCode(b32(rfc4226Raw), 0)
+	require.NoError(t, err)
+	// lowercase, spaces, and trailing padding must decode identically —
+	// users retype secrets by hand.
+	messy := "gezd gnbv gy3t qojq gezd gnbv gy3t qojq==="
+	got, err := tp.HOTPCode(messy, 0)
+	require.NoError(t, err)
+	assert.Equal(t, canonical, got)
+}
+
+func TestVerifyHOTP_MatchAndNextCounter(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	secret := b32(rfc4226Raw)
+
+	// Exact counter.
+	next, err := tp.VerifyHOTP(secret, rfc4226Codes[3], 3, 0)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(4), next)
+
+	// Within lookahead: stored counter 2, client advanced to 5.
+	next, err = tp.VerifyHOTP(secret, rfc4226Codes[5], 2, 4)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(6), next)
+
+	// Beyond lookahead.
+	_, err = tp.VerifyHOTP(secret, rfc4226Codes[9], 2, 4)
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+
+	// Behind the counter (replayed HOTP looks like any other mismatch).
+	_, err = tp.VerifyHOTP(secret, rfc4226Codes[1], 3, 4)
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+
+	// Negative lookahead is caller error, not ErrInvalidCode.
+	_, err = tp.VerifyHOTP(secret, rfc4226Codes[3], 3, -1)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, totp.ErrInvalidCode)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/totp/`
+Expected: FAIL — `tp.HOTPCode undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `auth/totp/totp.go` (add imports `crypto/hmac`, `encoding/base32`, `encoding/binary`, `strings`, and `github.com/dmitrymomot/forge/crypto/consttime`):
+
+```go
+// decodeSecret parses a base32 shared secret leniently: users retype
+// secrets by hand, so lowercase, interior spaces, and trailing padding are
+// all accepted. Never panics on malformed input.
+func decodeSecret(s string) ([]byte, error) {
+	s = strings.ToUpper(strings.ReplaceAll(s, " ", ""))
+	s = strings.TrimRight(s, "=")
+	b, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("totp: decode secret: %w", err)
+	}
+	return b, nil
+}
+
+// hotp computes the RFC 4226 code: HMAC(key, counter) → dynamic truncation
+// → digits decimal digits, zero-padded.
+func hotp(h func() hash.Hash, key []byte, counter uint64, digits int) string {
+	mac := hmac.New(h, key)
+	var msg [8]byte
+	binary.BigEndian.PutUint64(msg[:], counter)
+	mac.Write(msg[:])
+	sum := mac.Sum(nil)
+
+	off := sum[len(sum)-1] & 0x0f
+	v := binary.BigEndian.Uint32(sum[off:off+4]) & 0x7fffffff
+
+	mod := uint32(1_000_000)
+	if digits == 8 {
+		mod = 100_000_000
+	}
+	code := v % mod
+
+	out := make([]byte, digits)
+	for i := digits - 1; i >= 0; i-- {
+		out[i] = '0' + byte(code%10)
+		code /= 10
+	}
+	return string(out)
+}
+
+// HOTPCode computes the RFC 4226 code for counter. Counter state is the
+// caller's; most consumers want time-based Code/Verify instead.
+func (t *TOTP) HOTPCode(secret string, counter uint64) (string, error) {
+	key, err := decodeSecret(secret)
+	if err != nil {
+		return "", err
+	}
+	return hotp(t.cfg.algorithm.hashFunc(), key, counter, t.cfg.digits), nil
+}
+
+// VerifyHOTP checks code against counters counter..counter+lookahead
+// (constant-time, no early exit) and returns the next counter value to
+// persist (matched+1). ErrInvalidCode when nothing matches.
+func (t *TOTP) VerifyHOTP(secret, code string, counter uint64, lookahead int) (uint64, error) {
+	if lookahead < 0 {
+		return 0, fmt.Errorf("totp: negative lookahead %d", lookahead)
+	}
+	key, err := decodeSecret(secret)
+	if err != nil {
+		return 0, err
+	}
+	var next uint64
+	found := false
+	for i := range lookahead + 1 {
+		c := counter + uint64(i)
+		if consttime.StringEqual(hotp(t.cfg.algorithm.hashFunc(), key, c, t.cfg.digits), code) && !found {
+			next, found = c+1, true
+		}
+	}
+	if !found {
+		return 0, ErrInvalidCode
+	}
+	return next, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./auth/totp/`
+Expected: PASS (RFC 4226 vectors are authoritative — if a vector fails, the bug is in `hotp`, not the vector).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/totp/
+git add auth/totp/
+git commit -m "feat(totp): RFC 4226 HOTP core with lookahead verify and lenient secret decode"
+```
+
+---
+
+### Task 3: `GenerateSecret` + `Code` (RFC 6238)
+
+**Files:**
+- Create: `auth/totp/secret.go`
+- Modify: `auth/totp/totp.go` (append `Code`)
+- Test: `auth/totp/code_test.go`
+
+**Interfaces:**
+- Consumes: `decodeSecret`, `hotp` from Task 2; `core/random.Read`.
+- Produces: `(t *TOTP) GenerateSecret() (string, error)`; `(t *TOTP) Code(secret string, at time.Time) (string, error)`; unexported `(t *TOTP) stepSeconds() int64` reused in Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/totp/code_test.go`:
+
+```go
+package totp_test
+
+import (
+	"encoding/base32"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+// RFC 6238 Appendix B reference vectors: 8-digit codes, 30s period.
+// Secrets are the ASCII seed repeated to the hash length.
+func TestCode_RFC6238Vectors(t *testing.T) {
+	t.Parallel()
+	seeds := map[totp.Algorithm]string{
+		totp.SHA1:   "12345678901234567890",
+		totp.SHA256: "12345678901234567890123456789012",
+		totp.SHA512: "1234567890123456789012345678901234567890123456789012345678901234",
+	}
+	vectors := []struct {
+		unix  int64
+		codes map[totp.Algorithm]string
+	}{
+		{59, map[totp.Algorithm]string{totp.SHA1: "94287082", totp.SHA256: "46119246", totp.SHA512: "90693936"}},
+		{1111111109, map[totp.Algorithm]string{totp.SHA1: "07081804", totp.SHA256: "68084774", totp.SHA512: "25091201"}},
+		{1111111111, map[totp.Algorithm]string{totp.SHA1: "14050471", totp.SHA256: "67062674", totp.SHA512: "99943326"}},
+		{1234567890, map[totp.Algorithm]string{totp.SHA1: "89005924", totp.SHA256: "91819424", totp.SHA512: "93441116"}},
+		{2000000000, map[totp.Algorithm]string{totp.SHA1: "69279037", totp.SHA256: "90698825", totp.SHA512: "38618901"}},
+		{20000000000, map[totp.Algorithm]string{totp.SHA1: "65353130", totp.SHA256: "77737706", totp.SHA512: "47863826"}},
+	}
+	for alg, seed := range seeds {
+		tp, err := totp.New(totp.WithAlgorithm(alg), totp.WithDigits(8))
+		require.NoError(t, err)
+		secret := b32(seed)
+		for _, v := range vectors {
+			got, err := tp.Code(secret, time.Unix(v.unix, 0).UTC())
+			require.NoError(t, err)
+			assert.Equal(t, v.codes[alg], got, "alg %s time %d", alg, v.unix)
+		}
+	}
+}
+
+func TestCode_PreEpochRejected(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	_, err = tp.Code(b32(rfc4226Raw), time.Unix(-1, 0))
+	assert.Error(t, err)
+}
+
+func TestGenerateSecret(t *testing.T) {
+	t.Parallel()
+	sizes := map[totp.Algorithm]int{totp.SHA1: 20, totp.SHA256: 32, totp.SHA512: 64}
+	for alg, size := range sizes {
+		tp, err := totp.New(totp.WithAlgorithm(alg))
+		require.NoError(t, err)
+		s, err := tp.GenerateSecret()
+		require.NoError(t, err)
+		raw, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(s)
+		require.NoError(t, err, "secret must be canonical unpadded uppercase base32")
+		assert.Len(t, raw, size)
+
+		s2, err := tp.GenerateSecret()
+		require.NoError(t, err)
+		assert.NotEqual(t, s, s2, "secrets must be random")
+	}
+}
+
+func TestGenerateSecret_RoundTripsThroughCode(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	s, err := tp.GenerateSecret()
+	require.NoError(t, err)
+	_, err = tp.Code(s, time.Unix(59, 0))
+	require.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/totp/`
+Expected: FAIL — `tp.Code undefined`, `tp.GenerateSecret undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`auth/totp/secret.go`:
+
+```go
+package totp
+
+import (
+	"encoding/base32"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/core/random"
+)
+
+// GenerateSecret returns a new shared secret: cryptographically random
+// bytes sized to the configured algorithm's hash length (RFC 4226 §4),
+// encoded as unpadded uppercase base32 for authenticator-app entry.
+func (t *TOTP) GenerateSecret() (string, error) {
+	buf := make([]byte, t.cfg.algorithm.secretSize())
+	if err := random.Read(buf); err != nil {
+		return "", fmt.Errorf("totp: generate secret: %w", err)
+	}
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(buf), nil
+}
+```
+
+Append to `auth/totp/totp.go`:
+
+```go
+func (t *TOTP) stepSeconds() int64 { return int64(t.cfg.period / time.Second) }
+
+// Code computes the TOTP code for an explicit instant — client side, CLIs,
+// tests. Server-side verification should use Verify.
+func (t *TOTP) Code(secret string, at time.Time) (string, error) {
+	if at.Unix() < 0 {
+		return "", fmt.Errorf("totp: time %s is before the unix epoch", at)
+	}
+	key, err := decodeSecret(secret)
+	if err != nil {
+		return "", err
+	}
+	counter := uint64(at.Unix() / t.stepSeconds())
+	return hotp(t.cfg.algorithm.hashFunc(), key, counter, t.cfg.digits), nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./auth/totp/`
+Expected: PASS
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/totp/
+git add auth/totp/
+git commit -m "feat(totp): GenerateSecret and RFC 6238 Code with appendix-B vectors"
+```
+
+---
+
+### Task 4: `Verify` — skew window, replay rejection, `time.Time` round-trip
+
+**Files:**
+- Modify: `auth/totp/totp.go` (append `Verify`)
+- Test: `auth/totp/verify_test.go`
+
+**Interfaces:**
+- Consumes: `decodeSecret`, `hotp`, `stepSeconds`, `config.clk/skew` from earlier tasks; `clock.NewMock`.
+- Produces: `(t *TOTP) Verify(secret, code string, lastUsed time.Time) (time.Time, error)` — returns the matched STEP-START time in UTC; `ErrReplayed` when the only match is at or before `lastUsed`'s step; `ErrInvalidCode` otherwise. Task 8+ Manager calls this.
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/totp/verify_test.go`:
+
+```go
+package totp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// newVerifier pins the clock to a fixed instant so window math is exact.
+func newVerifier(t *testing.T, at time.Time, opts ...totp.Option) *totp.TOTP {
+	t.Helper()
+	tp, err := totp.New(append(opts, totp.WithClock(clock.NewMock(at)))...)
+	require.NoError(t, err)
+	return tp
+}
+
+func TestVerify_CurrentStep(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_111_111_111, 0).UTC()
+	tp := newVerifier(t, now)
+	secret := b32(rfc4226Raw)
+	code, err := tp.Code(secret, now)
+	require.NoError(t, err)
+
+	matchedAt, err := tp.Verify(secret, code, time.Time{})
+	require.NoError(t, err)
+	// Returned value is the step-start time: lossless counter round-trip.
+	assert.Equal(t, (now.Unix()/30)*30, matchedAt.Unix())
+	assert.Equal(t, int64(0), matchedAt.Unix()%30)
+}
+
+func TestVerify_SkewWindow(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_111_111_111, 0).UTC()
+	secret := b32(rfc4226Raw)
+	tp := newVerifier(t, now) // skew ±1
+
+	for _, offset := range []time.Duration{-30 * time.Second, 30 * time.Second} {
+		code, err := tp.Code(secret, now.Add(offset))
+		require.NoError(t, err)
+		_, err = tp.Verify(secret, code, time.Time{})
+		assert.NoError(t, err, "offset %s within ±1 skew", offset)
+	}
+	for _, offset := range []time.Duration{-60 * time.Second, 60 * time.Second} {
+		code, err := tp.Code(secret, now.Add(offset))
+		require.NoError(t, err)
+		_, err = tp.Verify(secret, code, time.Time{})
+		assert.ErrorIs(t, err, totp.ErrInvalidCode, "offset %s outside ±1 skew", offset)
+	}
+
+	strict := newVerifier(t, now, totp.WithSkew(0))
+	code, err := strict.Code(secret, now.Add(-30*time.Second))
+	require.NoError(t, err)
+	_, err = strict.Verify(secret, code, time.Time{})
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+}
+
+func TestVerify_Replay(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_111_111_111, 0).UTC()
+	tp := newVerifier(t, now)
+	secret := b32(rfc4226Raw)
+	code, err := tp.Code(secret, now)
+	require.NoError(t, err)
+
+	matchedAt, err := tp.Verify(secret, code, time.Time{})
+	require.NoError(t, err)
+
+	// Same code with lastUsed = the returned step: replayed.
+	_, err = tp.Verify(secret, code, matchedAt)
+	assert.ErrorIs(t, err, totp.ErrReplayed)
+
+	// Codes from steps before lastUsed are also replayed, not merely invalid.
+	prev, err := tp.Code(secret, now.Add(-30*time.Second))
+	require.NoError(t, err)
+	_, err = tp.Verify(secret, prev, matchedAt)
+	assert.ErrorIs(t, err, totp.ErrReplayed)
+
+	// A later step still verifies: clock advances one step, same lastUsed.
+	later := newVerifier(t, now.Add(30*time.Second))
+	next, err := later.Code(secret, now.Add(30*time.Second))
+	require.NoError(t, err)
+	nextAt, err := later.Verify(secret, next, matchedAt)
+	require.NoError(t, err)
+	assert.True(t, nextAt.After(matchedAt))
+}
+
+func TestVerify_TimeRoundTripSurvivesStorage(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_111_111_111, 0).UTC()
+	tp := newVerifier(t, now)
+	secret := b32(rfc4226Raw)
+	code, err := tp.Code(secret, now)
+	require.NoError(t, err)
+	matchedAt, err := tp.Verify(secret, code, time.Time{})
+	require.NoError(t, err)
+
+	// Round-tripping through unix seconds (a timestamptz column) preserves
+	// the replay boundary exactly.
+	stored := time.Unix(matchedAt.Unix(), 0)
+	_, err = tp.Verify(secret, code, stored)
+	assert.ErrorIs(t, err, totp.ErrReplayed)
+}
+
+func TestVerify_GarbageInputs(t *testing.T) {
+	t.Parallel()
+	tp := newVerifier(t, time.Unix(1_111_111_111, 0).UTC())
+	_, err := tp.Verify("###", "123456", time.Time{})
+	require.Error(t, err)
+	_, err = tp.Verify(b32(rfc4226Raw), "", time.Time{})
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+	_, err = tp.Verify(b32(rfc4226Raw), "abcdef", time.Time{})
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/totp/`
+Expected: FAIL — `tp.Verify undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `auth/totp/totp.go`:
+
+```go
+// Verify checks code against every step in [now-skew, now+skew] — all
+// windows evaluated without early exit, compared in constant time — then
+// rejects any match at or before lastUsed's step (ErrReplayed). On success
+// it returns the matched step-start time (UTC, whole seconds): persist it
+// and pass it back as lastUsed on the next call. Zero lastUsed = never
+// verified. ErrInvalidCode when no window matches.
+func (t *TOTP) Verify(secret, code string, lastUsed time.Time) (time.Time, error) {
+	key, err := decodeSecret(secret)
+	if err != nil {
+		return time.Time{}, err
+	}
+	step := t.stepSeconds()
+	cur := t.cfg.clk.Now().Unix() / step
+	last := int64(-1)
+	if !lastUsed.IsZero() {
+		last = lastUsed.Unix() / step
+	}
+
+	matched, replayed := int64(-1), false
+	for off := -t.cfg.skew; off <= t.cfg.skew; off++ {
+		c := cur + int64(off)
+		if c < 0 {
+			continue
+		}
+		if !consttime.StringEqual(hotp(t.cfg.algorithm.hashFunc(), key, uint64(c), t.cfg.digits), code) {
+			continue
+		}
+		if c <= last {
+			replayed = true
+		} else if c > matched {
+			matched = c
+		}
+	}
+	switch {
+	case matched >= 0:
+		return time.Unix(matched*step, 0).UTC(), nil
+	case replayed:
+		return time.Time{}, ErrReplayed
+	default:
+		return time.Time{}, ErrInvalidCode
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test ./auth/totp/`
+Expected: PASS (race-clean).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/totp/
+git add auth/totp/
+git commit -m "feat(totp): skew-window Verify with replay rejection and step-time round-trip"
+```
+
+---
+
+### Task 5: `ProvisioningURI`
+
+**Files:**
+- Modify: `auth/totp/secret.go` (append)
+- Test: `auth/totp/uri_test.go`
+
+**Interfaces:**
+- Consumes: `config.issuer/digits/period/algorithm`.
+- Produces: `(t *TOTP) ProvisioningURI(secret, account string) string`. Task 8's `BeginEnroll` embeds it in `Enrollment.URI`.
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/totp/uri_test.go`:
+
+```go
+package totp_test
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+func TestProvisioningURI_Full(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New(totp.WithIssuer("Acme Corp"), totp.WithDigits(8),
+		totp.WithPeriod(60*time.Second), totp.WithAlgorithm(totp.SHA256))
+	require.NoError(t, err)
+
+	uri := tp.ProvisioningURI("JBSWY3DPEHPK3PXP", "user+tag@acme.com")
+
+	u, err := url.Parse(uri)
+	require.NoError(t, err)
+	assert.Equal(t, "otpauth", u.Scheme)
+	assert.Equal(t, "totp", u.Host)
+	// Label is Issuer:account, path-escaped; url.Parse unescapes it.
+	assert.Equal(t, "/Acme Corp:user+tag@acme.com", u.Path)
+
+	q := u.Query()
+	assert.Equal(t, "JBSWY3DPEHPK3PXP", q.Get("secret"))
+	assert.Equal(t, "Acme Corp", q.Get("issuer"))
+	assert.Equal(t, "SHA256", q.Get("algorithm"))
+	assert.Equal(t, "8", q.Get("digits"))
+	assert.Equal(t, "60", q.Get("period"))
+}
+
+func TestProvisioningURI_EmptyIssuer(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	uri := tp.ProvisioningURI("JBSWY3DPEHPK3PXP", "user@acme.com")
+
+	u, err := url.Parse(uri)
+	require.NoError(t, err)
+	assert.Equal(t, "/user@acme.com", u.Path, "no issuer prefix in label")
+	assert.False(t, u.Query().Has("issuer"), "issuer param omitted")
+	assert.Equal(t, "30", u.Query().Get("period"))
+	assert.Equal(t, "6", u.Query().Get("digits"))
+	assert.Equal(t, "SHA1", u.Query().Get("algorithm"))
+}
+
+func TestProvisioningURI_EscapesLabel(t *testing.T) {
+	t.Parallel()
+	tp, err := totp.New(totp.WithIssuer("Ac/me:Corp"))
+	require.NoError(t, err)
+	uri := tp.ProvisioningURI("JBSWY3DPEHPK3PXP", "a b/c@x.io")
+	// Raw reserved characters must not appear unescaped in the label part.
+	label := strings.TrimPrefix(uri[:strings.Index(uri, "?")], "otpauth://totp/")
+	assert.NotContains(t, label, " ")
+	assert.NotContains(t, label, "/")
+	u, err := url.Parse(uri)
+	require.NoError(t, err)
+	assert.Equal(t, "Ac/me:Corp", u.Query().Get("issuer"))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/totp/`
+Expected: FAIL — `tp.ProvisioningURI undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `auth/totp/secret.go` (add imports `net/url`, `strconv`, `time`):
+
+```go
+// ProvisioningURI renders the otpauth:// Key Uri for authenticator-app
+// enrollment (render it as a QR with core/qrcode's DataURI, or show it for
+// manual entry). The label is Issuer:account (account only when the issuer
+// is empty); issuer, algorithm, digits, and period ride as query params so
+// the app enrolls with exactly the parameters Verify checks.
+func (t *TOTP) ProvisioningURI(secret, account string) string {
+	label := url.PathEscape(account)
+	q := url.Values{}
+	q.Set("secret", secret)
+	if t.cfg.issuer != "" {
+		label = url.PathEscape(t.cfg.issuer) + ":" + label
+		q.Set("issuer", t.cfg.issuer)
+	}
+	q.Set("algorithm", t.cfg.algorithm.String())
+	q.Set("digits", strconv.Itoa(t.cfg.digits))
+	q.Set("period", strconv.FormatInt(int64(t.cfg.period/time.Second), 10))
+	return "otpauth://totp/" + label + "?" + q.Encode()
+}
+```
+
+Note: `url.PathEscape` does not escape `:`; the test's `NotContains(label, "/")` is the load-bearing assertion. `q.Encode()` emits params alphabetically (algorithm, digits, issuer, period, secret) — stable output.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./auth/totp/`
+Expected: PASS
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/totp/
+git add auth/totp/
+git commit -m "feat(totp): otpauth provisioning URI with escaped label and canonical params"
+```
+
+---
+
+### Task 6: Backup codes — generate, normalize, verify
+
+**Files:**
+- Create: `auth/totp/backup.go`
+- Test: `auth/totp/backup_test.go`
+
+**Interfaces:**
+- Consumes: `core/random.String`, `crypto/consttime.BytesEqual`, stdlib `crypto/sha256`.
+- Produces: `GenerateBackupCodes(count, length int) (codes []string, hashes [][]byte, err error)` (package-level); `VerifyBackupCode(code string, hashes [][]byte) (idx int, ok bool)`; unexported `normalizeBackupCode(string) string` and `hashBackupCode(string) []byte` reused by Manager (Tasks 8–9).
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/totp/backup_test.go`:
+
+```go
+package totp_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+func TestGenerateBackupCodes(t *testing.T) {
+	t.Parallel()
+	codes, hashes, err := totp.GenerateBackupCodes(10, 10)
+	require.NoError(t, err)
+	require.Len(t, codes, 10)
+	require.Len(t, hashes, 10)
+
+	seen := map[string]bool{}
+	for _, c := range codes {
+		assert.Equal(t, "xxxxx-xxxxx", strings.Map(func(r rune) rune {
+			if r == '-' {
+				return '-'
+			}
+			return 'x'
+		}, c), "display format grouped by 5: %q", c)
+		assert.False(t, seen[c], "duplicate code %q", c)
+		seen[c] = true
+		for _, r := range strings.ReplaceAll(c, "-", "") {
+			assert.NotContains(t, "01ilo", string(r), "ambiguous char in %q", c)
+		}
+	}
+	for _, h := range hashes {
+		assert.Len(t, h, 32, "SHA-256 hash")
+	}
+}
+
+func TestGenerateBackupCodes_Validation(t *testing.T) {
+	t.Parallel()
+	_, _, err := totp.GenerateBackupCodes(0, 10)
+	assert.Error(t, err)
+	_, _, err = totp.GenerateBackupCodes(10, 7)
+	assert.Error(t, err, "length floor is 8 — the high-entropy claim needs it")
+}
+
+func TestVerifyBackupCode(t *testing.T) {
+	t.Parallel()
+	codes, hashes, err := totp.GenerateBackupCodes(5, 10)
+	require.NoError(t, err)
+
+	idx, ok := totp.VerifyBackupCode(codes[3], hashes)
+	require.True(t, ok)
+	assert.Equal(t, 3, idx)
+
+	_, ok = totp.VerifyBackupCode("aaaaa-aaaaa", hashes)
+	assert.False(t, ok)
+	_, ok = totp.VerifyBackupCode("", hashes)
+	assert.False(t, ok)
+	_, ok = totp.VerifyBackupCode(codes[0], nil)
+	assert.False(t, ok)
+}
+
+func TestVerifyBackupCode_NormalizationEquivalence(t *testing.T) {
+	t.Parallel()
+	codes, hashes, err := totp.GenerateBackupCodes(1, 10)
+	require.NoError(t, err)
+	variants := []string{
+		strings.ToUpper(codes[0]),                      // ABCDE-FGHIJ
+		strings.ReplaceAll(codes[0], "-", ""),          // abcdefghij
+		strings.ReplaceAll(codes[0], "-", " "),         // abcde fghij
+		" " + strings.ToUpper(strings.ReplaceAll(codes[0], "-", "")) + " ",
+	}
+	for _, v := range variants {
+		idx, ok := totp.VerifyBackupCode(v, hashes)
+		assert.True(t, ok, "variant %q must verify", v)
+		assert.Equal(t, 0, idx)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/totp/`
+Expected: FAIL — `totp.GenerateBackupCodes undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`auth/totp/backup.go`:
+
+```go
+package totp
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+
+	"github.com/dmitrymomot/forge/core/random"
+	"github.com/dmitrymomot/forge/crypto/consttime"
+)
+
+// backupAlphabet is lowercase alphanumeric minus the ambiguous 0/1/i/l/o —
+// backup codes are printed and retyped by hand.
+const backupAlphabet = "abcdefghjkmnpqrstuvwxyz23456789"
+
+// GenerateBackupCodes mints count one-time recovery codes of length random
+// characters each. It returns the display forms (dash-grouped every 5, e.g.
+// "abcde-fghij") to show the user exactly once, and the SHA-256 hashes of
+// the normalized forms to persist. A plain hash suffices: the codes are
+// high-entropy random strings, not human-chosen passwords — hence the
+// length floor of 8 (~40 bits over this alphabet).
+func GenerateBackupCodes(count, length int) (codes []string, hashes [][]byte, err error) {
+	if count < 1 {
+		return nil, nil, fmt.Errorf("totp: backup code count must be >= 1, got %d", count)
+	}
+	if length < 8 {
+		return nil, nil, fmt.Errorf("totp: backup code length must be >= 8, got %d", length)
+	}
+	codes = make([]string, count)
+	hashes = make([][]byte, count)
+	for i := range count {
+		raw := random.String(length, backupAlphabet)
+		codes[i] = formatBackupCode(raw)
+		hashes[i] = hashBackupCode(raw)
+	}
+	return codes, hashes, nil
+}
+
+// VerifyBackupCode reports whether code matches one of hashes, comparing
+// against every entry in constant time (no early exit), and returns the
+// matched index so the caller can consume exactly that hash. Input is
+// normalized first, so case and dash/space grouping don't matter.
+func VerifyBackupCode(code string, hashes [][]byte) (idx int, ok bool) {
+	sum := hashBackupCode(normalizeBackupCode(code))
+	idx = -1
+	for i, h := range hashes {
+		if consttime.BytesEqual(sum, h) && !ok {
+			idx, ok = i, true
+		}
+	}
+	return idx, ok
+}
+
+// formatBackupCode inserts a dash every 5 characters for readability.
+func formatBackupCode(raw string) string {
+	var b strings.Builder
+	b.Grow(len(raw) + len(raw)/5)
+	for i := 0; i < len(raw); i += 5 {
+		if i > 0 {
+			b.WriteByte('-')
+		}
+		end := min(i+5, len(raw))
+		b.WriteString(raw[i:end])
+	}
+	return b.String()
+}
+
+// normalizeBackupCode lowercases and strips dashes and spaces so user
+// typing quirks never fail a valid code. Hashes are always computed over
+// the normalized form.
+func normalizeBackupCode(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.ReplaceAll(s, "-", "")
+	return strings.ReplaceAll(s, " ", "")
+}
+
+func hashBackupCode(normalized string) []byte {
+	sum := sha256.Sum256([]byte(normalized))
+	return sum[:]
+}
+```
+
+Note: `hashBackupCode` in `GenerateBackupCodes` receives `raw`, which is already normalized (lowercase alphabet, no separators) — generation and verification hash the same form.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./auth/totp/`
+Expected: PASS
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/totp/
+git add auth/totp/
+git commit -m "feat(totp): one-time backup codes — unambiguous alphabet, normalization, constant-time verify"
+```
+
+---
+
+### Task 7: `Store` seam, `Record`, memory store
+
+**Files:**
+- Create: `auth/totp/store.go`
+- Test: `auth/totp/store_test.go`
+
+**Interfaces:**
+- Consumes: sentinels from Task 1.
+- Produces: `type Record struct { Secret []byte; Confirmed bool; LastUsedAt time.Time; BackupHashes [][]byte }`; `type Store interface { Get / Save / Delete / MarkUsed / ConsumeBackup / DeleteTenant }` (exact signatures below); `NewMemoryStore() Store`. Tasks 8–10 drive the Manager over this; Task 13's pgstore implements it.
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/totp/store_test.go`:
+
+```go
+package totp_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+func rec(confirmed bool) *totp.Record {
+	return &totp.Record{
+		Secret:       []byte("ciphertext"),
+		Confirmed:    confirmed,
+		BackupHashes: [][]byte{{1, 2}, {3, 4}},
+	}
+}
+
+func TestMemoryStore_CRUD(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+
+	_, err := s.Get(ctx, "", "alice")
+	assert.ErrorIs(t, err, totp.ErrNotFound)
+
+	require.NoError(t, s.Save(ctx, "", "alice", rec(false)))
+	got, err := s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.False(t, got.Confirmed)
+	assert.Equal(t, []byte("ciphertext"), got.Secret)
+
+	// Save is a full replace.
+	require.NoError(t, s.Save(ctx, "", "alice", rec(true)))
+	got, err = s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.True(t, got.Confirmed)
+
+	require.NoError(t, s.Delete(ctx, "", "alice"))
+	_, err = s.Get(ctx, "", "alice")
+	assert.ErrorIs(t, err, totp.ErrNotFound)
+
+	// Delete of an absent record is a no-op, not an error.
+	require.NoError(t, s.Delete(ctx, "", "alice"))
+}
+
+func TestMemoryStore_DeepCopies(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+	r := rec(true)
+	require.NoError(t, s.Save(ctx, "", "alice", r))
+
+	// Mutating the caller's record after Save must not affect the store.
+	r.Secret[0] = 'X'
+	r.BackupHashes[0][0] = 99
+	got, err := s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("ciphertext"), got.Secret)
+	assert.Equal(t, byte(1), got.BackupHashes[0][0])
+
+	// Mutating a Get result must not affect the store either.
+	got.Secret[0] = 'Y'
+	again, err := s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("ciphertext"), again.Secret)
+}
+
+func TestMemoryStore_MarkUsed(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+	require.NoError(t, s.Save(ctx, "", "alice", rec(true)))
+
+	t0 := time.Unix(3000, 0)
+	ok, err := s.MarkUsed(ctx, "", "alice", t0)
+	require.NoError(t, err)
+	assert.True(t, ok, "zero LastUsedAt accepts any step")
+
+	ok, err = s.MarkUsed(ctx, "", "alice", t0)
+	require.NoError(t, err)
+	assert.False(t, ok, "same step is claimed exactly once")
+
+	ok, err = s.MarkUsed(ctx, "", "alice", time.Unix(2970, 0))
+	require.NoError(t, err)
+	assert.False(t, ok, "earlier step rejected")
+
+	ok, err = s.MarkUsed(ctx, "", "alice", time.Unix(3030, 0))
+	require.NoError(t, err)
+	assert.True(t, ok, "later step advances")
+
+	ok, err = s.MarkUsed(ctx, "", "ghost", t0)
+	require.NoError(t, err)
+	assert.False(t, ok, "absent record: false, nil (pg driver parity)")
+}
+
+func TestMemoryStore_MarkUsed_ConcurrentSingleWinner(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+	require.NoError(t, s.Save(ctx, "", "alice", rec(true)))
+
+	const n = 32
+	wins := make(chan bool, n)
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			ok, err := s.MarkUsed(ctx, "", "alice", time.Unix(3000, 0))
+			assert.NoError(t, err)
+			wins <- ok
+		})
+	}
+	wg.Wait()
+	close(wins)
+	won := 0
+	for ok := range wins {
+		if ok {
+			won++
+		}
+	}
+	assert.Equal(t, 1, won, "exactly one concurrent verify claims the step")
+}
+
+func TestMemoryStore_ConsumeBackup(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+	require.NoError(t, s.Save(ctx, "", "alice", rec(true)))
+
+	ok, err := s.ConsumeBackup(ctx, "", "alice", []byte{1, 2})
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = s.ConsumeBackup(ctx, "", "alice", []byte{1, 2})
+	require.NoError(t, err)
+	assert.False(t, ok, "single use")
+
+	got, err := s.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{{3, 4}}, got.BackupHashes)
+
+	ok, err = s.ConsumeBackup(ctx, "", "ghost", []byte{3, 4})
+	require.NoError(t, err)
+	assert.False(t, ok, "absent record: false, nil")
+}
+
+func TestMemoryStore_TenantIsolationAndDeleteTenant(t *testing.T) {
+	t.Parallel()
+	s := totp.NewMemoryStore()
+	ctx := t.Context()
+	require.NoError(t, s.Save(ctx, "t1", "alice", rec(true)))
+	require.NoError(t, s.Save(ctx, "t2", "alice", rec(false)))
+	require.NoError(t, s.Save(ctx, "", "alice", rec(true)))
+
+	r1, err := s.Get(ctx, "t1", "alice")
+	require.NoError(t, err)
+	assert.True(t, r1.Confirmed)
+	r2, err := s.Get(ctx, "t2", "alice")
+	require.NoError(t, err)
+	assert.False(t, r2.Confirmed, "same subject, distinct records per tenant")
+
+	n, err := s.DeleteTenant(ctx, "t1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	_, err = s.Get(ctx, "t1", "alice")
+	assert.ErrorIs(t, err, totp.ErrNotFound)
+	_, err = s.Get(ctx, "t2", "alice")
+	assert.NoError(t, err, "other tenants untouched")
+	_, err = s.Get(ctx, "", "alice")
+	assert.NoError(t, err, "unscoped record untouched")
+
+	n, err = s.DeleteTenant(ctx, "t1")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/totp/`
+Expected: FAIL — `totp.NewMemoryStore undefined`, `totp.Record undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`auth/totp/store.go`:
+
+```go
+package totp
+
+import (
+	"bytes"
+	"context"
+	"slices"
+	"sync"
+	"time"
+)
+
+// Record is one enrollment as the store sees it: the secret is AEAD
+// ciphertext and backup codes are SHA-256 hashes — a store never holds
+// plaintext material.
+type Record struct {
+	Secret       []byte    // crypto/secret.Box ciphertext
+	Confirmed    bool      // false while enrollment is pending first-code proof
+	LastUsedAt   time.Time // step-start of the last verified TOTP; zero = never
+	BackupHashes [][]byte  // SHA-256 of normalized backup codes
+}
+
+// Store persists enrollment records keyed (tenant, subject); tenant "" is
+// the unscoped namespace and stores interpret it only by equality.
+// Implementations must be safe for concurrent use. MarkUsed and
+// ConsumeBackup carry all concurrency correctness — the rest is CRUD.
+type Store interface {
+	// Get returns the record, or ErrNotFound.
+	Get(ctx context.Context, tenant, subject string) (*Record, error)
+	// Save upserts the record (full replace).
+	Save(ctx context.Context, tenant, subject string, r *Record) error
+	// Delete removes the record; absent is a no-op.
+	Delete(ctx context.Context, tenant, subject string) error
+	// MarkUsed atomically sets LastUsedAt=usedAt iff the stored value is
+	// earlier (or zero). false = a concurrent verify already claimed this
+	// or a later step, or the record is gone. The replay/race gate.
+	MarkUsed(ctx context.Context, tenant, subject string, usedAt time.Time) (bool, error)
+	// ConsumeBackup atomically removes hash if present. false = not
+	// present (already spent, never existed, or record gone). The
+	// single-use gate.
+	ConsumeBackup(ctx context.Context, tenant, subject string, hash []byte) (bool, error)
+	// DeleteTenant removes every record in tenant, returning the count.
+	DeleteTenant(ctx context.Context, tenant string) (int, error)
+}
+
+type memKey struct{ tenant, subject string }
+
+type memoryStore struct {
+	mu   sync.RWMutex
+	recs map[memKey]*Record
+}
+
+// NewMemoryStore returns an in-memory Store for tests, development, and
+// single-process apps. State does not survive restarts.
+func NewMemoryStore() Store {
+	return &memoryStore{recs: make(map[memKey]*Record)}
+}
+
+// cloneRecord deep-copies so callers and the store never share slices.
+func cloneRecord(r *Record) *Record {
+	c := &Record{
+		Secret:     slices.Clone(r.Secret),
+		Confirmed:  r.Confirmed,
+		LastUsedAt: r.LastUsedAt,
+	}
+	if r.BackupHashes != nil {
+		c.BackupHashes = make([][]byte, len(r.BackupHashes))
+		for i, h := range r.BackupHashes {
+			c.BackupHashes[i] = slices.Clone(h)
+		}
+	}
+	return c
+}
+
+func (s *memoryStore) Get(_ context.Context, tenant, subject string) (*Record, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.recs[memKey{tenant, subject}]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return cloneRecord(r), nil
+}
+
+func (s *memoryStore) Save(_ context.Context, tenant, subject string, r *Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recs[memKey{tenant, subject}] = cloneRecord(r)
+	return nil
+}
+
+func (s *memoryStore) Delete(_ context.Context, tenant, subject string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.recs, memKey{tenant, subject})
+	return nil
+}
+
+func (s *memoryStore) MarkUsed(_ context.Context, tenant, subject string, usedAt time.Time) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.recs[memKey{tenant, subject}]
+	if !ok || (!r.LastUsedAt.IsZero() && !r.LastUsedAt.Before(usedAt)) {
+		return false, nil
+	}
+	r.LastUsedAt = usedAt
+	return true, nil
+}
+
+func (s *memoryStore) ConsumeBackup(_ context.Context, tenant, subject string, hash []byte) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.recs[memKey{tenant, subject}]
+	if !ok {
+		return false, nil
+	}
+	for i, h := range r.BackupHashes {
+		if bytes.Equal(h, hash) {
+			r.BackupHashes = slices.Delete(r.BackupHashes, i, i+1)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *memoryStore) DeleteTenant(_ context.Context, tenant string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for k := range s.recs {
+		if k.tenant == tenant {
+			delete(s.recs, k)
+			n++
+		}
+	}
+	return n, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test ./auth/totp/`
+Expected: PASS with `-race` clean (the concurrent MarkUsed test exercises the lock).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/totp/
+git add auth/totp/
+git commit -m "feat(totp): tenant-keyed Store seam with atomic MarkUsed/ConsumeBackup and memory store"
+```
+
+---
+
+### Task 8: Manager — constructors, scope resolution, `BeginEnroll`, `ConfirmEnroll`
+
+**Files:**
+- Create: `auth/totp/manager.go`
+- Test: `auth/totp/manager_test.go`
+
+**Interfaces:**
+- Consumes: `Store`/`Record` (Task 7), `*TOTP` primitives (Tasks 2–5), `GenerateBackupCodes` (Task 6), `crypto/secret.Box` (`secret.New`, `secret.FromKeyset`, `Encrypt`, `Decrypt`), `crypto/keyset.Keyset`.
+- Produces: `NewManager(store Store, key []byte, opts ...Option) (*Manager, error)`; `ManagerFromKeyset(store Store, ks *keyset.Keyset, opts ...Option) (*Manager, error)`; `type Enrollment struct { Secret, URI string }`; `(m *Manager) BeginEnroll(ctx, subject, account string) (*Enrollment, error)`; `(m *Manager) ConfirmEnroll(ctx, subject, code string) ([]string, error)`; unexported `(m *Manager) tenant(ctx) (string, error)` and `(m *Manager) record(ctx, tenant, subject string) (*Record, error)` reused in Tasks 9–10.
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/totp/manager_test.go`:
+
+```go
+package totp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+var testKey = []byte("0123456789abcdef0123456789abcdef")
+
+// fixedNow pins Manager clocks; individual tests advance via a fresh Manager.
+var fixedNow = time.Unix(1_700_000_000, 0).UTC()
+
+func newManager(t *testing.T, store totp.Store, opts ...totp.Option) *totp.Manager {
+	t.Helper()
+	opts = append([]totp.Option{
+		totp.WithIssuer("Acme"),
+		totp.WithClock(clock.NewMock(fixedNow)),
+	}, opts...)
+	m, err := totp.NewManager(store, testKey, opts...)
+	require.NoError(t, err)
+	return m
+}
+
+// codeFor computes the current valid code for an enrollment's secret.
+func codeFor(t *testing.T, enr *totp.Enrollment, at time.Time) string {
+	t.Helper()
+	tp, err := totp.New()
+	require.NoError(t, err)
+	code, err := tp.Code(enr.Secret, at)
+	require.NoError(t, err)
+	return code
+}
+
+func TestNewManager_Validation(t *testing.T) {
+	t.Parallel()
+	_, err := totp.NewManager(nil, testKey)
+	assert.Error(t, err, "nil store")
+	_, err = totp.NewManager(totp.NewMemoryStore(), []byte("short"))
+	assert.Error(t, err, "bad key size")
+	_, err = totp.NewManager(totp.NewMemoryStore(), testKey, totp.WithBackupCodeCount(0))
+	assert.Error(t, err)
+	_, err = totp.NewManager(totp.NewMemoryStore(), testKey, totp.WithBackupCodeLength(7))
+	assert.Error(t, err)
+}
+
+func TestManagerFromKeyset(t *testing.T) {
+	t.Parallel()
+	ks, err := keyset.New(keyset.WithPrimary(1, testKey))
+	require.NoError(t, err)
+	m, err := totp.ManagerFromKeyset(totp.NewMemoryStore(), ks, totp.WithIssuer("Acme"))
+	require.NoError(t, err)
+	require.NotNil(t, m)
+}
+
+func TestBeginEnroll(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store)
+	ctx := t.Context()
+
+	enr, err := m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+	assert.NotEmpty(t, enr.Secret)
+	assert.Contains(t, enr.URI, "otpauth://totp/")
+	assert.Contains(t, enr.URI, "issuer=Acme")
+
+	// The stored secret is ciphertext, not the plaintext we returned.
+	rec, err := store.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.False(t, rec.Confirmed)
+	assert.NotContains(t, string(rec.Secret), enr.Secret)
+
+	// Re-begin before confirm: idempotent overwrite, fresh secret.
+	enr2, err := m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+	assert.NotEqual(t, enr.Secret, enr2.Secret)
+
+	// Empty subject is caller error.
+	_, err = m.BeginEnroll(ctx, "", "x@acme.com")
+	assert.Error(t, err)
+}
+
+func TestConfirmEnroll(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store)
+	ctx := t.Context()
+
+	// No pending record.
+	_, err := m.ConfirmEnroll(ctx, "alice", "123456")
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+
+	enr, err := m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+
+	// Wrong first code: record stays pending.
+	_, err = m.ConfirmEnroll(ctx, "alice", "000000")
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+	rec, err := store.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.False(t, rec.Confirmed)
+
+	// Correct first code: confirmed, backup codes issued, step persisted.
+	codes, err := m.ConfirmEnroll(ctx, "alice", codeFor(t, enr, fixedNow))
+	require.NoError(t, err)
+	assert.Len(t, codes, 10)
+	rec, err = store.Get(ctx, "", "alice")
+	require.NoError(t, err)
+	assert.True(t, rec.Confirmed)
+	assert.Len(t, rec.BackupHashes, 10)
+	assert.False(t, rec.LastUsedAt.IsZero())
+
+	// BeginEnroll after confirm: refused.
+	_, err = m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	assert.ErrorIs(t, err, totp.ErrAlreadyEnrolled)
+
+	// ConfirmEnroll after confirm: refused.
+	_, err = m.ConfirmEnroll(ctx, "alice", codeFor(t, enr, fixedNow))
+	assert.ErrorIs(t, err, totp.ErrAlreadyEnrolled)
+}
+
+func TestConfirmEnroll_BackupOptionsRespected(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, totp.NewMemoryStore(),
+		totp.WithBackupCodeCount(4), totp.WithBackupCodeLength(15))
+	ctx := t.Context()
+	enr, err := m.BeginEnroll(ctx, "bob", "bob@acme.com")
+	require.NoError(t, err)
+	codes, err := m.ConfirmEnroll(ctx, "bob", codeFor(t, enr, fixedNow))
+	require.NoError(t, err)
+	require.Len(t, codes, 4)
+	assert.Equal(t, "xxxxx-xxxxx-xxxxx", func() string {
+		out := []byte{}
+		for _, r := range codes[0] {
+			if r == '-' {
+				out = append(out, '-')
+			} else {
+				out = append(out, 'x')
+			}
+		}
+		return string(out)
+	}())
+}
+
+func TestManager_WrongKeyDoesNotReadAsBadCode(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m1 := newManager(t, store)
+	ctx := t.Context()
+	enr, err := m1.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+
+	// A manager with different key material cannot decrypt: the error must
+	// NOT be ErrInvalidCode — this is an operator problem, not a user typo.
+	m2, err := totp.NewManager(store, []byte("ffffffffffffffffffffffffffffffff"),
+		totp.WithClock(clock.NewMock(fixedNow)))
+	require.NoError(t, err)
+	_, err = m2.ConfirmEnroll(ctx, "alice", codeFor(t, enr, fixedNow))
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, totp.ErrInvalidCode)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/totp/`
+Expected: FAIL — `totp.Manager undefined`, `totp.NewManager undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`auth/totp/manager.go`:
+
+```go
+package totp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/crypto/keyset"
+	"github.com/dmitrymomot/forge/crypto/secret"
+)
+
+// Manager orchestrates the full 2FA lifecycle — enroll, confirm, verify,
+// recover, disable — over a Store. Secrets are sealed with an AEAD box
+// before they reach the store and backup codes are stored as hashes;
+// encryption is mandatory by construction. Safe for concurrent use.
+type Manager struct {
+	t     *TOTP
+	store Store
+	box   *secret.Box
+}
+
+// Enrollment is what BeginEnroll hands the UI: the plaintext secret for
+// manual entry and the otpauth:// URI to render as a QR (core/qrcode's
+// DataURI composes). Neither is persisted in this form.
+type Enrollment struct {
+	Secret string
+	URI    string
+}
+
+// VerifyResult reports which path verified the code.
+type VerifyResult struct {
+	// UsedBackupCode is true when a one-time backup code (now consumed)
+	// matched instead of a TOTP code.
+	UsedBackupCode bool
+	// BackupRemaining is the number of backup codes left after this call;
+	// meaningful only when UsedBackupCode is true.
+	BackupRemaining int
+}
+
+// NewManager builds a Manager sealing secrets with key (32 bytes,
+// AES-256-GCM). Use ManagerFromKeyset for key rotation.
+func NewManager(store Store, key []byte, opts ...Option) (*Manager, error) {
+	box, err := secret.New(key)
+	if err != nil {
+		return nil, fmt.Errorf("totp: %w", err)
+	}
+	return newManager(store, box, opts)
+}
+
+// ManagerFromKeyset builds a Manager whose box encrypts under the keyset's
+// primary key and decrypts under any version — rotation without re-enrolling.
+func ManagerFromKeyset(store Store, ks *keyset.Keyset, opts ...Option) (*Manager, error) {
+	box, err := secret.FromKeyset(ks)
+	if err != nil {
+		return nil, fmt.Errorf("totp: %w", err)
+	}
+	return newManager(store, box, opts)
+}
+
+func newManager(store Store, box *secret.Box, opts []Option) (*Manager, error) {
+	if store == nil {
+		return nil, errors.New("totp: nil store")
+	}
+	t, err := New(opts...)
+	if err != nil {
+		return nil, err
+	}
+	if t.cfg.backupCount < 1 {
+		return nil, fmt.Errorf("totp: backup code count must be >= 1, got %d", t.cfg.backupCount)
+	}
+	if t.cfg.backupLength < 8 {
+		return nil, fmt.Errorf("totp: backup code length must be >= 8, got %d", t.cfg.backupLength)
+	}
+	return &Manager{t: t, store: store, box: box}, nil
+}
+
+// tenant resolves the scope hook, failing closed: with a hook configured, a
+// hook error or empty scope aborts the operation with ErrScope so a scoped
+// operation can never fall through to the unscoped ("") namespace.
+func (m *Manager) tenant(ctx context.Context) (string, error) {
+	if m.t.cfg.scope == nil {
+		return "", nil
+	}
+	s, err := m.t.cfg.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrScope, err)
+	}
+	if s == "" {
+		return "", ErrScope
+	}
+	return s, nil
+}
+
+// record fetches and translates the store sentinel: absent = ErrNotEnrolled
+// at the Manager surface.
+func (m *Manager) record(ctx context.Context, tenant, subject string) (*Record, error) {
+	r, err := m.store.Get(ctx, tenant, subject)
+	if errors.Is(err, ErrNotFound) {
+		return nil, ErrNotEnrolled
+	}
+	if err != nil {
+		return nil, fmt.Errorf("totp: store get: %w", err)
+	}
+	return r, nil
+}
+
+// openSecret unseals a record's secret. Failure means wrong key material —
+// an operator problem surfaced as secret.ErrDecryptFailed, never as
+// ErrInvalidCode.
+func (m *Manager) openSecret(r *Record) (string, error) {
+	plain, err := m.box.Decrypt(r.Secret)
+	if err != nil {
+		return "", fmt.Errorf("totp: unseal secret: %w", err)
+	}
+	return string(plain), nil
+}
+
+// BeginEnroll starts (or restarts) enrollment for subject: it generates a
+// fresh secret, seals it, saves an unconfirmed record — overwriting any
+// earlier unconfirmed one, so re-showing the QR is safe — and returns the
+// plaintext secret and provisioning URI for the UI. ErrAlreadyEnrolled if a
+// confirmed enrollment exists; Disable first to re-enroll.
+func (m *Manager) BeginEnroll(ctx context.Context, subject, account string) (*Enrollment, error) {
+	if subject == "" {
+		return nil, errors.New("totp: empty subject")
+	}
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	existing, err := m.store.Get(ctx, tenant, subject)
+	switch {
+	case err == nil && existing.Confirmed:
+		return nil, ErrAlreadyEnrolled
+	case err != nil && !errors.Is(err, ErrNotFound):
+		return nil, fmt.Errorf("totp: store get: %w", err)
+	}
+	plain, err := m.t.GenerateSecret()
+	if err != nil {
+		return nil, err
+	}
+	sealed, err := m.box.Encrypt([]byte(plain))
+	if err != nil {
+		return nil, fmt.Errorf("totp: seal secret: %w", err)
+	}
+	if err := m.store.Save(ctx, tenant, subject, &Record{Secret: sealed}); err != nil {
+		return nil, fmt.Errorf("totp: store save: %w", err)
+	}
+	return &Enrollment{Secret: plain, URI: m.t.ProvisioningURI(plain, account)}, nil
+}
+
+// ConfirmEnroll proves the authenticator was enrolled by verifying its
+// first code, activates the record, and returns the one-time backup codes —
+// the only time they exist in plaintext. ErrNotEnrolled without a pending
+// record; ErrInvalidCode leaves the record pending for another attempt.
+func (m *Manager) ConfirmEnroll(ctx context.Context, subject, code string) ([]string, error) {
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := m.record(ctx, tenant, subject)
+	if err != nil {
+		return nil, err
+	}
+	if rec.Confirmed {
+		return nil, ErrAlreadyEnrolled
+	}
+	plain, err := m.openSecret(rec)
+	if err != nil {
+		return nil, err
+	}
+	matchedAt, err := m.t.Verify(plain, code, time.Time{})
+	if err != nil {
+		return nil, err
+	}
+	codes, hashes, err := GenerateBackupCodes(m.t.cfg.backupCount, m.t.cfg.backupLength)
+	if err != nil {
+		return nil, err
+	}
+	rec.Confirmed = true
+	rec.LastUsedAt = matchedAt
+	rec.BackupHashes = hashes
+	if err := m.store.Save(ctx, tenant, subject, rec); err != nil {
+		return nil, fmt.Errorf("totp: store save: %w", err)
+	}
+	return codes, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test ./auth/totp/`
+Expected: PASS
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/totp/
+git add auth/totp/
+git commit -m "feat(totp): Manager constructors, fail-closed scope, BeginEnroll/ConfirmEnroll"
+```
+
+---
+
+### Task 9: Manager — `Verify`, `Enabled`, `LastVerified`
+
+**Files:**
+- Modify: `auth/totp/manager.go` (append)
+- Test: `auth/totp/verify_manager_test.go`
+
+**Interfaces:**
+- Consumes: Task 8 helpers (`tenant`, `record`, `openSecret`), Task 7 store atomics, Task 6 `normalizeBackupCode`/`hashBackupCode` (via `VerifyBackupCode`).
+- Produces: `(m *Manager) Verify(ctx, subject, code string) (VerifyResult, error)`; `(m *Manager) Enabled(ctx, subject string) (bool, error)`; `(m *Manager) LastVerified(ctx, subject string) (time.Time, error)`.
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/totp/verify_manager_test.go`:
+
+```go
+package totp_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// enroll provisions a confirmed enrollment and returns the manager,
+// enrollment (for code computation), and issued backup codes.
+func enroll(t *testing.T, store totp.Store, opts ...totp.Option) (*totp.Manager, *totp.Enrollment, []string) {
+	t.Helper()
+	m := newManager(t, store, opts...)
+	ctx := t.Context()
+	enr, err := m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+	backup, err := m.ConfirmEnroll(ctx, "alice", codeFor(t, enr, fixedNow))
+	require.NoError(t, err)
+	return m, enr, backup
+}
+
+func TestManagerVerify_TOTPPath(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	_, enr, _ := enroll(t, store)
+	ctx := t.Context()
+
+	// ConfirmEnroll consumed the fixedNow step; advance one step.
+	later := fixedNow.Add(30 * time.Second)
+	m2, err := totp.NewManager(store, testKey, totp.WithClock(clock.NewMock(later)))
+	require.NoError(t, err)
+
+	res, err := m2.Verify(ctx, "alice", codeFor(t, enr, later))
+	require.NoError(t, err)
+	assert.False(t, res.UsedBackupCode)
+
+	// Same code again: the step is spent.
+	_, err = m2.Verify(ctx, "alice", codeFor(t, enr, later))
+	assert.ErrorIs(t, err, totp.ErrReplayed)
+
+	// Garbage code.
+	_, err = m2.Verify(ctx, "alice", "000000")
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+}
+
+func TestManagerVerify_BackupPath(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m, _, backup := enroll(t, store)
+	ctx := t.Context()
+
+	res, err := m.Verify(ctx, "alice", backup[0])
+	require.NoError(t, err)
+	assert.True(t, res.UsedBackupCode)
+	assert.Equal(t, 9, res.BackupRemaining)
+
+	// Consumed: second use fails.
+	_, err = m.Verify(ctx, "alice", backup[0])
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+
+	// Normalization: uppercase + no dashes still verifies.
+	res, err = m.Verify(ctx, "alice", "  "+stringsUpperNoDash(backup[1])+" ")
+	require.NoError(t, err)
+	assert.True(t, res.UsedBackupCode)
+	assert.Equal(t, 8, res.BackupRemaining)
+}
+
+func stringsUpperNoDash(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := range len(s) {
+		c := s[i]
+		if c == '-' {
+			continue
+		}
+		if 'a' <= c && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func TestManagerVerify_Unenrolled(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store)
+	ctx := t.Context()
+
+	_, err := m.Verify(ctx, "ghost", "123456")
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+
+	// Pending (unconfirmed) enrollment refuses Verify too.
+	_, err = m.BeginEnroll(ctx, "bob", "bob@acme.com")
+	require.NoError(t, err)
+	_, err = m.Verify(ctx, "bob", "123456")
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+}
+
+func TestManagerVerify_ConcurrentSameCode_OneWinner(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	_, enr, _ := enroll(t, store)
+	ctx := t.Context()
+
+	later := fixedNow.Add(60 * time.Second)
+	m2, err := totp.NewManager(store, testKey, totp.WithClock(clock.NewMock(later)))
+	require.NoError(t, err)
+	code := codeFor(t, enr, later)
+
+	const n = 16
+	results := make(chan error, n)
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			_, err := m2.Verify(ctx, "alice", code)
+			results <- err
+		})
+	}
+	wg.Wait()
+	close(results)
+	okCount, replayCount := 0, 0
+	for err := range results {
+		switch {
+		case err == nil:
+			okCount++
+		case assert.ErrorIs(t, err, totp.ErrReplayed):
+			replayCount++
+		}
+	}
+	assert.Equal(t, 1, okCount, "exactly one concurrent verify succeeds")
+	assert.Equal(t, n-1, replayCount)
+}
+
+func TestEnabledAndLastVerified(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store)
+	ctx := t.Context()
+
+	on, err := m.Enabled(ctx, "alice")
+	require.NoError(t, err)
+	assert.False(t, on, "absent: false, nil — a policy query, not an error")
+	_, err = m.LastVerified(ctx, "alice")
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+
+	enr, err := m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+	on, err = m.Enabled(ctx, "alice")
+	require.NoError(t, err)
+	assert.False(t, on, "pending: still false")
+	_, err = m.LastVerified(ctx, "alice")
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled, "pending: not enrolled")
+
+	_, err = m.ConfirmEnroll(ctx, "alice", codeFor(t, enr, fixedNow))
+	require.NoError(t, err)
+	on, err = m.Enabled(ctx, "alice")
+	require.NoError(t, err)
+	assert.True(t, on)
+	last, err := m.LastVerified(ctx, "alice")
+	require.NoError(t, err)
+	assert.False(t, last.IsZero(), "confirm stamped the first verified step")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/totp/`
+Expected: FAIL — `m.Verify undefined` (Manager has no Verify yet), `m.Enabled undefined`, `m.LastVerified undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `auth/totp/manager.go`:
+
+```go
+// Verify checks code for subject: TOTP first (replay-safe — the matched
+// step is atomically claimed in the store), then falls back to one-time
+// backup codes (atomically consumed). One call serves a single "enter your
+// code or a backup code" input. ErrNotEnrolled for absent or unconfirmed
+// records; ErrReplayed when the step was already claimed (including by a
+// concurrent request); ErrInvalidCode otherwise.
+func (m *Manager) Verify(ctx context.Context, subject, code string) (VerifyResult, error) {
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	rec, err := m.record(ctx, tenant, subject)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	if !rec.Confirmed {
+		return VerifyResult{}, ErrNotEnrolled
+	}
+	plain, err := m.openSecret(rec)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+
+	matchedAt, verr := m.t.Verify(plain, code, rec.LastUsedAt)
+	switch {
+	case verr == nil:
+		ok, err := m.store.MarkUsed(ctx, tenant, subject, matchedAt)
+		if err != nil {
+			return VerifyResult{}, fmt.Errorf("totp: store mark used: %w", err)
+		}
+		if !ok {
+			return VerifyResult{}, ErrReplayed
+		}
+		return VerifyResult{}, nil
+	case errors.Is(verr, ErrReplayed):
+		return VerifyResult{}, ErrReplayed
+	}
+
+	// TOTP mismatch — try the backup codes.
+	idx, ok := VerifyBackupCode(code, rec.BackupHashes)
+	if !ok {
+		return VerifyResult{}, ErrInvalidCode
+	}
+	consumed, err := m.store.ConsumeBackup(ctx, tenant, subject, rec.BackupHashes[idx])
+	if err != nil {
+		return VerifyResult{}, fmt.Errorf("totp: store consume backup: %w", err)
+	}
+	if !consumed {
+		// Lost a race: someone spent this code between Get and here.
+		return VerifyResult{}, ErrInvalidCode
+	}
+	return VerifyResult{
+		UsedBackupCode: true,
+		// Count from the snapshot we verified against; a concurrent consume
+		// may make this off by one — it is advisory UI data, not state.
+		BackupRemaining: len(rec.BackupHashes) - 1,
+	}, nil
+}
+
+// Enabled reports whether subject has a confirmed enrollment. Absent and
+// pending both read false — it is a policy query, not an error path.
+func (m *Manager) Enabled(ctx context.Context, subject string) (bool, error) {
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return false, err
+	}
+	rec, err := m.store.Get(ctx, tenant, subject)
+	if errors.Is(err, ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("totp: store get: %w", err)
+	}
+	return rec.Confirmed, nil
+}
+
+// LastVerified returns the step-start time of the last successful TOTP
+// verification — the input to a grace-period check (see doc.go). Zero time
+// with a nil error cannot happen for a confirmed record (ConfirmEnroll
+// stamps the first step); ErrNotEnrolled for absent or pending records.
+func (m *Manager) LastVerified(ctx context.Context, subject string) (time.Time, error) {
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return time.Time{}, err
+	}
+	rec, err := m.record(ctx, tenant, subject)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !rec.Confirmed {
+		return time.Time{}, ErrNotEnrolled
+	}
+	return rec.LastUsedAt, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test ./auth/totp/`
+Expected: PASS with `-race` clean (concurrent same-code test).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/totp/
+git add auth/totp/
+git commit -m "feat(totp): Manager.Verify with TOTP+backup unified path, Enabled, LastVerified"
+```
+
+---
+
+### Task 10: Manager — `RegenerateBackupCodes`, `Disable`, `DisableTenant` + tenancy suite
+
+**Files:**
+- Modify: `auth/totp/manager.go` (append)
+- Test: `auth/totp/tenancy_test.go`
+
+**Interfaces:**
+- Consumes: everything from Tasks 7–9.
+- Produces: `(m *Manager) RegenerateBackupCodes(ctx, subject string) ([]string, error)`; `(m *Manager) Disable(ctx, subject string) error`; `(m *Manager) DisableTenant(ctx) (int, error)`.
+
+- [ ] **Step 1: Write the failing test**
+
+`auth/totp/tenancy_test.go`:
+
+```go
+package totp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+type tenantCtxKey struct{}
+
+func tenantCtx(t *testing.T, tenant string) context.Context {
+	t.Helper()
+	return context.WithValue(t.Context(), tenantCtxKey{}, tenant)
+}
+
+func scopeHook(ctx context.Context) (string, error) {
+	v, _ := ctx.Value(tenantCtxKey{}).(string)
+	return v, nil
+}
+
+// scopedEnroll enrolls subject under tenant and returns issued backup codes.
+func scopedEnroll(t *testing.T, m *totp.Manager, ctx context.Context, subject string) (*totp.Enrollment, []string) {
+	t.Helper()
+	enr, err := m.BeginEnroll(ctx, subject, subject+"@acme.com")
+	require.NoError(t, err)
+	codes, err := m.ConfirmEnroll(ctx, subject, codeFor(t, enr, fixedNow))
+	require.NoError(t, err)
+	return enr, codes
+}
+
+func TestRegenerateBackupCodes(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m, _, oldCodes := enroll(t, store)
+	ctx := t.Context()
+
+	newCodes, err := m.RegenerateBackupCodes(ctx, "alice")
+	require.NoError(t, err)
+	assert.Len(t, newCodes, 10)
+
+	// Old codes are dead, new ones live.
+	_, err = m.Verify(ctx, "alice", oldCodes[0])
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+	res, err := m.Verify(ctx, "alice", newCodes[0])
+	require.NoError(t, err)
+	assert.True(t, res.UsedBackupCode)
+
+	// Not enrolled / pending → ErrNotEnrolled.
+	_, err = m.RegenerateBackupCodes(ctx, "ghost")
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+}
+
+func TestDisable(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m, enr, _ := enroll(t, store)
+	ctx := t.Context()
+
+	require.NoError(t, m.Disable(ctx, "alice"))
+	on, err := m.Enabled(ctx, "alice")
+	require.NoError(t, err)
+	assert.False(t, on)
+	_, err = m.Verify(ctx, "alice", codeFor(t, enr, fixedNow))
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+
+	// Disable is idempotent; re-enroll works after it.
+	require.NoError(t, m.Disable(ctx, "alice"))
+	_, err = m.BeginEnroll(ctx, "alice", "alice@acme.com")
+	require.NoError(t, err)
+}
+
+func TestScope_IsolatesTenants(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store, totp.WithScope(scopeHook))
+
+	ctxA, ctxB := tenantCtx(t, "tenant-a"), tenantCtx(t, "tenant-b")
+	enrA, _ := scopedEnroll(t, m, ctxA, "alice")
+
+	// Same subject, other tenant: independent lifecycle.
+	on, err := m.Enabled(ctxB, "alice")
+	require.NoError(t, err)
+	assert.False(t, on, "tenant-b sees no enrollment")
+	_, err = m.Verify(ctxB, "alice", codeFor(t, enrA, fixedNow))
+	assert.ErrorIs(t, err, totp.ErrNotEnrolled)
+
+	enrB, _ := scopedEnroll(t, m, ctxB, "alice")
+	assert.NotEqual(t, enrA.Secret, enrB.Secret, "independent secrets per tenant")
+
+	// Disable in one tenant leaves the other intact.
+	require.NoError(t, m.Disable(ctxB, "alice"))
+	on, err = m.Enabled(ctxA, "alice")
+	require.NoError(t, err)
+	assert.True(t, on)
+}
+
+func TestScope_FailClosed(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+
+	// Hook returning empty scope → ErrScope on every method.
+	m := newManager(t, store, totp.WithScope(scopeHook))
+	noTenant := t.Context() // no tenant value in context → hook returns ""
+	_, err := m.BeginEnroll(noTenant, "alice", "a@acme.com")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	_, err = m.ConfirmEnroll(noTenant, "alice", "123456")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	_, err = m.Verify(noTenant, "alice", "123456")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	_, err = m.Enabled(noTenant, "alice")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	_, err = m.LastVerified(noTenant, "alice")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	_, err = m.RegenerateBackupCodes(noTenant, "alice")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	assert.ErrorIs(t, m.Disable(noTenant, "alice"), totp.ErrScope)
+	_, err = m.DisableTenant(noTenant)
+	assert.ErrorIs(t, err, totp.ErrScope)
+
+	// Hook returning an error → ErrScope wrapping it.
+	boom := errors.New("boom")
+	mErr := newManager(t, store, totp.WithScope(func(context.Context) (string, error) {
+		return "", boom
+	}))
+	_, err = mErr.Enabled(t.Context(), "alice")
+	assert.ErrorIs(t, err, totp.ErrScope)
+	assert.ErrorIs(t, err, boom)
+}
+
+func TestScope_UnscopedAndScopedNeverCollide(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	unscoped := newManager(t, store)
+	scoped := newManager(t, store, totp.WithScope(scopeHook))
+
+	enrU, _ := scopedEnroll(t, unscoped, t.Context(), "alice")
+	_ = enrU
+
+	on, err := scoped.Enabled(tenantCtx(t, "tenant-a"), "alice")
+	require.NoError(t, err)
+	assert.False(t, on, "scoped manager cannot see the unscoped record")
+}
+
+func TestDisableTenant(t *testing.T) {
+	t.Parallel()
+	store := totp.NewMemoryStore()
+	m := newManager(t, store, totp.WithScope(scopeHook))
+	ctxA, ctxB := tenantCtx(t, "tenant-a"), tenantCtx(t, "tenant-b")
+
+	scopedEnroll(t, m, ctxA, "alice")
+	scopedEnroll(t, m, ctxA, "bob")
+	scopedEnroll(t, m, ctxB, "alice")
+
+	n, err := m.DisableTenant(ctxA)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	on, err := m.Enabled(ctxA, "alice")
+	require.NoError(t, err)
+	assert.False(t, on)
+	on, err = m.Enabled(ctxB, "alice")
+	require.NoError(t, err)
+	assert.True(t, on, "tenant-b untouched")
+
+	// Unscoped manager has no tenant to delete.
+	unscoped := newManager(t, store)
+	_, err = unscoped.DisableTenant(t.Context())
+	assert.ErrorIs(t, err, totp.ErrScope)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./auth/totp/`
+Expected: FAIL — `m.RegenerateBackupCodes undefined`, `m.Disable undefined`, `m.DisableTenant undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `auth/totp/manager.go`:
+
+```go
+// RegenerateBackupCodes invalidates every outstanding backup code and
+// returns a fresh set — the only time the new codes exist in plaintext.
+// ErrNotEnrolled unless a confirmed enrollment exists.
+func (m *Manager) RegenerateBackupCodes(ctx context.Context, subject string) ([]string, error) {
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := m.record(ctx, tenant, subject)
+	if err != nil {
+		return nil, err
+	}
+	if !rec.Confirmed {
+		return nil, ErrNotEnrolled
+	}
+	codes, hashes, err := GenerateBackupCodes(m.t.cfg.backupCount, m.t.cfg.backupLength)
+	if err != nil {
+		return nil, err
+	}
+	rec.BackupHashes = hashes
+	if err := m.store.Save(ctx, tenant, subject, rec); err != nil {
+		return nil, fmt.Errorf("totp: store save: %w", err)
+	}
+	return codes, nil
+}
+
+// Disable removes the enrollment entirely — secret, backup codes, state.
+// Idempotent: disabling an absent enrollment is a no-op.
+func (m *Manager) Disable(ctx context.Context, subject string) error {
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return err
+	}
+	if err := m.store.Delete(ctx, tenant, subject); err != nil {
+		return fmt.Errorf("totp: store delete: %w", err)
+	}
+	return nil
+}
+
+// DisableTenant bulk-deletes every enrollment in the scope-resolved tenant
+// (offboarding, GDPR erasure) and returns the count. It requires WithScope:
+// an unscoped Manager has no tenant to delete and returns ErrScope.
+// Platform-level jobs run it with a context bound to the target tenant.
+func (m *Manager) DisableTenant(ctx context.Context) (int, error) {
+	if m.t.cfg.scope == nil {
+		return 0, ErrScope
+	}
+	tenant, err := m.tenant(ctx)
+	if err != nil {
+		return 0, err
+	}
+	n, err := m.store.DeleteTenant(ctx, tenant)
+	if err != nil {
+		return 0, fmt.Errorf("totp: store delete tenant: %w", err)
+	}
+	return n, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test ./auth/totp/`
+Expected: PASS
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+just fmt ./auth/totp/
+just lint
+git add auth/totp/
+git commit -m "feat(totp): RegenerateBackupCodes, Disable, DisableTenant with fail-closed tenancy"
+```
+
+---
+
+### Task 11: `doc.go` — package docs and recipes
+
+**Files:**
+- Create: `auth/totp/doc.go`
+- Delete the package comment line from `auth/totp/totp.go` (the `// Package totp ...` block moves to doc.go; totp.go keeps only `package totp`).
+
+**Interfaces:**
+- Consumes: the final public API from Tasks 1–10 (examples must compile against it mentally — godoc code blocks are not compiled, but they must be accurate).
+- Produces: package documentation. No code symbols.
+
+- [ ] **Step 1: Write doc.go**
+
+`auth/totp/doc.go`:
+
+```go
+// Package totp is the complete 2FA package: RFC 6238 TOTP and RFC 4226
+// HOTP code generation and verification, otpauth:// provisioning URIs,
+// and one-time backup codes — with a Manager that runs the whole
+// enrollment/verification lifecycle over a pluggable Store.
+//
+// Two layers are public. The Manager is the front door: it owns
+// pending-enrollment state, seals TOTP secrets with authenticated
+// encryption (crypto/secret) before they reach any store, stores backup
+// codes only as SHA-256 hashes, and routes replay/race protection through
+// two atomic store operations. The stateless primitives underneath
+// (Verify, Code, GenerateBackupCodes, ...) are the escape hatch for
+// consumers with their own storage discipline.
+//
+// # Usage
+//
+// Construction — encryption is mandatory, the key is 32 bytes (use
+// ManagerFromKeyset for rotation):
+//
+//	store := totp.NewMemoryStore() // or pgstore.New(pool), or your own
+//	mgr, err := totp.NewManager(store, key, totp.WithIssuer("Acme"))
+//
+// Enrollment — show the QR, then prove the authenticator works with its
+// first code; the returned backup codes exist in plaintext exactly once:
+//
+//	enr, err := mgr.BeginEnroll(ctx, user.ID, user.Email)
+//	img, err := qrcode.DataURI(enr.URI) // core/qrcode renders the otpauth URI
+//	// ... user scans and submits their first code ...
+//	backupCodes, err := mgr.ConfirmEnroll(ctx, user.ID, firstCode)
+//
+// Login — one call verifies both TOTP and backup codes, replay-safe:
+//
+//	res, err := mgr.Verify(ctx, user.ID, form.Code)
+//	switch {
+//	case errors.Is(err, totp.ErrReplayed), errors.Is(err, totp.ErrInvalidCode):
+//		// reject
+//	case err != nil:
+//		// operator problem (store down, wrong key material)
+//	case res.UsedBackupCode && res.BackupRemaining <= 2:
+//		// warn: few backup codes left — offer RegenerateBackupCodes
+//	}
+//
+// # Grace period (skip the prompt for a while)
+//
+// Whether to prompt at all is session policy, so it stays in the consumer.
+// User-scoped grace is one line off LastVerified:
+//
+//	last, err := mgr.LastVerified(ctx, user.ID)
+//	if err == nil && time.Since(last) < 12*time.Hour {
+//		// skip the OTP prompt
+//	}
+//
+// Caveat: this is user-global — verifying on one device silences the
+// prompt on every device for the window. Prefer device-scoped trust.
+//
+// # Remember this device (recommended)
+//
+// Device-scoped trust is a signed cookie via crypto/token; the trust
+// window is the token TTL and rotation revokes fleet-wide:
+//
+//	type trusted struct{ UserID string `json:"uid"` }
+//	codec, _ := token.New[trusted](key,
+//		token.WithTTL(30*24*time.Hour), token.WithPurpose("2fa-device"))
+//
+//	// after a successful Verify, when the user opts in:
+//	tok, _ := codec.Issue(trusted{UserID: user.ID})
+//	http.SetCookie(w, &http.Cookie{Name: "2fa_device", Value: tok,
+//		MaxAge: 30 * 24 * 3600, HttpOnly: true, Secure: true,
+//		SameSite: http.SameSiteLaxMode})
+//
+//	// before showing the OTP prompt:
+//	if c, err := r.Cookie("2fa_device"); err == nil {
+//		if got, err := codec.Parse(c.Value); err == nil && got.UserID == user.ID {
+//			// skip the prompt — this browser verified recently
+//		}
+//	}
+//
+// # Multi-tenancy
+//
+// Multi-tenant applications wire tenant isolation once, at construction,
+// with WithScope — never by encoding tenant IDs into subjects:
+//
+//	mgr, err := totp.NewManager(store, key,
+//		totp.WithIssuer("Acme"),
+//		totp.WithScope(func(ctx context.Context) (string, error) {
+//			return tenantFromContext(ctx) // e.g. tenant middleware
+//		}),
+//	)
+//
+// The hook runs inside every operation and fails closed: an error or empty
+// scope aborts with ErrScope instead of falling through to the unscoped
+// namespace. Pick the model by asking where an enrollment belongs:
+//
+//   - Single-tenant: omit WithScope.
+//   - Account-global 2FA (GitHub model — one enrollment serves every
+//     workspace the user belongs to): also omit WithScope; the subject is
+//     the global user ID.
+//   - Per-tenant enrollment (Slack model — identity lives inside the
+//     workspace): wire WithScope to the request's tenant. The same subject
+//     enrolls independently per tenant.
+//   - Platform-level operations while scoped: use a context bound to the
+//     target tenant, or a reserved non-empty sentinel scope (e.g.
+//     "@global") that no tenant ID can collide with.
+//
+// Cleanup: tenant offboarding is DisableTenant under a tenant-bound
+// context. Deleting one user across all tenants is the consumer's
+// membership loop — for each membership, run Disable with that tenant's
+// context; the application owns the membership list, not this package.
+//
+// # Custom stores
+//
+// A Store implementation is five CRUD-ish methods plus two atomic gates.
+// All correctness lives in the gates:
+//
+//   - MarkUsed(tenant, subject, usedAt) must atomically set LastUsedAt =
+//     usedAt only if the stored value is earlier (or zero), reporting
+//     whether it did. Reference SQL:
+//     UPDATE forge_totp SET last_used_at=$3 WHERE tenant=$1 AND subject=$2
+//     AND (last_used_at IS NULL OR last_used_at < $3)
+//   - ConsumeBackup(tenant, subject, hash) must atomically remove hash if
+//     present, reporting whether it did. Reference SQL:
+//     UPDATE forge_totp SET backup_hashes=array_remove(backup_hashes,$3)
+//     WHERE tenant=$1 AND subject=$2 AND $3 = ANY(backup_hashes)
+//
+// Both report false (not an error) when the condition fails, including for
+// absent records. Tenant is compared only by equality; "" is the unscoped
+// namespace.
+//
+// # Rate limiting
+//
+// This package does not count attempts. Six-digit codes survive online
+// brute force only behind a limiter — put auth/lockout (or
+// resilience/ratelimit) in front of Verify.
+package totp
+```
+
+- [ ] **Step 2: Verify docs render and tests still pass**
+
+Run: `go doc ./auth/totp | head -40 && just test ./auth/totp/`
+Expected: package summary renders; PASS.
+
+- [ ] **Step 3: Format, lint, commit**
+
+```bash
+just fmt ./auth/totp/
+just lint
+git add auth/totp/
+git commit -m "docs(totp): package documentation with grace, device-trust, tenancy, custom-store recipes"
+```
+
+---
+
+### Task 12: Fuzz + benchmarks
+
+**Files:**
+- Create: `auth/totp/fuzz_test.go`
+- Create: `auth/totp/bench_test.go`
+
+**Interfaces:**
+- Consumes: the public API only.
+- Produces: fuzz targets `FuzzVerify`, `FuzzBackupCode`; benchmarks `BenchmarkCode`, `BenchmarkVerify`, `BenchmarkManagerVerify`, `BenchmarkVerifyBackupCode`.
+
+- [ ] **Step 1: Write the fuzz tests**
+
+`auth/totp/fuzz_test.go`:
+
+```go
+package totp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+// FuzzVerify asserts Verify never panics on hostile secret/code input —
+// malformed base32 must surface as an error.
+func FuzzVerify(f *testing.F) {
+	f.Add("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ", "123456")
+	f.Add("", "")
+	f.Add("!!!!", "00000000")
+	f.Add("gezd gnbv====", "abcdef")
+	f.Add("A", "999999999999999999")
+	tp, err := totp.New()
+	require.NoError(f, err)
+	f.Fuzz(func(t *testing.T, secret, code string) {
+		_, _ = tp.Verify(secret, code, time.Time{})
+		_, _ = tp.Code(secret, time.Unix(59, 0))
+		_, _ = tp.HOTPCode(secret, 42)
+	})
+}
+
+// FuzzBackupCode asserts normalization/verification never panics and that
+// verification of arbitrary input against arbitrary hash sets is total.
+func FuzzBackupCode(f *testing.F) {
+	f.Add("abcde-fghij", []byte("0123456789abcdef0123456789abcdef"))
+	f.Add("", []byte{})
+	f.Add("ABCDE FGHIJ  ", []byte{1})
+	f.Fuzz(func(t *testing.T, code string, hash []byte) {
+		_, _ = totp.VerifyBackupCode(code, [][]byte{hash})
+		_, _ = totp.VerifyBackupCode(code, nil)
+	})
+}
+```
+
+- [ ] **Step 2: Write the benchmarks**
+
+`auth/totp/bench_test.go`:
+
+```go
+package totp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+func BenchmarkCode(b *testing.B) {
+	tp, err := totp.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	secret := "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+	at := time.Unix(1_700_000_000, 0)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := tp.Code(secret, at); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerify(b *testing.B) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	tp, err := totp.New(totp.WithClock(clock.NewMock(now)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	secret := "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+	code, err := tp.Code(secret, now)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := tp.Verify(secret, code, time.Time{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkManagerVerify(b *testing.B) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	store := totp.NewMemoryStore()
+	key := []byte("0123456789abcdef0123456789abcdef")
+	mgr, err := totp.NewManager(store, key, totp.WithClock(clock.NewMock(now)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := b.Context()
+	enr, err := mgr.BeginEnroll(ctx, "alice", "alice@acme.com")
+	if err != nil {
+		b.Fatal(err)
+	}
+	tp, err := totp.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	first, err := tp.Code(enr.Secret, now)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, err := mgr.ConfirmEnroll(ctx, "alice", first); err != nil {
+		b.Fatal(err)
+	}
+	// Bench the dominant path: a wrong TOTP code falling through the full
+	// window scan and the backup-hash scan (verify successes mutate state
+	// and cannot repeat in a loop).
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Verify(ctx, "alice", "000000"); err == nil {
+			b.Fatal("expected mismatch")
+		}
+	}
+}
+
+func BenchmarkVerifyBackupCode(b *testing.B) {
+	codes, hashes, err := totp.GenerateBackupCodes(10, 10)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, ok := totp.VerifyBackupCode(codes[9], hashes); !ok {
+			b.Fatal("expected match")
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Run fuzz smoke + benchmarks**
+
+Run: `go test -run='^$' -fuzz=FuzzVerify -fuzztime=20s ./auth/totp/ && go test -run='^$' -fuzz=FuzzBackupCode -fuzztime=10s ./auth/totp/`
+Expected: no crashers.
+
+Run: `just bench ./auth/totp/`
+Expected: numbers print; record them for the PR description. No optimization pass unless something is absurd (auth flows are not hot paths — magiclink precedent); any perf-motivated change needs the benchmark in the PR.
+
+- [ ] **Step 4: Run full package tests**
+
+Run: `just test ./auth/totp/`
+Expected: PASS
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just fmt ./auth/totp/
+git add auth/totp/
+git commit -m "test(totp): fuzz Verify/backup-code inputs; benchmarks for code paths"
+```
+
+---
+
+### Task 13: `pgstore` — migration, driver, integration tests
+
+**Files:**
+- Create: `auth/totp/pgstore/migrations/00001_totp.sql`
+- Create: `auth/totp/pgstore/pgstore.go`
+- Create: `auth/totp/pgstore/doc.go`
+- Test: `auth/totp/pgstore/pgstore_test.go`
+
+**Interfaces:**
+- Consumes: `totp.Store` contract + `totp.Record` + `totp.ErrNotFound` (Task 7); `data/postgres.Open`, `data/migration.New`, `pgx/v5`.
+- Produces: `pgstore.New(pool *pgxpool.Pool) *Store` implementing `totp.Store`; `pgstore.Migrations fs.FS` (rooted via `fs.Sub` — data/migration globs the fsys root).
+
+- [ ] **Step 1: Write the migration**
+
+`auth/totp/pgstore/migrations/00001_totp.sql`:
+
+```sql
+-- +goose Up
+CREATE TABLE forge_totp (
+    tenant        text NOT NULL DEFAULT '',
+    subject       text NOT NULL,
+    secret        bytea NOT NULL,
+    confirmed     boolean NOT NULL DEFAULT false,
+    last_used_at  timestamptz,
+    backup_hashes bytea[] NOT NULL DEFAULT '{}',
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    updated_at    timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant, subject)
+);
+
+-- +goose Down
+DROP TABLE forge_totp;
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+`auth/totp/pgstore/pgstore_test.go`:
+
+```go
+package pgstore_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+	"github.com/dmitrymomot/forge/auth/totp/pgstore"
+	"github.com/dmitrymomot/forge/core/random"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+)
+
+var _ totp.Store = (*pgstore.Store)(nil)
+
+func newStore(t *testing.T) *pgstore.Store {
+	t.Helper()
+	dsn := os.Getenv("FORGE_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("set FORGE_TEST_POSTGRES_DSN")
+	}
+	cfg := postgres.DefaultConfig()
+	cfg.URL = dsn
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgstore.Migrations, migration.WithTable("forge_totp_schema")).Up(context.Background(), db))
+	return pgstore.New(pool)
+}
+
+// subj returns a unique subject per call: the table persists across test
+// runs, so deterministic keys would collide on the PK.
+func subj() string { return "subj-" + random.String(12) }
+
+func rec(confirmed bool) *totp.Record {
+	return &totp.Record{
+		Secret:       []byte("ciphertext-bytes"),
+		Confirmed:    confirmed,
+		BackupHashes: [][]byte{{1, 2, 3}, {4, 5, 6}},
+	}
+}
+
+func TestPg_SaveGetRoundTrip(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	sub := subj()
+
+	_, err := s.Get(ctx, "", sub)
+	assert.ErrorIs(t, err, totp.ErrNotFound)
+
+	r := rec(true)
+	r.LastUsedAt = time.Unix(1_700_000_010, 0).UTC() // step-start: whole seconds
+	require.NoError(t, s.Save(ctx, "", sub, r))
+
+	got, err := s.Get(ctx, "", sub)
+	require.NoError(t, err)
+	assert.Equal(t, r.Secret, got.Secret)
+	assert.True(t, got.Confirmed)
+	assert.True(t, got.LastUsedAt.Equal(r.LastUsedAt), "timestamptz round-trip is exact for whole seconds")
+	assert.Equal(t, r.BackupHashes, got.BackupHashes)
+
+	// Upsert: full replace.
+	r2 := rec(false)
+	require.NoError(t, s.Save(ctx, "", sub, r2))
+	got, err = s.Get(ctx, "", sub)
+	require.NoError(t, err)
+	assert.False(t, got.Confirmed)
+	assert.True(t, got.LastUsedAt.IsZero(), "NULL maps back to zero time")
+}
+
+func TestPg_MarkUsed(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	sub := subj()
+	require.NoError(t, s.Save(ctx, "", sub, rec(true)))
+
+	t0 := time.Unix(1_700_000_010, 0).UTC()
+	ok, err := s.MarkUsed(ctx, "", sub, t0)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = s.MarkUsed(ctx, "", sub, t0)
+	require.NoError(t, err)
+	assert.False(t, ok, "same step claimed once")
+
+	ok, err = s.MarkUsed(ctx, "", sub, t0.Add(-30*time.Second))
+	require.NoError(t, err)
+	assert.False(t, ok, "earlier step rejected")
+
+	ok, err = s.MarkUsed(ctx, "", sub, t0.Add(30*time.Second))
+	require.NoError(t, err)
+	assert.True(t, ok, "later step advances")
+
+	ok, err = s.MarkUsed(ctx, "", "ghost-"+sub, t0)
+	require.NoError(t, err)
+	assert.False(t, ok, "absent record: false, nil")
+}
+
+func TestPg_ConsumeBackup(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	sub := subj()
+	require.NoError(t, s.Save(ctx, "", sub, rec(true)))
+
+	ok, err := s.ConsumeBackup(ctx, "", sub, []byte{1, 2, 3})
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = s.ConsumeBackup(ctx, "", sub, []byte{1, 2, 3})
+	require.NoError(t, err)
+	assert.False(t, ok, "single use")
+
+	got, err := s.Get(ctx, "", sub)
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{{4, 5, 6}}, got.BackupHashes)
+}
+
+func TestPg_DeleteAndDeleteTenant(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	tenant := "tenant-" + random.String(12)
+	subA, subB := subj(), subj()
+
+	require.NoError(t, s.Save(ctx, tenant, subA, rec(true)))
+	require.NoError(t, s.Save(ctx, tenant, subB, rec(true)))
+	require.NoError(t, s.Save(ctx, "", subA, rec(true)))
+
+	// Tenant isolation on point reads.
+	_, err := s.Get(ctx, tenant, subA)
+	require.NoError(t, err)
+	_, err = s.Get(ctx, "other-"+tenant, subA)
+	assert.ErrorIs(t, err, totp.ErrNotFound)
+
+	// Delete one record; absent delete is a no-op.
+	require.NoError(t, s.Delete(ctx, tenant, subB))
+	require.NoError(t, s.Delete(ctx, tenant, subB))
+	_, err = s.Get(ctx, tenant, subB)
+	assert.ErrorIs(t, err, totp.ErrNotFound)
+
+	// DeleteTenant removes exactly the tenant's records.
+	n, err := s.DeleteTenant(ctx, tenant)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	_, err = s.Get(ctx, "", subA)
+	assert.NoError(t, err, "unscoped record untouched")
+}
+
+func TestPg_ManagerLifecycleEndToEnd(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	key := []byte("0123456789abcdef0123456789abcdef")
+	mgr, err := totp.NewManager(s, key, totp.WithIssuer("Acme"))
+	require.NoError(t, err)
+	sub := subj()
+
+	enr, err := mgr.BeginEnroll(ctx, sub, sub+"@acme.com")
+	require.NoError(t, err)
+	tp, err := totp.New()
+	require.NoError(t, err)
+	code, err := tp.Code(enr.Secret, time.Now())
+	require.NoError(t, err)
+	backup, err := mgr.ConfirmEnroll(ctx, sub, code)
+	require.NoError(t, err)
+	require.Len(t, backup, 10)
+
+	// TOTP re-use of the confirm step is replayed.
+	_, err = mgr.Verify(ctx, sub, code)
+	assert.ErrorIs(t, err, totp.ErrReplayed)
+
+	// Backup code path works and consumes.
+	res, err := mgr.Verify(ctx, sub, backup[0])
+	require.NoError(t, err)
+	assert.True(t, res.UsedBackupCode)
+	assert.Equal(t, 9, res.BackupRemaining)
+	_, err = mgr.Verify(ctx, sub, backup[0])
+	assert.ErrorIs(t, err, totp.ErrInvalidCode)
+
+	require.NoError(t, mgr.Disable(ctx, sub))
+	on, err := mgr.Enabled(ctx, sub)
+	require.NoError(t, err)
+	assert.False(t, on)
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./auth/totp/pgstore/`
+Expected: FAIL — package does not compile (`pgstore.New` undefined). (Without `FORGE_TEST_POSTGRES_DSN` the tests skip once it compiles — compilation failure is the RED here.)
+
+- [ ] **Step 4: Write the implementation**
+
+`auth/totp/pgstore/doc.go`:
+
+```go
+// Package pgstore is the Postgres implementation of totp.Store: one
+// forge_totp table keyed (tenant, subject), with MarkUsed and
+// ConsumeBackup as single conditional UPDATEs so replay and backup-code
+// races resolve in the database. The DDL ships as an embedded goose
+// migration in Migrations; apply it via data/migration under its own
+// version table (e.g. "forge_totp_schema").
+package pgstore
+```
+
+`auth/totp/pgstore/pgstore.go`:
+
+```go
+package pgstore
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"io/fs"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/auth/totp"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_totp, rooted so its
+// .sql files sit at fsys root (data/migration.New globs the fsys root, not
+// subdirectories). Apply via data/migration under its own version table
+// ("forge_totp_schema").
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// Store is the Postgres implementation of totp.Store. The pool's lifecycle
+// is the caller's.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+var _ totp.Store = (*Store)(nil)
+
+// New builds a Postgres totp Store. Apply Migrations first.
+func New(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+// Get returns the record, or totp.ErrNotFound.
+func (s *Store) Get(ctx context.Context, tenant, subject string) (*totp.Record, error) {
+	var r totp.Record
+	var lastUsed *time.Time
+	err := s.pool.QueryRow(ctx,
+		`SELECT secret, confirmed, last_used_at, backup_hashes
+		 FROM forge_totp WHERE tenant = $1 AND subject = $2`,
+		tenant, subject).Scan(&r.Secret, &r.Confirmed, &lastUsed, &r.BackupHashes)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, totp.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if lastUsed != nil {
+		r.LastUsedAt = *lastUsed
+	}
+	return &r, nil
+}
+
+// Save upserts the record (full replace of mutable columns).
+func (s *Store) Save(ctx context.Context, tenant, subject string, r *totp.Record) error {
+	hashes := r.BackupHashes
+	if hashes == nil {
+		hashes = [][]byte{}
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO forge_totp (tenant, subject, secret, confirmed, last_used_at, backup_hashes)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (tenant, subject) DO UPDATE SET
+		   secret = EXCLUDED.secret,
+		   confirmed = EXCLUDED.confirmed,
+		   last_used_at = EXCLUDED.last_used_at,
+		   backup_hashes = EXCLUDED.backup_hashes,
+		   updated_at = now()`,
+		tenant, subject, r.Secret, r.Confirmed, nullTime(r.LastUsedAt), hashes)
+	return err
+}
+
+// Delete removes the record; absent is a no-op.
+func (s *Store) Delete(ctx context.Context, tenant, subject string) error {
+	_, err := s.pool.Exec(ctx,
+		`DELETE FROM forge_totp WHERE tenant = $1 AND subject = $2`, tenant, subject)
+	return err
+}
+
+// MarkUsed atomically advances last_used_at iff the stored value is
+// earlier (or NULL). The condition lives in the WHERE clause, so
+// concurrent verifies of the same step resolve to exactly one winner.
+func (s *Store) MarkUsed(ctx context.Context, tenant, subject string, usedAt time.Time) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE forge_totp SET last_used_at = $3, updated_at = now()
+		 WHERE tenant = $1 AND subject = $2
+		   AND (last_used_at IS NULL OR last_used_at < $3)`,
+		tenant, subject, usedAt)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// ConsumeBackup atomically removes hash if present; the ANY guard makes
+// concurrent consumes of the same code resolve to exactly one winner.
+func (s *Store) ConsumeBackup(ctx context.Context, tenant, subject string, hash []byte) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE forge_totp SET backup_hashes = array_remove(backup_hashes, $3), updated_at = now()
+		 WHERE tenant = $1 AND subject = $2 AND $3 = ANY(backup_hashes)`,
+		tenant, subject, hash)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// DeleteTenant removes every record in tenant — exact match on the leading
+// PK column, no pattern matching.
+func (s *Store) DeleteTenant(ctx context.Context, tenant string) (int, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM forge_totp WHERE tenant = $1`, tenant)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+// nullTime maps the zero time to SQL NULL.
+func nullTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}
+```
+
+- [ ] **Step 5: Run integration tests against ephemeral Postgres**
+
+```bash
+docker run -d --name forge-totp-pg -e POSTGRES_PASSWORD=test -e POSTGRES_DB=forge -p 5433:5432 postgres:16-alpine
+sleep 3
+FORGE_TEST_POSTGRES_DSN="postgres://postgres:test@localhost:5433/forge?sslmode=disable" go test -race -count=1 ./auth/totp/pgstore/
+docker rm -f forge-totp-pg
+```
+
+Expected: PASS live against pg16 (this is where plan-vs-postgres mismatches surface — bytea[] scanning, NULL mapping, rows-affected semantics). Also run `go test ./auth/totp/pgstore/` without the DSN — expected: SKIP, not FAIL.
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+just fmt ./auth/totp/pgstore/
+just lint
+git add auth/totp/pgstore/
+git commit -m "feat(totp): Postgres store — conditional-update replay/consume gates, embedded migration"
+```
+
+---
+
+### Task 14: Catalog update + final sweep
+
+**Files:**
+- Modify: `docs/packages.md` (delete the `**auth/totp**` roadmap entry — heading, description paragraph, and `Deps:` line, plus its `---` separator)
+
+**Interfaces:**
+- Consumes: design.md roadmap rule — "the moment a package ships, delete its entry"; the catalog carries no shipped markers.
+- Produces: clean catalog; green branch ready for PR.
+
+- [ ] **Step 1: Delete the roadmap entry**
+
+In `docs/packages.md`, remove the block (located around line 645):
+
+```markdown
+**auth/totp**
+
+The complete 2FA package: RFC 6238/4226 TOTP/HOTP secret generation,
+skew-window verify, otpauth:// provisioning URI, and one-time backup codes
+(generate/hash/verify-and-consume, constant-time). QR image rendering
+lights up via `core/qrcode`. Persistence is consumer DB.
+
+Deps: `core/qrcode`, `core/random`, `crypto/consttime`.
+
+---
+```
+
+Check whether any other packages.md entry references `auth/totp` in its Deps or prose (`grep -n "totp" docs/packages.md`) — `auth/lockout` mentions OTP flows generically and stays; only the totp entry itself goes.
+
+- [ ] **Step 2: Full-repo verification**
+
+```bash
+just fmt ./auth/totp/ && just fmt ./auth/totp/pgstore/
+just lint
+just test ./auth/totp/ ; just test ./auth/totp/pgstore/
+go test -race -count=1 ./...
+```
+
+Expected: lint clean (golangci, nilaway, betteralign, modernize), all tests green repo-wide.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/packages.md
+git commit -m "docs(packages): drop shipped auth/totp roadmap entry"
+```
+
+---
+
+## Self-Review Notes (already applied)
+
+- Spec coverage: every spec section maps to a task — primitives (T1–6), Store+memory (T7), Manager (T8–10), doc.go recipes (T11), fuzz/bench (T12), pgstore (T13), catalog (T14). Tenancy tests (spec §Testing) live in T10 + T13.
+- The spec's `New(pool, opts ...Option)` for pgstore was corrected to `New(pool)` in the spec itself (apikey precedent, no options exist).
+- Type consistency: `tenant()`/`record()`/`openSecret()` helper names used in T9–10 are defined in T8; `hotp`/`decodeSecret` used in T3–4 are defined in T2; `b32`/`rfc4226Raw`/`rfc4226Codes` test helpers used in T3–4 are defined in T2's test file; `newManager`/`codeFor`/`testKey`/`fixedNow` used in T9–10 tests are defined in T8's test file; `enroll` used in T10 is defined in T9's test file (same package).
+- `wg.Go` (not `wg.Add`+`go`+`defer Done`) in concurrent tests — modernize's waitgroupgo check requires it (recurring plan-authoring miss in earlier packages).

--- a/docs/superpowers/specs/2026-07-13-auth-totp-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-totp-design.md
@@ -55,16 +55,17 @@ core/qrcode".
   state machine; the store sees only opaque bytes.
 - **Encryption at rest is mandatory.** `NewManager` requires key material;
   there is no plaintext-storage configuration.
-- **Tenancy-agnostic via an opaque `subject` key.** Multi-tenant apps
-  disagree about where 2FA lives: account-global (GitHub — one enrollment
-  across all orgs; key = userID) vs per-tenant identity (Slack — separate
-  enrollment per workspace; key = tenantID+userID). The Manager/Store key is
-  therefore an opaque `subject string` — the consumer encodes whatever
-  identifies an enrollment in their auth model. Single-tenant apps pass the
-  user ID; per-tenant apps pass a composite like `tenantID + "/" + userID`
-  (safe when IDs cannot contain the separator — forge `core/id` IDs never
-  do). No tenant parameter, no ctx-derived tenant func (at login time there
-  is no authenticated context to derive from). Documented as a doc.go recipe.
+- **Tenancy via the canonical `WithScope` hook** (repo-wide rule; follows
+  `auth/apikey`/`auth/otp` shipped precedent). The Manager takes an optional
+  construction-time `WithScope(func(ctx) (string, error))` hook that derives
+  the tenant from the request context on every operation, so no call site
+  can forget isolation. Fail-closed: a hook error or empty scope aborts with
+  `ErrScope`. Tenant is a first-class dimension of the store key —
+  `(tenant, subject)` — never encoded into the subject string. Single-tenant
+  apps omit the option (tenant `""`), zero ceremony. Account-global 2FA in a
+  multi-tenant app (GitHub model) also omits it; per-tenant enrollment
+  (Slack model) wires the hook to the tenant middleware. Bulk cleanup is
+  exact-match by tenant — no prefix/LIKE matching anywhere.
 - **pgstore ships in the same PR** (precedent: `resilience/lock/pgstore`).
 
 ## API surface — core primitives
@@ -140,7 +141,7 @@ func (m *Manager) Enabled(ctx context.Context, subject string) (bool, error)
 func (m *Manager) LastVerified(ctx context.Context, subject string) (time.Time, error)
 func (m *Manager) RegenerateBackupCodes(ctx context.Context, subject string) ([]string, error)
 func (m *Manager) Disable(ctx context.Context, subject string) error
-func (m *Manager) DisableAll(ctx context.Context, subjectPrefix string) (int, error)
+func (m *Manager) DisableTenant(ctx context.Context) (int, error)
 
 type Enrollment struct {
     Secret string // show for manual entry
@@ -180,12 +181,19 @@ Semantics:
 - **LastVerified** — `ErrNotEnrolled` unless a confirmed record exists;
   zero time when confirmed but never re-verified.
 - **Disable** — deletes the record entirely (secret, hashes, state).
-- **DisableAll** — bulk-deletes every record whose subject starts with
-  `subjectPrefix` (tenant offboarding: `DisableAll(ctx, tenantID+"/")`),
-  returns the count. Requires the store to implement the optional
-  `BulkDeleter` extension — `ErrUnsupported` otherwise. Deleting one user
-  across all tenants is *not* prefix-shaped (user is the suffix); the doc.go
-  recipe is to iterate the app's own membership list and `Disable` each.
+- **DisableTenant** — bulk-deletes every record in the scope-resolved tenant
+  (offboarding, GDPR), returns the count. Requires `WithScope`: on an
+  unscoped Manager it returns `ErrScope` (an unscoped app has no tenant to
+  delete; platform-level jobs run it with a ctx bound to the target tenant —
+  the "tenant switching" pattern from the `auth/otp` docs). Deleting one
+  user across all tenants is the consumer's membership loop: per membership,
+  a tenant-bound ctx + `Disable` (doc.go recipe).
+
+Every Manager operation resolves the tenant via the scope hook first
+(`nil` hook → tenant `""`; hook error or empty scope → `ErrScope`) and passes
+it to the store alongside the subject. A record enrolled under one tenant is
+invisible to every other tenant — cross-tenant `Verify`/`Enabled`/`Disable`
+behave exactly as if the subject were not enrolled.
 
 ### Options (Manager-only, on top of core options)
 
@@ -193,6 +201,7 @@ Semantics:
 |---|---|
 | `WithBackupCodeCount(int)` | 10 |
 | `WithBackupCodeLength(int)` | 10 chars |
+| `WithScope(func(context.Context) (string, error))` | nil — unscoped, tenant `""` |
 
 ### Errors
 
@@ -203,7 +212,7 @@ var (
     ErrNotEnrolled     = errors.New("totp: not enrolled")
     ErrAlreadyEnrolled = errors.New("totp: already enrolled")
     ErrNotFound        = errors.New("totp: record not found") // store sentinel
-    ErrUnsupported     = errors.New("totp: store does not support bulk delete")
+    ErrScope           = errors.New("totp: scope resolution failed")
 )
 ```
 
@@ -222,35 +231,27 @@ type Record struct {
 }
 
 type Store interface {
-    Get(ctx context.Context, subject string) (*Record, error) // ErrNotFound when absent
-    Save(ctx context.Context, subject string, r *Record) error // upsert, full replace
-    Delete(ctx context.Context, subject string) error          // no-op when absent
+    Get(ctx context.Context, tenant, subject string) (*Record, error) // ErrNotFound when absent
+    Save(ctx context.Context, tenant, subject string, r *Record) error // upsert, full replace
+    Delete(ctx context.Context, tenant, subject string) error          // no-op when absent
     // MarkUsed atomically sets LastUsedAt=usedAt iff the stored value is
     // earlier (or zero). false = a concurrent verify already claimed this
     // or a later step. This is the replay/race gate.
-    MarkUsed(ctx context.Context, subject string, usedAt time.Time) (bool, error)
+    MarkUsed(ctx context.Context, tenant, subject string, usedAt time.Time) (bool, error)
     // ConsumeBackup atomically removes hash if present. false = not present
     // (already spent or never existed). This is the single-use gate.
-    ConsumeBackup(ctx context.Context, subject string, hash []byte) (bool, error)
+    ConsumeBackup(ctx context.Context, tenant, subject string, hash []byte) (bool, error)
+    // DeleteTenant removes every record in the tenant, returning the count.
+    DeleteTenant(ctx context.Context, tenant string) (int, error)
 }
 ```
 
-The two atomic methods carry all concurrency correctness; `Get`/`Save`/`Delete`
-are dumb CRUD. `NewMemoryStore()` ships in-package: `map[string]*Record` under
-an `sync.RWMutex`, records deep-copied on the way in and out.
-
-Optional extension (session `UserIndex` precedent — keeps the required seam
-small while both built-in stores implement it):
-
-```go
-type BulkDeleter interface {
-    DeleteByPrefix(ctx context.Context, subjectPrefix string) (int, error)
-}
-```
-
-`Manager.DisableAll` type-asserts the store and returns `ErrUnsupported` for
-custom stores that skip it. Memory store: `strings.HasPrefix` sweep under the
-write lock.
+Tenant is an explicit key dimension on every method (`""` = unscoped) — the
+Manager resolves it from the scope hook; stores never interpret it beyond
+equality. The two atomic methods carry all concurrency correctness; the rest
+is dumb CRUD. `NewMemoryStore()` ships in-package: map keyed on a
+`struct{ tenant, subject string }` under a `sync.RWMutex`, records
+deep-copied on the way in and out.
 
 ## pgstore
 
@@ -259,24 +260,24 @@ var Migrations fs.FS // embedded goose migration
 func New(pool *pgxpool.Pool, opts ...Option) *Store
 ```
 
-- Table `forge_totp`: `subject text PK`, `secret bytea NOT NULL`,
+- Table `forge_totp`: `tenant text NOT NULL DEFAULT ''`, `subject text`,
+  PK `(tenant, subject)`, `secret bytea NOT NULL`,
   `confirmed boolean NOT NULL DEFAULT false`,
   `last_used_at timestamptz`, `backup_hashes bytea[] NOT NULL DEFAULT '{}'`,
-  `created_at` / `updated_at timestamptz NOT NULL DEFAULT now()`.
+  `created_at` / `updated_at timestamptz NOT NULL DEFAULT now()`
+  (tenant column precedent: `auth/apikey` pgstore).
 - Applied via `data/migration` under its own version table
   (`forge_totp_schema`), same as lock/pgstore.
-- `MarkUsed`: `UPDATE forge_totp SET last_used_at=$2, updated_at=now()
-  WHERE subject=$1 AND (last_used_at IS NULL OR last_used_at < $2)` —
-  rows-affected = the boolean.
-- `ConsumeBackup`: `UPDATE forge_totp SET backup_hashes=array_remove(backup_hashes,$2),
-  updated_at=now() WHERE subject=$1 AND $2 = ANY(backup_hashes)` —
-  rows-affected = the boolean.
+- `MarkUsed`: `UPDATE forge_totp SET last_used_at=$3, updated_at=now()
+  WHERE tenant=$1 AND subject=$2 AND (last_used_at IS NULL OR last_used_at < $3)`
+  — rows-affected = the boolean.
+- `ConsumeBackup`: `UPDATE forge_totp SET backup_hashes=array_remove(backup_hashes,$3),
+  updated_at=now() WHERE tenant=$1 AND subject=$2 AND $3 = ANY(backup_hashes)`
+  — rows-affected = the boolean.
 - `Get` maps no-rows to `totp.ErrNotFound`. `Save` is an upsert
-  (`INSERT … ON CONFLICT (subject) DO UPDATE`).
-- `DeleteByPrefix`: `DELETE FROM forge_totp WHERE subject LIKE $1 || '%'`
-  with `%`, `_`, `\` escaped in the prefix; rows-affected = the count.
-  Prefix deletes are rare admin operations — a seq scan is acceptable, no
-  extra index.
+  (`INSERT … ON CONFLICT (tenant, subject) DO UPDATE`).
+- `DeleteTenant`: `DELETE FROM forge_totp WHERE tenant=$1` — exact match on
+  the leading PK column; rows-affected = the count.
 
 ## doc.go recipes
 
@@ -288,13 +289,15 @@ func New(pool *pgxpool.Pool, opts ...Option) *Store
 3. **Remember-this-device, device-scoped (recommended)** — signed cookie via
    `crypto/token` (`WithPurpose("2fa-device")`, TTL = trust window), checked
    before prompting. Three lines each side.
-4. **Multi-tenancy** — subject-key encoding for both models: account-global
-   2FA (`subject = userID`) vs per-tenant enrollment
-   (`subject = tenantID + "/" + userID`), with the separator-safety note and
-   guidance on picking a model (does an enrollment belong to the account or
-   to the membership?). Cleanup patterns: tenant offboarding =
-   `DisableAll(ctx, tenantID+"/")`; account deletion across tenants =
-   iterate the app's membership list, `Disable` each.
+4. **Multi-tenancy** — the `WithScope` hook wired to tenant middleware
+   (mirrors the `auth/otp` doc.go treatment): single-tenant omits the
+   option; account-global 2FA in a multi-tenant app (GitHub model) also
+   omits it; per-tenant enrollment (Slack model) returns the request's
+   tenant; platform-level code uses a reserved non-empty sentinel. Guidance
+   on picking a model (does an enrollment belong to the account or to the
+   membership?). Cleanup patterns: tenant offboarding = `DisableTenant`
+   under a tenant-bound ctx; account deletion across tenants = iterate the
+   app's membership list, `Disable` each.
 5. **Custom Store contract** — the exact atomicity requirements of
    `MarkUsed`/`ConsumeBackup`, with the reference SQL.
 6. **Brute-force pointer** — code guessing is rate-limited by `auth/lockout`
@@ -337,8 +340,13 @@ auth/totp/pgstore/
   exactly one success (`-race`).
 - **pgstore integration**: same lifecycle + MarkUsed/ConsumeBackup atomicity
   against ephemeral docker pg16; skipped without DSN.
-- **DeleteByPrefix**: deletes exactly the prefix-matched subjects (memory +
-  pg); LIKE metacharacters (`%`, `_`, `\`) in a prefix must not over-match.
+- **Tenancy** (mirrors `auth/otp` tenancy_test.go precedent): same subject
+  enrolled under two tenants = independent records (separate secrets,
+  counters, backup codes); cross-tenant Verify/Enabled/Disable see nothing;
+  fail-closed — hook error or empty scope → `ErrScope` on every method;
+  `DisableTenant` removes exactly one tenant's records (memory + pg) and
+  errors with `ErrScope` on an unscoped Manager; unscoped Manager and
+  scoped-with-sentinel Manager never collide.
 - **Fuzz**: `Verify` (secret/code inputs — malformed base32 must error, never
   panic) and backup-code normalization.
 - **Bench** (repo rule): `Verify` and `Code` with alloc counts; memory-store

--- a/docs/superpowers/specs/2026-07-13-auth-totp-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-totp-design.md
@@ -140,6 +140,7 @@ func (m *Manager) Enabled(ctx context.Context, subject string) (bool, error)
 func (m *Manager) LastVerified(ctx context.Context, subject string) (time.Time, error)
 func (m *Manager) RegenerateBackupCodes(ctx context.Context, subject string) ([]string, error)
 func (m *Manager) Disable(ctx context.Context, subject string) error
+func (m *Manager) DisableAll(ctx context.Context, subjectPrefix string) (int, error)
 
 type Enrollment struct {
     Secret string // show for manual entry
@@ -179,6 +180,12 @@ Semantics:
 - **LastVerified** — `ErrNotEnrolled` unless a confirmed record exists;
   zero time when confirmed but never re-verified.
 - **Disable** — deletes the record entirely (secret, hashes, state).
+- **DisableAll** — bulk-deletes every record whose subject starts with
+  `subjectPrefix` (tenant offboarding: `DisableAll(ctx, tenantID+"/")`),
+  returns the count. Requires the store to implement the optional
+  `BulkDeleter` extension — `ErrUnsupported` otherwise. Deleting one user
+  across all tenants is *not* prefix-shaped (user is the suffix); the doc.go
+  recipe is to iterate the app's own membership list and `Disable` each.
 
 ### Options (Manager-only, on top of core options)
 
@@ -196,6 +203,7 @@ var (
     ErrNotEnrolled     = errors.New("totp: not enrolled")
     ErrAlreadyEnrolled = errors.New("totp: already enrolled")
     ErrNotFound        = errors.New("totp: record not found") // store sentinel
+    ErrUnsupported     = errors.New("totp: store does not support bulk delete")
 )
 ```
 
@@ -231,6 +239,19 @@ The two atomic methods carry all concurrency correctness; `Get`/`Save`/`Delete`
 are dumb CRUD. `NewMemoryStore()` ships in-package: `map[string]*Record` under
 an `sync.RWMutex`, records deep-copied on the way in and out.
 
+Optional extension (session `UserIndex` precedent — keeps the required seam
+small while both built-in stores implement it):
+
+```go
+type BulkDeleter interface {
+    DeleteByPrefix(ctx context.Context, subjectPrefix string) (int, error)
+}
+```
+
+`Manager.DisableAll` type-asserts the store and returns `ErrUnsupported` for
+custom stores that skip it. Memory store: `strings.HasPrefix` sweep under the
+write lock.
+
 ## pgstore
 
 ```go
@@ -252,6 +273,10 @@ func New(pool *pgxpool.Pool, opts ...Option) *Store
   rows-affected = the boolean.
 - `Get` maps no-rows to `totp.ErrNotFound`. `Save` is an upsert
   (`INSERT … ON CONFLICT (subject) DO UPDATE`).
+- `DeleteByPrefix`: `DELETE FROM forge_totp WHERE subject LIKE $1 || '%'`
+  with `%`, `_`, `\` escaped in the prefix; rows-affected = the count.
+  Prefix deletes are rare admin operations — a seq scan is acceptable, no
+  extra index.
 
 ## doc.go recipes
 
@@ -267,7 +292,9 @@ func New(pool *pgxpool.Pool, opts ...Option) *Store
    2FA (`subject = userID`) vs per-tenant enrollment
    (`subject = tenantID + "/" + userID`), with the separator-safety note and
    guidance on picking a model (does an enrollment belong to the account or
-   to the membership?).
+   to the membership?). Cleanup patterns: tenant offboarding =
+   `DisableAll(ctx, tenantID+"/")`; account deletion across tenants =
+   iterate the app's membership list, `Disable` each.
 5. **Custom Store contract** — the exact atomicity requirements of
    `MarkUsed`/`ConsumeBackup`, with the reference SQL.
 6. **Brute-force pointer** — code guessing is rate-limited by `auth/lockout`
@@ -310,6 +337,8 @@ auth/totp/pgstore/
   exactly one success (`-race`).
 - **pgstore integration**: same lifecycle + MarkUsed/ConsumeBackup atomicity
   against ephemeral docker pg16; skipped without DSN.
+- **DeleteByPrefix**: deletes exactly the prefix-matched subjects (memory +
+  pg); LIKE metacharacters (`%`, `_`, `\`) in a prefix must not over-match.
 - **Fuzz**: `Verify` (secret/code inputs — malformed base32 must error, never
   panic) and backup-code normalization.
 - **Bench** (repo rule): `Verify` and `Code` with alloc counts; memory-store

--- a/docs/superpowers/specs/2026-07-13-auth-totp-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-totp-design.md
@@ -1,0 +1,311 @@
+# auth/totp — design
+
+Date: 2026-07-13
+Status: approved for planning
+
+## Purpose
+
+The complete 2FA package: RFC 6238 TOTP / RFC 4226 HOTP secret generation,
+skew-window verification with replay rejection, otpauth:// provisioning URIs,
+and one-time backup codes — plus a `Manager` over a `Store` seam that owns the
+whole enrollment/verify lifecycle so consumers never handle plaintext secrets,
+pending-enrollment state, hashing, or replay races themselves. Everything that
+touches the store is already encrypted (TOTP secret) or hashed (backup codes).
+
+## Placement
+
+```
+auth/totp/            core primitives + Manager + Store seam + memory store
+auth/totp/pgstore/    Postgres driver (pgx), embedded goose migrations
+```
+
+Two layers, both public:
+
+1. **Primitives** — stateless RFC math (`New`, `Verify`, `GenerateBackupCodes`,
+   …). Escape hatch for consumers with their own storage discipline.
+2. **Manager** — the flow orchestrator over `Store`. This is the documented
+   front door.
+
+`docs/packages.md` entry for `auth/totp` is updated in the same PR: deps become
+`core/random`, `core/clock`, `crypto/consttime`, `crypto/secret`
+(+ `crypto/keyset` for the rotation constructor); pgstore adds `data/postgres`
++ `data/migration`. `core/qrcode` is *not* imported — we emit the otpauth URI,
+the consumer renders it (`qrcode.DataURI(uri)`); the catalog note changes from
+"QR image rendering lights up via core/qrcode" to "QR rendering composes with
+core/qrcode".
+
+## Decisions (resolved during brainstorming)
+
+- **Replay protection is the default path.** `Verify` takes the last-used
+  value and returns the matched one; codes at or before the stored step are
+  rejected. Not optional, no boolean-only variant.
+- **`time.Time`, not raw counter, in the public API.** `Verify(secret, code,
+  lastUsed time.Time) (time.Time, error)` returns the *step-start* time
+  (`counter × period`), so the round-trip through a `timestamptz` column is
+  lossless (`t.Unix()/period` recovers the exact counter) and the stored value
+  survives a period reconfiguration. Zero `time.Time{}` = never verified.
+- **Grace period ("don't prompt again for N") is a recipe, not API.** It is
+  session policy: user-scoped grace is `time.Since(lastVerified) < N` off
+  `Manager.LastVerified`; device-scoped ("remember this browser") is a signed
+  cookie via `crypto/token`. Both documented in doc.go with the security
+  caveat that user-scoped grace silences 2FA on *all* devices.
+- **Manager + Store seam over consumer-managed columns.** Earlier drafts made
+  the consumer store pending secrets, hashes, and write conditional SQL; too
+  much boilerplate and too easy to store plaintext. The Manager owns the
+  state machine; the store sees only opaque bytes.
+- **Encryption at rest is mandatory.** `NewManager` requires key material;
+  there is no plaintext-storage configuration.
+- **pgstore ships in the same PR** (precedent: `resilience/lock/pgstore`).
+
+## API surface — core primitives
+
+```go
+func New(opts ...Option) (*TOTP, error)
+
+func (t *TOTP) GenerateSecret() (string, error)            // base32 (no padding), size per algorithm
+func (t *TOTP) ProvisioningURI(secret, account string) string
+func (t *TOTP) Code(secret string, at time.Time) (string, error)
+func (t *TOTP) Verify(secret, code string, lastUsed time.Time) (time.Time, error)
+
+// HOTP (RFC 4226); shares digits/algorithm config. Counter is caller state.
+func (t *TOTP) HOTPCode(secret string, counter uint64) (string, error)
+func (t *TOTP) VerifyHOTP(secret, code string, counter uint64, lookahead int) (uint64, error)
+```
+
+- `GenerateSecret`: random bytes via `core/random`, length matches the hash
+  (SHA-1 → 20, SHA-256 → 32, SHA-512 → 64) per RFC 4226 §4, encoded
+  uppercase base32 without padding.
+- `ProvisioningURI`: `otpauth://totp/<Issuer>:<account>?secret=…&issuer=…
+  &algorithm=…&digits=…&period=…` with label and params URL-escaped. Issuer
+  appears in both label and query param (Key Uri Format convention).
+- `Code`: computes the code for an explicit time — client side, CLIs, tests.
+- `Verify`: checks the presented code against every step in
+  `[now−skew, now+skew]` — evaluating **all** windows without early exit and
+  comparing via `crypto/consttime` — then rejects any matched step ≤ the step
+  derived from `lastUsed`. Success returns the matched step-start time for
+  the caller (or Manager) to persist.
+- `VerifyHOTP`: checks `counter … counter+lookahead`, returns the *next*
+  counter value to store on success (matched + 1).
+
+Backup codes are package-level functions (independent of TOTP params):
+
+```go
+func GenerateBackupCodes(count, length int) (codes []string, hashes [][]byte, err error)
+func VerifyBackupCode(code string, hashes [][]byte) (idx int, ok bool)
+```
+
+- Codes: `length` chars (Manager default 10) from an unambiguous alphanumeric
+  alphabet via `core/random`, displayed dash-grouped (`xxxxx-xxxxx`).
+- Normalization (lowercase, strip `-` and spaces) applied before hashing and
+  before verification, so user typing quirks don't matter.
+- Hashes: SHA-256 of the normalized code. Codes are high-entropy random —
+  a KDF (bcrypt/argon2) is unnecessary and would slow the constant-time scan.
+- `VerifyBackupCode` compares against **every** hash with
+  `consttime.BytesEqual` (no early exit), returns the matched index.
+
+### Options (core)
+
+| Option | Default | Validation |
+|---|---|---|
+| `WithIssuer(string)` | `""` | empty issuer → URI label is just the account, `issuer` param omitted (valid per Key Uri Format) |
+| `WithDigits(int)` | 6 | 6 or 8 |
+| `WithPeriod(time.Duration)` | 30s | ≥ 1s, whole seconds |
+| `WithAlgorithm(Algorithm)` | SHA1 | SHA1 \| SHA256 \| SHA512 |
+| `WithSkew(int)` | 1 | ≥ 0 |
+| `WithClock(clock.Clock)` | wall clock | — |
+
+`Algorithm` is a small enum type in this package (`totp.SHA1`, `totp.SHA256`,
+`totp.SHA512`).
+
+## API surface — Manager
+
+```go
+func NewManager(store Store, key []byte, opts ...Option) (*Manager, error)
+func ManagerFromKeyset(store Store, ks *keyset.Keyset, opts ...Option) (*Manager, error)
+
+func (m *Manager) BeginEnroll(ctx context.Context, userID, account string) (*Enrollment, error)
+func (m *Manager) ConfirmEnroll(ctx context.Context, userID, code string) (backupCodes []string, err error)
+func (m *Manager) Verify(ctx context.Context, userID, code string) (VerifyResult, error)
+func (m *Manager) Enabled(ctx context.Context, userID string) (bool, error)
+func (m *Manager) LastVerified(ctx context.Context, userID string) (time.Time, error)
+func (m *Manager) RegenerateBackupCodes(ctx context.Context, userID string) ([]string, error)
+func (m *Manager) Disable(ctx context.Context, userID string) error
+
+type Enrollment struct {
+    Secret string // show for manual entry
+    URI    string // render as QR (core/qrcode composes)
+}
+
+type VerifyResult struct {
+    UsedBackupCode  bool
+    BackupRemaining int // valid when UsedBackupCode
+}
+```
+
+Key material builds a `crypto/secret.Box` (AES-256-GCM, versioned ciphertext);
+`ManagerFromKeyset` mirrors `token.FromKeyset` and enables rotation.
+
+Semantics:
+
+- **BeginEnroll** — generates a secret, seals it, saves an *unconfirmed*
+  record (overwriting any earlier unconfirmed one — re-showing the QR is
+  idempotent). Fails with `ErrAlreadyEnrolled` if a confirmed record exists;
+  re-enrollment requires `Disable` first.
+- **ConfirmEnroll** — verifies the first code against the pending record
+  (lastUsed = zero), flips `Confirmed`, generates backup codes, stores hashes,
+  persists the matched step, returns plaintext codes exactly once.
+  `ErrNotEnrolled` without a pending record; `ErrInvalidCode` on mismatch
+  (record stays pending).
+- **Verify** — refuses unconfirmed records (`ErrNotEnrolled`). Tries TOTP
+  first: on code match, calls `Store.MarkUsed`; a `false` result means a
+  concurrent request or replay already consumed that step → `ErrReplayed`.
+  On TOTP mismatch, normalizes and hashes the input and scans backup hashes;
+  on match calls `Store.ConsumeBackup` (a `false` result → `ErrInvalidCode`,
+  the code was already spent). Neither path matching → `ErrInvalidCode`.
+- **RegenerateBackupCodes** — replaces all hashes, returns fresh plaintext
+  codes; `ErrNotEnrolled` unless confirmed.
+- **Enabled** — `true` only for a confirmed record; absent or pending →
+  `false, nil` (not an error — it's a policy query).
+- **LastVerified** — `ErrNotEnrolled` unless a confirmed record exists;
+  zero time when confirmed but never re-verified.
+- **Disable** — deletes the record entirely (secret, hashes, state).
+
+### Options (Manager-only, on top of core options)
+
+| Option | Default |
+|---|---|
+| `WithBackupCodeCount(int)` | 10 |
+| `WithBackupCodeLength(int)` | 10 chars |
+
+### Errors
+
+```go
+var (
+    ErrInvalidCode     = errors.New("totp: invalid code")
+    ErrReplayed        = errors.New("totp: code already used")
+    ErrNotEnrolled     = errors.New("totp: not enrolled")
+    ErrAlreadyEnrolled = errors.New("totp: already enrolled")
+    ErrNotFound        = errors.New("totp: record not found") // store sentinel
+)
+```
+
+Config validation errors surface from `New`/`NewManager` as plain wrapped
+errors. Decryption failure of a stored secret surfaces `secret.ErrDecryptFailed`
+wrapped — it means key material is wrong, not that the user typed a bad code.
+
+## Store contract
+
+```go
+type Record struct {
+    Secret       []byte    // AEAD ciphertext — the store never sees plaintext
+    Confirmed    bool
+    LastUsedAt   time.Time // zero = never verified
+    BackupHashes [][]byte  // SHA-256 of normalized codes
+}
+
+type Store interface {
+    Get(ctx context.Context, userID string) (*Record, error) // ErrNotFound when absent
+    Save(ctx context.Context, userID string, r *Record) error // upsert, full replace
+    Delete(ctx context.Context, userID string) error          // no-op when absent
+    // MarkUsed atomically sets LastUsedAt=usedAt iff the stored value is
+    // earlier (or zero). false = a concurrent verify already claimed this
+    // or a later step. This is the replay/race gate.
+    MarkUsed(ctx context.Context, userID string, usedAt time.Time) (bool, error)
+    // ConsumeBackup atomically removes hash if present. false = not present
+    // (already spent or never existed). This is the single-use gate.
+    ConsumeBackup(ctx context.Context, userID string, hash []byte) (bool, error)
+}
+```
+
+The two atomic methods carry all concurrency correctness; `Get`/`Save`/`Delete`
+are dumb CRUD. `NewMemoryStore()` ships in-package: `map[string]*Record` under
+an `sync.RWMutex`, records deep-copied on the way in and out.
+
+## pgstore
+
+```go
+var Migrations fs.FS // embedded goose migration
+func New(pool *pgxpool.Pool, opts ...Option) *Store
+```
+
+- Table `forge_totp`: `user_id text PK`, `secret bytea NOT NULL`,
+  `confirmed boolean NOT NULL DEFAULT false`,
+  `last_used_at timestamptz`, `backup_hashes bytea[] NOT NULL DEFAULT '{}'`,
+  `created_at` / `updated_at timestamptz NOT NULL DEFAULT now()`.
+- Applied via `data/migration` under its own version table
+  (`forge_totp_schema`), same as lock/pgstore.
+- `MarkUsed`: `UPDATE forge_totp SET last_used_at=$2, updated_at=now()
+  WHERE user_id=$1 AND (last_used_at IS NULL OR last_used_at < $2)` —
+  rows-affected = the boolean.
+- `ConsumeBackup`: `UPDATE forge_totp SET backup_hashes=array_remove(backup_hashes,$2),
+  updated_at=now() WHERE user_id=$1 AND $2 = ANY(backup_hashes)` —
+  rows-affected = the boolean.
+- `Get` maps no-rows to `totp.ErrNotFound`. `Save` is an upsert
+  (`INSERT … ON CONFLICT (user_id) DO UPDATE`).
+
+## doc.go recipes
+
+1. **Full flow** — enroll (QR via `qrcode.DataURI`), confirm, login verify —
+   the Manager version, a dozen lines.
+2. **Grace period, user-scoped** — `mgr.LastVerified` + `time.Since(...) < N`,
+   with the caveat: verifying on one device silences prompts on all devices
+   for N.
+3. **Remember-this-device, device-scoped (recommended)** — signed cookie via
+   `crypto/token` (`WithPurpose("2fa-device")`, TTL = trust window), checked
+   before prompting. Three lines each side.
+4. **Custom Store contract** — the exact atomicity requirements of
+   `MarkUsed`/`ConsumeBackup`, with the reference SQL.
+5. **Brute-force pointer** — code guessing is rate-limited by `auth/lockout`
+   (planned), not by this package.
+
+## File anatomy
+
+```
+auth/totp/
+    doc.go            package docs + recipes
+    totp.go           TOTP struct, New, Code, Verify, HOTP
+    secret.go         GenerateSecret, ProvisioningURI
+    backup.go         GenerateBackupCodes, VerifyBackupCode, normalization
+    manager.go        Manager
+    store.go          Store, Record, memory store
+    options.go        options for both constructors
+    errors.go         sentinels
+    *_test.go         black-box (package totp_test)
+    bench_test.go
+auth/totp/pgstore/
+    doc.go
+    pgstore.go
+    pgstore_test.go   integration, skips without docker DSN
+    migrations/00001_totp.sql
+```
+
+## Testing
+
+- **RFC vectors**: RFC 6238 Appendix B (all three algorithms, 8 digits) and
+  RFC 4226 Appendix D (10 HOTP codes) verbatim.
+- **Verify semantics**: skew acceptance at ±1, rejection at ±2; replay
+  rejection at the exact matched step and at earlier steps; `time.Time`
+  round-trip equals counter round-trip.
+- **Backup codes**: normalization equivalence (`ABCDE-FGHIJ` ≡ `abcdefghij`),
+  consume-once via store, constant scan over full list.
+- **Manager lifecycle**: begin → confirm → verify → regenerate → disable;
+  `ErrAlreadyEnrolled` / `ErrNotEnrolled` edges; unconfirmed record refuses
+  Verify; ConfirmEnroll failure leaves record pending.
+- **Concurrency**: parallel `Verify` with the same code against memory store —
+  exactly one success (`-race`).
+- **pgstore integration**: same lifecycle + MarkUsed/ConsumeBackup atomicity
+  against ephemeral docker pg16; skipped without DSN.
+- **Fuzz**: `Verify` (secret/code inputs — malformed base32 must error, never
+  panic) and backup-code normalization.
+- **Bench** (repo rule): `Verify` and `Code` with alloc counts; memory-store
+  `MarkUsed` under contention.
+
+## Non-goals (anti-scope)
+
+- No rate limiting / attempt counting — `auth/lockout` composes.
+- No HTTP handlers, middleware, or cookie management — recipes only.
+- No QR image rendering — emit URI, `core/qrcode` composes.
+- No plaintext-at-rest mode, no `WithoutEncryption`.
+- No `WithSecretSize` (derived from algorithm), no backup-code format options,
+  no otpauth `image` extension — icebox until a real consumer asks.
+- No SMS/email OTP — that's `auth/otp` (separate catalog entry).

--- a/docs/superpowers/specs/2026-07-13-auth-totp-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-totp-design.md
@@ -26,13 +26,12 @@ Two layers, both public:
 2. **Manager** — the flow orchestrator over `Store`. This is the documented
    front door.
 
-`docs/packages.md` entry for `auth/totp` is updated in the same PR: deps become
-`core/random`, `core/clock`, `crypto/consttime`, `crypto/secret`
-(+ `crypto/keyset` for the rotation constructor); pgstore adds `data/postgres`
-+ `data/migration`. `core/qrcode` is *not* imported — we emit the otpauth URI,
-the consumer renders it (`qrcode.DataURI(uri)`); the catalog note changes from
-"QR image rendering lights up via core/qrcode" to "QR rendering composes with
-core/qrcode".
+`docs/packages.md` entry for `auth/totp` is deleted in the same PR (design.md
+roadmap rule: the catalog lists only unbuilt packages; doc.go becomes the
+reference). Actual deps: `core/random`, `core/clock`, `crypto/consttime`,
+`crypto/secret` (+ `crypto/keyset` for the rotation constructor); pgstore adds
+`data/postgres` + `data/migration`. `core/qrcode` is *not* imported — we emit
+the otpauth URI, the consumer renders it (`qrcode.DataURI(uri)`).
 
 ## Decisions (resolved during brainstorming)
 
@@ -257,7 +256,7 @@ deep-copied on the way in and out.
 
 ```go
 var Migrations fs.FS // embedded goose migration
-func New(pool *pgxpool.Pool, opts ...Option) *Store
+func New(pool *pgxpool.Pool) *Store // no options needed (apikey/pgstore precedent)
 ```
 
 - Table `forge_totp`: `tenant text NOT NULL DEFAULT ''`, `subject text`,

--- a/docs/superpowers/specs/2026-07-13-auth-totp-design.md
+++ b/docs/superpowers/specs/2026-07-13-auth-totp-design.md
@@ -55,6 +55,16 @@ core/qrcode".
   state machine; the store sees only opaque bytes.
 - **Encryption at rest is mandatory.** `NewManager` requires key material;
   there is no plaintext-storage configuration.
+- **Tenancy-agnostic via an opaque `subject` key.** Multi-tenant apps
+  disagree about where 2FA lives: account-global (GitHub — one enrollment
+  across all orgs; key = userID) vs per-tenant identity (Slack — separate
+  enrollment per workspace; key = tenantID+userID). The Manager/Store key is
+  therefore an opaque `subject string` — the consumer encodes whatever
+  identifies an enrollment in their auth model. Single-tenant apps pass the
+  user ID; per-tenant apps pass a composite like `tenantID + "/" + userID`
+  (safe when IDs cannot contain the separator — forge `core/id` IDs never
+  do). No tenant parameter, no ctx-derived tenant func (at login time there
+  is no authenticated context to derive from). Documented as a doc.go recipe.
 - **pgstore ships in the same PR** (precedent: `resilience/lock/pgstore`).
 
 ## API surface — core primitives
@@ -123,13 +133,13 @@ func VerifyBackupCode(code string, hashes [][]byte) (idx int, ok bool)
 func NewManager(store Store, key []byte, opts ...Option) (*Manager, error)
 func ManagerFromKeyset(store Store, ks *keyset.Keyset, opts ...Option) (*Manager, error)
 
-func (m *Manager) BeginEnroll(ctx context.Context, userID, account string) (*Enrollment, error)
-func (m *Manager) ConfirmEnroll(ctx context.Context, userID, code string) (backupCodes []string, err error)
-func (m *Manager) Verify(ctx context.Context, userID, code string) (VerifyResult, error)
-func (m *Manager) Enabled(ctx context.Context, userID string) (bool, error)
-func (m *Manager) LastVerified(ctx context.Context, userID string) (time.Time, error)
-func (m *Manager) RegenerateBackupCodes(ctx context.Context, userID string) ([]string, error)
-func (m *Manager) Disable(ctx context.Context, userID string) error
+func (m *Manager) BeginEnroll(ctx context.Context, subject, account string) (*Enrollment, error)
+func (m *Manager) ConfirmEnroll(ctx context.Context, subject, code string) (backupCodes []string, err error)
+func (m *Manager) Verify(ctx context.Context, subject, code string) (VerifyResult, error)
+func (m *Manager) Enabled(ctx context.Context, subject string) (bool, error)
+func (m *Manager) LastVerified(ctx context.Context, subject string) (time.Time, error)
+func (m *Manager) RegenerateBackupCodes(ctx context.Context, subject string) ([]string, error)
+func (m *Manager) Disable(ctx context.Context, subject string) error
 
 type Enrollment struct {
     Secret string // show for manual entry
@@ -204,16 +214,16 @@ type Record struct {
 }
 
 type Store interface {
-    Get(ctx context.Context, userID string) (*Record, error) // ErrNotFound when absent
-    Save(ctx context.Context, userID string, r *Record) error // upsert, full replace
-    Delete(ctx context.Context, userID string) error          // no-op when absent
+    Get(ctx context.Context, subject string) (*Record, error) // ErrNotFound when absent
+    Save(ctx context.Context, subject string, r *Record) error // upsert, full replace
+    Delete(ctx context.Context, subject string) error          // no-op when absent
     // MarkUsed atomically sets LastUsedAt=usedAt iff the stored value is
     // earlier (or zero). false = a concurrent verify already claimed this
     // or a later step. This is the replay/race gate.
-    MarkUsed(ctx context.Context, userID string, usedAt time.Time) (bool, error)
+    MarkUsed(ctx context.Context, subject string, usedAt time.Time) (bool, error)
     // ConsumeBackup atomically removes hash if present. false = not present
     // (already spent or never existed). This is the single-use gate.
-    ConsumeBackup(ctx context.Context, userID string, hash []byte) (bool, error)
+    ConsumeBackup(ctx context.Context, subject string, hash []byte) (bool, error)
 }
 ```
 
@@ -228,20 +238,20 @@ var Migrations fs.FS // embedded goose migration
 func New(pool *pgxpool.Pool, opts ...Option) *Store
 ```
 
-- Table `forge_totp`: `user_id text PK`, `secret bytea NOT NULL`,
+- Table `forge_totp`: `subject text PK`, `secret bytea NOT NULL`,
   `confirmed boolean NOT NULL DEFAULT false`,
   `last_used_at timestamptz`, `backup_hashes bytea[] NOT NULL DEFAULT '{}'`,
   `created_at` / `updated_at timestamptz NOT NULL DEFAULT now()`.
 - Applied via `data/migration` under its own version table
   (`forge_totp_schema`), same as lock/pgstore.
 - `MarkUsed`: `UPDATE forge_totp SET last_used_at=$2, updated_at=now()
-  WHERE user_id=$1 AND (last_used_at IS NULL OR last_used_at < $2)` —
+  WHERE subject=$1 AND (last_used_at IS NULL OR last_used_at < $2)` —
   rows-affected = the boolean.
 - `ConsumeBackup`: `UPDATE forge_totp SET backup_hashes=array_remove(backup_hashes,$2),
-  updated_at=now() WHERE user_id=$1 AND $2 = ANY(backup_hashes)` —
+  updated_at=now() WHERE subject=$1 AND $2 = ANY(backup_hashes)` —
   rows-affected = the boolean.
 - `Get` maps no-rows to `totp.ErrNotFound`. `Save` is an upsert
-  (`INSERT … ON CONFLICT (user_id) DO UPDATE`).
+  (`INSERT … ON CONFLICT (subject) DO UPDATE`).
 
 ## doc.go recipes
 
@@ -253,9 +263,14 @@ func New(pool *pgxpool.Pool, opts ...Option) *Store
 3. **Remember-this-device, device-scoped (recommended)** — signed cookie via
    `crypto/token` (`WithPurpose("2fa-device")`, TTL = trust window), checked
    before prompting. Three lines each side.
-4. **Custom Store contract** — the exact atomicity requirements of
+4. **Multi-tenancy** — subject-key encoding for both models: account-global
+   2FA (`subject = userID`) vs per-tenant enrollment
+   (`subject = tenantID + "/" + userID`), with the separator-safety note and
+   guidance on picking a model (does an enrollment belong to the account or
+   to the membership?).
+5. **Custom Store contract** — the exact atomicity requirements of
    `MarkUsed`/`ConsumeBackup`, with the reference SQL.
-5. **Brute-force pointer** — code guessing is rate-limited by `auth/lockout`
+6. **Brute-force pointer** — code guessing is rate-limited by `auth/lockout`
    (planned), not by this package.
 
 ## File anatomy


### PR DESCRIPTION
## auth/totp — complete 2FA package

RFC 6238/4226 TOTP/HOTP primitives, otpauth:// provisioning, one-time backup codes, plus a `Manager` over a tenant-aware `Store` seam (memory + Postgres) with mandatory AEAD encryption of secrets at rest.

### Architecture

Two public layers:

- **Layer 1 — stateless RFC math** on `*totp.TOTP`: `HOTPCode`/`VerifyHOTP` (RFC 4226), `GenerateSecret`, `Code`, skew-window `Verify` with replay rejection (RFC 6238), `ProvisioningURI`, and package-level backup codes (`GenerateBackupCodes`/`VerifyBackupCode`, constant-time).
- **Layer 2 — `Manager`** orchestrating enroll → confirm → verify → recover → disable over a 6-method `Store` keyed `(tenant, subject)`. TOTP secrets are `crypto/secret.Box` ciphertext (AES-256-GCM) before reaching any store; backup codes are stored as SHA-256 hashes; replay/race protection lives in two atomic store methods (`MarkUsed`, `ConsumeBackup`). Multi-tenancy enters only via the canonical fail-closed `WithScope(ctx)` hook.

Drivers: in-memory store + `pgstore` (embedded goose migration, conditional-UPDATE atomic gates).

### Security invariants (verified end-to-end by whole-branch review)

- No plaintext at rest — secret is AEAD ciphertext, backup codes are hashes.
- Replay-safe: a TOTP step verifies at most once; concurrent verifies of the same step resolve to exactly one winner (atomic `MarkUsed`).
- A replayed TOTP code never falls through to consume a backup code.
- Wrong key material surfaces as an operator error, never `ErrInvalidCode`.
- Fail-closed tenancy: a scoped Manager can never touch the unscoped namespace; empty/erroring scope → `ErrScope` on all 8 methods.
- memory store and pgstore are behaviorally equivalent.
- Constant-time comparisons on all code/hash checks.

### Verification

- `go test -race -count=1 ./...` — PASS, with **pgstore live against Postgres 16** (5 integration tests incl. full Manager lifecycle).
- auth/totp coverage **93.4%**.
- Fuzz: `FuzzVerify` 5.3M execs, `FuzzBackupCode` 2.6M execs — **0 crashers**.
- Whole-repo lint (golangci-lint, nilaway, betteralign, modernize): **0 issues**.
- RFC 4226 Appendix D and RFC 6238 Appendix B reference vectors pass for SHA1/SHA256/SHA512.

### Benchmarks (ns/op | allocs/op)

Auth flows are not hot paths, so no optimization pass was performed (magiclink precedent).

| Benchmark | ns/op | allocs/op |
|---|---|---|
| `Code` | 424 | 9 |
| `Verify` | 3,470 | 70 |
| `ManagerVerify` (mismatch fall-through) | 12,030 | 218 |
| `VerifyBackupCode` | 7,765 | 132 |

### Review feedback addressed

The enroll/confirm concurrency findings from review are now fixed (not deferred):

- **Enroll/confirm races** — added two atomic `Store` gates mirroring `MarkUsed`/`ConsumeBackup`: `SavePending` (upsert-if-not-confirmed) stops a `BeginEnroll` from reverting a just-confirmed enrollment, and `Confirm` (activate only if still pending **and** the secret is unchanged) makes concurrent double-submits resolve to exactly one winner and never activates a secret the user did not prove. Both implemented as single conditional statements in the memory and Postgres drivers, with store-level single-winner concurrency tests and a manager-level double-submit test.
- **otpauth label** — colons inside the issuer/account are now escaped so authenticator apps split on the `Issuer:account` separator; the `issuer=` query param still carries the raw value.
- **Store parity** — memory-store `BackupHashes` is normalized to always non-nil, matching the pgstore read shape.

`Store` grew from 6 to 8 methods (the two new atomic gates); the package is unreleased so there are no external implementers. All checks green: `go test -race ./...` with pgstore live against Postgres 16, lint 0 issues, auth/totp coverage 93.2%.
