### PR TITLE
feat(core/fsm): immutable compiled finite-state machine with guards, hooks, wildcards, and runtime Compile

### DIFF
--- a/core/fsm/bench_test.go
+++ b/core/fsm/bench_test.go
@@ -1,0 +1,95 @@
+package fsm_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/fsm"
+)
+
+func BenchmarkFire_BareEdge(b *testing.B) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen, d.Edge(statusOpen, statusDone))
+	v := &task{}
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := m.Fire(ctx, v, statusOpen, statusDone); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFire_GuardsAndHooks(b *testing.B) {
+	pass := func(ctx context.Context, v *task, from, to status) error { return nil }
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusDone, d.Guard(pass), d.Hook(pass)),
+		d.OnEnter(statusDone, d.Guard(pass), d.Hook(pass)),
+		d.OnExit(statusOpen, d.Guard(pass), d.Hook(pass)),
+	)
+	v := &task{}
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := m.Fire(ctx, v, statusOpen, statusDone); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAllowed(b *testing.B) {
+	deny := func(ctx context.Context, v *task, from, to status) error { return errors.New("no") }
+	pass := func(ctx context.Context, v *task, from, to status) error { return nil }
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusInProgress, d.Guard(pass)),
+		d.Edge(statusOpen, statusReview, d.Guard(deny)),
+		d.Edge(statusOpen, statusDone, d.Guard(pass)),
+		d.EdgeFromAny(statusCancelled),
+	)
+	v := &task{}
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := m.Allowed(ctx, v, statusOpen); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCompile(b *testing.B) {
+	// Realistic tenant flow: 10 states, ~25 edges, a wildcard, named callbacks.
+	states := make([]fsm.StateDef, 10)
+	for i := range 10 {
+		states[i] = fsm.StateDef{Name: fmt.Sprintf("state_%d", i)}
+	}
+	states[9].OnEnterGuards = []string{"check"}
+	states[9].OnEnterHooks = []string{"stamp"}
+	edges := make([]fsm.EdgeDef, 0, 25)
+	for i := range 8 {
+		edges = append(edges,
+			fsm.EdgeDef{From: fmt.Sprintf("state_%d", i), To: fmt.Sprintf("state_%d", i+1)},
+			fsm.EdgeDef{From: fmt.Sprintf("state_%d", i+1), To: fmt.Sprintf("state_%d", i)},
+			fsm.EdgeDef{From: fmt.Sprintf("state_%d", i), To: "state_9", Guards: []string{"check"}},
+		)
+	}
+	edges = append(edges, fsm.EdgeDef{From: "*", To: "state_0"})
+	def := fsm.Definition{Initial: "state_0", States: states, Edges: edges}
+	reg := fsm.Registry[*task]{
+		Guards: map[string]fsm.Func[string, *task]{
+			"check": func(ctx context.Context, v *task, from, to string) error { return nil },
+		},
+		Hooks: map[string]fsm.Func[string, *task]{
+			"stamp": func(ctx context.Context, v *task, from, to string) error { return nil },
+		},
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := fsm.Compile(def, reg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/core/fsm/define.go
+++ b/core/fsm/define.go
@@ -1,0 +1,168 @@
+package fsm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Define is a zero-size type-parameter anchor: declare
+// `var d fsm.Define[Status, *Task]` once and every part constructed
+// through d infers both type parameters. It is stateless — parts still
+// flow into New.
+type Define[S ~string, V any] struct{}
+
+// Attachment is a guard or hook bound to an edge or state via Edge,
+// EdgeFromAny, OnEnter, or OnExit.
+type Attachment[S ~string, V any] struct {
+	fn      Func[S, V]
+	isGuard bool
+}
+
+type partKind uint8
+
+const (
+	partEdge partKind = iota
+)
+
+// Part is one construction element consumed by New.
+type Part[S ~string, V any] struct {
+	from   S
+	to     S
+	guards []Func[S, V]
+	hooks  []Func[S, V]
+	kind   partKind
+}
+
+func split[S ~string, V any](atts []Attachment[S, V]) (guards, hooks []Func[S, V]) {
+	for _, a := range atts {
+		if a.isGuard {
+			guards = append(guards, a.fn)
+		} else {
+			hooks = append(hooks, a.fn)
+		}
+	}
+	return guards, hooks
+}
+
+// Edge declares a transition from -> to with optional guard/hook
+// attachments. A self-transition requires an explicit Edge(s, s).
+func (Define[S, V]) Edge(from, to S, atts ...Attachment[S, V]) Part[S, V] {
+	guards, hooks := split(atts)
+	return Part[S, V]{kind: partEdge, from: from, to: to, guards: guards, hooks: hooks}
+}
+
+// New compiles a typed machine. States are inferred: every state mentioned
+// by initial or any part is declared, in first-mention order. All
+// validation issues are aggregated into one single-line
+// ErrInvalidDefinition.
+func New[S ~string, V any](initial S, parts ...Part[S, V]) (*Machine[S, V], error) {
+	return build(initial, parts, nil)
+}
+
+// MustNew is New that panics on error, for var initialization of
+// compile-time flows (the regexp.MustCompile precedent).
+func MustNew[S ~string, V any](initial S, parts ...Part[S, V]) *Machine[S, V] {
+	m, err := New(initial, parts...)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+type builder[S ~string, V any] struct {
+	stateSet  map[S]struct{}
+	edges     map[edgeKey[S]]callbacks[S, V]
+	enter     map[S]callbacks[S, V]
+	exit      map[S]callbacks[S, V]
+	issues    []string
+	states    []S
+	nextOrder []edgeKey[S]
+}
+
+func (b *builder[S, V]) declare(name S) {
+	if _, ok := b.stateSet[name]; ok {
+		return
+	}
+	if issue := checkName(string(name)); issue != "" {
+		b.issues = append(b.issues, issue)
+	}
+	b.stateSet[name] = struct{}{}
+	b.states = append(b.states, name)
+}
+
+func checkName(name string) string {
+	switch {
+	case name == "":
+		return "empty state name"
+	case name == "*":
+		return `state named "*"`
+	case strings.TrimSpace(name) != name:
+		return fmt.Sprintf("state name %q has leading or trailing whitespace", name)
+	}
+	return ""
+}
+
+// build is the shared constructor behind New and Compile. preIssues lets
+// Compile merge its definition-level issues into the same single-line
+// aggregate.
+func build[S ~string, V any](initial S, parts []Part[S, V], preIssues []string) (*Machine[S, V], error) {
+	b := &builder[S, V]{
+		issues:   preIssues,
+		stateSet: make(map[S]struct{}),
+		edges:    make(map[edgeKey[S]]callbacks[S, V]),
+		enter:    make(map[S]callbacks[S, V]),
+		exit:     make(map[S]callbacks[S, V]),
+	}
+
+	// Pass 1: declare every mentioned state in first-mention order.
+	b.declare(initial)
+	for _, p := range parts {
+		if p.kind == partEdge {
+			b.declare(p.from)
+			b.declare(p.to)
+		}
+	}
+
+	// Pass 2: duplicate detection over literal (from, to) pairs.
+	explicit := make(map[edgeKey[S]]struct{}, len(parts))
+	for _, p := range parts {
+		if p.kind == partEdge {
+			key := edgeKey[S]{from: p.from, to: p.to}
+			if _, dup := explicit[key]; dup {
+				b.issues = append(b.issues, fmt.Sprintf("duplicate edge %s -> %s", p.from, p.to))
+				continue
+			}
+			explicit[key] = struct{}{}
+		}
+	}
+
+	// Pass 3: materialize edges in declaration order.
+	for _, p := range parts {
+		if p.kind == partEdge {
+			key := edgeKey[S]{from: p.from, to: p.to}
+			if _, exists := b.edges[key]; exists {
+				continue // duplicate, reported in pass 2
+			}
+			b.edges[key] = callbacks[S, V]{guards: p.guards, hooks: p.hooks}
+			b.nextOrder = append(b.nextOrder, key)
+		}
+	}
+
+	if len(b.issues) > 0 {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidDefinition, strings.Join(b.issues, "; "))
+	}
+
+	next := make(map[S][]S, len(b.states))
+	for _, key := range b.nextOrder {
+		next[key.from] = append(next[key.from], key.to)
+	}
+	return &Machine[S, V]{
+		stateSet: b.stateSet,
+		edges:    b.edges,
+		enter:    b.enter,
+		exit:     b.exit,
+		next:     next,
+		states:   b.states,
+		initial:  initial,
+	}, nil
+}

--- a/core/fsm/define.go
+++ b/core/fsm/define.go
@@ -24,6 +24,7 @@ const (
 	partEdge partKind = iota
 	partOnEnter
 	partOnExit
+	partEdgeFromAny
 )
 
 // Part is one construction element consumed by New.
@@ -51,6 +52,16 @@ func split[S ~string, V any](atts []Attachment[S, V]) (guards, hooks []Func[S, V
 func (Define[S, V]) Edge(from, to S, atts ...Attachment[S, V]) Part[S, V] {
 	guards, hooks := split(atts)
 	return Part[S, V]{kind: partEdge, from: from, to: to, guards: guards, hooks: hooks}
+}
+
+// EdgeFromAny declares a wildcard edge into to from every other declared
+// state. It expands at construction into concrete edges — pure sugar, no
+// runtime wildcard logic. An explicit Edge for a pair fully replaces the
+// expanded one; no self-loop is generated (a self-transition needs an
+// explicit Edge(s, s)).
+func (Define[S, V]) EdgeFromAny(to S, atts ...Attachment[S, V]) Part[S, V] {
+	guards, hooks := split(atts)
+	return Part[S, V]{kind: partEdgeFromAny, to: to, guards: guards, hooks: hooks}
 }
 
 // Guard wraps fn as a guard attachment: a side-effect-free check over
@@ -156,11 +167,14 @@ func build[S ~string, V any](initial S, parts []Part[S, V], preIssues []string) 
 			b.declare(p.to)
 		case partOnEnter, partOnExit:
 			b.declare(p.from)
+		case partEdgeFromAny:
+			b.declare(p.to)
 		}
 	}
 
 	// Pass 2: duplicate detection over literal (from, to) pairs.
 	explicit := make(map[edgeKey[S]]struct{}, len(parts))
+	wildcardSeen := make(map[S]struct{})
 	for _, p := range parts {
 		switch p.kind {
 		case partEdge:
@@ -170,11 +184,18 @@ func build[S ~string, V any](initial S, parts []Part[S, V], preIssues []string) 
 				continue
 			}
 			explicit[key] = struct{}{}
+		case partEdgeFromAny:
+			if _, dup := wildcardSeen[p.to]; dup {
+				b.issues = append(b.issues, fmt.Sprintf("duplicate edge * -> %s", p.to))
+				continue
+			}
+			wildcardSeen[p.to] = struct{}{}
 		case partOnEnter, partOnExit:
 		}
 	}
 
 	// Pass 3: materialize edges in declaration order.
+	wildcardDone := make(map[S]struct{})
 	for _, p := range parts {
 		switch p.kind {
 		case partEdge:
@@ -184,6 +205,22 @@ func build[S ~string, V any](initial S, parts []Part[S, V], preIssues []string) 
 			}
 			b.edges[key] = callbacks[S, V]{guards: p.guards, hooks: p.hooks}
 			b.nextOrder = append(b.nextOrder, key)
+		case partEdgeFromAny:
+			if _, dup := wildcardDone[p.to]; dup {
+				continue // duplicate, reported in pass 2
+			}
+			wildcardDone[p.to] = struct{}{}
+			for _, from := range b.states {
+				if from == p.to {
+					continue // wildcards never generate self-loops
+				}
+				key := edgeKey[S]{from: from, to: p.to}
+				if _, isExplicit := explicit[key]; isExplicit {
+					continue // an explicit edge fully replaces the expanded one
+				}
+				b.edges[key] = callbacks[S, V]{guards: p.guards, hooks: p.hooks}
+				b.nextOrder = append(b.nextOrder, key)
+			}
 		case partOnEnter:
 			cbs := b.enter[p.from]
 			cbs.guards = append(cbs.guards, p.guards...)

--- a/core/fsm/define.go
+++ b/core/fsm/define.go
@@ -25,6 +25,7 @@ const (
 	partOnEnter
 	partOnExit
 	partEdgeFromAny
+	partState
 )
 
 // Part is one construction element consumed by New.
@@ -62,6 +63,13 @@ func (Define[S, V]) Edge(from, to S, atts ...Attachment[S, V]) Part[S, V] {
 func (Define[S, V]) EdgeFromAny(to S, atts ...Attachment[S, V]) Part[S, V] {
 	guards, hooks := split(atts)
 	return Part[S, V]{kind: partEdgeFromAny, to: to, guards: guards, hooks: hooks}
+}
+
+// declareState declares a state without edges or attachments. Compile uses
+// it so every explicitly listed StateDef exists in the machine even when
+// nothing references it.
+func declareState[S ~string, V any](name S) Part[S, V] {
+	return Part[S, V]{kind: partState, from: name}
 }
 
 // Guard wraps fn as a guard attachment: a side-effect-free check over
@@ -165,7 +173,7 @@ func build[S ~string, V any](initial S, parts []Part[S, V], preIssues []string) 
 		case partEdge:
 			b.declare(p.from)
 			b.declare(p.to)
-		case partOnEnter, partOnExit:
+		case partOnEnter, partOnExit, partState:
 			b.declare(p.from)
 		case partEdgeFromAny:
 			b.declare(p.to)
@@ -190,7 +198,7 @@ func build[S ~string, V any](initial S, parts []Part[S, V], preIssues []string) 
 				continue
 			}
 			wildcardSeen[p.to] = struct{}{}
-		case partOnEnter, partOnExit:
+		case partOnEnter, partOnExit, partState:
 		}
 	}
 
@@ -231,6 +239,7 @@ func build[S ~string, V any](initial S, parts []Part[S, V], preIssues []string) 
 			cbs.guards = append(cbs.guards, p.guards...)
 			cbs.hooks = append(cbs.hooks, p.hooks...)
 			b.exit[p.from] = cbs
+		case partState:
 		}
 	}
 

--- a/core/fsm/define.go
+++ b/core/fsm/define.go
@@ -22,6 +22,8 @@ type partKind uint8
 
 const (
 	partEdge partKind = iota
+	partOnEnter
+	partOnExit
 )
 
 // Part is one construction element consumed by New.
@@ -49,6 +51,37 @@ func split[S ~string, V any](atts []Attachment[S, V]) (guards, hooks []Func[S, V
 func (Define[S, V]) Edge(from, to S, atts ...Attachment[S, V]) Part[S, V] {
 	guards, hooks := split(atts)
 	return Part[S, V]{kind: partEdge, from: from, to: to, guards: guards, hooks: hooks}
+}
+
+// Guard wraps fn as a guard attachment: a side-effect-free check over
+// preloaded data on v that denies the transition by returning an error.
+// Keep I/O out of guards so ErrGuardDenied always means a domain denial.
+func (Define[S, V]) Guard(fn Func[S, V]) Attachment[S, V] {
+	return Attachment[S, V]{fn: fn, isGuard: true}
+}
+
+// Hook wraps fn as a hook attachment: it may mutate v; an error aborts the
+// transition. Hooks run only after every guard passed and must confine
+// themselves to entity mutation — external effects belong after the
+// caller persists.
+func (Define[S, V]) Hook(fn Func[S, V]) Attachment[S, V] {
+	return Attachment[S, V]{fn: fn}
+}
+
+// OnEnter attaches guards/hooks that run on every transition into state,
+// regardless of source edge. Multiple OnEnter parts for one state append
+// in declaration order.
+func (Define[S, V]) OnEnter(state S, atts ...Attachment[S, V]) Part[S, V] {
+	guards, hooks := split(atts)
+	return Part[S, V]{kind: partOnEnter, from: state, guards: guards, hooks: hooks}
+}
+
+// OnExit attaches guards/hooks that run on every transition out of state,
+// regardless of target edge. Multiple OnExit parts for one state append
+// in declaration order.
+func (Define[S, V]) OnExit(state S, atts ...Attachment[S, V]) Part[S, V] {
+	guards, hooks := split(atts)
+	return Part[S, V]{kind: partOnExit, from: state, guards: guards, hooks: hooks}
 }
 
 // New compiles a typed machine. States are inferred: every state mentioned
@@ -117,34 +150,50 @@ func build[S ~string, V any](initial S, parts []Part[S, V], preIssues []string) 
 	// Pass 1: declare every mentioned state in first-mention order.
 	b.declare(initial)
 	for _, p := range parts {
-		if p.kind == partEdge {
+		switch p.kind {
+		case partEdge:
 			b.declare(p.from)
 			b.declare(p.to)
+		case partOnEnter, partOnExit:
+			b.declare(p.from)
 		}
 	}
 
 	// Pass 2: duplicate detection over literal (from, to) pairs.
 	explicit := make(map[edgeKey[S]]struct{}, len(parts))
 	for _, p := range parts {
-		if p.kind == partEdge {
+		switch p.kind {
+		case partEdge:
 			key := edgeKey[S]{from: p.from, to: p.to}
 			if _, dup := explicit[key]; dup {
 				b.issues = append(b.issues, fmt.Sprintf("duplicate edge %s -> %s", p.from, p.to))
 				continue
 			}
 			explicit[key] = struct{}{}
+		case partOnEnter, partOnExit:
 		}
 	}
 
 	// Pass 3: materialize edges in declaration order.
 	for _, p := range parts {
-		if p.kind == partEdge {
+		switch p.kind {
+		case partEdge:
 			key := edgeKey[S]{from: p.from, to: p.to}
 			if _, exists := b.edges[key]; exists {
 				continue // duplicate, reported in pass 2
 			}
 			b.edges[key] = callbacks[S, V]{guards: p.guards, hooks: p.hooks}
 			b.nextOrder = append(b.nextOrder, key)
+		case partOnEnter:
+			cbs := b.enter[p.from]
+			cbs.guards = append(cbs.guards, p.guards...)
+			cbs.hooks = append(cbs.hooks, p.hooks...)
+			b.enter[p.from] = cbs
+		case partOnExit:
+			cbs := b.exit[p.from]
+			cbs.guards = append(cbs.guards, p.guards...)
+			cbs.hooks = append(cbs.hooks, p.hooks...)
+			b.exit[p.from] = cbs
 		}
 	}
 

--- a/core/fsm/define_test.go
+++ b/core/fsm/define_test.go
@@ -87,3 +87,76 @@ func TestOnEnterOnExit_DeclareTheirState(t *testing.T) {
 	)
 	assert.Contains(t, m.States(), statusCancelled)
 }
+
+// newWildcardBoard: open -> in_progress -> review -> done, plus cancel-from-anywhere;
+// done -> cancelled is explicitly replaced with an extra guard.
+func newWildcardBoard(t *testing.T, log *[]string) *fsm.Machine[status, *task] {
+	t.Helper()
+	var d fsm.Define[status, *task]
+	m, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, statusInProgress),
+		d.Edge(statusInProgress, statusReview),
+		d.Edge(statusReview, statusDone),
+		d.EdgeFromAny(statusCancelled, d.Guard(record(log, "wildcard-guard", ""))),
+		d.Edge(statusDone, statusCancelled, d.Guard(record(log, "explicit-guard", ""))),
+	)
+	require.NoError(t, err)
+	return m
+}
+
+func TestEdgeFromAny_ExpandsToAllStates(t *testing.T) {
+	m := newWildcardBoard(t, new([]string))
+	for _, from := range []status{statusOpen, statusInProgress, statusReview, statusDone} {
+		assert.True(t, m.Can(from, statusCancelled), "from %s", from)
+	}
+}
+
+func TestEdgeFromAny_NoSelfLoop(t *testing.T) {
+	m := newWildcardBoard(t, new([]string))
+	assert.False(t, m.Can(statusCancelled, statusCancelled))
+}
+
+func TestEdgeFromAny_WildcardGuardAppliesToExpandedEdges(t *testing.T) {
+	var log []string
+	m := newWildcardBoard(t, &log)
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusOpen, statusCancelled))
+	assert.Equal(t, []string{"wildcard-guard"}, log)
+}
+
+func TestEdgeFromAny_ExplicitEdgeReplacesExpanded(t *testing.T) {
+	var log []string
+	m := newWildcardBoard(t, &log)
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusDone, statusCancelled))
+	assert.Equal(t, []string{"explicit-guard"}, log, "wildcard guard must NOT run on the replaced pair")
+}
+
+func TestEdgeFromAny_DuplicateWildcard(t *testing.T) {
+	var d fsm.Define[status, *task]
+	_, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, statusDone),
+		d.EdgeFromAny(statusCancelled),
+		d.EdgeFromAny(statusCancelled),
+	)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrInvalidDefinition))
+	assert.Contains(t, err.Error(), "duplicate edge * -> cancelled")
+}
+
+func TestEdgeFromAny_NextKeepsDeclarationPosition(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusInProgress),
+		d.EdgeFromAny(statusCancelled),
+		d.Edge(statusOpen, statusReview),
+	)
+	assert.Equal(t, []status{statusInProgress, statusCancelled, statusReview}, m.Next(statusOpen), "wildcard expands at its declaration position")
+}
+
+func TestEdgeFromAny_DeclaresItsTarget(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusDone),
+		d.EdgeFromAny(statusCancelled),
+	)
+	assert.Contains(t, m.States(), statusCancelled)
+}

--- a/core/fsm/define_test.go
+++ b/core/fsm/define_test.go
@@ -1,6 +1,7 @@
 package fsm_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -64,4 +65,25 @@ func TestMustNew_ReturnsMachine(t *testing.T) {
 	var d fsm.Define[status, *task]
 	m := fsm.MustNew(statusOpen, d.Edge(statusOpen, statusDone))
 	assert.True(t, m.Can(statusOpen, statusDone))
+}
+
+func TestOnEnter_MultiplePartsAppendInOrder(t *testing.T) {
+	var log []string
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusReview,
+		d.Edge(statusReview, statusDone),
+		d.OnEnter(statusDone, d.Hook(record(&log, "first", ""))),
+		d.OnEnter(statusDone, d.Hook(record(&log, "second", ""))),
+	)
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusReview, statusDone))
+	assert.Equal(t, []string{"first", "second"}, log)
+}
+
+func TestOnEnterOnExit_DeclareTheirState(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusDone),
+		d.OnExit(statusCancelled), // mentions a state with no edges
+	)
+	assert.Contains(t, m.States(), statusCancelled)
 }

--- a/core/fsm/define_test.go
+++ b/core/fsm/define_test.go
@@ -1,0 +1,67 @@
+package fsm_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/fsm"
+)
+
+func TestNew_DuplicateEdge(t *testing.T) {
+	var d fsm.Define[status, *task]
+	_, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, statusDone),
+		d.Edge(statusOpen, statusDone),
+	)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrInvalidDefinition))
+	assert.Contains(t, err.Error(), "duplicate edge open -> done")
+}
+
+func TestNew_InvalidStateNames(t *testing.T) {
+	var d fsm.Define[status, *task]
+	_, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, status("")),
+		d.Edge(statusOpen, status("*")),
+		d.Edge(statusOpen, status("done ")),
+	)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrInvalidDefinition))
+	assert.Contains(t, err.Error(), "empty state name")
+	assert.Contains(t, err.Error(), `state named "*"`)
+	assert.Contains(t, err.Error(), "leading or trailing whitespace")
+}
+
+func TestNew_IssuesAggregateSingleLine(t *testing.T) {
+	var d fsm.Define[status, *task]
+	_, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, status("")),
+		d.Edge(statusOpen, statusDone),
+		d.Edge(statusOpen, statusDone),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "; ", "issues joined on one line")
+	assert.NotContains(t, err.Error(), "\n", "single-line error")
+}
+
+func TestNew_InternalSpacesLegal(t *testing.T) {
+	var d fsm.Define[status, *task]
+	_, err := fsm.New(status("In Progress"), d.Edge(status("In Progress"), statusDone))
+	require.NoError(t, err)
+}
+
+func TestMustNew_PanicsOnInvalid(t *testing.T) {
+	var d fsm.Define[status, *task]
+	assert.Panics(t, func() {
+		fsm.MustNew(statusOpen, d.Edge(statusOpen, statusDone), d.Edge(statusOpen, statusDone))
+	})
+}
+
+func TestMustNew_ReturnsMachine(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen, d.Edge(statusOpen, statusDone))
+	assert.True(t, m.Can(statusOpen, statusDone))
+}

--- a/core/fsm/definition.go
+++ b/core/fsm/definition.go
@@ -1,0 +1,121 @@
+package fsm
+
+import "fmt"
+
+// Definition is the serializable, tenant-facing flow description: states
+// and edges by name, guards and hooks referenced by registry name.
+// Consumers store it (typically JSON in their own DB) and compile it
+// against their registered vocabulary. Definitions arrive from the
+// consumer's own flow-save API — that API is where size limits belong;
+// the package imposes no hidden caps.
+type Definition struct {
+	Initial string     `json:"initial"`
+	States  []StateDef `json:"states"`
+	Edges   []EdgeDef  `json:"edges"`
+}
+
+// StateDef declares one state and its state-level guard/hook names.
+type StateDef struct {
+	Name          string   `json:"name"`
+	OnEnterGuards []string `json:"on_enter_guards,omitempty"`
+	OnEnterHooks  []string `json:"on_enter_hooks,omitempty"`
+	OnExitGuards  []string `json:"on_exit_guards,omitempty"`
+	OnExitHooks   []string `json:"on_exit_hooks,omitempty"`
+}
+
+// EdgeDef declares one edge; From may be "*", the source-side wildcard
+// (an edge from every other declared state).
+type EdgeDef struct {
+	From   string   `json:"from"`
+	To     string   `json:"to"`
+	Guards []string `json:"guards,omitempty"`
+	Hooks  []string `json:"hooks,omitempty"`
+}
+
+// Registry is the guard/hook vocabulary an application exposes to its
+// flow definitions. Nil maps are valid for definitions that reference no
+// names.
+type Registry[V any] struct {
+	Guards map[string]Func[string, V]
+	Hooks  map[string]Func[string, V]
+}
+
+// Compile validates def, resolves its guard/hook names against reg, and
+// builds the machine. All issues are aggregated into one single-line
+// ErrInvalidDefinition so a flow-builder shows every problem in one save
+// attempt. A definition that compiles fires cleanly — Fire never reports
+// a definition problem.
+func Compile[V any](def Definition, reg Registry[V]) (*Machine[string, V], error) {
+	if len(def.States) == 0 {
+		return nil, fmt.Errorf("%w: empty state set", ErrInvalidDefinition)
+	}
+
+	var issues []string
+	declared := make(map[string]struct{}, len(def.States))
+	for _, s := range def.States {
+		if _, dup := declared[s.Name]; dup {
+			issues = append(issues, fmt.Sprintf("duplicate state %q", s.Name))
+			continue
+		}
+		declared[s.Name] = struct{}{}
+	}
+	if _, ok := declared[def.Initial]; !ok {
+		issues = append(issues, fmt.Sprintf("initial state %q not declared", def.Initial))
+	}
+	for _, e := range def.Edges {
+		if e.From != "*" {
+			if _, ok := declared[e.From]; !ok {
+				issues = append(issues, fmt.Sprintf("edge references undeclared state %q", e.From))
+			}
+		}
+		if _, ok := declared[e.To]; !ok {
+			issues = append(issues, fmt.Sprintf("edge references undeclared state %q", e.To))
+		}
+	}
+
+	resolve := func(names []string, fns map[string]Func[string, V], kind string) []Func[string, V] {
+		out := make([]Func[string, V], 0, len(names))
+		for _, name := range names {
+			fn, ok := fns[name]
+			if !ok {
+				issues = append(issues, fmt.Sprintf("unknown %s %q", kind, name))
+				continue
+			}
+			out = append(out, fn)
+		}
+		return out
+	}
+
+	var d Define[string, V]
+	toAtts := func(guards, hooks []Func[string, V]) []Attachment[string, V] {
+		atts := make([]Attachment[string, V], 0, len(guards)+len(hooks))
+		for _, g := range guards {
+			atts = append(atts, d.Guard(g))
+		}
+		for _, h := range hooks {
+			atts = append(atts, d.Hook(h))
+		}
+		return atts
+	}
+
+	parts := make([]Part[string, V], 0, 2*len(def.States)+len(def.Edges))
+	for _, s := range def.States {
+		parts = append(parts, declareState[string, V](s.Name))
+		if atts := toAtts(resolve(s.OnEnterGuards, reg.Guards, "guard"), resolve(s.OnEnterHooks, reg.Hooks, "hook")); len(atts) > 0 {
+			parts = append(parts, d.OnEnter(s.Name, atts...))
+		}
+		if atts := toAtts(resolve(s.OnExitGuards, reg.Guards, "guard"), resolve(s.OnExitHooks, reg.Hooks, "hook")); len(atts) > 0 {
+			parts = append(parts, d.OnExit(s.Name, atts...))
+		}
+	}
+	for _, e := range def.Edges {
+		atts := toAtts(resolve(e.Guards, reg.Guards, "guard"), resolve(e.Hooks, reg.Hooks, "hook"))
+		if e.From == "*" {
+			parts = append(parts, d.EdgeFromAny(e.To, atts...))
+		} else {
+			parts = append(parts, d.Edge(e.From, e.To, atts...))
+		}
+	}
+
+	return build(def.Initial, parts, issues)
+}

--- a/core/fsm/definition_test.go
+++ b/core/fsm/definition_test.go
@@ -1,0 +1,214 @@
+package fsm_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/fsm"
+)
+
+type move struct {
+	task  *task
+	admin bool
+}
+
+func testRegistry(log *[]string) fsm.Registry[*move] {
+	return fsm.Registry[*move]{
+		Guards: map[string]fsm.Func[string, *move]{
+			"admin_only": func(ctx context.Context, m *move, from, to string) error {
+				if !m.admin {
+					return errors.New("only admins may do that")
+				}
+				return nil
+			},
+			"subtasks_closed": func(ctx context.Context, m *move, from, to string) error {
+				if m.task.openSubtasks > 0 {
+					return errors.New("subtasks still open")
+				}
+				return nil
+			},
+		},
+		Hooks: map[string]fsm.Func[string, *move]{
+			"stamp_completed": func(ctx context.Context, m *move, from, to string) error {
+				m.task.completedAt = "2026-07-14"
+				*log = append(*log, "stamp_completed")
+				return nil
+			},
+		},
+	}
+}
+
+func flowDefinition() fsm.Definition {
+	return fsm.Definition{
+		Initial: "open",
+		States: []fsm.StateDef{
+			{Name: "open"},
+			{Name: "in_progress"},
+			{Name: "done", OnEnterGuards: []string{"subtasks_closed"}, OnEnterHooks: []string{"stamp_completed"}},
+			{Name: "cancelled"},
+		},
+		Edges: []fsm.EdgeDef{
+			{From: "open", To: "in_progress"},
+			{From: "in_progress", To: "done"},
+			{From: "*", To: "cancelled"},
+			{From: "done", To: "open", Guards: []string{"admin_only"}},
+		},
+	}
+}
+
+func TestCompile_HappyPath(t *testing.T) {
+	var log []string
+	m, err := fsm.Compile(flowDefinition(), testRegistry(&log))
+	require.NoError(t, err)
+
+	assert.Equal(t, "open", m.Initial())
+	assert.Equal(t, []string{"open", "in_progress", "done", "cancelled"}, m.States())
+
+	// Guard denies, then passes; enter-hook stamps.
+	v := &move{task: &task{openSubtasks: 1}}
+	err = m.Fire(context.Background(), v, "in_progress", "done")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrGuardDenied))
+
+	v = &move{task: &task{}}
+	require.NoError(t, m.Fire(context.Background(), v, "in_progress", "done"))
+	assert.Equal(t, "2026-07-14", v.task.completedAt)
+	assert.Equal(t, []string{"stamp_completed"}, log)
+
+	// Wildcard expanded; admin-guarded reopen filters in Allowed.
+	assert.True(t, m.Can("open", "cancelled"))
+	assert.False(t, m.Can("cancelled", "cancelled"))
+
+	got, err := m.Allowed(context.Background(), &move{task: &task{}}, "done")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cancelled"}, got)
+
+	got, err = m.Allowed(context.Background(), &move{task: &task{}, admin: true}, "done")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cancelled", "open"}, got, "wildcard declared before the reopen edge")
+}
+
+func TestCompile_EmptyStateSet(t *testing.T) {
+	_, err := fsm.Compile(fsm.Definition{Initial: "open"}, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrInvalidDefinition))
+	assert.Contains(t, err.Error(), "empty state set")
+}
+
+func TestCompile_DuplicateState(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "open",
+		States:  []fsm.StateDef{{Name: "open"}, {Name: "open"}},
+	}
+	_, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate state "open"`)
+}
+
+func TestCompile_InitialNotDeclared(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "missing",
+		States:  []fsm.StateDef{{Name: "open"}},
+	}
+	_, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `initial state "missing" not declared`)
+}
+
+func TestCompile_EdgeReferencesUndeclaredState(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "open",
+		States:  []fsm.StateDef{{Name: "open"}},
+		Edges:   []fsm.EdgeDef{{From: "open", To: "ghost"}, {From: "phantom", To: "open"}},
+	}
+	_, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `edge references undeclared state "ghost"`)
+	assert.Contains(t, err.Error(), `edge references undeclared state "phantom"`)
+}
+
+func TestCompile_UnknownGuardAndHookNames(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "open",
+		States: []fsm.StateDef{
+			{Name: "open", OnExitHooks: []string{"no_such_hook"}},
+			{Name: "done"},
+		},
+		Edges: []fsm.EdgeDef{{From: "open", To: "done", Guards: []string{"no_such_guard"}}},
+	}
+	_, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown guard "no_such_guard"`)
+	assert.Contains(t, err.Error(), `unknown hook "no_such_hook"`)
+}
+
+func TestCompile_WhitespaceStateName(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "open",
+		States:  []fsm.StateDef{{Name: "open"}, {Name: "done "}},
+		Edges:   []fsm.EdgeDef{{From: "open", To: "done "}},
+	}
+	_, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "leading or trailing whitespace")
+}
+
+func TestCompile_AllIssuesReportedAtOnce(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "missing",
+		States:  []fsm.StateDef{{Name: "open"}, {Name: "open"}},
+		Edges: []fsm.EdgeDef{
+			{From: "open", To: "ghost"},
+			{From: "open", To: "open", Guards: []string{"no_such_guard"}},
+		},
+	}
+	_, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrInvalidDefinition))
+	assert.Contains(t, err.Error(), `duplicate state "open"`)
+	assert.Contains(t, err.Error(), `initial state "missing" not declared`)
+	assert.Contains(t, err.Error(), `edge references undeclared state "ghost"`)
+	assert.Contains(t, err.Error(), `unknown guard "no_such_guard"`)
+	assert.NotContains(t, err.Error(), "\n", "single-line aggregate")
+}
+
+func TestCompile_NilRegistryMapsValidWithoutNames(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "open",
+		States:  []fsm.StateDef{{Name: "open"}, {Name: "done"}},
+		Edges:   []fsm.EdgeDef{{From: "open", To: "done"}},
+	}
+	m, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.NoError(t, err)
+	require.NoError(t, m.Fire(context.Background(), &move{task: &task{}}, "open", "done"))
+}
+
+func TestDefinition_JSONRoundTrip(t *testing.T) {
+	def := flowDefinition()
+	raw, err := json.Marshal(def)
+	require.NoError(t, err)
+
+	var back fsm.Definition
+	require.NoError(t, json.Unmarshal(raw, &back))
+	assert.Equal(t, def, back)
+
+	assert.Contains(t, string(raw), `"on_enter_guards"`)
+	assert.NotContains(t, string(raw), `"on_exit_guards"`, "omitempty keeps unset lists out")
+}
+
+func TestCompile_DeclaredStateWithNoEdgesIsUsable(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "open",
+		States:  []fsm.StateDef{{Name: "open"}, {Name: "parked"}, {Name: "done"}},
+		Edges:   []fsm.EdgeDef{{From: "parked", To: "done"}, {From: "open", To: "done"}},
+	}
+	m, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.NoError(t, err)
+	// "parked" is unreachable from initial but still a valid source: reachability is not enforced.
+	require.NoError(t, m.Fire(context.Background(), &move{task: &task{}}, "parked", "done"))
+}

--- a/core/fsm/doc.go
+++ b/core/fsm/doc.go
@@ -1,0 +1,106 @@
+// Package fsm provides an immutable, compiled finite state machine:
+// declared states and target-driven transitions (edges from -> to) with
+// guards, hooks, and illegal-transition errors. A Machine is a stateless
+// table — the current state lives in the caller's storage (a status
+// column) and is passed into every call — so one compiled machine is
+// safely shared across goroutines. Persistence is caller-owned: Fire
+// approves or denies a transition and enriches the entity; the caller
+// writes the status column afterwards.
+//
+// Guards are side-effect-free checks over preloaded data on the subject
+// V; keep I/O out of guards so ErrGuardDenied always means a domain
+// denial. Hooks may mutate V and run only after every guard passed; an
+// error aborts the transition. Everything inside Fire happens before
+// persistence — post-persist effects (notifications, outbox events) run
+// after the caller's own DB write. Fire order: exit-guards(from),
+// edge-guards, enter-guards(to), then exit-hooks(from), edge-hooks,
+// enter-hooks(to); first error aborts.
+//
+// # Compile-time flows
+//
+// Declare a typed lifecycle once at package init. The Define anchor binds
+// both type parameters so every part infers them:
+//
+//	type Status string
+//
+//	const (
+//		StatusDraft  Status = "draft"
+//		StatusIssued Status = "issued"
+//		StatusPaid   Status = "paid"
+//		StatusVoid   Status = "void"
+//	)
+//
+//	var d fsm.Define[Status, *Invoice]
+//
+//	var InvoiceFSM = fsm.MustNew(StatusDraft,
+//		d.Edge(StatusDraft, StatusIssued, d.Hook(assignNumber)),
+//		d.Edge(StatusIssued, StatusPaid),
+//		d.EdgeFromAny(StatusVoid, d.Guard(notPaid)),
+//		d.OnEnter(StatusIssued, d.Hook(stampIssuedAt)),
+//	)
+//
+//	func Transition(ctx context.Context, inv *Invoice, to Status) error {
+//		if err := InvoiceFSM.Fire(ctx, inv, inv.Status, to); err != nil {
+//			return err
+//		}
+//		inv.Status = to
+//		return saveInvoice(ctx, inv) // conditional write, see below
+//	}
+//
+// # Tenant-defined flows
+//
+// Runtime flows load a Definition (JSON) from the consumer's DB and
+// compile it against the app's registered guard/hook vocabulary. Compile
+// fails closed with every issue in one single-line error — validate at
+// flow-save time and a stored definition always fires cleanly. Cache
+// compiled machines by (tenant, flow, version); they are immutable, so a
+// version-keyed cache never needs invalidation:
+//
+//	reg := fsm.Registry[*Move]{
+//		Guards: map[string]fsm.Func[string, *Move]{
+//			"admin_only":      adminOnly,
+//			"subtasks_closed": subtasksClosed,
+//		},
+//		Hooks: map[string]fsm.Func[string, *Move]{
+//			"stamp_completed": stampCompleted,
+//		},
+//	}
+//
+//	var def fsm.Definition
+//	if err := json.Unmarshal(row.FlowJSON, &def); err != nil {
+//		return err
+//	}
+//	m, err := fsm.Compile(def, reg) // cache under row.ProjectID + ":" + row.Version
+//
+//	err = m.Fire(ctx, &Move{Task: task, Actor: actor}, task.Status, target)
+//	switch {
+//	case errors.Is(err, fsm.ErrGuardDenied):
+//		// 422: err carries the human reason ("subtasks still open")
+//	case errors.Is(err, fsm.ErrIllegalTransition), errors.Is(err, fsm.ErrUnknownState):
+//		// 409: stale board — flow or task changed under the user
+//	case err != nil:
+//		// 500: a hook broke; nothing was persisted
+//	}
+//
+// Allowed returns the targets the current entity may actually move to
+// (guards evaluated, hooks never run) — it renders per-user status
+// dropdowns: an edge that exists but is guarded ("done -> open" for
+// admins only) appears only for entities that pass.
+//
+// # Consumer patterns
+//
+// Persist with a conditional write — UPDATE ... SET status = $to WHERE id
+// = $id AND status = $from — and treat 0 affected rows as a stale-board
+// conflict: Fire validated the from the caller loaded, and a concurrent
+// writer may have moved the row since. Timer-driven transitions ("solved
+// -> closed after 72h", bonus expiry) are a consumer cron/jobqueue sweep
+// that selects due rows and calls Fire with a system actor. Definitions
+// arrive from the consumer's own flow-save API; size limits belong there.
+//
+// Out of scope forever: timers, auto/cascade transitions (a hook cannot
+// fire another transition), per-instance state or persistence, flow
+// versioning/migration, assignment/roles/SLA semantics, definition
+// storage, post-persist effect execution, and parallel/composite states —
+// an entity with two independent lifecycles has two status columns, one
+// machine each.
+package fsm

--- a/core/fsm/errors.go
+++ b/core/fsm/errors.go
@@ -1,0 +1,20 @@
+package fsm
+
+import "errors"
+
+var (
+	// ErrInvalidDefinition reports construction-time validation failure; its message aggregates every issue found on a single line.
+	ErrInvalidDefinition = errors.New("fsm: invalid definition")
+
+	// ErrUnknownState reports a state outside the machine's declared set.
+	ErrUnknownState = errors.New("fsm: unknown state")
+
+	// ErrIllegalTransition reports a from -> to pair with no declared edge.
+	ErrIllegalTransition = errors.New("fsm: illegal transition")
+
+	// ErrGuardDenied reports a guard refusal; the guard's own error is wrapped alongside and survives errors.Is/As.
+	ErrGuardDenied = errors.New("fsm: guard denied")
+
+	// ErrHookFailed reports a hook error; the hook's own error is wrapped alongside and survives errors.Is/As.
+	ErrHookFailed = errors.New("fsm: hook failed")
+)

--- a/core/fsm/machine.go
+++ b/core/fsm/machine.go
@@ -1,0 +1,95 @@
+package fsm
+
+import (
+	"context"
+	"fmt"
+)
+
+// Func is the single callback type for guards and hooks. Guards are
+// side-effect-free checks over preloaded data on v; hooks may mutate v.
+// Either aborts the transition by returning an error.
+type Func[S ~string, V any] func(ctx context.Context, v V, from, to S) error
+
+type edgeKey[S ~string] struct{ from, to S }
+
+type callbacks[S ~string, V any] struct {
+	guards []Func[S, V]
+	hooks  []Func[S, V]
+}
+
+// Machine is an immutable compiled transition table. It holds no instance
+// state — the current state lives in the caller's storage and is passed
+// into every call — so one machine is safely shared across goroutines.
+type Machine[S ~string, V any] struct {
+	initial  S
+	stateSet map[S]struct{}
+	edges    map[edgeKey[S]]callbacks[S, V]
+	enter    map[S]callbacks[S, V]
+	exit     map[S]callbacks[S, V]
+	next     map[S][]S
+	states   []S
+}
+
+// Fire validates and executes the transition from -> to for v: legality,
+// then guards (exit, edge, enter), then hooks (exit, edge, enter), each
+// list in declaration order; the first error aborts. A nil return means
+// approved — the caller persists the new state. On error nothing was
+// persisted; the caller discards the loaded v.
+func (m *Machine[S, V]) Fire(ctx context.Context, v V, from, to S) error {
+	if _, ok := m.stateSet[from]; !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownState, from)
+	}
+	if _, ok := m.stateSet[to]; !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownState, to)
+	}
+	edge, ok := m.edges[edgeKey[S]{from: from, to: to}]
+	if !ok {
+		return fmt.Errorf("%w: %s -> %s", ErrIllegalTransition, from, to)
+	}
+	exit, enter := m.exit[from], m.enter[to]
+	for _, guards := range [3][]Func[S, V]{exit.guards, edge.guards, enter.guards} {
+		for _, guard := range guards {
+			if err := guard(ctx, v, from, to); err != nil {
+				return fmt.Errorf("%w: %s -> %s: %w", ErrGuardDenied, from, to, err)
+			}
+		}
+	}
+	for _, hooks := range [3][]Func[S, V]{exit.hooks, edge.hooks, enter.hooks} {
+		for _, hook := range hooks {
+			if err := hook(ctx, v, from, to); err != nil {
+				return fmt.Errorf("%w: %s -> %s: %w", ErrHookFailed, from, to, err)
+			}
+		}
+	}
+	return nil
+}
+
+// Can reports whether an edge from -> to exists. It ignores guards.
+func (m *Machine[S, V]) Can(from, to S) bool {
+	_, ok := m.edges[edgeKey[S]{from: from, to: to}]
+	return ok
+}
+
+// Next returns the structural targets reachable from the given state in
+// declaration order, nil when the state is unknown or has no outgoing
+// edges. The returned slice is an independent copy.
+func (m *Machine[S, V]) Next(from S) []S {
+	targets := m.next[from]
+	if len(targets) == 0 {
+		return nil
+	}
+	out := make([]S, len(targets))
+	copy(out, targets)
+	return out
+}
+
+// Initial returns the machine's declared initial state.
+func (m *Machine[S, V]) Initial() S { return m.initial }
+
+// States returns all declared states in first-mention order. The returned
+// slice is an independent copy.
+func (m *Machine[S, V]) States() []S {
+	out := make([]S, len(m.states))
+	copy(out, m.states)
+	return out
+}

--- a/core/fsm/machine.go
+++ b/core/fsm/machine.go
@@ -83,6 +83,41 @@ func (m *Machine[S, V]) Next(from S) []S {
 	return out
 }
 
+// Allowed returns the targets whose guards all pass for v now, in
+// declaration order. Hooks never run. A guard error excludes its target —
+// filtering, not failure — so keep I/O out of guards. It returns
+// ErrUnknownState for an undeclared from, and ctx.Err() when the context
+// is done, so a transient timeout never reads as "no moves possible".
+func (m *Machine[S, V]) Allowed(ctx context.Context, v V, from S) ([]S, error) {
+	if _, ok := m.stateSet[from]; !ok {
+		return nil, fmt.Errorf("%w: %s", ErrUnknownState, from)
+	}
+	targets := m.next[from]
+	out := make([]S, 0, len(targets))
+	for _, to := range targets {
+		if m.guardsPass(ctx, v, from, to) {
+			out = append(out, to)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (m *Machine[S, V]) guardsPass(ctx context.Context, v V, from, to S) bool {
+	edge := m.edges[edgeKey[S]{from: from, to: to}]
+	exit, enter := m.exit[from], m.enter[to]
+	for _, guards := range [3][]Func[S, V]{exit.guards, edge.guards, enter.guards} {
+		for _, guard := range guards {
+			if guard(ctx, v, from, to) != nil {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // Initial returns the machine's declared initial state.
 func (m *Machine[S, V]) Initial() S { return m.initial }
 

--- a/core/fsm/machine_test.go
+++ b/core/fsm/machine_test.go
@@ -112,3 +112,135 @@ func TestStatesAndInitial(t *testing.T) {
 	states[0] = "mutated"
 	assert.Equal(t, statusOpen, m.States()[0], "States() returns an independent copy")
 }
+
+// record returns a Func that logs its name; it fails when name == failOn.
+func record(log *[]string, name string, failOn string) fsm.Func[status, *task] {
+	return func(ctx context.Context, v *task, from, to status) error {
+		*log = append(*log, name)
+		if name == failOn {
+			return errors.New(name + " says no")
+		}
+		return nil
+	}
+}
+
+// newOrderMachine wires one guard and one hook onto every surface of the
+// review -> done edge so ordering is observable.
+func newOrderMachine(t *testing.T, log *[]string, failOn string) *fsm.Machine[status, *task] {
+	t.Helper()
+	var d fsm.Define[status, *task]
+	m, err := fsm.New(statusReview,
+		d.Edge(statusReview, statusDone,
+			d.Guard(record(log, "edge-guard", failOn)),
+			d.Hook(record(log, "edge-hook", failOn)),
+		),
+		d.OnEnter(statusDone,
+			d.Guard(record(log, "enter-guard", failOn)),
+			d.Hook(record(log, "enter-hook", failOn)),
+		),
+		d.OnExit(statusReview,
+			d.Guard(record(log, "exit-guard", failOn)),
+			d.Hook(record(log, "exit-hook", failOn)),
+		),
+	)
+	require.NoError(t, err)
+	return m
+}
+
+func TestFire_GuardHookOrdering(t *testing.T) {
+	var log []string
+	m := newOrderMachine(t, &log, "")
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusReview, statusDone))
+	assert.Equal(t, []string{
+		"exit-guard", "edge-guard", "enter-guard",
+		"exit-hook", "edge-hook", "enter-hook",
+	}, log, "guards exit->edge->enter, then hooks exit->edge->enter")
+}
+
+func TestFire_GuardDenialAbortsBeforeAnyHook(t *testing.T) {
+	var log []string
+	m := newOrderMachine(t, &log, "enter-guard")
+	err := m.Fire(context.Background(), &task{}, statusReview, statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrGuardDenied))
+	assert.Equal(t, []string{"exit-guard", "edge-guard", "enter-guard"}, log, "zero hooks ran")
+}
+
+func TestFire_FirstGuardFailureShortCircuits(t *testing.T) {
+	var log []string
+	m := newOrderMachine(t, &log, "exit-guard")
+	err := m.Fire(context.Background(), &task{}, statusReview, statusDone)
+	require.Error(t, err)
+	assert.Equal(t, []string{"exit-guard"}, log)
+}
+
+func TestFire_HookFailureAborts(t *testing.T) {
+	var log []string
+	m := newOrderMachine(t, &log, "edge-hook")
+	err := m.Fire(context.Background(), &task{}, statusReview, statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrHookFailed))
+	assert.Equal(t, []string{
+		"exit-guard", "edge-guard", "enter-guard",
+		"exit-hook", "edge-hook",
+	}, log, "enter-hook never ran")
+}
+
+var errDomainDenied = errors.New("3 subtasks still open")
+
+func TestFire_GuardErrorSurvivesDoubleWrap(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusReview,
+		d.Edge(statusReview, statusDone, d.Guard(func(ctx context.Context, v *task, from, to status) error {
+			return errDomainDenied
+		})),
+	)
+	err := m.Fire(context.Background(), &task{}, statusReview, statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrGuardDenied), "sentinel matches")
+	assert.True(t, errors.Is(err, errDomainDenied), "domain error survives")
+	assert.Contains(t, err.Error(), "3 subtasks still open")
+	assert.NotContains(t, err.Error(), "\n", "single-line error")
+}
+
+func TestFire_HookErrorSurvivesDoubleWrap(t *testing.T) {
+	errBoom := errors.New("stamp exploded")
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusReview,
+		d.Edge(statusReview, statusDone, d.Hook(func(ctx context.Context, v *task, from, to status) error {
+			return errBoom
+		})),
+	)
+	err := m.Fire(context.Background(), &task{}, statusReview, statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrHookFailed))
+	assert.True(t, errors.Is(err, errBoom))
+}
+
+func TestFire_HookMutatesEntity(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusReview,
+		d.Edge(statusReview, statusDone),
+		d.OnEnter(statusDone, d.Hook(func(ctx context.Context, v *task, from, to status) error {
+			v.completedAt = "2026-07-14"
+			return nil
+		})),
+	)
+	v := &task{}
+	require.NoError(t, m.Fire(context.Background(), v, statusReview, statusDone))
+	assert.Equal(t, "2026-07-14", v.completedAt)
+}
+
+func TestFire_GuardInspectsEntity(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusReview,
+		d.Edge(statusReview, statusDone, d.Guard(func(ctx context.Context, v *task, from, to status) error {
+			if v.openSubtasks > 0 {
+				return errors.New("subtasks open")
+			}
+			return nil
+		})),
+	)
+	require.Error(t, m.Fire(context.Background(), &task{openSubtasks: 2}, statusReview, statusDone))
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusReview, statusDone))
+}

--- a/core/fsm/machine_test.go
+++ b/core/fsm/machine_test.go
@@ -244,3 +244,74 @@ func TestFire_GuardInspectsEntity(t *testing.T) {
 	require.Error(t, m.Fire(context.Background(), &task{openSubtasks: 2}, statusReview, statusDone))
 	require.NoError(t, m.Fire(context.Background(), &task{}, statusReview, statusDone))
 }
+
+// newAdminBoard: done -> open guarded by admin-only; cancel from anywhere.
+func newAdminBoard(t *testing.T) *fsm.Machine[status, *task] {
+	t.Helper()
+	var d fsm.Define[status, *task]
+	m, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, statusDone),
+		d.Edge(statusDone, statusOpen, d.Guard(func(ctx context.Context, v *task, from, to status) error {
+			if !v.admin {
+				return errors.New("only admins may reopen")
+			}
+			return nil
+		})),
+		d.EdgeFromAny(statusCancelled),
+	)
+	require.NoError(t, err)
+	return m
+}
+
+func TestAllowed_FiltersByGuards(t *testing.T) {
+	m := newAdminBoard(t)
+
+	got, err := m.Allowed(context.Background(), &task{admin: false}, statusDone)
+	require.NoError(t, err)
+	assert.Equal(t, []status{statusCancelled}, got, "non-admin cannot reopen")
+
+	got, err = m.Allowed(context.Background(), &task{admin: true}, statusDone)
+	require.NoError(t, err)
+	assert.Equal(t, []status{statusOpen, statusCancelled}, got, "admin sees reopen, declaration order")
+}
+
+func TestAllowed_UnknownState(t *testing.T) {
+	m := newAdminBoard(t)
+	_, err := m.Allowed(context.Background(), &task{}, status("nope"))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrUnknownState))
+}
+
+func TestAllowed_CancelledContextIsAnError(t *testing.T) {
+	m := newAdminBoard(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	got, err := m.Allowed(ctx, &task{admin: true}, statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+	assert.Nil(t, got, "a dead context must not read as 'no moves possible'")
+}
+
+func TestAllowed_EmptyResultIsNotAnError(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusDone, d.Guard(func(ctx context.Context, v *task, from, to status) error {
+			return errors.New("always denied")
+		})),
+	)
+	got, err := m.Allowed(context.Background(), &task{}, statusOpen)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestAllowed_RunsNoHooks(t *testing.T) {
+	var log []string
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusDone, d.Hook(record(&log, "edge-hook", ""))),
+		d.OnEnter(statusDone, d.Hook(record(&log, "enter-hook", ""))),
+	)
+	_, err := m.Allowed(context.Background(), &task{}, statusOpen)
+	require.NoError(t, err)
+	assert.Empty(t, log, "Allowed evaluates guards only")
+}

--- a/core/fsm/machine_test.go
+++ b/core/fsm/machine_test.go
@@ -1,0 +1,114 @@
+package fsm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/fsm"
+)
+
+type status string
+
+const (
+	statusOpen       status = "open"
+	statusInProgress status = "in_progress"
+	statusReview     status = "review"
+	statusDone       status = "done"
+	statusCancelled  status = "cancelled"
+)
+
+type task struct {
+	completedAt  string
+	openSubtasks int
+	admin        bool
+}
+
+// newBoard compiles the reference flow used across tests:
+// open -> in_progress -> review -> (in_progress | done).
+func newBoard(t *testing.T) *fsm.Machine[status, *task] {
+	t.Helper()
+	var d fsm.Define[status, *task]
+	m, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, statusInProgress),
+		d.Edge(statusInProgress, statusReview),
+		d.Edge(statusReview, statusInProgress),
+		d.Edge(statusReview, statusDone),
+	)
+	require.NoError(t, err)
+	return m
+}
+
+func TestFire_LegalTransition(t *testing.T) {
+	m := newBoard(t)
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusOpen, statusInProgress))
+}
+
+func TestFire_IllegalTransition(t *testing.T) {
+	m := newBoard(t)
+	err := m.Fire(context.Background(), &task{}, statusOpen, statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrIllegalTransition))
+	assert.Contains(t, err.Error(), "open")
+	assert.Contains(t, err.Error(), "done")
+}
+
+func TestFire_UnknownState(t *testing.T) {
+	m := newBoard(t)
+
+	err := m.Fire(context.Background(), &task{}, status("nope"), statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrUnknownState))
+
+	err = m.Fire(context.Background(), &task{}, statusOpen, status("nope"))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrUnknownState))
+}
+
+func TestFire_SelfTransitionNeedsExplicitEdge(t *testing.T) {
+	m := newBoard(t)
+	err := m.Fire(context.Background(), &task{}, statusOpen, statusOpen)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrIllegalTransition))
+}
+
+func TestFire_ExplicitSelfEdgeAllowed(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m, err := fsm.New(statusOpen, d.Edge(statusOpen, statusOpen))
+	require.NoError(t, err)
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusOpen, statusOpen))
+}
+
+func TestCan(t *testing.T) {
+	m := newBoard(t)
+	assert.True(t, m.Can(statusOpen, statusInProgress))
+	assert.False(t, m.Can(statusOpen, statusDone))
+	assert.False(t, m.Can(status("nope"), statusDone))
+}
+
+func TestNext_DeclarationOrder(t *testing.T) {
+	m := newBoard(t)
+	assert.Equal(t, []status{statusInProgress, statusDone}, m.Next(statusReview))
+	assert.Nil(t, m.Next(statusDone), "no outgoing edges")
+	assert.Nil(t, m.Next(status("nope")), "unknown state")
+}
+
+func TestNext_ReturnsCopy(t *testing.T) {
+	m := newBoard(t)
+	next := m.Next(statusReview)
+	next[0] = "mutated"
+	assert.Equal(t, statusInProgress, m.Next(statusReview)[0])
+}
+
+func TestStatesAndInitial(t *testing.T) {
+	m := newBoard(t)
+	assert.Equal(t, statusOpen, m.Initial())
+	assert.Equal(t, []status{statusOpen, statusInProgress, statusReview, statusDone}, m.States(), "first-mention order")
+
+	states := m.States()
+	states[0] = "mutated"
+	assert.Equal(t, statusOpen, m.States()[0], "States() returns an independent copy")
+}

--- a/core/fsm/machine_test.go
+++ b/core/fsm/machine_test.go
@@ -3,6 +3,7 @@ package fsm_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -314,4 +315,43 @@ func TestAllowed_RunsNoHooks(t *testing.T) {
 	_, err := m.Allowed(context.Background(), &task{}, statusOpen)
 	require.NoError(t, err)
 	assert.Empty(t, log, "Allowed evaluates guards only")
+}
+
+func TestFire_ZeroAllocsOnBareEdge(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen, d.Edge(statusOpen, statusDone))
+	v := &task{}
+	ctx := context.Background()
+	allocs := testing.AllocsPerRun(100, func() {
+		if err := m.Fire(ctx, v, statusOpen, statusDone); err != nil {
+			t.Fatal(err)
+		}
+	})
+	assert.Zero(t, allocs, "bare Fire is the hot path: 0 allocs/op")
+}
+
+func TestMachine_ConcurrentUse(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusDone, d.Guard(func(ctx context.Context, v *task, from, to status) error {
+			if v.openSubtasks > 0 {
+				return errors.New("subtasks open")
+			}
+			return nil
+		})),
+		d.EdgeFromAny(statusCancelled),
+	)
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			v := &task{}
+			for range 100 {
+				_ = m.Fire(context.Background(), v, statusOpen, statusDone)
+				_, _ = m.Allowed(context.Background(), v, statusOpen)
+				_ = m.Next(statusOpen)
+				_ = m.States()
+			}
+		})
+	}
+	wg.Wait()
 }

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -19,17 +19,6 @@ External module deps stay in the entry prose. Composition partners
 
 ---
 
-**core/fsm**
-
-Typed finite state machine: declared states and transitions with guards,
-on-transition hooks, and illegal-transition errors; pure generics, zero
-deps. Persistence is caller-owned — apply it to a status column. The
-lifecycle brick under order/subscription/verification/payout flows.
-
-Deps: none (stdlib only).
-
----
-
 **core/country**
 
 Curated ISO-3166 static data: alpha-2/alpha-3 codes, English names,
@@ -437,7 +426,7 @@ determined; rendering stays out (HTML is a `render` recipe, PDF
 consumer-side); no dunning, no e-invoicing formats, no subscription or
 pricing logic (the billing anti-scope stands).
 
-Deps: `core/money`; `core/fsm` (planned).
+Deps: `core/money`; `core/fsm`.
 
 ## async/
 

--- a/docs/superpowers/plans/2026-07-14-core-fsm.md
+++ b/docs/superpowers/plans/2026-07-14-core-fsm.md
@@ -1,0 +1,1908 @@
+# core/fsm Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `core/fsm` — an immutable compiled finite-state-machine brick with target-driven transitions, guards/hooks on edges and state enter/exit, source-side wildcards, and a runtime `Definition`/`Registry`/`Compile` layer for tenant-defined flows.
+
+**Architecture:** One kernel type `Machine[S ~string, V any]` — a stateless, immutable transition table built either from typed parts (`Define[S, V]` anchor → `New`/`MustNew`) or from a JSON-taggable `Definition` resolved against a named-func `Registry` (`Compile`). `Fire` runs legality → guards (exit, edge, enter) → hooks (exit, edge, enter), first error aborts; persistence is caller-owned. Spec: `docs/superpowers/specs/2026-07-14-core-fsm-design.md`.
+
+**Tech Stack:** Go 1.26, stdlib only (zero deps). Tests: testify (`assert`/`require`), black-box in package `fsm_test`.
+
+## Global Constraints
+
+- Package path `core/fsm`, import `github.com/dmitrymomot/forge/core/fsm`. Zero non-stdlib deps in implementation files.
+- Black-box tests only (`package fsm_test`).
+- All error sentinels single-line; validation issues aggregate into ONE `"; "`-joined single-line message wrapped under `ErrInvalidDefinition` (NOT `errors.Join` — its `Error()` renders newlines, violating the repo single-line-error rule).
+- Guard failures wrap `ErrGuardDenied` AND the guard's own error via two `%w` verbs in one `fmt.Errorf`; hook failures likewise with `ErrHookFailed`.
+- Bare `Fire` (no guards/hooks) must be 0 allocs/op — gated by a `testing.AllocsPerRun` test in Task 6.
+- After changing files: `just fmt ./core/fsm/...` (package-path form — the single-file form trips a betteralign quirk). After each task: `just lint`.
+- Go 1.26 idioms: `wg.Go(...)` not `wg.Add/go/defer Done` (modernize gate), `for range N` loops, `b.Loop()` in benchmarks, `new(expr)` where a pointer-to-value is needed.
+- Commit after each task; conventional-commit subjects; NO Claude attribution lines anywhere.
+- Machines are immutable after construction and safe for concurrent use — nothing in the implementation may mutate `Machine` fields post-build.
+
+---
+
+## File Structure
+
+- `core/fsm/errors.go` — 5 sentinels (Task 1).
+- `core/fsm/machine.go` — `Func`, `Machine`, `Fire`, `Can`, `Next`, `Allowed`, `Initial`, `States` (Tasks 1, 4).
+- `core/fsm/define.go` — `Define` anchor, `Attachment`, `Part`, part constructors, `New`, `MustNew`, internal `build`/`builder` (Tasks 1, 2, 3, 5).
+- `core/fsm/definition.go` — `Definition`, `StateDef`, `EdgeDef`, `Registry`, `Compile` (Task 5).
+- `core/fsm/doc.go` — package doc with usage + consumer patterns + anti-scope (Task 6).
+- `core/fsm/machine_test.go`, `core/fsm/define_test.go`, `core/fsm/definition_test.go`, `core/fsm/bench_test.go` — black-box tests/benchmarks.
+- `docs/packages.md` — delete the `core/fsm` roadmap entry (Task 6).
+
+---
+
+### Task 1: Kernel — sentinels, Machine, legality-checking Fire, typed construction
+
+**Files:**
+- Create: `core/fsm/errors.go`
+- Create: `core/fsm/machine.go`
+- Create: `core/fsm/define.go`
+- Test: `core/fsm/machine_test.go`, `core/fsm/define_test.go`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces (later tasks rely on these exact names):
+  - `type Func[S ~string, V any] func(ctx context.Context, v V, from, to S) error`
+  - `type Machine[S ~string, V any] struct{ ... }` with `Fire(ctx context.Context, v V, from, to S) error`, `Can(from, to S) bool`, `Next(from S) []S`, `Initial() S`, `States() []S`
+  - `type Define[S ~string, V any] struct{}` with method `Edge(from, to S, atts ...Attachment[S, V]) Part[S, V]` — `Attachment` is declared in this task as an opaque struct; its constructors arrive in Task 2
+  - `New[S ~string, V any](initial S, parts ...Part[S, V]) (*Machine[S, V], error)`, `MustNew` panicking variant
+  - unexported: `edgeKey[S]`, `callbacks[S, V]`, `partKind` (`partEdge`), `split`, `build(initial S, parts []Part[S, V], preIssues []string) (*Machine[S, V], error)` — `build`'s `preIssues` param exists NOW so Task 5's `Compile` can merge its own issues without refactoring
+  - Sentinels: `ErrInvalidDefinition`, `ErrUnknownState`, `ErrIllegalTransition`, `ErrGuardDenied`, `ErrHookFailed`
+
+Note: `Fire` is implemented with its full guard/hook pipeline in this task (the loops iterate zero times until Task 2 adds attachment constructors) — this avoids unused-parameter lint noise on `ctx`/`v` and means Task 2 only *adds* constructors, never edits `Fire`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `core/fsm/machine_test.go`:
+
+```go
+package fsm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/fsm"
+)
+
+type status string
+
+const (
+	statusOpen       status = "open"
+	statusInProgress status = "in_progress"
+	statusReview     status = "review"
+	statusDone       status = "done"
+	statusCancelled  status = "cancelled"
+)
+
+type task struct {
+	completedAt  string
+	openSubtasks int
+	admin        bool
+}
+
+// newBoard compiles the reference flow used across tests:
+// open -> in_progress -> review -> (in_progress | done).
+func newBoard(t *testing.T) *fsm.Machine[status, *task] {
+	t.Helper()
+	var d fsm.Define[status, *task]
+	m, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, statusInProgress),
+		d.Edge(statusInProgress, statusReview),
+		d.Edge(statusReview, statusInProgress),
+		d.Edge(statusReview, statusDone),
+	)
+	require.NoError(t, err)
+	return m
+}
+
+func TestFire_LegalTransition(t *testing.T) {
+	m := newBoard(t)
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusOpen, statusInProgress))
+}
+
+func TestFire_IllegalTransition(t *testing.T) {
+	m := newBoard(t)
+	err := m.Fire(context.Background(), &task{}, statusOpen, statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrIllegalTransition))
+	assert.Contains(t, err.Error(), "open")
+	assert.Contains(t, err.Error(), "done")
+}
+
+func TestFire_UnknownState(t *testing.T) {
+	m := newBoard(t)
+
+	err := m.Fire(context.Background(), &task{}, status("nope"), statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrUnknownState))
+
+	err = m.Fire(context.Background(), &task{}, statusOpen, status("nope"))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrUnknownState))
+}
+
+func TestFire_SelfTransitionNeedsExplicitEdge(t *testing.T) {
+	m := newBoard(t)
+	err := m.Fire(context.Background(), &task{}, statusOpen, statusOpen)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrIllegalTransition))
+}
+
+func TestFire_ExplicitSelfEdgeAllowed(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m, err := fsm.New(statusOpen, d.Edge(statusOpen, statusOpen))
+	require.NoError(t, err)
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusOpen, statusOpen))
+}
+
+func TestCan(t *testing.T) {
+	m := newBoard(t)
+	assert.True(t, m.Can(statusOpen, statusInProgress))
+	assert.False(t, m.Can(statusOpen, statusDone))
+	assert.False(t, m.Can(status("nope"), statusDone))
+}
+
+func TestNext_DeclarationOrder(t *testing.T) {
+	m := newBoard(t)
+	assert.Equal(t, []status{statusInProgress, statusDone}, m.Next(statusReview))
+	assert.Nil(t, m.Next(statusDone), "no outgoing edges")
+	assert.Nil(t, m.Next(status("nope")), "unknown state")
+}
+
+func TestNext_ReturnsCopy(t *testing.T) {
+	m := newBoard(t)
+	next := m.Next(statusReview)
+	next[0] = "mutated"
+	assert.Equal(t, statusInProgress, m.Next(statusReview)[0])
+}
+
+func TestStatesAndInitial(t *testing.T) {
+	m := newBoard(t)
+	assert.Equal(t, statusOpen, m.Initial())
+	assert.Equal(t, []status{statusOpen, statusInProgress, statusReview, statusDone}, m.States(), "first-mention order")
+
+	states := m.States()
+	states[0] = "mutated"
+	assert.Equal(t, statusOpen, m.States()[0], "States() returns an independent copy")
+}
+```
+
+Create `core/fsm/define_test.go`:
+
+```go
+package fsm_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/fsm"
+)
+
+func TestNew_DuplicateEdge(t *testing.T) {
+	var d fsm.Define[status, *task]
+	_, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, statusDone),
+		d.Edge(statusOpen, statusDone),
+	)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrInvalidDefinition))
+	assert.Contains(t, err.Error(), "duplicate edge open -> done")
+}
+
+func TestNew_InvalidStateNames(t *testing.T) {
+	var d fsm.Define[status, *task]
+	_, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, status("")),
+		d.Edge(statusOpen, status("*")),
+		d.Edge(statusOpen, status("done ")),
+	)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrInvalidDefinition))
+	assert.Contains(t, err.Error(), "empty state name")
+	assert.Contains(t, err.Error(), `state named "*"`)
+	assert.Contains(t, err.Error(), "leading or trailing whitespace")
+}
+
+func TestNew_IssuesAggregateSingleLine(t *testing.T) {
+	var d fsm.Define[status, *task]
+	_, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, status("")),
+		d.Edge(statusOpen, statusDone),
+		d.Edge(statusOpen, statusDone),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "; ", "issues joined on one line")
+	assert.NotContains(t, err.Error(), "\n", "single-line error")
+}
+
+func TestNew_InternalSpacesLegal(t *testing.T) {
+	var d fsm.Define[status, *task]
+	_, err := fsm.New(status("In Progress"), d.Edge(status("In Progress"), statusDone))
+	require.NoError(t, err)
+}
+
+func TestMustNew_PanicsOnInvalid(t *testing.T) {
+	var d fsm.Define[status, *task]
+	assert.Panics(t, func() {
+		fsm.MustNew(statusOpen, d.Edge(statusOpen, statusDone), d.Edge(statusOpen, statusDone))
+	})
+}
+
+func TestMustNew_ReturnsMachine(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen, d.Edge(statusOpen, statusDone))
+	assert.True(t, m.Can(statusOpen, statusDone))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./core/fsm/ 2>&1 | head -20`
+Expected: compile error — `undefined: fsm` / no Go files in package.
+
+- [ ] **Step 3: Implement errors.go, machine.go, define.go**
+
+Create `core/fsm/errors.go`:
+
+```go
+package fsm
+
+import "errors"
+
+var (
+	// ErrInvalidDefinition reports construction-time validation failure; its message aggregates every issue found on a single line.
+	ErrInvalidDefinition = errors.New("fsm: invalid definition")
+
+	// ErrUnknownState reports a state outside the machine's declared set.
+	ErrUnknownState = errors.New("fsm: unknown state")
+
+	// ErrIllegalTransition reports a from -> to pair with no declared edge.
+	ErrIllegalTransition = errors.New("fsm: illegal transition")
+
+	// ErrGuardDenied reports a guard refusal; the guard's own error is wrapped alongside and survives errors.Is/As.
+	ErrGuardDenied = errors.New("fsm: guard denied")
+
+	// ErrHookFailed reports a hook error; the hook's own error is wrapped alongside and survives errors.Is/As.
+	ErrHookFailed = errors.New("fsm: hook failed")
+)
+```
+
+Create `core/fsm/machine.go`:
+
+```go
+package fsm
+
+import (
+	"context"
+	"fmt"
+)
+
+// Func is the single callback type for guards and hooks. Guards are
+// side-effect-free checks over preloaded data on v; hooks may mutate v.
+// Either aborts the transition by returning an error.
+type Func[S ~string, V any] func(ctx context.Context, v V, from, to S) error
+
+type edgeKey[S ~string] struct{ from, to S }
+
+type callbacks[S ~string, V any] struct {
+	guards []Func[S, V]
+	hooks  []Func[S, V]
+}
+
+// Machine is an immutable compiled transition table. It holds no instance
+// state — the current state lives in the caller's storage and is passed
+// into every call — so one machine is safely shared across goroutines.
+type Machine[S ~string, V any] struct {
+	stateSet map[S]struct{}
+	edges    map[edgeKey[S]]callbacks[S, V]
+	enter    map[S]callbacks[S, V]
+	exit     map[S]callbacks[S, V]
+	next     map[S][]S
+	states   []S
+	initial  S
+}
+
+// Fire validates and executes the transition from -> to for v: legality,
+// then guards (exit, edge, enter), then hooks (exit, edge, enter), each
+// list in declaration order; the first error aborts. A nil return means
+// approved — the caller persists the new state. On error nothing was
+// persisted; the caller discards the loaded v.
+func (m *Machine[S, V]) Fire(ctx context.Context, v V, from, to S) error {
+	if _, ok := m.stateSet[from]; !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownState, from)
+	}
+	if _, ok := m.stateSet[to]; !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownState, to)
+	}
+	edge, ok := m.edges[edgeKey[S]{from: from, to: to}]
+	if !ok {
+		return fmt.Errorf("%w: %s -> %s", ErrIllegalTransition, from, to)
+	}
+	exit, enter := m.exit[from], m.enter[to]
+	for _, guards := range [3][]Func[S, V]{exit.guards, edge.guards, enter.guards} {
+		for _, guard := range guards {
+			if err := guard(ctx, v, from, to); err != nil {
+				return fmt.Errorf("%w: %s -> %s: %w", ErrGuardDenied, from, to, err)
+			}
+		}
+	}
+	for _, hooks := range [3][]Func[S, V]{exit.hooks, edge.hooks, enter.hooks} {
+		for _, hook := range hooks {
+			if err := hook(ctx, v, from, to); err != nil {
+				return fmt.Errorf("%w: %s -> %s: %w", ErrHookFailed, from, to, err)
+			}
+		}
+	}
+	return nil
+}
+
+// Can reports whether an edge from -> to exists. It ignores guards.
+func (m *Machine[S, V]) Can(from, to S) bool {
+	_, ok := m.edges[edgeKey[S]{from: from, to: to}]
+	return ok
+}
+
+// Next returns the structural targets reachable from the given state in
+// declaration order, nil when the state is unknown or has no outgoing
+// edges. The returned slice is an independent copy.
+func (m *Machine[S, V]) Next(from S) []S {
+	targets := m.next[from]
+	if len(targets) == 0 {
+		return nil
+	}
+	out := make([]S, len(targets))
+	copy(out, targets)
+	return out
+}
+
+// Initial returns the machine's declared initial state.
+func (m *Machine[S, V]) Initial() S { return m.initial }
+
+// States returns all declared states in first-mention order. The returned
+// slice is an independent copy.
+func (m *Machine[S, V]) States() []S {
+	out := make([]S, len(m.states))
+	copy(out, m.states)
+	return out
+}
+```
+
+Create `core/fsm/define.go`:
+
+```go
+package fsm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Define is a zero-size type-parameter anchor: declare
+// `var d fsm.Define[Status, *Task]` once and every part constructed
+// through d infers both type parameters. It is stateless — parts still
+// flow into New.
+type Define[S ~string, V any] struct{}
+
+// Attachment is a guard or hook bound to an edge or state via Edge,
+// EdgeFromAny, OnEnter, or OnExit.
+type Attachment[S ~string, V any] struct {
+	fn      Func[S, V]
+	isGuard bool
+}
+
+type partKind uint8
+
+const (
+	partEdge partKind = iota
+)
+
+// Part is one construction element consumed by New.
+type Part[S ~string, V any] struct {
+	guards []Func[S, V]
+	hooks  []Func[S, V]
+	from   S
+	to     S
+	kind   partKind
+}
+
+func split[S ~string, V any](atts []Attachment[S, V]) (guards, hooks []Func[S, V]) {
+	for _, a := range atts {
+		if a.isGuard {
+			guards = append(guards, a.fn)
+		} else {
+			hooks = append(hooks, a.fn)
+		}
+	}
+	return guards, hooks
+}
+
+// Edge declares a transition from -> to with optional guard/hook
+// attachments. A self-transition requires an explicit Edge(s, s).
+func (Define[S, V]) Edge(from, to S, atts ...Attachment[S, V]) Part[S, V] {
+	guards, hooks := split(atts)
+	return Part[S, V]{kind: partEdge, from: from, to: to, guards: guards, hooks: hooks}
+}
+
+// New compiles a typed machine. States are inferred: every state mentioned
+// by initial or any part is declared, in first-mention order. All
+// validation issues are aggregated into one single-line
+// ErrInvalidDefinition.
+func New[S ~string, V any](initial S, parts ...Part[S, V]) (*Machine[S, V], error) {
+	return build(initial, parts, nil)
+}
+
+// MustNew is New that panics on error, for var initialization of
+// compile-time flows (the regexp.MustCompile precedent).
+func MustNew[S ~string, V any](initial S, parts ...Part[S, V]) *Machine[S, V] {
+	m, err := New(initial, parts...)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+type builder[S ~string, V any] struct {
+	issues    []string
+	states    []S
+	nextOrder []edgeKey[S]
+	stateSet  map[S]struct{}
+	edges     map[edgeKey[S]]callbacks[S, V]
+	enter     map[S]callbacks[S, V]
+	exit      map[S]callbacks[S, V]
+}
+
+func (b *builder[S, V]) declare(name S) {
+	if _, ok := b.stateSet[name]; ok {
+		return
+	}
+	if issue := checkName(string(name)); issue != "" {
+		b.issues = append(b.issues, issue)
+	}
+	b.stateSet[name] = struct{}{}
+	b.states = append(b.states, name)
+}
+
+func checkName(name string) string {
+	switch {
+	case name == "":
+		return "empty state name"
+	case name == "*":
+		return `state named "*"`
+	case strings.TrimSpace(name) != name:
+		return fmt.Sprintf("state name %q has leading or trailing whitespace", name)
+	}
+	return ""
+}
+
+// build is the shared constructor behind New and Compile. preIssues lets
+// Compile merge its definition-level issues into the same single-line
+// aggregate.
+func build[S ~string, V any](initial S, parts []Part[S, V], preIssues []string) (*Machine[S, V], error) {
+	b := &builder[S, V]{
+		issues:   preIssues,
+		stateSet: make(map[S]struct{}),
+		edges:    make(map[edgeKey[S]]callbacks[S, V]),
+		enter:    make(map[S]callbacks[S, V]),
+		exit:     make(map[S]callbacks[S, V]),
+	}
+
+	// Pass 1: declare every mentioned state in first-mention order.
+	b.declare(initial)
+	for _, p := range parts {
+		switch p.kind {
+		case partEdge:
+			b.declare(p.from)
+			b.declare(p.to)
+		}
+	}
+
+	// Pass 2: duplicate detection over literal (from, to) pairs.
+	explicit := make(map[edgeKey[S]]struct{}, len(parts))
+	for _, p := range parts {
+		switch p.kind {
+		case partEdge:
+			key := edgeKey[S]{from: p.from, to: p.to}
+			if _, dup := explicit[key]; dup {
+				b.issues = append(b.issues, fmt.Sprintf("duplicate edge %s -> %s", p.from, p.to))
+				continue
+			}
+			explicit[key] = struct{}{}
+		}
+	}
+
+	// Pass 3: materialize edges in declaration order.
+	for _, p := range parts {
+		switch p.kind {
+		case partEdge:
+			key := edgeKey[S]{from: p.from, to: p.to}
+			if _, exists := b.edges[key]; exists {
+				continue // duplicate, reported in pass 2
+			}
+			b.edges[key] = callbacks[S, V]{guards: p.guards, hooks: p.hooks}
+			b.nextOrder = append(b.nextOrder, key)
+		}
+	}
+
+	if len(b.issues) > 0 {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidDefinition, strings.Join(b.issues, "; "))
+	}
+
+	next := make(map[S][]S, len(b.states))
+	for _, key := range b.nextOrder {
+		next[key.from] = append(next[key.from], key.to)
+	}
+	return &Machine[S, V]{
+		stateSet: b.stateSet,
+		edges:    b.edges,
+		enter:    b.enter,
+		exit:     b.exit,
+		next:     next,
+		states:   b.states,
+		initial:  initial,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./core/fsm/ -race -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Format and lint**
+
+Run: `just fmt ./core/fsm/...` then `just lint`
+Expected: clean (betteralign may reorder struct fields — accept its edits, rerun tests). If the linter flags the single-case `switch p.kind` statements in `build` (gocritic singleCaseSwitch), convert them to `if p.kind == partEdge { ... }` for this task — Tasks 2–5 add more cases and restore the switch form. Note: any harness "undefined" diagnostics after the RED step are usually stale LSP snapshots — trust `go test`/`go build` at HEAD.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/fsm/
+git commit -m "feat(fsm): add transition-table kernel with legality checks and typed construction"
+```
+
+---
+
+### Task 2: Guards and hooks — attachments, six surfaces, deterministic ordering
+
+**Files:**
+- Modify: `core/fsm/define.go`
+- Test: `core/fsm/machine_test.go` (append), `core/fsm/define_test.go` (append)
+
+**Interfaces:**
+- Consumes: `Define`, `Attachment`, `Part`, `partKind`, `split`, `build`, `callbacks` from Task 1; `Fire`'s pipeline already executes `exit.guards/edge.guards/enter.guards` then `exit.hooks/edge.hooks/enter.hooks`.
+- Produces:
+  - `(Define[S, V]) Guard(fn Func[S, V]) Attachment[S, V]`
+  - `(Define[S, V]) Hook(fn Func[S, V]) Attachment[S, V]`
+  - `(Define[S, V]) OnEnter(state S, atts ...Attachment[S, V]) Part[S, V]`
+  - `(Define[S, V]) OnExit(state S, atts ...Attachment[S, V]) Part[S, V]`
+  - new `partKind` values `partOnEnter`, `partOnExit`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `core/fsm/machine_test.go`:
+
+```go
+// record returns a Func that logs its name; it fails when name == failOn.
+func record(log *[]string, name string, failOn string) fsm.Func[status, *task] {
+	return func(ctx context.Context, v *task, from, to status) error {
+		*log = append(*log, name)
+		if name == failOn {
+			return errors.New(name + " says no")
+		}
+		return nil
+	}
+}
+
+// newOrderMachine wires one guard and one hook onto every surface of the
+// review -> done edge so ordering is observable.
+func newOrderMachine(t *testing.T, log *[]string, failOn string) *fsm.Machine[status, *task] {
+	t.Helper()
+	var d fsm.Define[status, *task]
+	m, err := fsm.New(statusReview,
+		d.Edge(statusReview, statusDone,
+			d.Guard(record(log, "edge-guard", failOn)),
+			d.Hook(record(log, "edge-hook", failOn)),
+		),
+		d.OnEnter(statusDone,
+			d.Guard(record(log, "enter-guard", failOn)),
+			d.Hook(record(log, "enter-hook", failOn)),
+		),
+		d.OnExit(statusReview,
+			d.Guard(record(log, "exit-guard", failOn)),
+			d.Hook(record(log, "exit-hook", failOn)),
+		),
+	)
+	require.NoError(t, err)
+	return m
+}
+
+func TestFire_GuardHookOrdering(t *testing.T) {
+	var log []string
+	m := newOrderMachine(t, &log, "")
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusReview, statusDone))
+	assert.Equal(t, []string{
+		"exit-guard", "edge-guard", "enter-guard",
+		"exit-hook", "edge-hook", "enter-hook",
+	}, log, "guards exit->edge->enter, then hooks exit->edge->enter")
+}
+
+func TestFire_GuardDenialAbortsBeforeAnyHook(t *testing.T) {
+	var log []string
+	m := newOrderMachine(t, &log, "enter-guard")
+	err := m.Fire(context.Background(), &task{}, statusReview, statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrGuardDenied))
+	assert.Equal(t, []string{"exit-guard", "edge-guard", "enter-guard"}, log, "zero hooks ran")
+}
+
+func TestFire_FirstGuardFailureShortCircuits(t *testing.T) {
+	var log []string
+	m := newOrderMachine(t, &log, "exit-guard")
+	err := m.Fire(context.Background(), &task{}, statusReview, statusDone)
+	require.Error(t, err)
+	assert.Equal(t, []string{"exit-guard"}, log)
+}
+
+func TestFire_HookFailureAborts(t *testing.T) {
+	var log []string
+	m := newOrderMachine(t, &log, "edge-hook")
+	err := m.Fire(context.Background(), &task{}, statusReview, statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrHookFailed))
+	assert.Equal(t, []string{
+		"exit-guard", "edge-guard", "enter-guard",
+		"exit-hook", "edge-hook",
+	}, log, "enter-hook never ran")
+}
+
+var errDomainDenied = errors.New("3 subtasks still open")
+
+func TestFire_GuardErrorSurvivesDoubleWrap(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusReview,
+		d.Edge(statusReview, statusDone, d.Guard(func(ctx context.Context, v *task, from, to status) error {
+			return errDomainDenied
+		})),
+	)
+	err := m.Fire(context.Background(), &task{}, statusReview, statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrGuardDenied), "sentinel matches")
+	assert.True(t, errors.Is(err, errDomainDenied), "domain error survives")
+	assert.Contains(t, err.Error(), "3 subtasks still open")
+	assert.NotContains(t, err.Error(), "\n", "single-line error")
+}
+
+func TestFire_HookErrorSurvivesDoubleWrap(t *testing.T) {
+	errBoom := errors.New("stamp exploded")
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusReview,
+		d.Edge(statusReview, statusDone, d.Hook(func(ctx context.Context, v *task, from, to status) error {
+			return errBoom
+		})),
+	)
+	err := m.Fire(context.Background(), &task{}, statusReview, statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrHookFailed))
+	assert.True(t, errors.Is(err, errBoom))
+}
+
+func TestFire_HookMutatesEntity(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusReview,
+		d.Edge(statusReview, statusDone),
+		d.OnEnter(statusDone, d.Hook(func(ctx context.Context, v *task, from, to status) error {
+			v.completedAt = "2026-07-14"
+			return nil
+		})),
+	)
+	v := &task{}
+	require.NoError(t, m.Fire(context.Background(), v, statusReview, statusDone))
+	assert.Equal(t, "2026-07-14", v.completedAt)
+}
+
+func TestFire_GuardInspectsEntity(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusReview,
+		d.Edge(statusReview, statusDone, d.Guard(func(ctx context.Context, v *task, from, to status) error {
+			if v.openSubtasks > 0 {
+				return errors.New("subtasks open")
+			}
+			return nil
+		})),
+	)
+	require.Error(t, m.Fire(context.Background(), &task{openSubtasks: 2}, statusReview, statusDone))
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusReview, statusDone))
+}
+```
+
+Append to `core/fsm/define_test.go`:
+
+```go
+func TestOnEnter_MultiplePartsAppendInOrder(t *testing.T) {
+	var log []string
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusReview,
+		d.Edge(statusReview, statusDone),
+		d.OnEnter(statusDone, d.Hook(record(&log, "first", ""))),
+		d.OnEnter(statusDone, d.Hook(record(&log, "second", ""))),
+	)
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusReview, statusDone))
+	assert.Equal(t, []string{"first", "second"}, log)
+}
+
+func TestOnEnterOnExit_DeclareTheirState(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusDone),
+		d.OnExit(statusCancelled), // mentions a state with no edges
+	)
+	assert.Contains(t, m.States(), statusCancelled)
+}
+```
+
+(`define_test.go` needs `context` added to its imports.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./core/fsm/ 2>&1 | head -10`
+Expected: compile error — `d.Guard undefined` / `d.OnEnter undefined`.
+
+- [ ] **Step 3: Implement attachments and state parts**
+
+In `core/fsm/define.go`, replace the `partKind` const block with:
+
+```go
+const (
+	partEdge partKind = iota
+	partOnEnter
+	partOnExit
+)
+```
+
+Add after the `Edge` method:
+
+```go
+// Guard wraps fn as a guard attachment: a side-effect-free check over
+// preloaded data on v that denies the transition by returning an error.
+// Keep I/O out of guards so ErrGuardDenied always means a domain denial.
+func (Define[S, V]) Guard(fn Func[S, V]) Attachment[S, V] {
+	return Attachment[S, V]{fn: fn, isGuard: true}
+}
+
+// Hook wraps fn as a hook attachment: it may mutate v; an error aborts the
+// transition. Hooks run only after every guard passed and must confine
+// themselves to entity mutation — external effects belong after the
+// caller persists.
+func (Define[S, V]) Hook(fn Func[S, V]) Attachment[S, V] {
+	return Attachment[S, V]{fn: fn}
+}
+
+// OnEnter attaches guards/hooks that run on every transition into state,
+// regardless of source edge. Multiple OnEnter parts for one state append
+// in declaration order.
+func (Define[S, V]) OnEnter(state S, atts ...Attachment[S, V]) Part[S, V] {
+	guards, hooks := split(atts)
+	return Part[S, V]{kind: partOnEnter, from: state, guards: guards, hooks: hooks}
+}
+
+// OnExit attaches guards/hooks that run on every transition out of state,
+// regardless of target edge. Multiple OnExit parts for one state append
+// in declaration order.
+func (Define[S, V]) OnExit(state S, atts ...Attachment[S, V]) Part[S, V] {
+	guards, hooks := split(atts)
+	return Part[S, V]{kind: partOnExit, from: state, guards: guards, hooks: hooks}
+}
+```
+
+In `build`, extend the three switches:
+
+Pass 1 — add case:
+
+```go
+		case partOnEnter, partOnExit:
+			b.declare(p.from)
+```
+
+Pass 2 — add case (no-op, keeps the switch exhaustive):
+
+```go
+		case partOnEnter, partOnExit:
+		}
+```
+
+Pass 3 — add cases:
+
+```go
+		case partOnEnter:
+			cbs := b.enter[p.from]
+			cbs.guards = append(cbs.guards, p.guards...)
+			cbs.hooks = append(cbs.hooks, p.hooks...)
+			b.enter[p.from] = cbs
+		case partOnExit:
+			cbs := b.exit[p.from]
+			cbs.guards = append(cbs.guards, p.guards...)
+			cbs.hooks = append(cbs.hooks, p.hooks...)
+			b.exit[p.from] = cbs
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./core/fsm/ -race -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+just fmt ./core/fsm/...
+just lint
+git add core/fsm/
+git commit -m "feat(fsm): add guards and hooks with deterministic exit-edge-enter ordering"
+```
+
+---
+
+### Task 3: Source-side wildcard edges
+
+**Files:**
+- Modify: `core/fsm/define.go`
+- Test: `core/fsm/define_test.go` (append)
+
+**Interfaces:**
+- Consumes: Task 1's `build` pass structure, Task 2's `Attachment`.
+- Produces: `(Define[S, V]) EdgeFromAny(to S, atts ...Attachment[S, V]) Part[S, V]`, new `partKind` value `partEdgeFromAny`. Task 5's `Compile` maps `EdgeDef.From == "*"` onto this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `core/fsm/define_test.go`:
+
+```go
+// newWildcardBoard: open -> in_progress -> review -> done, plus cancel-from-anywhere;
+// done -> cancelled is explicitly replaced with an extra guard.
+func newWildcardBoard(t *testing.T, log *[]string) *fsm.Machine[status, *task] {
+	t.Helper()
+	var d fsm.Define[status, *task]
+	m, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, statusInProgress),
+		d.Edge(statusInProgress, statusReview),
+		d.Edge(statusReview, statusDone),
+		d.EdgeFromAny(statusCancelled, d.Guard(record(log, "wildcard-guard", ""))),
+		d.Edge(statusDone, statusCancelled, d.Guard(record(log, "explicit-guard", ""))),
+	)
+	require.NoError(t, err)
+	return m
+}
+
+func TestEdgeFromAny_ExpandsToAllStates(t *testing.T) {
+	m := newWildcardBoard(t, new([]string))
+	for _, from := range []status{statusOpen, statusInProgress, statusReview, statusDone} {
+		assert.True(t, m.Can(from, statusCancelled), "from %s", from)
+	}
+}
+
+func TestEdgeFromAny_NoSelfLoop(t *testing.T) {
+	m := newWildcardBoard(t, new([]string))
+	assert.False(t, m.Can(statusCancelled, statusCancelled))
+}
+
+func TestEdgeFromAny_WildcardGuardAppliesToExpandedEdges(t *testing.T) {
+	var log []string
+	m := newWildcardBoard(t, &log)
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusOpen, statusCancelled))
+	assert.Equal(t, []string{"wildcard-guard"}, log)
+}
+
+func TestEdgeFromAny_ExplicitEdgeReplacesExpanded(t *testing.T) {
+	var log []string
+	m := newWildcardBoard(t, &log)
+	require.NoError(t, m.Fire(context.Background(), &task{}, statusDone, statusCancelled))
+	assert.Equal(t, []string{"explicit-guard"}, log, "wildcard guard must NOT run on the replaced pair")
+}
+
+func TestEdgeFromAny_DuplicateWildcard(t *testing.T) {
+	var d fsm.Define[status, *task]
+	_, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, statusDone),
+		d.EdgeFromAny(statusCancelled),
+		d.EdgeFromAny(statusCancelled),
+	)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrInvalidDefinition))
+	assert.Contains(t, err.Error(), "duplicate edge * -> cancelled")
+}
+
+func TestEdgeFromAny_NextKeepsDeclarationPosition(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusInProgress),
+		d.EdgeFromAny(statusCancelled),
+		d.Edge(statusOpen, statusReview),
+	)
+	assert.Equal(t, []status{statusInProgress, statusCancelled, statusReview}, m.Next(statusOpen), "wildcard expands at its declaration position")
+}
+
+func TestEdgeFromAny_DeclaresItsTarget(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusDone),
+		d.EdgeFromAny(statusCancelled),
+	)
+	assert.Contains(t, m.States(), statusCancelled)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./core/fsm/ 2>&1 | head -10`
+Expected: compile error — `d.EdgeFromAny undefined`.
+
+- [ ] **Step 3: Implement wildcard parts and expansion**
+
+In `core/fsm/define.go`, replace the `partKind` const block with:
+
+```go
+const (
+	partEdge partKind = iota
+	partOnEnter
+	partOnExit
+	partEdgeFromAny
+)
+```
+
+Add after the `Edge` method:
+
+```go
+// EdgeFromAny declares a wildcard edge into to from every other declared
+// state. It expands at construction into concrete edges — pure sugar, no
+// runtime wildcard logic. An explicit Edge for a pair fully replaces the
+// expanded one; no self-loop is generated (a self-transition needs an
+// explicit Edge(s, s)).
+func (Define[S, V]) EdgeFromAny(to S, atts ...Attachment[S, V]) Part[S, V] {
+	guards, hooks := split(atts)
+	return Part[S, V]{kind: partEdgeFromAny, to: to, guards: guards, hooks: hooks}
+}
+```
+
+In `build`, extend the three passes:
+
+Pass 1 — add case:
+
+```go
+		case partEdgeFromAny:
+			b.declare(p.to)
+```
+
+Pass 2 — add `wildcardSeen := make(map[S]struct{})` above the loop, and the case:
+
+```go
+		case partEdgeFromAny:
+			if _, dup := wildcardSeen[p.to]; dup {
+				b.issues = append(b.issues, fmt.Sprintf("duplicate edge * -> %s", p.to))
+				continue
+			}
+			wildcardSeen[p.to] = struct{}{}
+```
+
+Pass 3 — add `wildcardDone := make(map[S]struct{})` above the loop, and the case:
+
+```go
+		case partEdgeFromAny:
+			if _, dup := wildcardDone[p.to]; dup {
+				continue // duplicate, reported in pass 2
+			}
+			wildcardDone[p.to] = struct{}{}
+			for _, from := range b.states {
+				if from == p.to {
+					continue // wildcards never generate self-loops
+				}
+				key := edgeKey[S]{from: from, to: p.to}
+				if _, isExplicit := explicit[key]; isExplicit {
+					continue // an explicit edge fully replaces the expanded one
+				}
+				b.edges[key] = callbacks[S, V]{guards: p.guards, hooks: p.hooks}
+				b.nextOrder = append(b.nextOrder, key)
+			}
+```
+
+Pass 3 works because pass 1 already declared every state (including ones mentioned only after the wildcard part) and pass 2 collected the complete explicit-edge set — so expansion at the wildcard's declaration position sees the full picture.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./core/fsm/ -race -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+just fmt ./core/fsm/...
+just lint
+git add core/fsm/
+git commit -m "feat(fsm): add source-side wildcard edges with construction-time expansion"
+```
+
+---
+
+### Task 4: Allowed — guard-filtered targets with honest context errors
+
+**Files:**
+- Modify: `core/fsm/machine.go`
+- Test: `core/fsm/machine_test.go` (append)
+
+**Interfaces:**
+- Consumes: `Machine` internals (`next`, `edges`, `enter`, `exit`, `stateSet`) from Tasks 1–2.
+- Produces: `(m *Machine[S, V]) Allowed(ctx context.Context, v V, from S) ([]S, error)`; unexported `guardsPass`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `core/fsm/machine_test.go`:
+
+```go
+// newAdminBoard: done -> open guarded by admin-only; cancel from anywhere.
+func newAdminBoard(t *testing.T) *fsm.Machine[status, *task] {
+	t.Helper()
+	var d fsm.Define[status, *task]
+	m, err := fsm.New(statusOpen,
+		d.Edge(statusOpen, statusDone),
+		d.Edge(statusDone, statusOpen, d.Guard(func(ctx context.Context, v *task, from, to status) error {
+			if !v.admin {
+				return errors.New("only admins may reopen")
+			}
+			return nil
+		})),
+		d.EdgeFromAny(statusCancelled),
+	)
+	require.NoError(t, err)
+	return m
+}
+
+func TestAllowed_FiltersByGuards(t *testing.T) {
+	m := newAdminBoard(t)
+
+	got, err := m.Allowed(context.Background(), &task{admin: false}, statusDone)
+	require.NoError(t, err)
+	assert.Equal(t, []status{statusCancelled}, got, "non-admin cannot reopen")
+
+	got, err = m.Allowed(context.Background(), &task{admin: true}, statusDone)
+	require.NoError(t, err)
+	assert.Equal(t, []status{statusOpen, statusCancelled}, got, "admin sees reopen, declaration order")
+}
+
+func TestAllowed_UnknownState(t *testing.T) {
+	m := newAdminBoard(t)
+	_, err := m.Allowed(context.Background(), &task{}, status("nope"))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrUnknownState))
+}
+
+func TestAllowed_CancelledContextIsAnError(t *testing.T) {
+	m := newAdminBoard(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	got, err := m.Allowed(ctx, &task{admin: true}, statusDone)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+	assert.Nil(t, got, "a dead context must not read as 'no moves possible'")
+}
+
+func TestAllowed_EmptyResultIsNotAnError(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusDone, d.Guard(func(ctx context.Context, v *task, from, to status) error {
+			return errors.New("always denied")
+		})),
+	)
+	got, err := m.Allowed(context.Background(), &task{}, statusOpen)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestAllowed_RunsNoHooks(t *testing.T) {
+	var log []string
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusDone, d.Hook(record(&log, "edge-hook", ""))),
+		d.OnEnter(statusDone, d.Hook(record(&log, "enter-hook", ""))),
+	)
+	_, err := m.Allowed(context.Background(), &task{}, statusOpen)
+	require.NoError(t, err)
+	assert.Empty(t, log, "Allowed evaluates guards only")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./core/fsm/ 2>&1 | head -10`
+Expected: compile error — `m.Allowed undefined`.
+
+- [ ] **Step 3: Implement Allowed**
+
+Add to `core/fsm/machine.go` (after `Next`):
+
+```go
+// Allowed returns the targets whose guards all pass for v now, in
+// declaration order. Hooks never run. A guard error excludes its target —
+// filtering, not failure — so keep I/O out of guards. It returns
+// ErrUnknownState for an undeclared from, and ctx.Err() when the context
+// is done, so a transient timeout never reads as "no moves possible".
+func (m *Machine[S, V]) Allowed(ctx context.Context, v V, from S) ([]S, error) {
+	if _, ok := m.stateSet[from]; !ok {
+		return nil, fmt.Errorf("%w: %s", ErrUnknownState, from)
+	}
+	targets := m.next[from]
+	out := make([]S, 0, len(targets))
+	for _, to := range targets {
+		if m.guardsPass(ctx, v, from, to) {
+			out = append(out, to)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (m *Machine[S, V]) guardsPass(ctx context.Context, v V, from, to S) bool {
+	edge := m.edges[edgeKey[S]{from: from, to: to}]
+	exit, enter := m.exit[from], m.enter[to]
+	for _, guards := range [3][]Func[S, V]{exit.guards, edge.guards, enter.guards} {
+		for _, guard := range guards {
+			if guard(ctx, v, from, to) != nil {
+				return false
+			}
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./core/fsm/ -race -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+just fmt ./core/fsm/...
+just lint
+git add core/fsm/
+git commit -m "feat(fsm): add guard-filtered Allowed with context-cancellation error"
+```
+
+---
+
+### Task 5: Runtime layer — Definition, Registry, Compile
+
+**Files:**
+- Create: `core/fsm/definition.go`
+- Modify: `core/fsm/define.go` (add `partState` + `declareState`)
+- Test: `core/fsm/definition_test.go`
+
+**Interfaces:**
+- Consumes: `build(initial, parts, preIssues)`, `Define`, `Attachment`, `Part`, part constructors from Tasks 1–3.
+- Produces:
+  - `type Definition struct { Initial string; States []StateDef; Edges []EdgeDef }` (JSON tags below)
+  - `type StateDef struct { Name string; OnEnterGuards, OnEnterHooks, OnExitGuards, OnExitHooks []string }`
+  - `type EdgeDef struct { From, To string; Guards, Hooks []string }`
+  - `type Registry[V any] struct { Guards, Hooks map[string]Func[string, V] }`
+  - `Compile[V any](def Definition, reg Registry[V]) (*Machine[string, V], error)`
+  - unexported `partState` kind + `declareState[S, V](name S) Part[S, V]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `core/fsm/definition_test.go`:
+
+```go
+package fsm_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/fsm"
+)
+
+type move struct {
+	task  *task
+	admin bool
+}
+
+func testRegistry(log *[]string) fsm.Registry[*move] {
+	return fsm.Registry[*move]{
+		Guards: map[string]fsm.Func[string, *move]{
+			"admin_only": func(ctx context.Context, m *move, from, to string) error {
+				if !m.admin {
+					return errors.New("only admins may do that")
+				}
+				return nil
+			},
+			"subtasks_closed": func(ctx context.Context, m *move, from, to string) error {
+				if m.task.openSubtasks > 0 {
+					return errors.New("subtasks still open")
+				}
+				return nil
+			},
+		},
+		Hooks: map[string]fsm.Func[string, *move]{
+			"stamp_completed": func(ctx context.Context, m *move, from, to string) error {
+				m.task.completedAt = "2026-07-14"
+				*log = append(*log, "stamp_completed")
+				return nil
+			},
+		},
+	}
+}
+
+func flowDefinition() fsm.Definition {
+	return fsm.Definition{
+		Initial: "open",
+		States: []fsm.StateDef{
+			{Name: "open"},
+			{Name: "in_progress"},
+			{Name: "done", OnEnterGuards: []string{"subtasks_closed"}, OnEnterHooks: []string{"stamp_completed"}},
+			{Name: "cancelled"},
+		},
+		Edges: []fsm.EdgeDef{
+			{From: "open", To: "in_progress"},
+			{From: "in_progress", To: "done"},
+			{From: "*", To: "cancelled"},
+			{From: "done", To: "open", Guards: []string{"admin_only"}},
+		},
+	}
+}
+
+func TestCompile_HappyPath(t *testing.T) {
+	var log []string
+	m, err := fsm.Compile(flowDefinition(), testRegistry(&log))
+	require.NoError(t, err)
+
+	assert.Equal(t, "open", m.Initial())
+	assert.Equal(t, []string{"open", "in_progress", "done", "cancelled"}, m.States())
+
+	// Guard denies, then passes; enter-hook stamps.
+	v := &move{task: &task{openSubtasks: 1}}
+	err = m.Fire(context.Background(), v, "in_progress", "done")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrGuardDenied))
+
+	v = &move{task: &task{}}
+	require.NoError(t, m.Fire(context.Background(), v, "in_progress", "done"))
+	assert.Equal(t, "2026-07-14", v.task.completedAt)
+	assert.Equal(t, []string{"stamp_completed"}, log)
+
+	// Wildcard expanded; admin-guarded reopen filters in Allowed.
+	assert.True(t, m.Can("open", "cancelled"))
+	assert.False(t, m.Can("cancelled", "cancelled"))
+
+	got, err := m.Allowed(context.Background(), &move{task: &task{}}, "done")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cancelled"}, got)
+
+	got, err = m.Allowed(context.Background(), &move{task: &task{}, admin: true}, "done")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cancelled", "open"}, got, "wildcard declared before the reopen edge")
+}
+
+func TestCompile_EmptyStateSet(t *testing.T) {
+	_, err := fsm.Compile(fsm.Definition{Initial: "open"}, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrInvalidDefinition))
+	assert.Contains(t, err.Error(), "empty state set")
+}
+
+func TestCompile_DuplicateState(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "open",
+		States:  []fsm.StateDef{{Name: "open"}, {Name: "open"}},
+	}
+	_, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate state "open"`)
+}
+
+func TestCompile_InitialNotDeclared(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "missing",
+		States:  []fsm.StateDef{{Name: "open"}},
+	}
+	_, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `initial state "missing" not declared`)
+}
+
+func TestCompile_EdgeReferencesUndeclaredState(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "open",
+		States:  []fsm.StateDef{{Name: "open"}},
+		Edges:   []fsm.EdgeDef{{From: "open", To: "ghost"}, {From: "phantom", To: "open"}},
+	}
+	_, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `edge references undeclared state "ghost"`)
+	assert.Contains(t, err.Error(), `edge references undeclared state "phantom"`)
+}
+
+func TestCompile_UnknownGuardAndHookNames(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "open",
+		States: []fsm.StateDef{
+			{Name: "open", OnExitHooks: []string{"no_such_hook"}},
+			{Name: "done"},
+		},
+		Edges: []fsm.EdgeDef{{From: "open", To: "done", Guards: []string{"no_such_guard"}}},
+	}
+	_, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown guard "no_such_guard"`)
+	assert.Contains(t, err.Error(), `unknown hook "no_such_hook"`)
+}
+
+func TestCompile_WhitespaceStateName(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "open",
+		States:  []fsm.StateDef{{Name: "open"}, {Name: "done "}},
+		Edges:   []fsm.EdgeDef{{From: "open", To: "done "}},
+	}
+	_, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "leading or trailing whitespace")
+}
+
+func TestCompile_AllIssuesReportedAtOnce(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "missing",
+		States:  []fsm.StateDef{{Name: "open"}, {Name: "open"}},
+		Edges: []fsm.EdgeDef{
+			{From: "open", To: "ghost"},
+			{From: "open", To: "open", Guards: []string{"no_such_guard"}},
+		},
+	}
+	_, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fsm.ErrInvalidDefinition))
+	assert.Contains(t, err.Error(), `duplicate state "open"`)
+	assert.Contains(t, err.Error(), `initial state "missing" not declared`)
+	assert.Contains(t, err.Error(), `edge references undeclared state "ghost"`)
+	assert.Contains(t, err.Error(), `unknown guard "no_such_guard"`)
+	assert.NotContains(t, err.Error(), "\n", "single-line aggregate")
+}
+
+func TestCompile_NilRegistryMapsValidWithoutNames(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "open",
+		States:  []fsm.StateDef{{Name: "open"}, {Name: "done"}},
+		Edges:   []fsm.EdgeDef{{From: "open", To: "done"}},
+	}
+	m, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.NoError(t, err)
+	require.NoError(t, m.Fire(context.Background(), &move{task: &task{}}, "open", "done"))
+}
+
+func TestDefinition_JSONRoundTrip(t *testing.T) {
+	def := flowDefinition()
+	raw, err := json.Marshal(def)
+	require.NoError(t, err)
+
+	var back fsm.Definition
+	require.NoError(t, json.Unmarshal(raw, &back))
+	assert.Equal(t, def, back)
+
+	assert.Contains(t, string(raw), `"on_enter_guards"`)
+	assert.NotContains(t, string(raw), `"on_exit_guards"`, "omitempty keeps unset lists out")
+}
+
+func TestCompile_DeclaredStateWithNoEdgesIsUsable(t *testing.T) {
+	def := fsm.Definition{
+		Initial: "open",
+		States:  []fsm.StateDef{{Name: "open"}, {Name: "parked"}, {Name: "done"}},
+		Edges:   []fsm.EdgeDef{{From: "parked", To: "done"}, {From: "open", To: "done"}},
+	}
+	m, err := fsm.Compile(def, fsm.Registry[*move]{})
+	require.NoError(t, err)
+	// "parked" is unreachable from initial but still a valid source: reachability is not enforced.
+	require.NoError(t, m.Fire(context.Background(), &move{task: &task{}}, "parked", "done"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./core/fsm/ 2>&1 | head -10`
+Expected: compile error — `undefined: fsm.Registry` / `fsm.Definition`.
+
+- [ ] **Step 3: Implement definition.go and declareState**
+
+In `core/fsm/define.go`, replace the `partKind` const block with:
+
+```go
+const (
+	partEdge partKind = iota
+	partOnEnter
+	partOnExit
+	partEdgeFromAny
+	partState
+)
+```
+
+Add after `EdgeFromAny`:
+
+```go
+// declareState declares a state without edges or attachments. Compile uses
+// it so every explicitly listed StateDef exists in the machine even when
+// nothing references it.
+func declareState[S ~string, V any](name S) Part[S, V] {
+	return Part[S, V]{kind: partState, from: name}
+}
+```
+
+In `build` pass 1, extend the enter/exit case to include `partState`:
+
+```go
+		case partOnEnter, partOnExit, partState:
+			b.declare(p.from)
+```
+
+(Passes 2 and 3 need no `partState` handling — extend their `partOnEnter, partOnExit` no-op cases to `partOnEnter, partOnExit, partState` where present for switch clarity.)
+
+Create `core/fsm/definition.go`:
+
+```go
+package fsm
+
+import "fmt"
+
+// Definition is the serializable, tenant-facing flow description: states
+// and edges by name, guards and hooks referenced by registry name.
+// Consumers store it (typically JSON in their own DB) and compile it
+// against their registered vocabulary. Definitions arrive from the
+// consumer's own flow-save API — that API is where size limits belong;
+// the package imposes no hidden caps.
+type Definition struct {
+	Initial string     `json:"initial"`
+	States  []StateDef `json:"states"`
+	Edges   []EdgeDef  `json:"edges"`
+}
+
+// StateDef declares one state and its state-level guard/hook names.
+type StateDef struct {
+	Name          string   `json:"name"`
+	OnEnterGuards []string `json:"on_enter_guards,omitempty"`
+	OnEnterHooks  []string `json:"on_enter_hooks,omitempty"`
+	OnExitGuards  []string `json:"on_exit_guards,omitempty"`
+	OnExitHooks   []string `json:"on_exit_hooks,omitempty"`
+}
+
+// EdgeDef declares one edge; From may be "*", the source-side wildcard
+// (an edge from every other declared state).
+type EdgeDef struct {
+	From   string   `json:"from"`
+	To     string   `json:"to"`
+	Guards []string `json:"guards,omitempty"`
+	Hooks  []string `json:"hooks,omitempty"`
+}
+
+// Registry is the guard/hook vocabulary an application exposes to its
+// flow definitions. Nil maps are valid for definitions that reference no
+// names.
+type Registry[V any] struct {
+	Guards map[string]Func[string, V]
+	Hooks  map[string]Func[string, V]
+}
+
+// Compile validates def, resolves its guard/hook names against reg, and
+// builds the machine. All issues are aggregated into one single-line
+// ErrInvalidDefinition so a flow-builder shows every problem in one save
+// attempt. A definition that compiles fires cleanly — Fire never reports
+// a definition problem.
+func Compile[V any](def Definition, reg Registry[V]) (*Machine[string, V], error) {
+	if len(def.States) == 0 {
+		return nil, fmt.Errorf("%w: empty state set", ErrInvalidDefinition)
+	}
+
+	var issues []string
+	declared := make(map[string]struct{}, len(def.States))
+	for _, s := range def.States {
+		if _, dup := declared[s.Name]; dup {
+			issues = append(issues, fmt.Sprintf("duplicate state %q", s.Name))
+			continue
+		}
+		declared[s.Name] = struct{}{}
+	}
+	if _, ok := declared[def.Initial]; !ok {
+		issues = append(issues, fmt.Sprintf("initial state %q not declared", def.Initial))
+	}
+	for _, e := range def.Edges {
+		if e.From != "*" {
+			if _, ok := declared[e.From]; !ok {
+				issues = append(issues, fmt.Sprintf("edge references undeclared state %q", e.From))
+			}
+		}
+		if _, ok := declared[e.To]; !ok {
+			issues = append(issues, fmt.Sprintf("edge references undeclared state %q", e.To))
+		}
+	}
+
+	resolve := func(names []string, fns map[string]Func[string, V], kind string) []Func[string, V] {
+		out := make([]Func[string, V], 0, len(names))
+		for _, name := range names {
+			fn, ok := fns[name]
+			if !ok {
+				issues = append(issues, fmt.Sprintf("unknown %s %q", kind, name))
+				continue
+			}
+			out = append(out, fn)
+		}
+		return out
+	}
+
+	var d Define[string, V]
+	toAtts := func(guards, hooks []Func[string, V]) []Attachment[string, V] {
+		atts := make([]Attachment[string, V], 0, len(guards)+len(hooks))
+		for _, g := range guards {
+			atts = append(atts, d.Guard(g))
+		}
+		for _, h := range hooks {
+			atts = append(atts, d.Hook(h))
+		}
+		return atts
+	}
+
+	parts := make([]Part[string, V], 0, 2*len(def.States)+len(def.Edges))
+	for _, s := range def.States {
+		parts = append(parts, declareState[string, V](s.Name))
+		if atts := toAtts(resolve(s.OnEnterGuards, reg.Guards, "guard"), resolve(s.OnEnterHooks, reg.Hooks, "hook")); len(atts) > 0 {
+			parts = append(parts, d.OnEnter(s.Name, atts...))
+		}
+		if atts := toAtts(resolve(s.OnExitGuards, reg.Guards, "guard"), resolve(s.OnExitHooks, reg.Hooks, "hook")); len(atts) > 0 {
+			parts = append(parts, d.OnExit(s.Name, atts...))
+		}
+	}
+	for _, e := range def.Edges {
+		atts := toAtts(resolve(e.Guards, reg.Guards, "guard"), resolve(e.Hooks, reg.Hooks, "hook"))
+		if e.From == "*" {
+			parts = append(parts, d.EdgeFromAny(e.To, atts...))
+		} else {
+			parts = append(parts, d.Edge(e.From, e.To, atts...))
+		}
+	}
+
+	return build(def.Initial, parts, issues)
+}
+```
+
+Note the happy-path `Allowed` assertion in the test: the wildcard edge is declared BEFORE the `done -> open` edge in `flowDefinition()`, so for state `done` the expanded `done -> cancelled` sits at the wildcard's declaration position, giving `["cancelled", "open"]`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./core/fsm/ -race -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+just fmt ./core/fsm/...
+just lint
+git add core/fsm/
+git commit -m "feat(fsm): add runtime Definition, Registry, and Compile for tenant-defined flows"
+```
+
+---
+
+### Task 6: doc.go, benchmarks, zero-alloc gate, race coverage, roadmap cleanup
+
+**Files:**
+- Create: `core/fsm/doc.go`
+- Create: `core/fsm/bench_test.go`
+- Test: `core/fsm/machine_test.go` (append)
+- Modify: `docs/packages.md` (delete the `core/fsm` entry)
+
+**Interfaces:**
+- Consumes: the full public API from Tasks 1–5. Produces nothing new.
+
+- [ ] **Step 1: Write the zero-alloc gate and race test (failing/new)**
+
+Append to `core/fsm/machine_test.go`:
+
+```go
+func TestFire_ZeroAllocsOnBareEdge(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen, d.Edge(statusOpen, statusDone))
+	v := &task{}
+	ctx := context.Background()
+	allocs := testing.AllocsPerRun(100, func() {
+		if err := m.Fire(ctx, v, statusOpen, statusDone); err != nil {
+			t.Fatal(err)
+		}
+	})
+	assert.Zero(t, allocs, "bare Fire is the hot path: 0 allocs/op")
+}
+
+func TestMachine_ConcurrentUse(t *testing.T) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusDone, d.Guard(func(ctx context.Context, v *task, from, to status) error {
+			if v.openSubtasks > 0 {
+				return errors.New("subtasks open")
+			}
+			return nil
+		})),
+		d.EdgeFromAny(statusCancelled),
+	)
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			v := &task{}
+			for range 100 {
+				_ = m.Fire(context.Background(), v, statusOpen, statusDone)
+				_, _ = m.Allowed(context.Background(), v, statusOpen)
+				_ = m.Next(statusOpen)
+				_ = m.States()
+			}
+		})
+	}
+	wg.Wait()
+}
+```
+
+(`machine_test.go` needs `sync` added to its imports.)
+
+Create `core/fsm/bench_test.go`:
+
+```go
+package fsm_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/fsm"
+)
+
+func BenchmarkFire_BareEdge(b *testing.B) {
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen, d.Edge(statusOpen, statusDone))
+	v := &task{}
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := m.Fire(ctx, v, statusOpen, statusDone); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFire_GuardsAndHooks(b *testing.B) {
+	pass := func(ctx context.Context, v *task, from, to status) error { return nil }
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusDone, d.Guard(pass), d.Hook(pass)),
+		d.OnEnter(statusDone, d.Guard(pass), d.Hook(pass)),
+		d.OnExit(statusOpen, d.Guard(pass), d.Hook(pass)),
+	)
+	v := &task{}
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := m.Fire(ctx, v, statusOpen, statusDone); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAllowed(b *testing.B) {
+	deny := func(ctx context.Context, v *task, from, to status) error { return errors.New("no") }
+	pass := func(ctx context.Context, v *task, from, to status) error { return nil }
+	var d fsm.Define[status, *task]
+	m := fsm.MustNew(statusOpen,
+		d.Edge(statusOpen, statusInProgress, d.Guard(pass)),
+		d.Edge(statusOpen, statusReview, d.Guard(deny)),
+		d.Edge(statusOpen, statusDone, d.Guard(pass)),
+		d.EdgeFromAny(statusCancelled),
+	)
+	v := &task{}
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := m.Allowed(ctx, v, statusOpen); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCompile(b *testing.B) {
+	// Realistic tenant flow: 10 states, ~25 edges, a wildcard, named callbacks.
+	states := make([]fsm.StateDef, 10)
+	for i := range 10 {
+		states[i] = fsm.StateDef{Name: fmt.Sprintf("state_%d", i)}
+	}
+	states[9].OnEnterGuards = []string{"check"}
+	states[9].OnEnterHooks = []string{"stamp"}
+	edges := make([]fsm.EdgeDef, 0, 25)
+	for i := range 8 {
+		edges = append(edges,
+			fsm.EdgeDef{From: fmt.Sprintf("state_%d", i), To: fmt.Sprintf("state_%d", i+1)},
+			fsm.EdgeDef{From: fmt.Sprintf("state_%d", i+1), To: fmt.Sprintf("state_%d", i)},
+			fsm.EdgeDef{From: fmt.Sprintf("state_%d", i), To: "state_9", Guards: []string{"check"}},
+		)
+	}
+	edges = append(edges, fsm.EdgeDef{From: "*", To: "state_0"})
+	def := fsm.Definition{Initial: "state_0", States: states, Edges: edges}
+	reg := fsm.Registry[*task]{
+		Guards: map[string]fsm.Func[string, *task]{
+			"check": func(ctx context.Context, v *task, from, to string) error { return nil },
+		},
+		Hooks: map[string]fsm.Func[string, *task]{
+			"stamp": func(ctx context.Context, v *task, from, to string) error { return nil },
+		},
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := fsm.Compile(def, reg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the new tests and benchmarks**
+
+Run: `go test ./core/fsm/ -race -run 'TestFire_ZeroAllocs|TestMachine_ConcurrentUse' -v`
+Expected: PASS. If `TestFire_ZeroAllocsOnBareEdge` fails, the `[3][]Func{...}` composite literal is escaping — replace the two array-literal loops in `Fire` with an unexported helper called three times per phase (`runGuards(ctx, v, from, to, exit.guards)` etc.) and re-measure; keep whichever form benchmarks at 0 allocs.
+
+Run: `go test ./core/fsm/ -bench . -benchmem -run '^$' | tee /tmp/fsm_bench_before.txt`
+Expected: `BenchmarkFire_BareEdge` shows `0 allocs/op`. Record all numbers — they go in the PR body as the before/after table (post-benchmark optimization pass: apply ONLY measured wins; if no optimization is warranted, the before numbers are the after numbers and say so in the PR).
+
+- [ ] **Step 3: Write doc.go**
+
+Create `core/fsm/doc.go`:
+
+```go
+// Package fsm provides an immutable, compiled finite state machine:
+// declared states and target-driven transitions (edges from -> to) with
+// guards, hooks, and illegal-transition errors. A Machine is a stateless
+// table — the current state lives in the caller's storage (a status
+// column) and is passed into every call — so one compiled machine is
+// safely shared across goroutines. Persistence is caller-owned: Fire
+// approves or denies a transition and enriches the entity; the caller
+// writes the status column afterwards.
+//
+// Guards are side-effect-free checks over preloaded data on the subject
+// V; keep I/O out of guards so ErrGuardDenied always means a domain
+// denial. Hooks may mutate V and run only after every guard passed; an
+// error aborts the transition. Everything inside Fire happens before
+// persistence — post-persist effects (notifications, outbox events) run
+// after the caller's own DB write. Fire order: exit-guards(from),
+// edge-guards, enter-guards(to), then exit-hooks(from), edge-hooks,
+// enter-hooks(to); first error aborts.
+//
+// # Compile-time flows
+//
+// Declare a typed lifecycle once at package init. The Define anchor binds
+// both type parameters so every part infers them:
+//
+//	type Status string
+//
+//	const (
+//		StatusDraft  Status = "draft"
+//		StatusIssued Status = "issued"
+//		StatusPaid   Status = "paid"
+//		StatusVoid   Status = "void"
+//	)
+//
+//	var d fsm.Define[Status, *Invoice]
+//
+//	var InvoiceFSM = fsm.MustNew(StatusDraft,
+//		d.Edge(StatusDraft, StatusIssued, d.Hook(assignNumber)),
+//		d.Edge(StatusIssued, StatusPaid),
+//		d.EdgeFromAny(StatusVoid, d.Guard(notPaid)),
+//		d.OnEnter(StatusIssued, d.Hook(stampIssuedAt)),
+//	)
+//
+//	func Transition(ctx context.Context, inv *Invoice, to Status) error {
+//		if err := InvoiceFSM.Fire(ctx, inv, inv.Status, to); err != nil {
+//			return err
+//		}
+//		inv.Status = to
+//		return saveInvoice(ctx, inv) // conditional write, see below
+//	}
+//
+// # Tenant-defined flows
+//
+// Runtime flows load a Definition (JSON) from the consumer's DB and
+// compile it against the app's registered guard/hook vocabulary. Compile
+// fails closed with every issue in one single-line error — validate at
+// flow-save time and a stored definition always fires cleanly. Cache
+// compiled machines by (tenant, flow, version); they are immutable, so a
+// version-keyed cache never needs invalidation:
+//
+//	reg := fsm.Registry[*Move]{
+//		Guards: map[string]fsm.Func[string, *Move]{
+//			"admin_only":      adminOnly,
+//			"subtasks_closed": subtasksClosed,
+//		},
+//		Hooks: map[string]fsm.Func[string, *Move]{
+//			"stamp_completed": stampCompleted,
+//		},
+//	}
+//
+//	var def fsm.Definition
+//	if err := json.Unmarshal(row.FlowJSON, &def); err != nil {
+//		return err
+//	}
+//	m, err := fsm.Compile(def, reg) // cache under row.ProjectID + ":" + row.Version
+//
+//	err = m.Fire(ctx, &Move{Task: task, Actor: actor}, task.Status, target)
+//	switch {
+//	case errors.Is(err, fsm.ErrGuardDenied):
+//		// 422: err carries the human reason ("subtasks still open")
+//	case errors.Is(err, fsm.ErrIllegalTransition), errors.Is(err, fsm.ErrUnknownState):
+//		// 409: stale board — flow or task changed under the user
+//	case err != nil:
+//		// 500: a hook broke; nothing was persisted
+//	}
+//
+// Allowed returns the targets the current entity may actually move to
+// (guards evaluated, hooks never run) — it renders per-user status
+// dropdowns: an edge that exists but is guarded ("done -> open" for
+// admins only) appears only for entities that pass.
+//
+// # Consumer patterns
+//
+// Persist with a conditional write — UPDATE ... SET status = $to WHERE id
+// = $id AND status = $from — and treat 0 affected rows as a stale-board
+// conflict: Fire validated the from the caller loaded, and a concurrent
+// writer may have moved the row since. Timer-driven transitions ("solved
+// -> closed after 72h", bonus expiry) are a consumer cron/jobqueue sweep
+// that selects due rows and calls Fire with a system actor. Definitions
+// arrive from the consumer's own flow-save API; size limits belong there.
+//
+// Out of scope forever: timers, auto/cascade transitions (a hook cannot
+// fire another transition), per-instance state or persistence, flow
+// versioning/migration, assignment/roles/SLA semantics, definition
+// storage, post-persist effect execution, and parallel/composite states —
+// an entity with two independent lifecycles has two status columns, one
+// machine each.
+package fsm
+```
+
+- [ ] **Step 4: Delete the roadmap entry**
+
+In `docs/packages.md`, delete the entire `**core/fsm**` entry (the block from `**core/fsm**` through its `Deps: none (stdlib only).` line plus the surrounding `---` separator, matching how other shipped entries were removed). The `finance/invoice` entry's `Deps: core/money; core/fsm (planned).` line: remove the `(planned)` tag from `core/fsm` since the package now exists — the line becomes `Deps: `core/money`; `core/fsm`.`
+
+- [ ] **Step 5: Run everything, format, lint**
+
+Run: `go test ./core/fsm/ -race -v` — all PASS, including the doc build.
+Run: `go vet ./core/fsm/` — clean.
+Run: `just fmt ./core/fsm/...` then `just lint` — clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/fsm/ docs/packages.md
+git commit -m "docs(fsm): add package docs, benchmarks, zero-alloc gate, race coverage; drop roadmap entry"
+```
+
+---
+
+## Plan Self-Review Notes
+
+- Spec coverage: decisions 1–7 → Tasks 1–3, 5; Fire semantics + guard/hook discipline → Tasks 1–2 + doc.go; read API incl. `Allowed` ctx.Err → Tasks 1, 4; wildcard rules → Task 3; validation matrix incl. whitespace → Tasks 1, 5; errors → Task 1 (tested across 2, 5); tenancy/cache pattern + consumer patterns + anti-scope → Task 6 doc.go; performance targets + benchmarks → Task 6; ship checklist (packages.md) → Task 6.
+- The `finance/invoice` dep-line tweak in Task 6 Step 4 goes beyond the spec's "stays valid as-is" — the catalog convention is that unmarked deps are shipped, so dropping `(planned)` is the required bookkeeping.
+- Type consistency: `Func[S, V]`, `Part[S, V]`, `Attachment[S, V]`, `build(initial, parts, preIssues)`, `declareState[S, V]` are used with identical signatures across tasks.

--- a/docs/superpowers/specs/2026-07-14-core-fsm-design.md
+++ b/docs/superpowers/specs/2026-07-14-core-fsm-design.md
@@ -13,7 +13,7 @@ Typed finite state machine brick: an immutable compiled transition table with gu
 3. **Typed subject.** `Machine[S ~string, V any]` — `V` is the entity (or entity+actor composite) that guards inspect and hooks mutate. No context smuggling, no `any` assertions.
 4. **Guards return `error`, not `bool`** — a denial carries a human-readable reason the UI can show, wrapped so sentinels still match.
 5. **Full symmetric attachment surfaces.** Guards and hooks attach to edges and to states (on-enter, on-exit). State-level attachment is what tenant-drawn graphs require: the app declares "entering `done` runs `subtasks_closed`" without knowing which edges the tenant drew into `done`.
-6. **Strict construction-time resolution.** `Compile`/`New` fail closed with all issues joined; `Fire` never discovers a definition problem at runtime.
+6. **Strict construction-time resolution.** `Compile`/`New` fail closed with all issues aggregated into one error; `Fire` never discovers a definition problem at runtime.
 7. **Source-side wildcard.** `"*" → X` (typed: `EdgeFromAny(X)`) expands at construction into concrete edges; pure sugar, zero runtime wildcard logic.
 
 ## Package shape
@@ -116,7 +116,7 @@ Expansion happens at construction, after the full state set is known: a wildcard
 
 ## Validation (construction-time, fail closed)
 
-`New` and `Compile` collect all issues via `errors.Join`, wrapped under `ErrInvalidDefinition`, so a flow-builder shows every problem in one save attempt. Issue classes: empty state set; empty or duplicate state name; state name with leading or trailing whitespace (a tenant typing `"done "` compiles fine and then never matches `"done"` from the UI; internal spaces like `"In Progress"` stay legal); state named `"*"`; initial missing or undeclared; edge referencing an undeclared state; duplicate edge for a literal `(from, to)` pair (the wildcard `"*"` counts as a literal source here, so two wildcard edges to one target are duplicates); (`Compile` only) guard/hook name absent from the registry. Reachability is deliberately not enforced: a state with no inbound edges is still usable (bulk imports, admin overrides set status outside the FSM); it is a lint concern, not an integrity one.
+`New` and `Compile` collect all issues into one single-line `"; "`-joined message wrapped under `ErrInvalidDefinition` (the repo's single-line-error rule rules out `errors.Join`'s newline rendering; issue classes are display strings, not sentinels, so nothing is lost), so a flow-builder shows every problem in one save attempt. Issue classes: empty state set; empty or duplicate state name; state name with leading or trailing whitespace (a tenant typing `"done "` compiles fine and then never matches `"done"` from the UI; internal spaces like `"In Progress"` stay legal); state named `"*"`; initial missing or undeclared; edge referencing an undeclared state; duplicate edge for a literal `(from, to)` pair (the wildcard `"*"` counts as a literal source here, so two wildcard edges to one target are duplicates); (`Compile` only) guard/hook name absent from the registry. Reachability is deliberately not enforced: a state with no inbound edges is still usable (bulk imports, admin overrides set status outside the FSM); it is a lint concern, not an integrity one.
 
 ## Errors
 
@@ -150,7 +150,7 @@ No storage, no seam: multi-tenancy is which machine you compiled. The doc exampl
 - Ordering: a recording spy proves exit → edge → enter order for guards then hooks, guards-before-any-hook, first-error abort (failing enter-guard ⇒ zero hooks ran).
 - Hook mutation on success; abort mid-hooks leaves caller free to discard (documented semantics).
 - Wildcard expansion and explicit-edge-replaces-wildcard precedence, including wildcard guards applying to expanded edges.
-- Validation matrix: one test per issue class, multi-issue accumulation via `errors.Join`, `errors.Is` matching for every sentinel, guard/hook domain errors surviving the double-wrap.
+- Validation matrix: one test per issue class, multi-issue accumulation in one single-line message, `errors.Is` matching for every sentinel, guard/hook domain errors surviving the double-wrap.
 - `Definition` JSON round-trip; `Allowed` filtering (admin vs non-admin case); `Allowed` under a cancelled context returns `ctx.Err()`, not an empty list; concurrent `Fire` on a shared machine under `-race`.
 
 ## Anti-scope (restated in doc.go)

--- a/docs/superpowers/specs/2026-07-14-core-fsm-design.md
+++ b/docs/superpowers/specs/2026-07-14-core-fsm-design.md
@@ -70,7 +70,7 @@ var InvoiceFSM = fsm.MustNew(StatusDraft,
 )
 ```
 
-`Define[S, V]` is stateless — not a builder; its methods construct parts that flow into `New(initial S, parts ...) (*Machine[S, V], error)`. `MustNew` panics, for `var`-init (the `regexp.MustCompile` precedent). `d.Guard`/`d.Hook` produce attachments accepted by `Edge`, `EdgeFromAny`, `OnEnter`, `OnExit`. States are inferred in typed mode: every state mentioned (initial, edge endpoints, wildcard targets, OnEnter/OnExit subjects) is declared; Go constants make an explicit list redundant.
+`Define[S, V]` is stateless — not a builder; its methods construct parts that flow into `New(initial S, parts ...Part[S, V]) (*Machine[S, V], error)`. `MustNew` panics, for `var`-init (the `regexp.MustCompile` precedent). `d.Guard`/`d.Hook` produce attachments accepted by `Edge`, `EdgeFromAny`, `OnEnter`, `OnExit`. States are inferred in typed mode: every state mentioned (initial, edge endpoints, wildcard targets, OnEnter/OnExit subjects) is declared; Go constants make an explicit list redundant.
 
 ## Runtime construction (tenant-defined flows)
 
@@ -114,7 +114,7 @@ Expansion happens at construction, after the full state set is known: a wildcard
 
 ## Validation (construction-time, fail closed)
 
-`New` and `Compile` collect all issues via `errors.Join`, wrapped under `ErrInvalidDefinition`, so a flow-builder shows every problem in one save attempt. Issue classes: empty state set; empty or duplicate state name; state named `"*"`; initial missing or undeclared; edge referencing an undeclared state; duplicate explicit edge for a `(from, to)` pair; (`Compile` only) guard/hook name absent from the registry. Reachability is deliberately not enforced: a state with no inbound edges is still usable (bulk imports, admin overrides set status outside the FSM); it is a lint concern, not an integrity one.
+`New` and `Compile` collect all issues via `errors.Join`, wrapped under `ErrInvalidDefinition`, so a flow-builder shows every problem in one save attempt. Issue classes: empty state set; empty or duplicate state name; state named `"*"`; initial missing or undeclared; edge referencing an undeclared state; duplicate edge for a literal `(from, to)` pair (the wildcard `"*"` counts as a literal source here, so two wildcard edges to one target are duplicates); (`Compile` only) guard/hook name absent from the registry. Reachability is deliberately not enforced: a state with no inbound edges is still usable (bulk imports, admin overrides set status outside the FSM); it is a lint concern, not an integrity one.
 
 ## Errors
 

--- a/docs/superpowers/specs/2026-07-14-core-fsm-design.md
+++ b/docs/superpowers/specs/2026-07-14-core-fsm-design.md
@@ -44,11 +44,13 @@ type Machine[S ~string, V any] struct{ /* immutable after construction */ }
 
 Everything inside `Fire` happens before persistence. On any error the caller discards the loaded entity — nothing was written, so nothing rolls back; earlier hooks may have mutated the in-memory `v`, which the caller simply drops. Post-persist effects (notifications, outbox events) are explicitly out of scope: consumers run them after their own DB write. A hook must not fire another transition (no cascades).
 
+**Guard and hook discipline.** Guards read preloaded data on `V` and stay free of I/O — then `ErrGuardDenied` always means a domain denial, never "the risk service was down", and consumers can safely map it to a user-facing 4xx. A consumer that insists on an I/O guard must wrap its own infrastructure sentinel into the returned error (the multi-`%w` chain preserves it) and check that sentinel before `ErrGuardDenied`. Hooks confine themselves to mutating `v` and work that commits in the caller's own DB transaction; a hook that calls an external system (PSP, email) leaves an un-rollbackable side effect when a later hook aborts — external effects belong after persistence.
+
 ## Read API
 
 - `Can(from, to S) bool` — structural: edge exists.
 - `Next(from S) []S` — structural targets in first-declaration order; nil for an unknown state (mirrors `Can`'s false).
-- `Allowed(ctx context.Context, v V, from S) ([]S, error)` — targets whose guards all pass for this entity now; hooks never run; a guard error excludes that target (it is filtering, not failure); error only for an unknown `from` (`ErrUnknownState`).
+- `Allowed(ctx context.Context, v V, from S) ([]S, error)` — targets whose guards all pass for this entity now; hooks never run; a guard error excludes that target (it is filtering, not failure); errors: unknown `from` (`ErrUnknownState`), or `ctx.Err()` when the context was cancelled or expired during evaluation — without that check a transient timeout would fail every guard and render as a legitimate "no moves possible" empty list.
 - `Initial() S`, `States() []S` — declaration order; returned slices are copies.
 
 `Next` renders the generic status dropdown; `Allowed` renders it per-user/per-entity (e.g. a done task offers `open` to admins only, because the `done → open` edge is guarded by `admin_only`). The design idiom: "X is impossible except for role Y" is an existing edge with a guard, never a missing edge.
@@ -114,7 +116,7 @@ Expansion happens at construction, after the full state set is known: a wildcard
 
 ## Validation (construction-time, fail closed)
 
-`New` and `Compile` collect all issues via `errors.Join`, wrapped under `ErrInvalidDefinition`, so a flow-builder shows every problem in one save attempt. Issue classes: empty state set; empty or duplicate state name; state named `"*"`; initial missing or undeclared; edge referencing an undeclared state; duplicate edge for a literal `(from, to)` pair (the wildcard `"*"` counts as a literal source here, so two wildcard edges to one target are duplicates); (`Compile` only) guard/hook name absent from the registry. Reachability is deliberately not enforced: a state with no inbound edges is still usable (bulk imports, admin overrides set status outside the FSM); it is a lint concern, not an integrity one.
+`New` and `Compile` collect all issues via `errors.Join`, wrapped under `ErrInvalidDefinition`, so a flow-builder shows every problem in one save attempt. Issue classes: empty state set; empty or duplicate state name; state name with leading or trailing whitespace (a tenant typing `"done "` compiles fine and then never matches `"done"` from the UI; internal spaces like `"In Progress"` stay legal); state named `"*"`; initial missing or undeclared; edge referencing an undeclared state; duplicate edge for a literal `(from, to)` pair (the wildcard `"*"` counts as a literal source here, so two wildcard edges to one target are duplicates); (`Compile` only) guard/hook name absent from the registry. Reachability is deliberately not enforced: a state with no inbound edges is still usable (bulk imports, admin overrides set status outside the FSM); it is a lint concern, not an integrity one.
 
 ## Errors
 
@@ -132,6 +134,12 @@ Single-line sentinels in `errors.go`, all `errors.Is`-matchable:
 
 No storage, no seam: multi-tenancy is which machine you compiled. The doc example shows the pattern — cache compiled machines keyed by `(tenant, flow, version)`, recompile on flow edit; machines are immutable so the cache needs no invalidation beyond the version key. Single-tenant typed use pays zero ceremony (`var InvoiceFSM = fsm.MustNew(...)`). This satisfies the repo tenancy rule by construction: there is no key composition or scoped storage to fail open.
 
+## Consumer patterns (pinned in doc.go)
+
+- **Conditional persist against lost updates.** `Fire` validates against the `from` the caller loaded; a concurrent writer can move the row between load and write. Persist with a conditional write — `UPDATE tasks SET status = $to WHERE id = $id AND status = $from` — and treat 0 affected rows as a stale-board conflict (409). Without this, the last write wins and a transition (with its hook enrichments and audit trail) is silently swallowed.
+- **Timer-driven transitions are a sweep, not a feature.** "Solved → closed after 72h", bonus expiry, cool-off ending: a consumer cron/jobqueue job selects due rows and calls `Fire` with a system actor. The machine stays timer-free.
+- **Definition size trust boundary.** Definitions arrive from the consumer's own flow-save API, not raw wire input; that API is where size limits belong. The package imposes no hidden caps.
+
 ## Performance
 
 `Fire` on a bare edge (no guards/hooks) is the hot path: target 0 allocs/op via a `struct{ from, to S }` map key for edge lookup. `Next`/`States`/`Allowed` allocate (they return copies). Benchmarks: bare `Fire`, `Fire` with guards+hooks, `Allowed` over a fan-out state, `Compile` of a realistic ~10-state/25-edge definition. Post-benchmark optimization pass with before/after numbers in the PR, per repo policy.
@@ -143,11 +151,11 @@ No storage, no seam: multi-tenancy is which machine you compiled. The doc exampl
 - Hook mutation on success; abort mid-hooks leaves caller free to discard (documented semantics).
 - Wildcard expansion and explicit-edge-replaces-wildcard precedence, including wildcard guards applying to expanded edges.
 - Validation matrix: one test per issue class, multi-issue accumulation via `errors.Join`, `errors.Is` matching for every sentinel, guard/hook domain errors surviving the double-wrap.
-- `Definition` JSON round-trip; `Allowed` filtering (admin vs non-admin case); concurrent `Fire` on a shared machine under `-race`.
+- `Definition` JSON round-trip; `Allowed` filtering (admin vs non-admin case); `Allowed` under a cancelled context returns `ctx.Err()`, not an empty list; concurrent `Fire` on a shared machine under `-race`.
 
 ## Anti-scope (restated in doc.go)
 
-No timers, no auto/cascade transitions, no per-instance state or persistence, no flow versioning/migration (recompile per version; migrating in-flight entities is consumer domain), no assignment/roles/SLA semantics, no event labels (additive later), no definition storage, no post-persist effect execution.
+No timers, no auto/cascade transitions, no per-instance state or persistence, no flow versioning/migration (recompile per version; migrating in-flight entities is consumer domain), no assignment/roles/SLA semantics, no event labels (additive later), no definition storage, no post-persist effect execution, no parallel/composite/hierarchical states — an entity that is simultaneously "interview scheduled" and "reference check pending" has two status columns, one machine each; orthogonal aspects compose, they don't nest.
 
 ## Ship checklist
 

--- a/docs/superpowers/specs/2026-07-14-core-fsm-design.md
+++ b/docs/superpowers/specs/2026-07-14-core-fsm-design.md
@@ -1,0 +1,154 @@
+# core/fsm — Design Spec
+
+Date: 2026-07-14. Status: approved design, pre-implementation.
+
+## Purpose
+
+Typed finite state machine brick: an immutable compiled transition table with guards, hooks, and illegal-transition errors. Pure generics, zero deps, no reflection. Persistence is caller-owned — the machine approves or denies a transition and enriches the entity; the caller writes the status column. Serves two consumer classes with one kernel: compile-time typed lifecycles declared in Go (`finance/invoice`: draft → issued → paid/partially-paid/void/overdue) and runtime-defined flows loaded from tenant configuration (task manager, support-ticket, HR-portal SaaS where each tenant — even each project — draws its own status graph, several flows per tenant).
+
+## Decisions (settled during brainstorming)
+
+1. **Stateless table, caller holds state.** The machine is an immutable declared graph, constructed once and shared; the current state lives in the consumer's DB row and is passed into every call. No instance state, trivially goroutine-safe, cacheable per tenant-flow. No stateful wrapper (YAGNI; ~10 consumer lines if ever wanted).
+2. **Target-driven transitions.** The graph is edges `from → to`; firing means naming the target state, matching how status UIs work (kanban drag, status dropdown). No event names in v1; an optional event label on edges is an additive non-breaking change if a consumer ever needs named actions. Two business actions sharing one edge with different rules are dispatched in consumer code.
+3. **Typed subject.** `Machine[S ~string, V any]` — `V` is the entity (or entity+actor composite) that guards inspect and hooks mutate. No context smuggling, no `any` assertions.
+4. **Guards return `error`, not `bool`** — a denial carries a human-readable reason the UI can show, wrapped so sentinels still match.
+5. **Full symmetric attachment surfaces.** Guards and hooks attach to edges and to states (on-enter, on-exit). State-level attachment is what tenant-drawn graphs require: the app declares "entering `done` runs `subtasks_closed`" without knowing which edges the tenant drew into `done`.
+6. **Strict construction-time resolution.** `Compile`/`New` fail closed with all issues joined; `Fire` never discovers a definition problem at runtime.
+7. **Source-side wildcard.** `"*" → X` (typed: `EdgeFromAny(X)`) expands at construction into concrete edges; pure sugar, zero runtime wildcard logic.
+
+## Package shape
+
+Location `core/fsm`, single package, no subpackages. Files: `doc.go` (runnable example including the compile-and-cache tenant pattern), `machine.go` (Machine, Fire, read API), `define.go` (typed construction: `Define` anchor + parts), `definition.go` (runtime `Definition`/`Registry`/`Compile`), `errors.go`, black-box tests + `bench_test.go`. Estimated ~500–650 implementation LOC. Not an env-configured service: no `config.go`/`options.go` (the `enum` precedent).
+
+## Core types
+
+```go
+// Func is the single callback type for guards and hooks.
+// Guards are side-effect-free checks; hooks may mutate v. Both abort the transition by returning an error.
+type Func[S ~string, V any] func(ctx context.Context, v V, from, to S) error
+
+type Machine[S ~string, V any] struct{ /* immutable after construction */ }
+```
+
+`Machine` is immutable after construction and safe for concurrent use. Public methods return exported types only.
+
+## Fire semantics
+
+`Fire(ctx context.Context, v V, from, to S) error`:
+
+1. `from` and `to` must be declared states, else `ErrUnknownState`.
+2. An edge `from → to` must exist, else `ErrIllegalTransition` (message carries both states). `from == to` requires an explicit literal self-edge.
+3. Guards run in deterministic order — exit-guards(`from`), edge-guards, enter-guards(`to`), each list in declaration order. First error aborts, wrapped as `ErrGuardDenied` + the guard's own error (multi-`%w`).
+4. Hooks run only after every guard passed — exit-hooks(`from`), edge-hooks, enter-hooks(`to`), declaration order. First error aborts, wrapped as `ErrHookFailed` + the hook's own error.
+5. `nil` return means approved: the caller now persists the new status (and whatever hooks stamped onto `v`).
+
+Everything inside `Fire` happens before persistence. On any error the caller discards the loaded entity — nothing was written, so nothing rolls back; earlier hooks may have mutated the in-memory `v`, which the caller simply drops. Post-persist effects (notifications, outbox events) are explicitly out of scope: consumers run them after their own DB write. A hook must not fire another transition (no cascades).
+
+## Read API
+
+- `Can(from, to S) bool` — structural: edge exists.
+- `Next(from S) []S` — structural targets in first-declaration order; nil for an unknown state (mirrors `Can`'s false).
+- `Allowed(ctx context.Context, v V, from S) ([]S, error)` — targets whose guards all pass for this entity now; hooks never run; a guard error excludes that target (it is filtering, not failure); error only for an unknown `from` (`ErrUnknownState`).
+- `Initial() S`, `States() []S` — declaration order; returned slices are copies.
+
+`Next` renders the generic status dropdown; `Allowed` renders it per-user/per-entity (e.g. a done task offers `open` to admins only, because the `done → open` edge is guarded by `admin_only`). The design idiom: "X is impossible except for role Y" is an existing edge with a guard, never a missing edge.
+
+## Typed construction (compile-time flows)
+
+Go cannot infer `V` through plain option funcs (an edge with no guard never mentions `V`), so construction parts hang off a zero-size type-parameter anchor — one `var` line buys full inference:
+
+```go
+var d fsm.Define[Status, *Invoice]
+
+var InvoiceFSM = fsm.MustNew(StatusDraft,
+    d.Edge(StatusDraft, StatusIssued, d.Hook(assignNumber)),
+    d.Edge(StatusIssued, StatusPaid),
+    d.Edge(StatusIssued, StatusPartiallyPaid),
+    d.Edge(StatusPartiallyPaid, StatusPaid),
+    d.EdgeFromAny(StatusVoid, d.Guard(notPaid)),
+    d.OnEnter(StatusIssued, d.Hook(stampIssuedAt)),
+)
+```
+
+`Define[S, V]` is stateless — not a builder; its methods construct parts that flow into `New(initial S, parts ...) (*Machine[S, V], error)`. `MustNew` panics, for `var`-init (the `regexp.MustCompile` precedent). `d.Guard`/`d.Hook` produce attachments accepted by `Edge`, `EdgeFromAny`, `OnEnter`, `OnExit`. States are inferred in typed mode: every state mentioned (initial, edge endpoints, wildcard targets, OnEnter/OnExit subjects) is declared; Go constants make an explicit list redundant.
+
+## Runtime construction (tenant-defined flows)
+
+The tenant-facing definition is a plain JSON-tagged struct; consumers store it in their own DB (definition storage is out of scope):
+
+```go
+type Definition struct {
+    Initial string     `json:"initial"`
+    States  []StateDef `json:"states"`
+    Edges   []EdgeDef  `json:"edges"`
+}
+
+type StateDef struct {
+    Name          string   `json:"name"`
+    OnEnterGuards []string `json:"on_enter_guards,omitempty"`
+    OnEnterHooks  []string `json:"on_enter_hooks,omitempty"`
+    OnExitGuards  []string `json:"on_exit_guards,omitempty"`
+    OnExitHooks   []string `json:"on_exit_hooks,omitempty"`
+}
+
+type EdgeDef struct {
+    From   string   `json:"from"` // "*" = any (source-side wildcard)
+    To     string   `json:"to"`
+    Guards []string `json:"guards,omitempty"`
+    Hooks  []string `json:"hooks,omitempty"`
+}
+
+type Registry[V any] struct {
+    Guards map[string]Func[string, V]
+    Hooks  map[string]Func[string, V]
+}
+
+func Compile[V any](def Definition, reg Registry[V]) (*Machine[string, V], error)
+```
+
+Runtime states have no compile-time identity, so `S` is `string`. The registry is the vocabulary the app exposes to its flow-builder UI; names bind to Go funcs at `Compile`. States are declared explicitly here (unlike typed mode) so typos in edges are caught. A consumer's flow-save endpoint calls `Compile` and surfaces the joined issue list (e.g. 422); a definition that compiles is guaranteed to fire cleanly.
+
+## Wildcard expansion
+
+Expansion happens at construction, after the full state set is known: a wildcard edge to `X` produces a concrete edge from every declared state except `X` itself (wildcards never generate self-loops; self-transitions require an explicit literal self-edge). An explicit edge for a pair fully replaces the expanded one — that is how one source gets extra or different guards. Guards/hooks on the wildcard edge apply to every edge it expands to. Duplicate detection runs on literal `(from, to)` pairs, so two wildcard edges to the same target are duplicates.
+
+## Validation (construction-time, fail closed)
+
+`New` and `Compile` collect all issues via `errors.Join`, wrapped under `ErrInvalidDefinition`, so a flow-builder shows every problem in one save attempt. Issue classes: empty state set; empty or duplicate state name; state named `"*"`; initial missing or undeclared; edge referencing an undeclared state; duplicate explicit edge for a `(from, to)` pair; (`Compile` only) guard/hook name absent from the registry. Reachability is deliberately not enforced: a state with no inbound edges is still usable (bulk imports, admin overrides set status outside the FSM); it is a lint concern, not an integrity one.
+
+## Errors
+
+Single-line sentinels in `errors.go`, all `errors.Is`-matchable:
+
+- `ErrInvalidDefinition` — construction failure; wraps the joined issue list.
+- `ErrUnknownState` — `Fire`/`Allowed` given a state outside the declared set.
+- `ErrIllegalTransition` — no edge `from → to`.
+- `ErrGuardDenied` — guard refused; multi-`%w` wraps sentinel + guard error so the domain reason ("3 subtasks still open") survives to the UI.
+- `ErrHookFailed` — same double-wrap for hook errors.
+
+`ErrGuardDenied` vs `ErrHookFailed` is the consumer's 4xx/5xx split: user-visible refusal versus something broke mid-transition.
+
+## Tenancy
+
+No storage, no seam: multi-tenancy is which machine you compiled. The doc example shows the pattern — cache compiled machines keyed by `(tenant, flow, version)`, recompile on flow edit; machines are immutable so the cache needs no invalidation beyond the version key. Single-tenant typed use pays zero ceremony (`var InvoiceFSM = fsm.MustNew(...)`). This satisfies the repo tenancy rule by construction: there is no key composition or scoped storage to fail open.
+
+## Performance
+
+`Fire` on a bare edge (no guards/hooks) is the hot path: target 0 allocs/op via a `struct{ from, to S }` map key for edge lookup. `Next`/`States`/`Allowed` allocate (they return copies). Benchmarks: bare `Fire`, `Fire` with guards+hooks, `Allowed` over a fan-out state, `Compile` of a realistic ~10-state/25-edge definition. Post-benchmark optimization pass with before/after numbers in the PR, per repo policy.
+
+## Testing (black-box, `fsm_test`)
+
+- Legality matrix: unknown states, illegal transitions, explicit self-edge allowed, wildcard generates no self-loop, `from == to` without explicit edge fails.
+- Ordering: a recording spy proves exit → edge → enter order for guards then hooks, guards-before-any-hook, first-error abort (failing enter-guard ⇒ zero hooks ran).
+- Hook mutation on success; abort mid-hooks leaves caller free to discard (documented semantics).
+- Wildcard expansion and explicit-edge-replaces-wildcard precedence, including wildcard guards applying to expanded edges.
+- Validation matrix: one test per issue class, multi-issue accumulation via `errors.Join`, `errors.Is` matching for every sentinel, guard/hook domain errors surviving the double-wrap.
+- `Definition` JSON round-trip; `Allowed` filtering (admin vs non-admin case); concurrent `Fire` on a shared machine under `-race`.
+
+## Anti-scope (restated in doc.go)
+
+No timers, no auto/cascade transitions, no per-instance state or persistence, no flow versioning/migration (recompile per version; migrating in-flight entities is consumer domain), no assignment/roles/SLA semantics, no event labels (additive later), no definition storage, no post-persist effect execution.
+
+## Ship checklist
+
+Delete the `core/fsm` entry from `docs/packages.md` (the `finance/invoice` dep line stays valid as-is). `doc.go` carries the runnable example: typed lifecycle + compile-and-cache tenant flow with named guards.


### PR DESCRIPTION
## Summary

Ships `core/fsm` — an immutable, compiled finite-state-machine brick with target-driven transitions, guards/hooks on edges and state enter/exit, source-side wildcards, and a runtime `Definition`/`Registry`/`Compile` layer for tenant-defined flows. Zero non-stdlib deps in implementation; black-box tests only.

A `Machine[S ~string, V any]` is a stateless, immutable transition table shared safely across goroutines — the current state lives in the caller's storage (a status column) and is passed into every call. `Fire` runs legality → guards (exit, edge, enter) → hooks (exit, edge, enter); first error aborts. Persistence is caller-owned.

Spec: `docs/superpowers/specs/2026-07-14-core-fsm-design.md`. Plan: `docs/superpowers/plans/2026-07-14-core-fsm.md`.

## What's included

- **Kernel** (`machine.go`, `define.go`, `errors.go`): `Fire`, `Can`, `Next`, `Initial`, `States`; typed `New`/`MustNew` via a zero-size `Define[S, V]` type-parameter anchor; 5 error sentinels. Construction infers states in first-mention order and aggregates every validation issue into one single-line `ErrInvalidDefinition`.
- **Guards & hooks**: six attachment surfaces (edge/enter/exit × guard/hook) with deterministic exit→edge→enter ordering. Guards are side-effect-free domain checks; hooks may mutate the entity. `ErrGuardDenied`/`ErrHookFailed` double-wrap the callback's own error so `errors.Is` matches both.
- **Source-side wildcards**: `EdgeFromAny(to)` expands at construction into concrete edges — an explicit `Edge` for a pair fully replaces the expanded one; no self-loops.
- **`Allowed`**: guard-filtered reachable targets for per-user UI (hooks never run); returns `ctx.Err()` on a done context so a transient timeout never reads as "no moves possible".
- **Runtime layer** (`definition.go`): JSON-taggable `Definition`/`StateDef`/`EdgeDef` + named-func `Registry`, compiled via `Compile`. All validation (duplicate/undeclared/whitespace states, unknown guard/hook names) aggregates into one single-line error so a flow-builder shows every problem in one save attempt.
- **`doc.go`**: package docs with compile-time and tenant-defined usage, consumer patterns (conditional writes, timer sweeps), and anti-scope.

## Testing

- `go test ./core/fsm/ -race` — all pass, **99.4%** statement coverage.
- 32-goroutine concurrent-use test under `-race`.
- `go vet` clean; `golangci-lint` (modernize/betteralign/nilaway/unused) 0 issues.

## Benchmarks (Apple M3 Max, darwin/arm64)

| Benchmark | ns/op | B/op | allocs/op |
|-----------|------:|-----:|----------:|
| `Fire_BareEdge` | 38.3 | 0 | **0** |
| `Fire_GuardsAndHooks` | 54.1 | 0 | 0 |
| `Allowed` | 139.0 | 80 | 2 |
| `Compile` | 7803 | 23496 | 78 |

Bare `Fire` (the hot path) is 0 allocs/op, gated by a `testing.AllocsPerRun` test. `Allowed`'s 2 allocs are the returned target slice; `Compile` is a construction-time path. No post-benchmark optimization was warranted — before numbers are the after numbers.
