### PR TITLE
feat(auth): rbac brick + guard/access authz seam wiring

### DIFF
--- a/auth/access/access.go
+++ b/auth/access/access.go
@@ -14,6 +14,7 @@ type Subject struct {
 	ID     string         // principal id
 	Tenant string         // optional tenant scope
 	Scopes []string       // token scopes; ScopeDecider reads these
+	Roles  []string       // role names; rbac.FromSubject reads these
 }
 
 // Action is a verb-on-noun permission string, e.g. "documents:read".
@@ -102,13 +103,13 @@ func Named(name string, d Decider) Decider {
 }
 
 // SubjectFromIdentity adapts a guard.Identity into a Subject. It is zero-alloc:
-// it copies ID, Tenant, and the Scopes slice header (shared, read-only) and
-// leaves Attrs nil. guard.Identity.Meta is NOT promoted into Attrs — that
-// would allocate a map on every request and the common scope/tenant checks
-// never read it. Consumers needing identity metadata in predicates populate
-// Attrs themselves via a WithSubject resolver.
+// it copies ID, Tenant, and the Scopes and Roles slice headers (shared,
+// read-only) and leaves Attrs nil. guard.Identity.Meta is NOT promoted into
+// Attrs — that would allocate a map on every request and the common
+// scope/tenant checks never read it. Consumers needing identity metadata in
+// predicates populate Attrs themselves via a WithSubject resolver.
 func SubjectFromIdentity(id guard.Identity) Subject {
-	return Subject{ID: id.Subject, Tenant: id.Tenant, Scopes: id.Scopes}
+	return Subject{ID: id.Subject, Tenant: id.Tenant, Scopes: id.Scopes, Roles: id.Roles}
 }
 
 // Authorize runs d.Decide and closes it fail-closed: Abstain becomes a Deny

--- a/auth/access/checker.go
+++ b/auth/access/checker.go
@@ -1,0 +1,52 @@
+package access
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/dmitrymomot/forge/core/ctxkey"
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+// checker binds an app decider to the request's resolved Subject so view code
+// can ask the SAME authorization question the route gate asks.
+type checker struct {
+	d   Decider
+	sub Subject
+	ok  bool
+}
+
+var checkerKey = ctxkey.New[checker]("access.checker")
+
+// WithChecker resolves the Subject once per request (the same resolver
+// RequirePermission uses — default guard) and binds {decider, subject} into
+// the context. Mount it alongside the gate so Can/CanResource run the exact
+// decider chain the routes gate on. It never denies; it only binds.
+func WithChecker(d Decider, opts ...Option) middleware.Middleware {
+	cfg := newConfig(opts...)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sub, ok := cfg.subject(r)
+			ctx := checkerKey.With(r.Context(), checker{d: d, sub: sub, ok: ok})
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// Can reports whether the bound subject is allowed to perform action on a
+// type-level (zero) resource. False when no checker is bound or no subject was
+// resolved. For conditional rendering (show/hide a control).
+func Can(ctx context.Context, action Action) bool {
+	return CanResource(ctx, action, Resource{})
+}
+
+// CanResource is Can with an explicit resource — for acl/abac view checks that
+// depend on the object (owner, tenant, attributes).
+func CanResource(ctx context.Context, action Action, r Resource) bool {
+	c, ok := checkerKey.From(ctx)
+	if !ok || !c.ok {
+		return false
+	}
+	dec, err := Authorize(ctx, c.d, c.sub, action, r)
+	return err == nil && dec.Effect == Allow
+}

--- a/auth/access/checker_test.go
+++ b/auth/access/checker_test.go
@@ -1,0 +1,52 @@
+package access_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+func TestCheckerCanMatchesDecider(t *testing.T) {
+	// decider allows exactly "documents:read"
+	d := access.DeciderFunc(func(_ context.Context, _ access.Subject, a access.Action, _ access.Resource) (access.Decision, error) {
+		if a == "documents:read" {
+			return access.Allow.Because("ok"), nil
+		}
+		return access.Decision{Effect: access.Abstain}, nil
+	})
+	sub := access.WithSubject(func(r *http.Request) (access.Subject, bool) {
+		return access.Subject{ID: "u1"}, true
+	})
+
+	var gotRead, gotWrite bool
+	h := access.WithChecker(d, sub)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRead = access.Can(r.Context(), "documents:read")
+		gotWrite = access.Can(r.Context(), "documents:write")
+	}))
+
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.True(t, gotRead, "read allowed")
+	assert.False(t, gotWrite, "write abstains -> not allowed")
+}
+
+func TestCanFalseWhenUnbound(t *testing.T) {
+	assert.False(t, access.Can(context.Background(), "documents:read"))
+}
+
+func TestCheckerFalseWhenNoSubject(t *testing.T) {
+	d := access.AllowAll()
+	sub := access.WithSubject(func(r *http.Request) (access.Subject, bool) {
+		return access.Subject{}, false // unauthenticated
+	})
+	var got bool
+	h := access.WithChecker(d, sub)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = access.Can(r.Context(), "documents:read")
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.False(t, got, "no subject -> not allowed even under AllowAll")
+}

--- a/auth/access/forbidden_test.go
+++ b/auth/access/forbidden_test.go
@@ -1,0 +1,42 @@
+package access_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+func TestWithForbiddenRendersCustomBody(t *testing.T) {
+	// deny-all decider; subject supplied so the decider is reached
+	deny := access.DenyAll("nope")
+	sub := access.WithSubject(func(r *http.Request) (access.Subject, bool) {
+		return access.Subject{ID: "u1"}, true
+	})
+	mw := access.RequirePermission(deny, "documents:read", sub,
+		access.WithForbidden(func(w http.ResponseWriter, r *http.Request) {
+			// Decision is on the context on the deny path
+			dec, ok := access.DecisionFrom(r.Context())
+			require.True(t, ok)
+			assert.Equal(t, access.Deny, dec.Effect)
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("<h1>Forbidden</h1>"))
+		}),
+	)
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler must not run on deny")
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/docs/1", nil).WithContext(context.Background())
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, "<h1>Forbidden</h1>", rec.Body.String())
+	assert.NotContains(t, rec.Header().Get("Content-Type"), "problem+json")
+}

--- a/auth/access/options.go
+++ b/auth/access/options.go
@@ -11,6 +11,7 @@ import (
 type config struct {
 	resource  func(*http.Request) Resource
 	subject   func(*http.Request) (Subject, bool)
+	forbidden func(http.ResponseWriter, *http.Request)
 	responder problem.Responder
 	loadError func(http.ResponseWriter, *http.Request, error)
 	logger    *slog.Logger
@@ -38,6 +39,18 @@ func WithSubject(fn func(r *http.Request) (Subject, bool)) Option {
 	return func(c *config) {
 		if fn != nil {
 			c.subject = fn
+		}
+	}
+}
+
+// WithForbidden overrides the deny response with a custom renderer — an HTML
+// 403 page or a redirect for server-rendered apps (default: problem.JSON 403).
+// The denied Decision is on the request context (DecisionFrom) for the reason.
+// Takes precedence over WithResponder on the deny path.
+func WithForbidden(fn func(w http.ResponseWriter, r *http.Request)) Option {
+	return func(c *config) {
+		if fn != nil {
+			c.forbidden = fn
 		}
 	}
 }
@@ -111,6 +124,10 @@ func newConfig(opts ...Option) config {
 func (c config) reject(w http.ResponseWriter, r *http.Request, cause error) {
 	if cause != nil && c.logger != nil {
 		c.logger.WarnContext(r.Context(), "access decider error", slog.Any("error", cause))
+	}
+	if c.forbidden != nil {
+		c.forbidden(w, r)
+		return
 	}
 	c.responder(w, r, errDenied)
 }

--- a/auth/access/subject_roles_test.go
+++ b/auth/access/subject_roles_test.go
@@ -1,0 +1,18 @@
+package access_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+func TestSubjectFromIdentityCopiesRoles(t *testing.T) {
+	id := guard.Identity{Subject: "u1", Tenant: "acme", Scopes: []string{"s"}, Roles: []string{"admin"}}
+	s := access.SubjectFromIdentity(id)
+	assert.Equal(t, "u1", s.ID)
+	assert.Equal(t, "acme", s.Tenant)
+	assert.Equal(t, []string{"admin"}, s.Roles)
+}

--- a/auth/guard/guard.go
+++ b/auth/guard/guard.go
@@ -11,15 +11,17 @@ import (
 )
 
 // Identity is the authenticated principal a Verifier resolved. Subject is
-// never empty on a successful verification; Tenant, Scopes, and Meta are
-// optional. Scopes is carried for the future authorization decision seam
-// (401-vs-403 split) — guard itself never reads it.
+// never empty on a successful verification; Tenant, Scopes, Roles, and Meta are
+// optional. Scopes and Roles are carried for the authorization decision seam
+// (access.ScopeDecider / access.Subject.Roles → rbac) — guard itself never
+// reads them.
 type Identity struct {
 	Meta    map[string]string // verifier-specific extras (email, key id, …)
 	Subject string            // principal id — never empty on success
 	Tenant  string            // optional tenant id
 	Method  Method            // how the request authenticated; see the Method* constants
-	Scopes  []string          // permissions/scopes for the future authz seam
+	Scopes  []string          // permissions/scopes for the authz seam (access.ScopeDecider)
+	Roles   []string          // role names for the authz seam (access.Subject.Roles → rbac)
 }
 
 // Method names how a request authenticated. The constants below cover the

--- a/auth/guard/identity_roles_test.go
+++ b/auth/guard/identity_roles_test.go
@@ -1,0 +1,14 @@
+package guard_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+)
+
+func TestIdentityCarriesRoles(t *testing.T) {
+	id := guard.Identity{Subject: "u1", Roles: []string{"admin", "editor"}}
+	assert.Equal(t, []string{"admin", "editor"}, id.Roles)
+}

--- a/auth/rbac/bench_test.go
+++ b/auth/rbac/bench_test.go
@@ -1,0 +1,73 @@
+package rbac_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/auth/rbac"
+)
+
+func benchSet(b *testing.B) *rbac.RoleSet {
+	b.Helper()
+	rs, err := rbac.NewRoleSet(
+		rbac.WithRoles(
+			rbac.Role("viewer", "documents:read", "comments:read"),
+			rbac.Role("editor", "documents:*"),
+			rbac.Role("admin", "*"),
+			rbac.Role("auditor", "auditlog:read"),
+		),
+		rbac.WithRoleInheritance(
+			rbac.RoleInherits("editor", "viewer"),
+			rbac.RoleInherits("manager", "editor", "auditor"),
+		),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return rs
+}
+
+func BenchmarkCan(b *testing.B) {
+	rs := benchSet(b)
+	roles := []string{"editor"}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = rs.Can(roles, "documents:write")
+	}
+}
+
+func BenchmarkHasRole(b *testing.B) {
+	rs := benchSet(b)
+	roles := []string{"manager"}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = rs.HasRole(roles, "viewer")
+	}
+}
+
+func BenchmarkDeciderFromSubject(b *testing.B) {
+	rs := benchSet(b)
+	d := rbac.Decider(rs, rbac.FromSubject())
+	sub := access.Subject{ID: "u1", Roles: []string{"editor"}}
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = d.Decide(ctx, sub, "documents:write", access.Resource{})
+	}
+}
+
+func BenchmarkResolve(b *testing.B) {
+	rs := benchSet(b)
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = rs.Resolve("manager")
+	}
+}
+
+func BenchmarkNewRoleSet(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = benchSet(b)
+	}
+}

--- a/auth/rbac/decider.go
+++ b/auth/rbac/decider.go
@@ -1,0 +1,50 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+// RoleSource yields a subject's role names for a decision.
+type RoleSource interface {
+	Roles(ctx context.Context, s access.Subject) ([]string, error)
+}
+
+type roleSourceFunc func(ctx context.Context, s access.Subject) ([]string, error)
+
+func (f roleSourceFunc) Roles(ctx context.Context, s access.Subject) ([]string, error) {
+	return f(ctx, s)
+}
+
+// FromSubject reads roles straight off the Subject (populated from
+// guard.Identity.Roles). Zero-I/O fast path.
+func FromSubject() RoleSource {
+	return roleSourceFunc(func(_ context.Context, s access.Subject) ([]string, error) {
+		return s.Roles, nil
+	})
+}
+
+// FromStore reads roles from the assignment Store for (Subject.Tenant,
+// Subject.ID) — the runtime-assigned-roles path.
+func FromStore(store Store) RoleSource {
+	return roleSourceFunc(func(ctx context.Context, s access.Subject) ([]string, error) {
+		return store.RolesFor(ctx, s.Tenant, s.ID)
+	})
+}
+
+// Decider adapts the engine to the access seam: Allow when the subject's roles
+// grant the action, else Abstain (never Deny — a missing grant must not veto
+// acl/abac). A RoleSource error is returned so the chain fails closed.
+func Decider(rs *RoleSet, src RoleSource) access.Decider {
+	return access.DeciderFunc(func(ctx context.Context, s access.Subject, a access.Action, _ access.Resource) (access.Decision, error) {
+		roles, err := src.Roles(ctx, s)
+		if err != nil {
+			return access.Decision{Effect: access.Abstain, Decider: "rbac"}, err
+		}
+		if rs.Can(roles, string(a)) {
+			return access.Decision{Effect: access.Allow, Decider: "rbac", Reason: "role grants permission"}, nil
+		}
+		return access.Decision{Effect: access.Abstain, Decider: "rbac", Reason: "no role grants permission"}, nil
+	})
+}

--- a/auth/rbac/decider_test.go
+++ b/auth/rbac/decider_test.go
@@ -1,0 +1,45 @@
+package rbac_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/auth/rbac"
+)
+
+func TestDeciderFromSubjectAllowAbstain(t *testing.T) {
+	rs := mkSet(t)
+	d := rbac.Decider(rs, rbac.FromSubject())
+	ctx := context.Background()
+
+	dec, err := d.Decide(ctx, access.Subject{ID: "u1", Roles: []string{"editor"}}, "documents:write", access.Resource{})
+	require.NoError(t, err)
+	assert.Equal(t, access.Allow, dec.Effect)
+
+	dec, err = d.Decide(ctx, access.Subject{ID: "u1", Roles: []string{"viewer"}}, "documents:write", access.Resource{})
+	require.NoError(t, err)
+	assert.Equal(t, access.Abstain, dec.Effect) // missing grant -> abstain, never deny
+}
+
+func TestDeciderFromStore(t *testing.T) {
+	rs := mkSet(t)
+	store := rbac.NewMemoryStore()
+	require.NoError(t, store.Assign(context.Background(), "", "u1", []string{"admin"}))
+
+	d := rbac.Decider(rs, rbac.FromStore(store))
+	dec, err := d.Decide(context.Background(), access.Subject{ID: "u1"}, "anything:here", access.Resource{})
+	require.NoError(t, err)
+	assert.Equal(t, access.Allow, dec.Effect) // admin has "*"
+}
+
+func TestDeciderAbstainClosesToDenyViaAuthorize(t *testing.T) {
+	rs := mkSet(t)
+	d := rbac.Decider(rs, rbac.FromSubject())
+	dec, err := access.Authorize(context.Background(), d, access.Subject{ID: "u1", Roles: []string{"viewer"}}, "documents:write", access.Resource{})
+	require.NoError(t, err)
+	assert.Equal(t, access.Deny, dec.Effect) // Authorize turns all-abstain into fail-closed deny
+}

--- a/auth/rbac/doc.go
+++ b/auth/rbac/doc.go
@@ -1,0 +1,46 @@
+// Package rbac is role-based access control: predefined roles with permission
+// grants, inheritance (nesting + multi-parent), out-of-hierarchy standalone
+// roles, and wildcard grants. It resolves a subject's role names into an
+// effective permission set (Can), reports inheritance-aware role membership
+// (HasRole), and plugs into the auth/access decision seam as one Decider —
+// Allow when a role grants the action, else Abstain (never Deny; acl/abac
+// layer on top). Runtime subject→role assignments live behind a storage-
+// agnostic Store (in-memory built in; rbac/pgstore for Postgres), scoped by an
+// optional WithScope tenancy hook that fails closed.
+//
+// Roles reach the decider automatically: guard.Identity.Roles →
+// access.Subject.Roles → rbac.Decider(rs, rbac.FromSubject()). Gate routes with
+// access.RequirePermission and toggle views with access.Can.
+package rbac
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+func Example() {
+	rs, err := NewRoleSet(
+		WithRoles(
+			Role("viewer", "documents:read"),
+			Role("editor", "documents:*"),
+			Role("admin", "*"),
+		),
+		WithRoleInheritance(
+			RoleInherits("editor", "viewer"),
+		),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	d := Decider(rs, FromSubject())
+	dec, _ := access.Authorize(
+		context.Background(), d,
+		access.Subject{ID: "u1", Roles: []string{"editor"}},
+		"documents:write", access.Resource{},
+	)
+	fmt.Println(dec.Effect)
+	// Output: allow
+}

--- a/auth/rbac/errors.go
+++ b/auth/rbac/errors.go
@@ -1,0 +1,21 @@
+package rbac
+
+import "errors"
+
+var (
+	// ErrDuplicateRole is returned by NewRoleSet when a role name is declared
+	// more than once via WithRoles.
+	ErrDuplicateRole = errors.New("rbac: duplicate role")
+
+	// ErrUnknownRole is returned by NewRoleSet when an inheritance edge names a
+	// role not defined via WithRoles (child or parent).
+	ErrUnknownRole = errors.New("rbac: unknown role in inheritance edge")
+
+	// ErrCycle is returned by NewRoleSet when the inheritance graph contains a
+	// cycle.
+	ErrCycle = errors.New("rbac: inheritance cycle")
+
+	// ErrScope fails a Manager operation closed when the WithScope hook errors
+	// or yields an empty tenant.
+	ErrScope = errors.New("rbac: scope hook failed")
+)

--- a/auth/rbac/memory.go
+++ b/auth/rbac/memory.go
@@ -47,9 +47,13 @@ func (s *memoryStore) Assign(_ context.Context, tenant, subject string, roles []
 func (s *memoryStore) Unassign(_ context.Context, tenant, subject string, roles []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	set := s.m[memKey(tenant, subject)]
+	k := memKey(tenant, subject)
+	set := s.m[k]
 	for _, r := range roles {
 		delete(set, r)
+	}
+	if len(set) == 0 {
+		delete(s.m, k) // reclaim the key once the subject holds no roles
 	}
 	return nil
 }

--- a/auth/rbac/memory.go
+++ b/auth/rbac/memory.go
@@ -1,0 +1,55 @@
+package rbac
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+)
+
+type memoryStore struct {
+	m  map[string]map[string]struct{} // key(tenant,subject) -> role set
+	mu sync.RWMutex
+}
+
+// NewMemoryStore returns an in-memory Store for tests and single-node dev use.
+func NewMemoryStore() Store {
+	return &memoryStore{m: map[string]map[string]struct{}{}}
+}
+
+func memKey(tenant, subject string) string { return tenant + "\x00" + subject }
+
+func (s *memoryStore) RolesFor(_ context.Context, tenant, subject string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	set := s.m[memKey(tenant, subject)]
+	if len(set) == 0 {
+		return nil, nil
+	}
+	return slices.Collect(maps.Keys(set)), nil
+}
+
+func (s *memoryStore) Assign(_ context.Context, tenant, subject string, roles []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := memKey(tenant, subject)
+	set := s.m[k]
+	if set == nil {
+		set = map[string]struct{}{}
+		s.m[k] = set
+	}
+	for _, r := range roles {
+		set[r] = struct{}{}
+	}
+	return nil
+}
+
+func (s *memoryStore) Unassign(_ context.Context, tenant, subject string, roles []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	set := s.m[memKey(tenant, subject)]
+	for _, r := range roles {
+		delete(set, r)
+	}
+	return nil
+}

--- a/auth/rbac/options_test.go
+++ b/auth/rbac/options_test.go
@@ -1,0 +1,25 @@
+package rbac_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/auth/rbac"
+)
+
+func TestRoleAndInheritConstructors(t *testing.T) {
+	// Constructors are opaque values consumed by the options; we assert they
+	// compile and thread through NewRoleSet without error (behavior verified
+	// in Task 7). Here we only pin the option surface.
+	_, err := rbac.NewRoleSet(
+		rbac.WithRoles(
+			rbac.Role("viewer", "documents:read"),
+			rbac.Role("admin", "*"),
+		),
+		rbac.WithRoleInheritance(
+			rbac.RoleInherits("admin", "viewer"),
+		),
+	)
+	assert.NoError(t, err)
+}

--- a/auth/rbac/permset_internal_test.go
+++ b/auth/rbac/permset_internal_test.go
@@ -1,0 +1,30 @@
+package rbac
+
+import "testing"
+
+func TestPermSetAllows(t *testing.T) {
+	p := newPermSet([]string{"documents:read", "reports:*"})
+	cases := []struct {
+		action string
+		want   bool
+	}{
+		{"documents:read", true}, // exact
+		{"documents:write", false},
+		{"reports:view", true}, // segment wildcard
+		{"reports:export", true},
+		{"reports", false}, // no colon -> not matched by "reports:*"
+		{"other:read", false},
+	}
+	for _, c := range cases {
+		if got := p.allows(c.action); got != c.want {
+			t.Errorf("allows(%q) = %v, want %v", c.action, got, c.want)
+		}
+	}
+}
+
+func TestPermSetSuperWildcard(t *testing.T) {
+	p := newPermSet([]string{"*"})
+	if !p.allows("anything:here") || !p.allows("x") {
+		t.Fatal("super wildcard must allow everything")
+	}
+}

--- a/auth/rbac/pgstore/doc.go
+++ b/auth/rbac/pgstore/doc.go
@@ -1,0 +1,5 @@
+// Package pgstore is the Postgres driver for rbac.Store: subject→role
+// assignments in forge_rbac_assignments, scoped by tenant. Apply Migrations
+// (under its own version table) before use; the pool's lifecycle is the
+// caller's. See auth/rbac for the engine and the access.Decider adapter.
+package pgstore

--- a/auth/rbac/pgstore/migrations/00001_create_forge_rbac_assignments.sql
+++ b/auth/rbac/pgstore/migrations/00001_create_forge_rbac_assignments.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+CREATE TABLE forge_rbac_assignments (
+    tenant  text NOT NULL DEFAULT '',
+    subject text NOT NULL,
+    role    text NOT NULL,
+    PRIMARY KEY (tenant, subject, role)
+);
+
+-- +goose Down
+DROP TABLE forge_rbac_assignments;

--- a/auth/rbac/pgstore/pgstore.go
+++ b/auth/rbac/pgstore/pgstore.go
@@ -1,0 +1,94 @@
+package pgstore
+
+import (
+	"context"
+	"embed"
+	"io/fs"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/auth/rbac"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_rbac_assignments, rooted
+// so its .sql files sit at fsys root (data/migration.New globs the root). Apply
+// via data/migration under its own version table ("forge_rbac_schema").
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// Store is the Postgres implementation of rbac.Store. The pool's lifecycle is
+// the caller's.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+var _ rbac.Store = (*Store)(nil)
+
+// New builds a Postgres rbac assignment Store. Apply Migrations first.
+func New(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
+
+// RolesFor returns the roles assigned to subject within tenant.
+func (s *Store) RolesFor(ctx context.Context, tenant, subject string) ([]string, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT role FROM forge_rbac_assignments WHERE tenant = $1 AND subject = $2`, tenant, subject)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var roles []string
+	for rows.Next() {
+		var role string
+		if err := rows.Scan(&role); err != nil {
+			return nil, err
+		}
+		roles = append(roles, role)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return roles, nil
+}
+
+// Assign grants roles to subject within tenant. Idempotent (ON CONFLICT DO
+// NOTHING) and batched in one round-trip.
+func (s *Store) Assign(ctx context.Context, tenant, subject string, roles []string) error {
+	if len(roles) == 0 {
+		return nil
+	}
+	batch := &pgx.Batch{}
+	for _, role := range roles {
+		batch.Queue(
+			`INSERT INTO forge_rbac_assignments (tenant, subject, role)
+			 VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`, tenant, subject, role)
+	}
+	br := s.pool.SendBatch(ctx, batch)
+	defer br.Close()
+	for range roles {
+		if _, err := br.Exec(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Unassign revokes roles from subject within tenant.
+func (s *Store) Unassign(ctx context.Context, tenant, subject string, roles []string) error {
+	if len(roles) == 0 {
+		return nil
+	}
+	_, err := s.pool.Exec(ctx,
+		`DELETE FROM forge_rbac_assignments WHERE tenant = $1 AND subject = $2 AND role = ANY($3)`,
+		tenant, subject, roles)
+	return err
+}

--- a/auth/rbac/pgstore/pgstore.go
+++ b/auth/rbac/pgstore/pgstore.go
@@ -73,13 +73,13 @@ func (s *Store) Assign(ctx context.Context, tenant, subject string, roles []stri
 			 VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`, tenant, subject, role)
 	}
 	br := s.pool.SendBatch(ctx, batch)
-	defer br.Close()
 	for range roles {
 		if _, err := br.Exec(); err != nil {
+			_ = br.Close()
 			return err
 		}
 	}
-	return nil
+	return br.Close()
 }
 
 // Unassign revokes roles from subject within tenant.

--- a/auth/rbac/pgstore/pgstore_test.go
+++ b/auth/rbac/pgstore/pgstore_test.go
@@ -1,0 +1,60 @@
+package pgstore_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/rbac"
+	"github.com/dmitrymomot/forge/auth/rbac/pgstore"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+)
+
+var _ rbac.Store = (*pgstore.Store)(nil)
+
+func newStore(t *testing.T) *pgstore.Store {
+	t.Helper()
+	dsn := os.Getenv("FORGE_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("set FORGE_TEST_POSTGRES_DSN")
+	}
+	cfg := postgres.DefaultConfig()
+	cfg.URL = dsn
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgstore.Migrations, migration.WithTable("forge_rbac_schema")).Up(context.Background(), db))
+	return pgstore.New(pool)
+}
+
+func TestPgAssignRolesForUnassign(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	subject := id.NewUUID().String() // unique per run; table persists
+	tenant := "acme"
+
+	require.NoError(t, s.Assign(ctx, tenant, subject, []string{"editor", "auditor"}))
+	require.NoError(t, s.Assign(ctx, tenant, subject, []string{"editor"})) // idempotent
+
+	roles, err := s.RolesFor(ctx, tenant, subject)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"editor", "auditor"}, roles)
+
+	// tenant isolation
+	other, err := s.RolesFor(ctx, "other", subject)
+	require.NoError(t, err)
+	assert.Empty(t, other)
+
+	require.NoError(t, s.Unassign(ctx, tenant, subject, []string{"auditor"}))
+	roles, err = s.RolesFor(ctx, tenant, subject)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"editor"}, roles)
+}

--- a/auth/rbac/roleset.go
+++ b/auth/rbac/roleset.go
@@ -1,5 +1,7 @@
 package rbac
 
+import "strings"
+
 // RoleDef is a role and its own granted permission patterns, built by Role.
 type RoleDef struct {
 	name   string
@@ -53,3 +55,44 @@ func NewRoleSet(opts ...RoleSetOption) (*RoleSet, error) {
 
 // RoleSet is fleshed out in Task 7.
 type RoleSet struct{}
+
+// permSet is a role's effective, pre-expanded permission set. Lookups are O(1)
+// and allocation-free.
+type permSet struct {
+	exact    map[string]struct{} // "documents:read"
+	wildcard map[string]struct{} // noun before ":*", stored bare: "documents"
+	super    bool                // "*" grants everything
+}
+
+// newPermSet classifies grant patterns into the three match forms.
+func newPermSet(grants []string) *permSet {
+	p := &permSet{exact: map[string]struct{}{}, wildcard: map[string]struct{}{}}
+	for _, g := range grants {
+		switch {
+		case g == "*":
+			p.super = true
+		case strings.HasSuffix(g, ":*"):
+			p.wildcard[g[:len(g)-2]] = struct{}{}
+		default:
+			p.exact[g] = struct{}{}
+		}
+	}
+	return p
+}
+
+// allows reports whether action is granted. Zero-alloc: Cut returns substrings
+// that share action's backing array, so the noun lookup never allocates.
+func (p *permSet) allows(action string) bool {
+	if p.super {
+		return true
+	}
+	if _, ok := p.exact[action]; ok {
+		return true
+	}
+	noun, _, found := strings.Cut(action, ":")
+	if !found {
+		return false
+	}
+	_, ok := p.wildcard[noun]
+	return ok
+}

--- a/auth/rbac/roleset.go
+++ b/auth/rbac/roleset.go
@@ -1,0 +1,55 @@
+package rbac
+
+// RoleDef is a role and its own granted permission patterns, built by Role.
+type RoleDef struct {
+	name   string
+	grants []string
+}
+
+// Role declares a role named name granting the given permission patterns
+// (exact "documents:read", segment wildcard "documents:*", or super "*").
+func Role(name string, grants ...string) RoleDef {
+	return RoleDef{name: name, grants: grants}
+}
+
+// InheritEdge is one inheritance edge (child inherits from parents), built by
+// RoleInherits. Multi-parent is supported.
+type InheritEdge struct {
+	child   string
+	parents []string
+}
+
+// RoleInherits declares that child inherits the permissions of every parent.
+func RoleInherits(child string, parents ...string) InheritEdge {
+	return InheritEdge{child: child, parents: parents}
+}
+
+type roleSetConfig struct {
+	roles []RoleDef
+	edges []InheritEdge
+}
+
+// RoleSetOption configures NewRoleSet.
+type RoleSetOption func(*roleSetConfig)
+
+// WithRoles adds role definitions. Accumulates across calls.
+func WithRoles(defs ...RoleDef) RoleSetOption {
+	return func(c *roleSetConfig) { c.roles = append(c.roles, defs...) }
+}
+
+// WithRoleInheritance adds inheritance edges. Accumulates across calls.
+func WithRoleInheritance(edges ...InheritEdge) RoleSetOption {
+	return func(c *roleSetConfig) { c.edges = append(c.edges, edges...) }
+}
+
+// NewRoleSet is completed in Task 7; this stub lets the option surface compile.
+func NewRoleSet(opts ...RoleSetOption) (*RoleSet, error) {
+	cfg := roleSetConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return &RoleSet{}, nil
+}
+
+// RoleSet is fleshed out in Task 7.
+type RoleSet struct{}

--- a/auth/rbac/roleset.go
+++ b/auth/rbac/roleset.go
@@ -1,6 +1,9 @@
 package rbac
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // RoleDef is a role and its own granted permission patterns, built by Role.
 type RoleDef struct {
@@ -44,17 +47,162 @@ func WithRoleInheritance(edges ...InheritEdge) RoleSetOption {
 	return func(c *roleSetConfig) { c.edges = append(c.edges, edges...) }
 }
 
-// NewRoleSet is completed in Task 7; this stub lets the option surface compile.
+// RoleSet is an immutable, concurrent-safe set of role definitions with
+// inheritance resolved. Effective permission sets and ancestor closures are
+// pre-expanded per role so Can/HasRole are map lookups.
+type RoleSet struct {
+	effective map[string]*permSet            // role -> effective (own + inherited) grants
+	ancestors map[string]map[string]struct{} // role -> {self + all inherited role names}
+	grants    map[string][]string            // role -> effective grant patterns (for Resolve.List)
+}
+
+// NewRoleSet validates the definitions and pre-expands inheritance. Errors:
+// ErrDuplicateRole, ErrUnknownRole, ErrCycle.
 func NewRoleSet(opts ...RoleSetOption) (*RoleSet, error) {
 	cfg := roleSetConfig{}
 	for _, o := range opts {
 		o(&cfg)
 	}
-	return &RoleSet{}, nil
+
+	own := make(map[string][]string, len(cfg.roles)) // role -> own grants
+	for _, d := range cfg.roles {
+		if _, dup := own[d.name]; dup {
+			return nil, fmt.Errorf("%w: %q", ErrDuplicateRole, d.name)
+		}
+		own[d.name] = d.grants
+	}
+
+	// An inheritance edge's child defines a role even if it has no own grants
+	// (a "pure aggregator", e.g. manager = editor + auditor). Parents, however,
+	// must be roles that exist (in WithRoles or as another edge's child).
+	parents := make(map[string][]string, len(cfg.edges)) // role -> direct parents
+	for _, e := range cfg.edges {
+		if _, ok := own[e.child]; !ok {
+			own[e.child] = nil // pure aggregator: known, but grants nothing itself
+		}
+		parents[e.child] = append(parents[e.child], e.parents...)
+	}
+	for _, e := range cfg.edges {
+		for _, p := range e.parents {
+			if _, ok := own[p]; !ok {
+				return nil, fmt.Errorf("%w: %q", ErrUnknownRole, p)
+			}
+		}
+	}
+
+	rs := &RoleSet{
+		effective: make(map[string]*permSet, len(own)),
+		ancestors: make(map[string]map[string]struct{}, len(own)),
+		grants:    make(map[string][]string, len(own)),
+	}
+
+	// Depth-first closure per role with cycle detection.
+	const (
+		visiting = 1
+		done     = 2
+	)
+	state := make(map[string]int, len(own))
+	closure := make(map[string]map[string]struct{}, len(own)) // role -> ancestor names
+
+	var walk func(role string) (map[string]struct{}, error)
+	walk = func(role string) (map[string]struct{}, error) {
+		if state[role] == done {
+			return closure[role], nil
+		}
+		if state[role] == visiting {
+			return nil, fmt.Errorf("%w: at %q", ErrCycle, role)
+		}
+		state[role] = visiting
+		acc := map[string]struct{}{role: {}}
+		for _, p := range parents[role] {
+			pc, err := walk(p)
+			if err != nil {
+				return nil, err
+			}
+			for name := range pc {
+				acc[name] = struct{}{}
+			}
+		}
+		state[role] = done
+		closure[role] = acc
+		return acc, nil
+	}
+
+	for role := range own {
+		acc, err := walk(role)
+		if err != nil {
+			return nil, err
+		}
+		var eff []string
+		for name := range acc {
+			eff = append(eff, own[name]...)
+		}
+		rs.ancestors[role] = acc
+		rs.effective[role] = newPermSet(eff)
+		rs.grants[role] = eff
+	}
+	return rs, nil
 }
 
-// RoleSet is fleshed out in Task 7.
-type RoleSet struct{}
+// Can reports whether any of roleNames grants action (through inheritance and
+// wildcards). Zero-alloc; short-circuits on the first grant. Unknown role
+// names contribute nothing.
+func (rs *RoleSet) Can(roleNames []string, action string) bool {
+	for _, r := range roleNames {
+		if p, ok := rs.effective[r]; ok && p.allows(action) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasRole reports whether required is in the inheritance closure of roleNames
+// (holding editor, which inherits viewer, satisfies HasRole(…, "viewer")).
+// Zero-alloc. Unknown role names contribute nothing.
+func (rs *RoleSet) HasRole(roleNames []string, required string) bool {
+	for _, r := range roleNames {
+		if anc, ok := rs.ancestors[r]; ok {
+			if _, has := anc[required]; has {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// PermissionSet is the effective permission set of some roles — for listing,
+// debugging, and admin UIs. Not the hot path.
+type PermissionSet struct {
+	set      *permSet
+	patterns []string
+}
+
+// Resolve returns the union of the effective permissions of roleNames.
+func (rs *RoleSet) Resolve(roleNames ...string) PermissionSet {
+	var pats []string
+	seen := map[string]struct{}{}
+	for _, r := range roleNames {
+		for _, g := range rs.grants[r] {
+			if _, dup := seen[g]; dup {
+				continue
+			}
+			seen[g] = struct{}{}
+			pats = append(pats, g)
+		}
+	}
+	return PermissionSet{set: newPermSet(pats), patterns: pats}
+}
+
+// Allows reports whether action is granted by this set.
+func (ps PermissionSet) Allows(action string) bool {
+	if ps.set == nil {
+		return false
+	}
+	return ps.set.allows(action)
+}
+
+// List returns the effective grant patterns (deduped, unordered).
+func (ps PermissionSet) List() []string { return ps.patterns }
 
 // permSet is a role's effective, pre-expanded permission set. Lookups are O(1)
 // and allocation-free.

--- a/auth/rbac/roleset_test.go
+++ b/auth/rbac/roleset_test.go
@@ -1,0 +1,86 @@
+package rbac_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/rbac"
+)
+
+func mkSet(t *testing.T) *rbac.RoleSet {
+	t.Helper()
+	rs, err := rbac.NewRoleSet(
+		rbac.WithRoles(
+			rbac.Role("viewer", "documents:read", "comments:read"),
+			rbac.Role("editor", "documents:*"),
+			rbac.Role("admin", "*"),
+			rbac.Role("auditor", "auditlog:read"),
+		),
+		rbac.WithRoleInheritance(
+			rbac.RoleInherits("editor", "viewer"),
+			rbac.RoleInherits("manager", "editor", "auditor"),
+		),
+	)
+	require.NoError(t, err)
+	return rs
+}
+
+func TestCanDirectAndWildcard(t *testing.T) {
+	rs := mkSet(t)
+	assert.True(t, rs.Can([]string{"viewer"}, "documents:read"))
+	assert.False(t, rs.Can([]string{"viewer"}, "documents:write"))
+	assert.True(t, rs.Can([]string{"editor"}, "documents:write")) // wildcard
+	assert.True(t, rs.Can([]string{"admin"}, "anything:here"))    // super
+}
+
+func TestCanThroughInheritance(t *testing.T) {
+	rs := mkSet(t)
+	// editor inherits viewer's grants
+	assert.True(t, rs.Can([]string{"editor"}, "comments:read"))
+	// manager inherits editor (-> viewer) and auditor
+	assert.True(t, rs.Can([]string{"manager"}, "documents:write"))
+	assert.True(t, rs.Can([]string{"manager"}, "auditlog:read"))
+	assert.True(t, rs.Can([]string{"manager"}, "comments:read"))
+}
+
+func TestCanUnknownRoleSkipped(t *testing.T) {
+	rs := mkSet(t)
+	assert.False(t, rs.Can([]string{"ghost"}, "documents:read"))
+	assert.True(t, rs.Can([]string{"ghost", "viewer"}, "documents:read"))
+}
+
+func TestHasRoleInheritanceAware(t *testing.T) {
+	rs := mkSet(t)
+	assert.True(t, rs.HasRole([]string{"editor"}, "viewer"))   // ancestor
+	assert.True(t, rs.HasRole([]string{"editor"}, "editor"))   // self
+	assert.True(t, rs.HasRole([]string{"manager"}, "auditor")) // multi-parent
+	assert.False(t, rs.HasRole([]string{"viewer"}, "editor"))  // descendant, not held
+	assert.False(t, rs.HasRole([]string{"viewer"}, "ghost"))
+}
+
+func TestResolveListsEffectivePermissions(t *testing.T) {
+	rs := mkSet(t)
+	ps := rs.Resolve("editor")
+	assert.True(t, ps.Allows("documents:write"))
+	assert.True(t, ps.Allows("comments:read"))
+	assert.ElementsMatch(t, []string{"documents:*", "comments:read", "documents:read"}, ps.List())
+}
+
+func TestNewRoleSetErrors(t *testing.T) {
+	_, err := rbac.NewRoleSet(rbac.WithRoles(rbac.Role("a", "x"), rbac.Role("a", "y")))
+	assert.ErrorIs(t, err, rbac.ErrDuplicateRole)
+
+	_, err = rbac.NewRoleSet(
+		rbac.WithRoles(rbac.Role("a", "x")),
+		rbac.WithRoleInheritance(rbac.RoleInherits("a", "missing")),
+	)
+	assert.ErrorIs(t, err, rbac.ErrUnknownRole)
+
+	_, err = rbac.NewRoleSet(
+		rbac.WithRoles(rbac.Role("a", "x"), rbac.Role("b", "y")),
+		rbac.WithRoleInheritance(rbac.RoleInherits("a", "b"), rbac.RoleInherits("b", "a")),
+	)
+	assert.ErrorIs(t, err, rbac.ErrCycle)
+}

--- a/auth/rbac/store.go
+++ b/auth/rbac/store.go
@@ -1,0 +1,87 @@
+package rbac
+
+import (
+	"context"
+	"fmt"
+)
+
+// Store persists subject→role assignments. Tenant is explicit at the boundary
+// (single-tenant callers pass ""). Implementations must be safe for concurrent
+// use and idempotent on Assign.
+type Store interface {
+	RolesFor(ctx context.Context, tenant, subject string) ([]string, error)
+	Assign(ctx context.Context, tenant, subject string, roles []string) error
+	Unassign(ctx context.Context, tenant, subject string, roles []string) error
+}
+
+type managerConfig struct {
+	scope func(context.Context) (string, error)
+}
+
+// Option configures a Manager.
+type Option func(*managerConfig)
+
+// WithScope derives the tenant from context for every Manager operation and
+// fails closed (ErrScope) when the hook errors or yields an empty tenant. A nil
+// fn (or no WithScope) leaves the Manager single-tenant, operating on "".
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *managerConfig) { c.scope = fn }
+}
+
+// Manager is the tenant-scoped admin surface over a Store: assign, unassign,
+// and read a subject's roles.
+type Manager struct {
+	store Store
+	cfg   managerConfig
+}
+
+// NewManager wraps store with the given options.
+func NewManager(store Store, opts ...Option) *Manager {
+	var cfg managerConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return &Manager{store: store, cfg: cfg}
+}
+
+// tenant resolves the scope for this operation. No hook -> "" (single-tenant).
+func (m *Manager) tenant(ctx context.Context) (string, error) {
+	if m.cfg.scope == nil {
+		return "", nil
+	}
+	t, err := m.cfg.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrScope, err)
+	}
+	if t == "" {
+		return "", fmt.Errorf("%w: empty tenant", ErrScope)
+	}
+	return t, nil
+}
+
+// Assign grants roles to subject (idempotent).
+func (m *Manager) Assign(ctx context.Context, subject string, roles ...string) error {
+	t, err := m.tenant(ctx)
+	if err != nil {
+		return err
+	}
+	return m.store.Assign(ctx, t, subject, roles)
+}
+
+// Unassign revokes roles from subject.
+func (m *Manager) Unassign(ctx context.Context, subject string, roles ...string) error {
+	t, err := m.tenant(ctx)
+	if err != nil {
+		return err
+	}
+	return m.store.Unassign(ctx, t, subject, roles)
+}
+
+// RolesFor returns subject's assigned roles within the resolved tenant.
+func (m *Manager) RolesFor(ctx context.Context, subject string) ([]string, error) {
+	t, err := m.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return m.store.RolesFor(ctx, t, subject)
+}

--- a/auth/rbac/store_test.go
+++ b/auth/rbac/store_test.go
@@ -1,0 +1,58 @@
+package rbac_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/rbac"
+)
+
+func TestManagerAssignRolesForUnassign(t *testing.T) {
+	m := rbac.NewManager(rbac.NewMemoryStore())
+	ctx := context.Background()
+
+	require.NoError(t, m.Assign(ctx, "u1", "editor", "auditor"))
+	require.NoError(t, m.Assign(ctx, "u1", "editor")) // idempotent
+
+	roles, err := m.RolesFor(ctx, "u1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"editor", "auditor"}, roles)
+
+	require.NoError(t, m.Unassign(ctx, "u1", "auditor"))
+	roles, err = m.RolesFor(ctx, "u1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"editor"}, roles)
+}
+
+func TestManagerScopeIsolation(t *testing.T) {
+	store := rbac.NewMemoryStore()
+	tenant := "acme"
+	m := rbac.NewManager(store, rbac.WithScope(func(context.Context) (string, error) {
+		return tenant, nil
+	}))
+	ctx := context.Background()
+	require.NoError(t, m.Assign(ctx, "u1", "editor"))
+
+	// another tenant sees nothing
+	tenant = "other"
+	roles, err := m.RolesFor(ctx, "u1")
+	require.NoError(t, err)
+	assert.Empty(t, roles)
+}
+
+func TestManagerScopeFailClosed(t *testing.T) {
+	m := rbac.NewManager(rbac.NewMemoryStore(), rbac.WithScope(func(context.Context) (string, error) {
+		return "", errors.New("no tenant in context")
+	}))
+	err := m.Assign(context.Background(), "u1", "editor")
+	assert.ErrorIs(t, err, rbac.ErrScope)
+
+	m2 := rbac.NewManager(rbac.NewMemoryStore(), rbac.WithScope(func(context.Context) (string, error) {
+		return "", nil // empty tenant -> fail closed
+	}))
+	assert.ErrorIs(t, m2.Assign(context.Background(), "u1", "editor"), rbac.ErrScope)
+}

--- a/auth/rbac/store_test.go
+++ b/auth/rbac/store_test.go
@@ -28,6 +28,18 @@ func TestManagerAssignRolesForUnassign(t *testing.T) {
 	assert.ElementsMatch(t, []string{"editor"}, roles)
 }
 
+func TestManagerUnassignAllReclaims(t *testing.T) {
+	m := rbac.NewManager(rbac.NewMemoryStore())
+	ctx := context.Background()
+
+	require.NoError(t, m.Assign(ctx, "u1", "editor"))
+	require.NoError(t, m.Unassign(ctx, "u1", "editor")) // empties the role set
+
+	roles, err := m.RolesFor(ctx, "u1")
+	require.NoError(t, err)
+	assert.Empty(t, roles)
+}
+
 func TestManagerScopeIsolation(t *testing.T) {
 	store := rbac.NewMemoryStore()
 	tenant := "acme"


### PR DESCRIPTION
Ships `auth/rbac` — a role-based access control brick (engine + `access.Decider` adapter + assignment `Store`) — plus two small enabling changes to `auth/guard` and `auth/access` so wiring is trivial for JSON APIs and full-stack (templ) apps alike. Implements [docs/superpowers/plans/2026-07-14-auth-rbac.md](docs/superpowers/plans/2026-07-14-auth-rbac.md).

## What's in it

**auth/guard** — `Identity.Roles []string` carried through to the authz seam (guard never reads it).

**auth/access**
- `Subject.Roles []string`; `SubjectFromIdentity` copies it (zero-alloc, shared slice header).
- `WithForbidden(fn)` — override the deny response with an HTML 403 page or redirect for server-rendered apps; the denied `Decision` is on the request context. Takes precedence over `WithResponder` on the deny path.
- `WithChecker(d, opts...)` + `Can(ctx, action)` / `CanResource(ctx, action, r)` — bind the gate's decider once per request so view code asks the exact same authorization question the route gates on.

**auth/rbac** (new)
- Pure, forge-dep-free engine: `RoleSet` with inheritance (nesting + multi-parent), out-of-hierarchy standalone roles, and wildcard grants (`exact`, `noun:*`, super `*`). `Can`/`HasRole`/`Resolve`, with `NewRoleSet` validating duplicate/unknown-role/cycle up front and pre-expanding effective permission sets + ancestor closures.
- `Decider(rs, src)` adapts the engine to `access.Decider`: **Allow** when a role grants the action, else **Abstain** — never `Deny`, so a missing grant can't veto acl/abac. Fail-closed `Deny` remains `access.Authorize`'s job.
- `RoleSource`: `FromSubject()` (zero-I/O fast path off `Subject.Roles`) and `FromStore(store)` (runtime-assigned roles).
- Assignment `Store` + in-memory impl + `Manager` with an optional `WithScope(ctx)` tenancy hook that **fails closed** (`ErrScope`) on hook error or empty tenant; single-tenant use pays zero ceremony (tenant `""`).
- `rbac/pgstore` — Postgres driver (`forge_rbac_assignments`, tenant-scoped, batched idempotent Assign) + embedded migration under its own version table.

Roles flow automatically: `guard.Identity.Roles → access.Subject.Roles → rbac.Decider(rs, rbac.FromSubject())`. Gate routes with `access.RequirePermission`; toggle views with `access.Can`. Role-name route-gating is intentionally absent (retired in the spec — permission gating covers it; `rs.HasRole` covers cosmetic checks).

## Testing

- `go test -race -cover`: rbac **93.2%**, access **96.4%**, guard **99.3%**.
- `pgstore` exercised against **live Postgres 16** (assign / idempotent re-assign / tenant isolation / unassign) — not just DSN-skipped.
- `just lint` clean (vet, build, golangci-lint, nilaway, betteralign, modernize).

## Benchmarks

Hot paths meet the 0-alloc target; no optimization pass changes were warranted (measured — hot paths already at 0 allocs; `Resolve`/`NewRoleSet` allocate by design and are cold-path admin/construction, where the perf rules discourage adding complexity).

| Benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| `Can` | 25.4 | 0 | **0** |
| `HasRole` | 13.1 | 0 | **0** |
| `DeciderFromSubject` | 31.3 | 0 | **0** |
| `Resolve` (cold, admin) | 275.7 | 648 | 8 |
| `NewRoleSet` (cold, construction) | 2555 | 4801 | 56 |

_(Apple M-series, `-benchmem`.)_
