### PR TITLE
feat(core): country + phone packages

### DIFF
--- a/core/country/bench_test.go
+++ b/core/country/bench_test.go
@@ -1,0 +1,31 @@
+package country_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/country"
+)
+
+func BenchmarkByAlpha2(b *testing.B) {
+	for b.Loop() {
+		_, _ = country.ByAlpha2("US")
+	}
+}
+
+func BenchmarkByDialCode(b *testing.B) {
+	for b.Loop() {
+		_ = country.ByDialCode("1")
+	}
+}
+
+func BenchmarkAll(b *testing.B) {
+	for b.Loop() {
+		_ = country.All()
+	}
+}
+
+func BenchmarkNewSetFromCodes(b *testing.B) {
+	for b.Loop() {
+		_, _ = country.NewSetFromCodes("US", "GB", "DE", "FR")
+	}
+}

--- a/core/country/country.go
+++ b/core/country/country.go
@@ -78,11 +78,24 @@ func ByNumeric(code string) (Country, bool) {
 	return c, ok
 }
 
-// ByDialCode returns every country sharing an E.164 dial code (many share "1").
-// The returned slice is shared internal state sorted by Name and must not be
-// modified; it is nil when no country uses the code.
+// ByDialCode returns every country sharing an E.164 dial code (many share "1"),
+// sorted by Name. The returned slice is a fresh copy the caller may sort or
+// modify; it is nil when no country uses the code. Use HasDialCode for a
+// zero-allocation existence check.
 func ByDialCode(code string) []Country {
-	return byDial[code]
+	s := byDial[code]
+	if len(s) == 0 {
+		return nil
+	}
+	out := make([]Country, len(s))
+	copy(out, s)
+	return out
+}
+
+// HasDialCode reports whether any country uses the given E.164 dial code. It
+// allocates nothing, unlike ByDialCode, and backs prefix matching on hot paths.
+func HasDialCode(code string) bool {
+	return len(byDial[code]) > 0
 }
 
 // All returns every bundled country sorted by Name. The returned slice is a

--- a/core/country/country.go
+++ b/core/country/country.go
@@ -1,0 +1,94 @@
+package country
+
+import (
+	"sort"
+	"strings"
+)
+
+// Country is one ISO-3166-1 entry: its alpha-2 (the canonical key), alpha-3, and
+// numeric-3 codes, English short name, primary official ISO-4217 currency code,
+// E.164 dial code (no leading +), and flag emoji.
+type Country struct {
+	Alpha2   string
+	Alpha3   string
+	Numeric  string
+	Name     string
+	Currency string
+	DialCode string
+	Emoji    string
+}
+
+var (
+	byAlpha2  = map[string]Country{}
+	byAlpha3  = map[string]Country{}
+	byNumeric = map[string]Country{}
+	byDial    = map[string][]Country{}
+	sorted    []Country
+)
+
+func init() {
+	for _, c := range all {
+		c.Emoji = flagEmoji(c.Alpha2)
+	}
+	sorted = make([]Country, 0, len(all))
+	for _, c := range all {
+		byAlpha2[c.Alpha2] = *c
+		byAlpha3[c.Alpha3] = *c
+		byNumeric[c.Numeric] = *c
+		byDial[c.DialCode] = append(byDial[c.DialCode], *c)
+		sorted = append(sorted, *c)
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+	for k := range byDial {
+		s := byDial[k]
+		sort.Slice(s, func(i, j int) bool { return s[i].Name < s[j].Name })
+	}
+}
+
+// flagEmoji derives a flag from an alpha-2 code by mapping each letter to its
+// Unicode regional-indicator symbol. It returns "" for non-two-letter or
+// non-A–Z input.
+func flagEmoji(alpha2 string) string {
+	if len(alpha2) != 2 {
+		return ""
+	}
+	a, b := alpha2[0], alpha2[1]
+	if a < 'A' || a > 'Z' || b < 'A' || b > 'Z' {
+		return ""
+	}
+	const base = 0x1F1E6
+	return string([]rune{rune(base + int(a-'A')), rune(base + int(b-'A'))})
+}
+
+// ByAlpha2 looks up a country by ISO-3166-1 alpha-2 code, case-insensitively.
+func ByAlpha2(code string) (Country, bool) {
+	c, ok := byAlpha2[strings.ToUpper(code)]
+	return c, ok
+}
+
+// ByAlpha3 looks up a country by ISO-3166-1 alpha-3 code, case-insensitively.
+func ByAlpha3(code string) (Country, bool) {
+	c, ok := byAlpha3[strings.ToUpper(code)]
+	return c, ok
+}
+
+// ByNumeric looks up a country by ISO-3166-1 numeric-3 code.
+func ByNumeric(code string) (Country, bool) {
+	c, ok := byNumeric[code]
+	return c, ok
+}
+
+// ByDialCode returns every country sharing an E.164 dial code (many share "1").
+// The returned slice is shared internal state sorted by Name and must not be
+// modified; it is nil when no country uses the code.
+func ByDialCode(code string) []Country {
+	return byDial[code]
+}
+
+// All returns every bundled country sorted by Name. The returned slice is a
+// fresh copy the caller may retain and modify.
+func All() []Country {
+	out := make([]Country, len(sorted))
+	copy(out, sorted)
+	return out
+}

--- a/core/country/country_test.go
+++ b/core/country/country_test.go
@@ -34,6 +34,11 @@ func TestByAlpha3AndNumeric(t *testing.T) {
 	c, ok = country.ByNumeric("826")
 	assert.True(t, ok)
 	assert.Equal(t, "GB", c.Alpha2)
+
+	_, ok = country.ByAlpha3("ZZZ")
+	assert.False(t, ok)
+	_, ok = country.ByNumeric("000")
+	assert.False(t, ok)
 }
 
 func TestByDialCode_Shared(t *testing.T) {

--- a/core/country/country_test.go
+++ b/core/country/country_test.go
@@ -1,0 +1,58 @@
+package country_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/core/country"
+)
+
+func TestByAlpha2_HitAndCaseInsensitive(t *testing.T) {
+	c, ok := country.ByAlpha2("us")
+	assert.True(t, ok)
+	assert.Equal(t, "US", c.Alpha2)
+	assert.Equal(t, "USA", c.Alpha3)
+	assert.Equal(t, "840", c.Numeric)
+	assert.Equal(t, "United States", c.Name)
+	assert.Equal(t, "USD", c.Currency)
+	assert.Equal(t, "1", c.DialCode)
+	assert.Equal(t, "\U0001F1FA\U0001F1F8", c.Emoji) // 🇺🇸
+}
+
+func TestByAlpha2_Miss(t *testing.T) {
+	_, ok := country.ByAlpha2("ZZ")
+	assert.False(t, ok)
+}
+
+func TestByAlpha3AndNumeric(t *testing.T) {
+	c, ok := country.ByAlpha3("deu")
+	assert.True(t, ok)
+	assert.Equal(t, "DE", c.Alpha2)
+	c, ok = country.ByNumeric("826")
+	assert.True(t, ok)
+	assert.Equal(t, "GB", c.Alpha2)
+}
+
+func TestByDialCode_Shared(t *testing.T) {
+	cs := country.ByDialCode("1")
+	codes := make([]string, len(cs))
+	for i, c := range cs {
+		codes[i] = c.Alpha2
+	}
+	assert.Contains(t, codes, "US")
+	assert.Contains(t, codes, "CA")
+	assert.Nil(t, country.ByDialCode("999"))
+}
+
+func TestAll_SortedByName(t *testing.T) {
+	all := country.All()
+	assert.NotEmpty(t, all)
+	assert.True(t, sort.SliceIsSorted(all, func(i, j int) bool { return all[i].Name < all[j].Name }))
+}
+
+func TestVars_Populated(t *testing.T) {
+	assert.Equal(t, "GB", country.GB.Alpha2)
+	assert.Equal(t, "\U0001F1E9\U0001F1EA", country.DE.Emoji) // 🇩🇪 filled at init
+}

--- a/core/country/country_test.go
+++ b/core/country/country_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dmitrymomot/forge/core/country"
 )
@@ -55,4 +56,22 @@ func TestAll_SortedByName(t *testing.T) {
 func TestVars_Populated(t *testing.T) {
 	assert.Equal(t, "GB", country.GB.Alpha2)
 	assert.Equal(t, "\U0001F1E9\U0001F1EA", country.DE.Emoji) // 🇩🇪 filled at init
+}
+
+func TestByDialCode_ReturnsFreshCopy(t *testing.T) {
+	// Mutating the returned slice must not corrupt shared package state.
+	a := country.ByDialCode("1")
+	require.NotEmpty(t, a)
+	orig := a[0]
+	a[0] = country.Country{Alpha2: "ZZ"} // scribble on the caller's copy
+	b := country.ByDialCode("1")
+	require.NotEmpty(t, b)
+	assert.Equal(t, orig, b[0], "second call must be unaffected by mutation of the first")
+	assert.Nil(t, country.ByDialCode("999"))
+}
+
+func TestHasDialCode(t *testing.T) {
+	assert.True(t, country.HasDialCode("1"))
+	assert.True(t, country.HasDialCode("380"))
+	assert.False(t, country.HasDialCode("999"))
 }

--- a/core/country/data.go
+++ b/core/country/data.go
@@ -6,23 +6,283 @@ package country
 // alpha-2 pair at package init. Source: ISO-3166-1 (2026 edition).
 
 var (
+	AD = Country{Alpha2: "AD", Alpha3: "AND", Numeric: "020", Name: "Andorra", Currency: "EUR", DialCode: "376"}
+	AE = Country{Alpha2: "AE", Alpha3: "ARE", Numeric: "784", Name: "United Arab Emirates", Currency: "AED", DialCode: "971"}
+	AF = Country{Alpha2: "AF", Alpha3: "AFG", Numeric: "004", Name: "Afghanistan", Currency: "AFN", DialCode: "93"}
+	AG = Country{Alpha2: "AG", Alpha3: "ATG", Numeric: "028", Name: "Antigua and Barbuda", Currency: "XCD", DialCode: "1"}
+	AI = Country{Alpha2: "AI", Alpha3: "AIA", Numeric: "660", Name: "Anguilla", Currency: "XCD", DialCode: "1"}
+	AL = Country{Alpha2: "AL", Alpha3: "ALB", Numeric: "008", Name: "Albania", Currency: "ALL", DialCode: "355"}
+	AM = Country{Alpha2: "AM", Alpha3: "ARM", Numeric: "051", Name: "Armenia", Currency: "AMD", DialCode: "374"}
+	AO = Country{Alpha2: "AO", Alpha3: "AGO", Numeric: "024", Name: "Angola", Currency: "AOA", DialCode: "244"}
+	AQ = Country{Alpha2: "AQ", Alpha3: "ATA", Numeric: "010", Name: "Antarctica", Currency: "USD", DialCode: "672"}
+	AR = Country{Alpha2: "AR", Alpha3: "ARG", Numeric: "032", Name: "Argentina", Currency: "ARS", DialCode: "54"}
+	AS = Country{Alpha2: "AS", Alpha3: "ASM", Numeric: "016", Name: "American Samoa", Currency: "USD", DialCode: "1"}
+	AT = Country{Alpha2: "AT", Alpha3: "AUT", Numeric: "040", Name: "Austria", Currency: "EUR", DialCode: "43"}
 	AU = Country{Alpha2: "AU", Alpha3: "AUS", Numeric: "036", Name: "Australia", Currency: "AUD", DialCode: "61"}
+	AW = Country{Alpha2: "AW", Alpha3: "ABW", Numeric: "533", Name: "Aruba", Currency: "AWG", DialCode: "297"}
+	AX = Country{Alpha2: "AX", Alpha3: "ALA", Numeric: "248", Name: "Åland Islands", Currency: "EUR", DialCode: "358"}
+	AZ = Country{Alpha2: "AZ", Alpha3: "AZE", Numeric: "031", Name: "Azerbaijan", Currency: "AZN", DialCode: "994"}
+	BA = Country{Alpha2: "BA", Alpha3: "BIH", Numeric: "070", Name: "Bosnia and Herzegovina", Currency: "BAM", DialCode: "387"}
+	BB = Country{Alpha2: "BB", Alpha3: "BRB", Numeric: "052", Name: "Barbados", Currency: "BBD", DialCode: "1"}
+	BD = Country{Alpha2: "BD", Alpha3: "BGD", Numeric: "050", Name: "Bangladesh", Currency: "BDT", DialCode: "880"}
+	BE = Country{Alpha2: "BE", Alpha3: "BEL", Numeric: "056", Name: "Belgium", Currency: "EUR", DialCode: "32"}
+	BF = Country{Alpha2: "BF", Alpha3: "BFA", Numeric: "854", Name: "Burkina Faso", Currency: "XOF", DialCode: "226"}
+	BG = Country{Alpha2: "BG", Alpha3: "BGR", Numeric: "100", Name: "Bulgaria", Currency: "BGN", DialCode: "359"}
+	BH = Country{Alpha2: "BH", Alpha3: "BHR", Numeric: "048", Name: "Bahrain", Currency: "BHD", DialCode: "973"}
+	BI = Country{Alpha2: "BI", Alpha3: "BDI", Numeric: "108", Name: "Burundi", Currency: "BIF", DialCode: "257"}
+	BJ = Country{Alpha2: "BJ", Alpha3: "BEN", Numeric: "204", Name: "Benin", Currency: "XOF", DialCode: "229"}
+	BL = Country{Alpha2: "BL", Alpha3: "BLM", Numeric: "652", Name: "Saint Barthélemy", Currency: "EUR", DialCode: "590"}
+	BM = Country{Alpha2: "BM", Alpha3: "BMU", Numeric: "060", Name: "Bermuda", Currency: "BMD", DialCode: "1"}
+	BN = Country{Alpha2: "BN", Alpha3: "BRN", Numeric: "096", Name: "Brunei Darussalam", Currency: "BND", DialCode: "673"}
+	BO = Country{Alpha2: "BO", Alpha3: "BOL", Numeric: "068", Name: "Bolivia", Currency: "BOB", DialCode: "591"}
+	BQ = Country{Alpha2: "BQ", Alpha3: "BES", Numeric: "535", Name: "Bonaire, Sint Eustatius and Saba", Currency: "USD", DialCode: "599"}
 	BR = Country{Alpha2: "BR", Alpha3: "BRA", Numeric: "076", Name: "Brazil", Currency: "BRL", DialCode: "55"}
+	BS = Country{Alpha2: "BS", Alpha3: "BHS", Numeric: "044", Name: "Bahamas", Currency: "BSD", DialCode: "1"}
+	BT = Country{Alpha2: "BT", Alpha3: "BTN", Numeric: "064", Name: "Bhutan", Currency: "BTN", DialCode: "975"}
+	BV = Country{Alpha2: "BV", Alpha3: "BVT", Numeric: "074", Name: "Bouvet Island", Currency: "NOK", DialCode: "47"}
+	BW = Country{Alpha2: "BW", Alpha3: "BWA", Numeric: "072", Name: "Botswana", Currency: "BWP", DialCode: "267"}
+	BY = Country{Alpha2: "BY", Alpha3: "BLR", Numeric: "112", Name: "Belarus", Currency: "BYN", DialCode: "375"}
+	BZ = Country{Alpha2: "BZ", Alpha3: "BLZ", Numeric: "084", Name: "Belize", Currency: "BZD", DialCode: "501"}
 	CA = Country{Alpha2: "CA", Alpha3: "CAN", Numeric: "124", Name: "Canada", Currency: "CAD", DialCode: "1"}
+	CC = Country{Alpha2: "CC", Alpha3: "CCK", Numeric: "166", Name: "Cocos (Keeling) Islands", Currency: "AUD", DialCode: "61"}
+	CD = Country{Alpha2: "CD", Alpha3: "COD", Numeric: "180", Name: "Congo (Democratic Republic)", Currency: "CDF", DialCode: "243"}
+	CF = Country{Alpha2: "CF", Alpha3: "CAF", Numeric: "140", Name: "Central African Republic", Currency: "XAF", DialCode: "236"}
+	CG = Country{Alpha2: "CG", Alpha3: "COG", Numeric: "178", Name: "Congo", Currency: "XAF", DialCode: "242"}
+	CH = Country{Alpha2: "CH", Alpha3: "CHE", Numeric: "756", Name: "Switzerland", Currency: "CHF", DialCode: "41"}
+	CI = Country{Alpha2: "CI", Alpha3: "CIV", Numeric: "384", Name: "Côte d'Ivoire", Currency: "XOF", DialCode: "225"}
+	CK = Country{Alpha2: "CK", Alpha3: "COK", Numeric: "184", Name: "Cook Islands", Currency: "NZD", DialCode: "682"}
+	CL = Country{Alpha2: "CL", Alpha3: "CHL", Numeric: "152", Name: "Chile", Currency: "CLP", DialCode: "56"}
+	CM = Country{Alpha2: "CM", Alpha3: "CMR", Numeric: "120", Name: "Cameroon", Currency: "XAF", DialCode: "237"}
+	CN = Country{Alpha2: "CN", Alpha3: "CHN", Numeric: "156", Name: "China", Currency: "CNY", DialCode: "86"}
+	CO = Country{Alpha2: "CO", Alpha3: "COL", Numeric: "170", Name: "Colombia", Currency: "COP", DialCode: "57"}
+	CR = Country{Alpha2: "CR", Alpha3: "CRI", Numeric: "188", Name: "Costa Rica", Currency: "CRC", DialCode: "506"}
+	CU = Country{Alpha2: "CU", Alpha3: "CUB", Numeric: "192", Name: "Cuba", Currency: "CUP", DialCode: "53"}
+	CV = Country{Alpha2: "CV", Alpha3: "CPV", Numeric: "132", Name: "Cabo Verde", Currency: "CVE", DialCode: "238"}
+	CW = Country{Alpha2: "CW", Alpha3: "CUW", Numeric: "531", Name: "Curaçao", Currency: "ANG", DialCode: "599"}
+	CX = Country{Alpha2: "CX", Alpha3: "CXR", Numeric: "162", Name: "Christmas Island", Currency: "AUD", DialCode: "61"}
+	CY = Country{Alpha2: "CY", Alpha3: "CYP", Numeric: "196", Name: "Cyprus", Currency: "EUR", DialCode: "357"}
+	CZ = Country{Alpha2: "CZ", Alpha3: "CZE", Numeric: "203", Name: "Czechia", Currency: "CZK", DialCode: "420"}
 	DE = Country{Alpha2: "DE", Alpha3: "DEU", Numeric: "276", Name: "Germany", Currency: "EUR", DialCode: "49"}
+	DJ = Country{Alpha2: "DJ", Alpha3: "DJI", Numeric: "262", Name: "Djibouti", Currency: "DJF", DialCode: "253"}
+	DK = Country{Alpha2: "DK", Alpha3: "DNK", Numeric: "208", Name: "Denmark", Currency: "DKK", DialCode: "45"}
+	DM = Country{Alpha2: "DM", Alpha3: "DMA", Numeric: "212", Name: "Dominica", Currency: "XCD", DialCode: "1"}
+	DO = Country{Alpha2: "DO", Alpha3: "DOM", Numeric: "214", Name: "Dominican Republic", Currency: "DOP", DialCode: "1"}
+	DZ = Country{Alpha2: "DZ", Alpha3: "DZA", Numeric: "012", Name: "Algeria", Currency: "DZD", DialCode: "213"}
+	EC = Country{Alpha2: "EC", Alpha3: "ECU", Numeric: "218", Name: "Ecuador", Currency: "USD", DialCode: "593"}
+	EE = Country{Alpha2: "EE", Alpha3: "EST", Numeric: "233", Name: "Estonia", Currency: "EUR", DialCode: "372"}
+	EG = Country{Alpha2: "EG", Alpha3: "EGY", Numeric: "818", Name: "Egypt", Currency: "EGP", DialCode: "20"}
+	EH = Country{Alpha2: "EH", Alpha3: "ESH", Numeric: "732", Name: "Western Sahara", Currency: "MAD", DialCode: "212"}
+	ER = Country{Alpha2: "ER", Alpha3: "ERI", Numeric: "232", Name: "Eritrea", Currency: "ERN", DialCode: "291"}
+	ES = Country{Alpha2: "ES", Alpha3: "ESP", Numeric: "724", Name: "Spain", Currency: "EUR", DialCode: "34"}
+	ET = Country{Alpha2: "ET", Alpha3: "ETH", Numeric: "231", Name: "Ethiopia", Currency: "ETB", DialCode: "251"}
+	FI = Country{Alpha2: "FI", Alpha3: "FIN", Numeric: "246", Name: "Finland", Currency: "EUR", DialCode: "358"}
+	FJ = Country{Alpha2: "FJ", Alpha3: "FJI", Numeric: "242", Name: "Fiji", Currency: "FJD", DialCode: "679"}
+	FK = Country{Alpha2: "FK", Alpha3: "FLK", Numeric: "238", Name: "Falkland Islands", Currency: "FKP", DialCode: "500"}
+	FM = Country{Alpha2: "FM", Alpha3: "FSM", Numeric: "583", Name: "Micronesia", Currency: "USD", DialCode: "691"}
+	FO = Country{Alpha2: "FO", Alpha3: "FRO", Numeric: "234", Name: "Faroe Islands", Currency: "DKK", DialCode: "298"}
 	FR = Country{Alpha2: "FR", Alpha3: "FRA", Numeric: "250", Name: "France", Currency: "EUR", DialCode: "33"}
+	GA = Country{Alpha2: "GA", Alpha3: "GAB", Numeric: "266", Name: "Gabon", Currency: "XAF", DialCode: "241"}
 	GB = Country{Alpha2: "GB", Alpha3: "GBR", Numeric: "826", Name: "United Kingdom", Currency: "GBP", DialCode: "44"}
+	GD = Country{Alpha2: "GD", Alpha3: "GRD", Numeric: "308", Name: "Grenada", Currency: "XCD", DialCode: "1"}
+	GE = Country{Alpha2: "GE", Alpha3: "GEO", Numeric: "268", Name: "Georgia", Currency: "GEL", DialCode: "995"}
+	GF = Country{Alpha2: "GF", Alpha3: "GUF", Numeric: "254", Name: "French Guiana", Currency: "EUR", DialCode: "594"}
+	GG = Country{Alpha2: "GG", Alpha3: "GGY", Numeric: "831", Name: "Guernsey", Currency: "GBP", DialCode: "44"}
+	GH = Country{Alpha2: "GH", Alpha3: "GHA", Numeric: "288", Name: "Ghana", Currency: "GHS", DialCode: "233"}
+	GI = Country{Alpha2: "GI", Alpha3: "GIB", Numeric: "292", Name: "Gibraltar", Currency: "GIP", DialCode: "350"}
+	GL = Country{Alpha2: "GL", Alpha3: "GRL", Numeric: "304", Name: "Greenland", Currency: "DKK", DialCode: "299"}
+	GM = Country{Alpha2: "GM", Alpha3: "GMB", Numeric: "270", Name: "Gambia", Currency: "GMD", DialCode: "220"}
+	GN = Country{Alpha2: "GN", Alpha3: "GIN", Numeric: "324", Name: "Guinea", Currency: "GNF", DialCode: "224"}
+	GP = Country{Alpha2: "GP", Alpha3: "GLP", Numeric: "312", Name: "Guadeloupe", Currency: "EUR", DialCode: "590"}
+	GQ = Country{Alpha2: "GQ", Alpha3: "GNQ", Numeric: "226", Name: "Equatorial Guinea", Currency: "XAF", DialCode: "240"}
+	GR = Country{Alpha2: "GR", Alpha3: "GRC", Numeric: "300", Name: "Greece", Currency: "EUR", DialCode: "30"}
+	GS = Country{Alpha2: "GS", Alpha3: "SGS", Numeric: "239", Name: "South Georgia and the South Sandwich Islands", Currency: "GBP", DialCode: "500"}
+	GT = Country{Alpha2: "GT", Alpha3: "GTM", Numeric: "320", Name: "Guatemala", Currency: "GTQ", DialCode: "502"}
+	GU = Country{Alpha2: "GU", Alpha3: "GUM", Numeric: "316", Name: "Guam", Currency: "USD", DialCode: "1"}
+	GW = Country{Alpha2: "GW", Alpha3: "GNB", Numeric: "624", Name: "Guinea-Bissau", Currency: "XOF", DialCode: "245"}
+	GY = Country{Alpha2: "GY", Alpha3: "GUY", Numeric: "328", Name: "Guyana", Currency: "GYD", DialCode: "592"}
+	HK = Country{Alpha2: "HK", Alpha3: "HKG", Numeric: "344", Name: "Hong Kong", Currency: "HKD", DialCode: "852"}
+	HM = Country{Alpha2: "HM", Alpha3: "HMD", Numeric: "334", Name: "Heard Island and McDonald Islands", Currency: "AUD", DialCode: "672"}
+	HN = Country{Alpha2: "HN", Alpha3: "HND", Numeric: "340", Name: "Honduras", Currency: "HNL", DialCode: "504"}
+	HR = Country{Alpha2: "HR", Alpha3: "HRV", Numeric: "191", Name: "Croatia", Currency: "EUR", DialCode: "385"}
+	HT = Country{Alpha2: "HT", Alpha3: "HTI", Numeric: "332", Name: "Haiti", Currency: "HTG", DialCode: "509"}
+	HU = Country{Alpha2: "HU", Alpha3: "HUN", Numeric: "348", Name: "Hungary", Currency: "HUF", DialCode: "36"}
+	ID = Country{Alpha2: "ID", Alpha3: "IDN", Numeric: "360", Name: "Indonesia", Currency: "IDR", DialCode: "62"}
+	IE = Country{Alpha2: "IE", Alpha3: "IRL", Numeric: "372", Name: "Ireland", Currency: "EUR", DialCode: "353"}
+	IL = Country{Alpha2: "IL", Alpha3: "ISR", Numeric: "376", Name: "Israel", Currency: "ILS", DialCode: "972"}
+	IM = Country{Alpha2: "IM", Alpha3: "IMN", Numeric: "833", Name: "Isle of Man", Currency: "GBP", DialCode: "44"}
 	IN = Country{Alpha2: "IN", Alpha3: "IND", Numeric: "356", Name: "India", Currency: "INR", DialCode: "91"}
+	IO = Country{Alpha2: "IO", Alpha3: "IOT", Numeric: "086", Name: "British Indian Ocean Territory", Currency: "USD", DialCode: "246"}
+	IQ = Country{Alpha2: "IQ", Alpha3: "IRQ", Numeric: "368", Name: "Iraq", Currency: "IQD", DialCode: "964"}
+	IR = Country{Alpha2: "IR", Alpha3: "IRN", Numeric: "364", Name: "Iran", Currency: "IRR", DialCode: "98"}
+	IS = Country{Alpha2: "IS", Alpha3: "ISL", Numeric: "352", Name: "Iceland", Currency: "ISK", DialCode: "354"}
+	IT = Country{Alpha2: "IT", Alpha3: "ITA", Numeric: "380", Name: "Italy", Currency: "EUR", DialCode: "39"}
+	JE = Country{Alpha2: "JE", Alpha3: "JEY", Numeric: "832", Name: "Jersey", Currency: "GBP", DialCode: "44"}
+	JM = Country{Alpha2: "JM", Alpha3: "JAM", Numeric: "388", Name: "Jamaica", Currency: "JMD", DialCode: "1"}
+	JO = Country{Alpha2: "JO", Alpha3: "JOR", Numeric: "400", Name: "Jordan", Currency: "JOD", DialCode: "962"}
 	JP = Country{Alpha2: "JP", Alpha3: "JPN", Numeric: "392", Name: "Japan", Currency: "JPY", DialCode: "81"}
+	KE = Country{Alpha2: "KE", Alpha3: "KEN", Numeric: "404", Name: "Kenya", Currency: "KES", DialCode: "254"}
+	KG = Country{Alpha2: "KG", Alpha3: "KGZ", Numeric: "417", Name: "Kyrgyzstan", Currency: "KGS", DialCode: "996"}
+	KH = Country{Alpha2: "KH", Alpha3: "KHM", Numeric: "116", Name: "Cambodia", Currency: "KHR", DialCode: "855"}
+	KI = Country{Alpha2: "KI", Alpha3: "KIR", Numeric: "296", Name: "Kiribati", Currency: "AUD", DialCode: "686"}
+	KM = Country{Alpha2: "KM", Alpha3: "COM", Numeric: "174", Name: "Comoros", Currency: "KMF", DialCode: "269"}
+	KN = Country{Alpha2: "KN", Alpha3: "KNA", Numeric: "659", Name: "Saint Kitts and Nevis", Currency: "XCD", DialCode: "1"}
+	KP = Country{Alpha2: "KP", Alpha3: "PRK", Numeric: "408", Name: "North Korea", Currency: "KPW", DialCode: "850"}
+	KR = Country{Alpha2: "KR", Alpha3: "KOR", Numeric: "410", Name: "South Korea", Currency: "KRW", DialCode: "82"}
+	KW = Country{Alpha2: "KW", Alpha3: "KWT", Numeric: "414", Name: "Kuwait", Currency: "KWD", DialCode: "965"}
+	KY = Country{Alpha2: "KY", Alpha3: "CYM", Numeric: "136", Name: "Cayman Islands", Currency: "KYD", DialCode: "1"}
+	KZ = Country{Alpha2: "KZ", Alpha3: "KAZ", Numeric: "398", Name: "Kazakhstan", Currency: "KZT", DialCode: "7"}
+	LA = Country{Alpha2: "LA", Alpha3: "LAO", Numeric: "418", Name: "Laos", Currency: "LAK", DialCode: "856"}
+	LB = Country{Alpha2: "LB", Alpha3: "LBN", Numeric: "422", Name: "Lebanon", Currency: "LBP", DialCode: "961"}
+	LC = Country{Alpha2: "LC", Alpha3: "LCA", Numeric: "662", Name: "Saint Lucia", Currency: "XCD", DialCode: "1"}
+	LI = Country{Alpha2: "LI", Alpha3: "LIE", Numeric: "438", Name: "Liechtenstein", Currency: "CHF", DialCode: "423"}
+	LK = Country{Alpha2: "LK", Alpha3: "LKA", Numeric: "144", Name: "Sri Lanka", Currency: "LKR", DialCode: "94"}
+	LR = Country{Alpha2: "LR", Alpha3: "LBR", Numeric: "430", Name: "Liberia", Currency: "LRD", DialCode: "231"}
+	LS = Country{Alpha2: "LS", Alpha3: "LSO", Numeric: "426", Name: "Lesotho", Currency: "LSL", DialCode: "266"}
+	LT = Country{Alpha2: "LT", Alpha3: "LTU", Numeric: "440", Name: "Lithuania", Currency: "EUR", DialCode: "370"}
+	LU = Country{Alpha2: "LU", Alpha3: "LUX", Numeric: "442", Name: "Luxembourg", Currency: "EUR", DialCode: "352"}
+	LV = Country{Alpha2: "LV", Alpha3: "LVA", Numeric: "428", Name: "Latvia", Currency: "EUR", DialCode: "371"}
+	LY = Country{Alpha2: "LY", Alpha3: "LBY", Numeric: "434", Name: "Libya", Currency: "LYD", DialCode: "218"}
+	MA = Country{Alpha2: "MA", Alpha3: "MAR", Numeric: "504", Name: "Morocco", Currency: "MAD", DialCode: "212"}
+	MC = Country{Alpha2: "MC", Alpha3: "MCO", Numeric: "492", Name: "Monaco", Currency: "EUR", DialCode: "377"}
+	MD = Country{Alpha2: "MD", Alpha3: "MDA", Numeric: "498", Name: "Moldova", Currency: "MDL", DialCode: "373"}
+	ME = Country{Alpha2: "ME", Alpha3: "MNE", Numeric: "499", Name: "Montenegro", Currency: "EUR", DialCode: "382"}
+	MF = Country{Alpha2: "MF", Alpha3: "MAF", Numeric: "663", Name: "Saint Martin (French part)", Currency: "EUR", DialCode: "590"}
+	MG = Country{Alpha2: "MG", Alpha3: "MDG", Numeric: "450", Name: "Madagascar", Currency: "MGA", DialCode: "261"}
+	MH = Country{Alpha2: "MH", Alpha3: "MHL", Numeric: "584", Name: "Marshall Islands", Currency: "USD", DialCode: "692"}
+	MK = Country{Alpha2: "MK", Alpha3: "MKD", Numeric: "807", Name: "North Macedonia", Currency: "MKD", DialCode: "389"}
+	ML = Country{Alpha2: "ML", Alpha3: "MLI", Numeric: "466", Name: "Mali", Currency: "XOF", DialCode: "223"}
+	MM = Country{Alpha2: "MM", Alpha3: "MMR", Numeric: "104", Name: "Myanmar", Currency: "MMK", DialCode: "95"}
+	MN = Country{Alpha2: "MN", Alpha3: "MNG", Numeric: "496", Name: "Mongolia", Currency: "MNT", DialCode: "976"}
+	MO = Country{Alpha2: "MO", Alpha3: "MAC", Numeric: "446", Name: "Macao", Currency: "MOP", DialCode: "853"}
+	MP = Country{Alpha2: "MP", Alpha3: "MNP", Numeric: "580", Name: "Northern Mariana Islands", Currency: "USD", DialCode: "1"}
+	MQ = Country{Alpha2: "MQ", Alpha3: "MTQ", Numeric: "474", Name: "Martinique", Currency: "EUR", DialCode: "596"}
+	MR = Country{Alpha2: "MR", Alpha3: "MRT", Numeric: "478", Name: "Mauritania", Currency: "MRU", DialCode: "222"}
+	MS = Country{Alpha2: "MS", Alpha3: "MSR", Numeric: "500", Name: "Montserrat", Currency: "XCD", DialCode: "1"}
+	MT = Country{Alpha2: "MT", Alpha3: "MLT", Numeric: "470", Name: "Malta", Currency: "EUR", DialCode: "356"}
+	MU = Country{Alpha2: "MU", Alpha3: "MUS", Numeric: "480", Name: "Mauritius", Currency: "MUR", DialCode: "230"}
+	MV = Country{Alpha2: "MV", Alpha3: "MDV", Numeric: "462", Name: "Maldives", Currency: "MVR", DialCode: "960"}
+	MW = Country{Alpha2: "MW", Alpha3: "MWI", Numeric: "454", Name: "Malawi", Currency: "MWK", DialCode: "265"}
+	MX = Country{Alpha2: "MX", Alpha3: "MEX", Numeric: "484", Name: "Mexico", Currency: "MXN", DialCode: "52"}
+	MY = Country{Alpha2: "MY", Alpha3: "MYS", Numeric: "458", Name: "Malaysia", Currency: "MYR", DialCode: "60"}
+	MZ = Country{Alpha2: "MZ", Alpha3: "MOZ", Numeric: "508", Name: "Mozambique", Currency: "MZN", DialCode: "258"}
+	NA = Country{Alpha2: "NA", Alpha3: "NAM", Numeric: "516", Name: "Namibia", Currency: "NAD", DialCode: "264"}
+	NC = Country{Alpha2: "NC", Alpha3: "NCL", Numeric: "540", Name: "New Caledonia", Currency: "XPF", DialCode: "687"}
+	NE = Country{Alpha2: "NE", Alpha3: "NER", Numeric: "562", Name: "Niger", Currency: "XOF", DialCode: "227"}
+	NF = Country{Alpha2: "NF", Alpha3: "NFK", Numeric: "574", Name: "Norfolk Island", Currency: "AUD", DialCode: "672"}
+	NG = Country{Alpha2: "NG", Alpha3: "NGA", Numeric: "566", Name: "Nigeria", Currency: "NGN", DialCode: "234"}
+	NI = Country{Alpha2: "NI", Alpha3: "NIC", Numeric: "558", Name: "Nicaragua", Currency: "NIO", DialCode: "505"}
+	NL = Country{Alpha2: "NL", Alpha3: "NLD", Numeric: "528", Name: "Netherlands", Currency: "EUR", DialCode: "31"}
 	NO = Country{Alpha2: "NO", Alpha3: "NOR", Numeric: "578", Name: "Norway", Currency: "NOK", DialCode: "47"}
+	NP = Country{Alpha2: "NP", Alpha3: "NPL", Numeric: "524", Name: "Nepal", Currency: "NPR", DialCode: "977"}
+	NR = Country{Alpha2: "NR", Alpha3: "NRU", Numeric: "520", Name: "Nauru", Currency: "AUD", DialCode: "674"}
+	NU = Country{Alpha2: "NU", Alpha3: "NIU", Numeric: "570", Name: "Niue", Currency: "NZD", DialCode: "683"}
+	NZ = Country{Alpha2: "NZ", Alpha3: "NZL", Numeric: "554", Name: "New Zealand", Currency: "NZD", DialCode: "64"}
+	OM = Country{Alpha2: "OM", Alpha3: "OMN", Numeric: "512", Name: "Oman", Currency: "OMR", DialCode: "968"}
+	PA = Country{Alpha2: "PA", Alpha3: "PAN", Numeric: "591", Name: "Panama", Currency: "PAB", DialCode: "507"}
+	PE = Country{Alpha2: "PE", Alpha3: "PER", Numeric: "604", Name: "Peru", Currency: "PEN", DialCode: "51"}
+	PF = Country{Alpha2: "PF", Alpha3: "PYF", Numeric: "258", Name: "French Polynesia", Currency: "XPF", DialCode: "689"}
+	PG = Country{Alpha2: "PG", Alpha3: "PNG", Numeric: "598", Name: "Papua New Guinea", Currency: "PGK", DialCode: "675"}
+	PH = Country{Alpha2: "PH", Alpha3: "PHL", Numeric: "608", Name: "Philippines", Currency: "PHP", DialCode: "63"}
+	PK = Country{Alpha2: "PK", Alpha3: "PAK", Numeric: "586", Name: "Pakistan", Currency: "PKR", DialCode: "92"}
+	PL = Country{Alpha2: "PL", Alpha3: "POL", Numeric: "616", Name: "Poland", Currency: "PLN", DialCode: "48"}
+	PM = Country{Alpha2: "PM", Alpha3: "SPM", Numeric: "666", Name: "Saint Pierre and Miquelon", Currency: "EUR", DialCode: "508"}
+	PN = Country{Alpha2: "PN", Alpha3: "PCN", Numeric: "612", Name: "Pitcairn", Currency: "NZD", DialCode: "64"}
+	PR = Country{Alpha2: "PR", Alpha3: "PRI", Numeric: "630", Name: "Puerto Rico", Currency: "USD", DialCode: "1"}
+	PS = Country{Alpha2: "PS", Alpha3: "PSE", Numeric: "275", Name: "Palestine", Currency: "ILS", DialCode: "970"}
+	PT = Country{Alpha2: "PT", Alpha3: "PRT", Numeric: "620", Name: "Portugal", Currency: "EUR", DialCode: "351"}
+	PW = Country{Alpha2: "PW", Alpha3: "PLW", Numeric: "585", Name: "Palau", Currency: "USD", DialCode: "680"}
+	PY = Country{Alpha2: "PY", Alpha3: "PRY", Numeric: "600", Name: "Paraguay", Currency: "PYG", DialCode: "595"}
+	QA = Country{Alpha2: "QA", Alpha3: "QAT", Numeric: "634", Name: "Qatar", Currency: "QAR", DialCode: "974"}
+	RE = Country{Alpha2: "RE", Alpha3: "REU", Numeric: "638", Name: "Réunion", Currency: "EUR", DialCode: "262"}
+	RO = Country{Alpha2: "RO", Alpha3: "ROU", Numeric: "642", Name: "Romania", Currency: "RON", DialCode: "40"}
+	RS = Country{Alpha2: "RS", Alpha3: "SRB", Numeric: "688", Name: "Serbia", Currency: "RSD", DialCode: "381"}
+	RU = Country{Alpha2: "RU", Alpha3: "RUS", Numeric: "643", Name: "Russia", Currency: "RUB", DialCode: "7"}
+	RW = Country{Alpha2: "RW", Alpha3: "RWA", Numeric: "646", Name: "Rwanda", Currency: "RWF", DialCode: "250"}
+	SA = Country{Alpha2: "SA", Alpha3: "SAU", Numeric: "682", Name: "Saudi Arabia", Currency: "SAR", DialCode: "966"}
+	SB = Country{Alpha2: "SB", Alpha3: "SLB", Numeric: "090", Name: "Solomon Islands", Currency: "SBD", DialCode: "677"}
+	SC = Country{Alpha2: "SC", Alpha3: "SYC", Numeric: "690", Name: "Seychelles", Currency: "SCR", DialCode: "248"}
+	SD = Country{Alpha2: "SD", Alpha3: "SDN", Numeric: "729", Name: "Sudan", Currency: "SDG", DialCode: "249"}
+	SE = Country{Alpha2: "SE", Alpha3: "SWE", Numeric: "752", Name: "Sweden", Currency: "SEK", DialCode: "46"}
+	SG = Country{Alpha2: "SG", Alpha3: "SGP", Numeric: "702", Name: "Singapore", Currency: "SGD", DialCode: "65"}
+	SH = Country{Alpha2: "SH", Alpha3: "SHN", Numeric: "654", Name: "Saint Helena, Ascension and Tristan da Cunha", Currency: "SHP", DialCode: "290"}
+	SI = Country{Alpha2: "SI", Alpha3: "SVN", Numeric: "705", Name: "Slovenia", Currency: "EUR", DialCode: "386"}
+	SJ = Country{Alpha2: "SJ", Alpha3: "SJM", Numeric: "744", Name: "Svalbard and Jan Mayen", Currency: "NOK", DialCode: "47"}
+	SK = Country{Alpha2: "SK", Alpha3: "SVK", Numeric: "703", Name: "Slovakia", Currency: "EUR", DialCode: "421"}
+	SL = Country{Alpha2: "SL", Alpha3: "SLE", Numeric: "694", Name: "Sierra Leone", Currency: "SLE", DialCode: "232"}
+	SM = Country{Alpha2: "SM", Alpha3: "SMR", Numeric: "674", Name: "San Marino", Currency: "EUR", DialCode: "378"}
+	SN = Country{Alpha2: "SN", Alpha3: "SEN", Numeric: "686", Name: "Senegal", Currency: "XOF", DialCode: "221"}
+	SO = Country{Alpha2: "SO", Alpha3: "SOM", Numeric: "706", Name: "Somalia", Currency: "SOS", DialCode: "252"}
+	SR = Country{Alpha2: "SR", Alpha3: "SUR", Numeric: "740", Name: "Suriname", Currency: "SRD", DialCode: "597"}
+	SS = Country{Alpha2: "SS", Alpha3: "SSD", Numeric: "728", Name: "South Sudan", Currency: "SSP", DialCode: "211"}
+	ST = Country{Alpha2: "ST", Alpha3: "STP", Numeric: "678", Name: "Sao Tome and Principe", Currency: "STN", DialCode: "239"}
+	SV = Country{Alpha2: "SV", Alpha3: "SLV", Numeric: "222", Name: "El Salvador", Currency: "USD", DialCode: "503"}
+	SX = Country{Alpha2: "SX", Alpha3: "SXM", Numeric: "534", Name: "Sint Maarten (Dutch part)", Currency: "ANG", DialCode: "1"}
+	SY = Country{Alpha2: "SY", Alpha3: "SYR", Numeric: "760", Name: "Syria", Currency: "SYP", DialCode: "963"}
+	SZ = Country{Alpha2: "SZ", Alpha3: "SWZ", Numeric: "748", Name: "Eswatini", Currency: "SZL", DialCode: "268"}
+	TC = Country{Alpha2: "TC", Alpha3: "TCA", Numeric: "796", Name: "Turks and Caicos Islands", Currency: "USD", DialCode: "1"}
+	TD = Country{Alpha2: "TD", Alpha3: "TCD", Numeric: "148", Name: "Chad", Currency: "XAF", DialCode: "235"}
+	TF = Country{Alpha2: "TF", Alpha3: "ATF", Numeric: "260", Name: "French Southern Territories", Currency: "EUR", DialCode: "262"}
+	TG = Country{Alpha2: "TG", Alpha3: "TGO", Numeric: "768", Name: "Togo", Currency: "XOF", DialCode: "228"}
+	TH = Country{Alpha2: "TH", Alpha3: "THA", Numeric: "764", Name: "Thailand", Currency: "THB", DialCode: "66"}
+	TJ = Country{Alpha2: "TJ", Alpha3: "TJK", Numeric: "762", Name: "Tajikistan", Currency: "TJS", DialCode: "992"}
+	TK = Country{Alpha2: "TK", Alpha3: "TKL", Numeric: "772", Name: "Tokelau", Currency: "NZD", DialCode: "690"}
+	TL = Country{Alpha2: "TL", Alpha3: "TLS", Numeric: "626", Name: "Timor-Leste", Currency: "USD", DialCode: "670"}
+	TM = Country{Alpha2: "TM", Alpha3: "TKM", Numeric: "795", Name: "Turkmenistan", Currency: "TMT", DialCode: "993"}
+	TN = Country{Alpha2: "TN", Alpha3: "TUN", Numeric: "788", Name: "Tunisia", Currency: "TND", DialCode: "216"}
+	TO = Country{Alpha2: "TO", Alpha3: "TON", Numeric: "776", Name: "Tonga", Currency: "TOP", DialCode: "676"}
+	TR = Country{Alpha2: "TR", Alpha3: "TUR", Numeric: "792", Name: "Türkiye", Currency: "TRY", DialCode: "90"}
+	TT = Country{Alpha2: "TT", Alpha3: "TTO", Numeric: "780", Name: "Trinidad and Tobago", Currency: "TTD", DialCode: "1"}
+	TV = Country{Alpha2: "TV", Alpha3: "TUV", Numeric: "798", Name: "Tuvalu", Currency: "AUD", DialCode: "688"}
+	TW = Country{Alpha2: "TW", Alpha3: "TWN", Numeric: "158", Name: "Taiwan", Currency: "TWD", DialCode: "886"}
+	TZ = Country{Alpha2: "TZ", Alpha3: "TZA", Numeric: "834", Name: "Tanzania", Currency: "TZS", DialCode: "255"}
 	UA = Country{Alpha2: "UA", Alpha3: "UKR", Numeric: "804", Name: "Ukraine", Currency: "UAH", DialCode: "380"}
+	UG = Country{Alpha2: "UG", Alpha3: "UGA", Numeric: "800", Name: "Uganda", Currency: "UGX", DialCode: "256"}
+	UM = Country{Alpha2: "UM", Alpha3: "UMI", Numeric: "581", Name: "United States Minor Outlying Islands", Currency: "USD", DialCode: "1"}
 	US = Country{Alpha2: "US", Alpha3: "USA", Numeric: "840", Name: "United States", Currency: "USD", DialCode: "1"}
+	UY = Country{Alpha2: "UY", Alpha3: "URY", Numeric: "858", Name: "Uruguay", Currency: "UYU", DialCode: "598"}
+	UZ = Country{Alpha2: "UZ", Alpha3: "UZB", Numeric: "860", Name: "Uzbekistan", Currency: "UZS", DialCode: "998"}
+	VA = Country{Alpha2: "VA", Alpha3: "VAT", Numeric: "336", Name: "Holy See", Currency: "EUR", DialCode: "379"}
+	VC = Country{Alpha2: "VC", Alpha3: "VCT", Numeric: "670", Name: "Saint Vincent and the Grenadines", Currency: "XCD", DialCode: "1"}
+	VE = Country{Alpha2: "VE", Alpha3: "VEN", Numeric: "862", Name: "Venezuela", Currency: "VES", DialCode: "58"}
+	VG = Country{Alpha2: "VG", Alpha3: "VGB", Numeric: "092", Name: "Virgin Islands (British)", Currency: "USD", DialCode: "1"}
+	VI = Country{Alpha2: "VI", Alpha3: "VIR", Numeric: "850", Name: "Virgin Islands (U.S.)", Currency: "USD", DialCode: "1"}
+	VN = Country{Alpha2: "VN", Alpha3: "VNM", Numeric: "704", Name: "Vietnam", Currency: "VND", DialCode: "84"}
+	VU = Country{Alpha2: "VU", Alpha3: "VUT", Numeric: "548", Name: "Vanuatu", Currency: "VUV", DialCode: "678"}
+	WF = Country{Alpha2: "WF", Alpha3: "WLF", Numeric: "876", Name: "Wallis and Futuna", Currency: "XPF", DialCode: "681"}
+	WS = Country{Alpha2: "WS", Alpha3: "WSM", Numeric: "882", Name: "Samoa", Currency: "WST", DialCode: "685"}
+	YE = Country{Alpha2: "YE", Alpha3: "YEM", Numeric: "887", Name: "Yemen", Currency: "YER", DialCode: "967"}
+	YT = Country{Alpha2: "YT", Alpha3: "MYT", Numeric: "175", Name: "Mayotte", Currency: "EUR", DialCode: "262"}
 	ZA = Country{Alpha2: "ZA", Alpha3: "ZAF", Numeric: "710", Name: "South Africa", Currency: "ZAR", DialCode: "27"}
+	ZM = Country{Alpha2: "ZM", Alpha3: "ZMB", Numeric: "894", Name: "Zambia", Currency: "ZMW", DialCode: "260"}
+	ZW = Country{Alpha2: "ZW", Alpha3: "ZWE", Numeric: "716", Name: "Zimbabwe", Currency: "ZWG", DialCode: "263"}
 )
 
 // all is the bundled table as pointers into the exported vars, so the init emoji
-// fill lands on the vars themselves. Extended to the full ISO-3166-1 set in a
-// later task.
+// fill lands on the vars themselves. Full ISO-3166-1 set, alpha-2 ordered.
 var all = []*Country{
-	&AU, &BR, &CA, &DE, &FR, &GB, &IN, &JP, &NO, &UA, &US, &ZA,
+	&AD, &AE, &AF, &AG, &AI, &AL, &AM, &AO, &AQ, &AR, &AS, &AT, &AU, &AW, &AX, &AZ,
+	&BA, &BB, &BD, &BE, &BF, &BG, &BH, &BI, &BJ, &BL, &BM, &BN, &BO, &BQ, &BR, &BS, &BT, &BV, &BW, &BY, &BZ,
+	&CA, &CC, &CD, &CF, &CG, &CH, &CI, &CK, &CL, &CM, &CN, &CO, &CR, &CU, &CV, &CW, &CX, &CY, &CZ,
+	&DE, &DJ, &DK, &DM, &DO, &DZ,
+	&EC, &EE, &EG, &EH, &ER, &ES, &ET,
+	&FI, &FJ, &FK, &FM, &FO, &FR,
+	&GA, &GB, &GD, &GE, &GF, &GG, &GH, &GI, &GL, &GM, &GN, &GP, &GQ, &GR, &GS, &GT, &GU, &GW, &GY,
+	&HK, &HM, &HN, &HR, &HT, &HU,
+	&ID, &IE, &IL, &IM, &IN, &IO, &IQ, &IR, &IS, &IT,
+	&JE, &JM, &JO, &JP,
+	&KE, &KG, &KH, &KI, &KM, &KN, &KP, &KR, &KW, &KY, &KZ,
+	&LA, &LB, &LC, &LI, &LK, &LR, &LS, &LT, &LU, &LV, &LY,
+	&MA, &MC, &MD, &ME, &MF, &MG, &MH, &MK, &ML, &MM, &MN, &MO, &MP, &MQ, &MR, &MS, &MT, &MU, &MV, &MW, &MX, &MY, &MZ,
+	&NA, &NC, &NE, &NF, &NG, &NI, &NL, &NO, &NP, &NR, &NU, &NZ,
+	&OM,
+	&PA, &PE, &PF, &PG, &PH, &PK, &PL, &PM, &PN, &PR, &PS, &PT, &PW, &PY,
+	&QA,
+	&RE, &RO, &RS, &RU, &RW,
+	&SA, &SB, &SC, &SD, &SE, &SG, &SH, &SI, &SJ, &SK, &SL, &SM, &SN, &SO, &SR, &SS, &ST, &SV, &SX, &SY, &SZ,
+	&TC, &TD, &TF, &TG, &TH, &TJ, &TK, &TL, &TM, &TN, &TO, &TR, &TT, &TV, &TW, &TZ,
+	&UA, &UG, &UM, &US, &UY, &UZ,
+	&VA, &VC, &VE, &VG, &VI, &VN, &VU,
+	&WF, &WS,
+	&YE, &YT,
+	&ZA, &ZM, &ZW,
 }

--- a/core/country/data.go
+++ b/core/country/data.go
@@ -1,0 +1,28 @@
+package country
+
+// ISO-3166-1 static data: alpha-2/alpha-3/numeric codes, English short name,
+// primary official ISO-4217 currency, and E.164 dial code. Curated static data
+// committed to the repo — no runtime fetch. Emoji flags are derived from the
+// alpha-2 pair at package init. Source: ISO-3166-1 (2026 edition).
+
+var (
+	AU = Country{Alpha2: "AU", Alpha3: "AUS", Numeric: "036", Name: "Australia", Currency: "AUD", DialCode: "61"}
+	BR = Country{Alpha2: "BR", Alpha3: "BRA", Numeric: "076", Name: "Brazil", Currency: "BRL", DialCode: "55"}
+	CA = Country{Alpha2: "CA", Alpha3: "CAN", Numeric: "124", Name: "Canada", Currency: "CAD", DialCode: "1"}
+	DE = Country{Alpha2: "DE", Alpha3: "DEU", Numeric: "276", Name: "Germany", Currency: "EUR", DialCode: "49"}
+	FR = Country{Alpha2: "FR", Alpha3: "FRA", Numeric: "250", Name: "France", Currency: "EUR", DialCode: "33"}
+	GB = Country{Alpha2: "GB", Alpha3: "GBR", Numeric: "826", Name: "United Kingdom", Currency: "GBP", DialCode: "44"}
+	IN = Country{Alpha2: "IN", Alpha3: "IND", Numeric: "356", Name: "India", Currency: "INR", DialCode: "91"}
+	JP = Country{Alpha2: "JP", Alpha3: "JPN", Numeric: "392", Name: "Japan", Currency: "JPY", DialCode: "81"}
+	NO = Country{Alpha2: "NO", Alpha3: "NOR", Numeric: "578", Name: "Norway", Currency: "NOK", DialCode: "47"}
+	UA = Country{Alpha2: "UA", Alpha3: "UKR", Numeric: "804", Name: "Ukraine", Currency: "UAH", DialCode: "380"}
+	US = Country{Alpha2: "US", Alpha3: "USA", Numeric: "840", Name: "United States", Currency: "USD", DialCode: "1"}
+	ZA = Country{Alpha2: "ZA", Alpha3: "ZAF", Numeric: "710", Name: "South Africa", Currency: "ZAR", DialCode: "27"}
+)
+
+// all is the bundled table as pointers into the exported vars, so the init emoji
+// fill lands on the vars themselves. Extended to the full ISO-3166-1 set in a
+// later task.
+var all = []*Country{
+	&AU, &BR, &CA, &DE, &FR, &GB, &IN, &JP, &NO, &UA, &US, &ZA,
+}

--- a/core/country/data.go
+++ b/core/country/data.go
@@ -58,7 +58,7 @@ var (
 	CR = Country{Alpha2: "CR", Alpha3: "CRI", Numeric: "188", Name: "Costa Rica", Currency: "CRC", DialCode: "506"}
 	CU = Country{Alpha2: "CU", Alpha3: "CUB", Numeric: "192", Name: "Cuba", Currency: "CUP", DialCode: "53"}
 	CV = Country{Alpha2: "CV", Alpha3: "CPV", Numeric: "132", Name: "Cabo Verde", Currency: "CVE", DialCode: "238"}
-	CW = Country{Alpha2: "CW", Alpha3: "CUW", Numeric: "531", Name: "Curaçao", Currency: "ANG", DialCode: "599"}
+	CW = Country{Alpha2: "CW", Alpha3: "CUW", Numeric: "531", Name: "Curaçao", Currency: "XCG", DialCode: "599"}
 	CX = Country{Alpha2: "CX", Alpha3: "CXR", Numeric: "162", Name: "Christmas Island", Currency: "AUD", DialCode: "61"}
 	CY = Country{Alpha2: "CY", Alpha3: "CYP", Numeric: "196", Name: "Cyprus", Currency: "EUR", DialCode: "357"}
 	CZ = Country{Alpha2: "CZ", Alpha3: "CZE", Numeric: "203", Name: "Czechia", Currency: "CZK", DialCode: "420"}
@@ -216,7 +216,7 @@ var (
 	SS = Country{Alpha2: "SS", Alpha3: "SSD", Numeric: "728", Name: "South Sudan", Currency: "SSP", DialCode: "211"}
 	ST = Country{Alpha2: "ST", Alpha3: "STP", Numeric: "678", Name: "Sao Tome and Principe", Currency: "STN", DialCode: "239"}
 	SV = Country{Alpha2: "SV", Alpha3: "SLV", Numeric: "222", Name: "El Salvador", Currency: "USD", DialCode: "503"}
-	SX = Country{Alpha2: "SX", Alpha3: "SXM", Numeric: "534", Name: "Sint Maarten (Dutch part)", Currency: "ANG", DialCode: "1"}
+	SX = Country{Alpha2: "SX", Alpha3: "SXM", Numeric: "534", Name: "Sint Maarten (Dutch part)", Currency: "XCG", DialCode: "1"}
 	SY = Country{Alpha2: "SY", Alpha3: "SYR", Numeric: "760", Name: "Syria", Currency: "SYP", DialCode: "963"}
 	SZ = Country{Alpha2: "SZ", Alpha3: "SWZ", Numeric: "748", Name: "Eswatini", Currency: "SZL", DialCode: "268"}
 	TC = Country{Alpha2: "TC", Alpha3: "TCA", Numeric: "796", Name: "Turks and Caicos Islands", Currency: "USD", DialCode: "1"}

--- a/core/country/data_test.go
+++ b/core/country/data_test.go
@@ -1,0 +1,57 @@
+package country_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/core/country"
+)
+
+func flag(alpha2 string) string {
+	const base = 0x1F1E6
+	return string([]rune{rune(base + int(alpha2[0]-'A')), rune(base + int(alpha2[1]-'A'))})
+}
+
+func TestTable_Invariants(t *testing.T) {
+	all := country.All()
+	assert.GreaterOrEqual(t, len(all), 240, "expected the full ISO-3166-1 set")
+
+	seenA2 := map[string]bool{}
+	seenA3 := map[string]bool{}
+	seenNum := map[string]bool{}
+	for _, c := range all {
+		assert.Len(t, c.Alpha2, 2, "alpha2 %q", c.Alpha2)
+		assert.Len(t, c.Alpha3, 3, "alpha3 %q", c.Alpha3)
+		assert.Len(t, c.Numeric, 3, "numeric %q for %s", c.Numeric, c.Alpha2)
+		assert.NotEmpty(t, c.Name, "name for %s", c.Alpha2)
+		assert.Len(t, c.Currency, 3, "currency %q for %s", c.Currency, c.Alpha2)
+		assert.NotEmpty(t, c.DialCode, "dial for %s", c.Alpha2)
+		for i := range len(c.DialCode) {
+			assert.True(t, c.DialCode[i] >= '0' && c.DialCode[i] <= '9', "dial %q not numeric", c.DialCode)
+		}
+		assert.LessOrEqual(t, len(c.DialCode), 3, "dial %q too long", c.DialCode)
+		assert.Equal(t, flag(c.Alpha2), c.Emoji, "emoji mismatch for %s", c.Alpha2)
+
+		assert.False(t, seenA2[c.Alpha2], "duplicate alpha2 %s", c.Alpha2)
+		assert.False(t, seenA3[c.Alpha3], "duplicate alpha3 %s", c.Alpha3)
+		assert.False(t, seenNum[c.Numeric], "duplicate numeric %s", c.Numeric)
+		seenA2[c.Alpha2], seenA3[c.Alpha3], seenNum[c.Numeric] = true, true, true
+	}
+}
+
+func TestTable_KnownSpotChecks(t *testing.T) {
+	for _, tc := range []struct{ code, name, cur, dial string }{
+		{"AD", "Andorra", "EUR", "376"},
+		{"CN", "China", "CNY", "86"},
+		{"EG", "Egypt", "EGP", "20"},
+		{"NZ", "New Zealand", "NZD", "64"},
+		{"ZW", "Zimbabwe", "ZWG", "263"},
+	} {
+		c, ok := country.ByAlpha2(tc.code)
+		assert.True(t, ok, tc.code)
+		assert.Equal(t, tc.name, c.Name, tc.code)
+		assert.Equal(t, tc.cur, c.Currency, tc.code)
+		assert.Equal(t, tc.dial, c.DialCode, tc.code)
+	}
+}

--- a/core/country/doc.go
+++ b/core/country/doc.go
@@ -1,0 +1,37 @@
+// Package country provides curated ISO-3166-1 static data — alpha-2, alpha-3,
+// and numeric codes, English short name, primary official ISO-4217 currency
+// code, E.164 dial code, and flag emoji — plus case-insensitive lookups and a
+// Set type expressing a "supported countries" policy.
+//
+// Every country is exposed as a package-level Country var (US, GB, DE, …) and
+// indexed for lookup by ByAlpha2, ByAlpha3, ByNumeric, and ByDialCode; All
+// returns the whole table sorted by Name (a dropdown source). Because many
+// countries share one dial code (+1 covers the US, Canada, and the Caribbean),
+// ByDialCode returns a slice. The data is committed static — no runtime fetch;
+// flag emoji are derived from the alpha-2 pair at package init.
+//
+// A Set is an explicit, immutable collection a consumer constructs (NewSet, or
+// NewSetFromCodes over configuration strings, which fails closed on an unknown
+// code) and passes wherever a supported-countries policy is needed — the
+// filtered All dropdown, or core/phone's parse gate. The zero Set is a valid
+// empty set that contains nothing, so a gate configured with it fails closed.
+//
+// What this is NOT: it carries only the primary official currency per country
+// (not de-facto multi-currency reality), no ISO-3166-2 subdivisions/states, no
+// translated names (that is an i18n concern), and no historical or deprecated
+// codes. Cheap shape-only validation of a country code lives in core/validate;
+// this package is the authoritative data.
+//
+// # Usage
+//
+//	c, ok := country.ByAlpha2("us")
+//	if ok {
+//		_ = c.Name     // "United States"
+//		_ = c.Currency // "USD"
+//		_ = c.Emoji    // "🇺🇸"
+//	}
+//
+//	supported, _ := country.NewSetFromCodes("US", "GB", "DE")
+//	_ = supported.ContainsCode("fr") // false
+//	_ = supported.All()              // sorted, for a filtered dropdown
+package country

--- a/core/country/errors.go
+++ b/core/country/errors.go
@@ -1,0 +1,7 @@
+package country
+
+import "errors"
+
+// ErrUnknownCode is returned by NewSetFromCodes when a supplied alpha-2 code is
+// not present in the bundled ISO-3166-1 table.
+var ErrUnknownCode = errors.New("country: unknown code")

--- a/core/country/set.go
+++ b/core/country/set.go
@@ -28,7 +28,7 @@ func NewSet(cs ...Country) Set {
 		if canon, ok := ByAlpha2(c.Alpha2); ok {
 			s.m[canon.Alpha2] = canon
 		} else {
-			s.m[c.Alpha2] = c
+			s.m[strings.ToUpper(c.Alpha2)] = c
 		}
 	}
 	return s
@@ -49,9 +49,10 @@ func NewSetFromCodes(codes ...string) (Set, error) {
 	return s, nil
 }
 
-// Contains reports whether c is in the set.
+// Contains reports whether c is in the set, matching on its alpha-2 code
+// case-insensitively (consistent with ContainsCode and how members are keyed).
 func (s Set) Contains(c Country) bool {
-	_, ok := s.m[c.Alpha2]
+	_, ok := s.m[strings.ToUpper(c.Alpha2)]
 	return ok
 }
 

--- a/core/country/set.go
+++ b/core/country/set.go
@@ -15,10 +15,19 @@ type Set struct {
 }
 
 // NewSet builds a Set from Country values. Zero-value countries are ignored.
+// A recognized alpha-2 is stored in canonical form (re-derived from the bundled
+// table), so a partially-filled Country still yields full data from All; an
+// unrecognized alpha-2 is stored as given, keeping Contains, Len, and All
+// mutually consistent.
 func NewSet(cs ...Country) Set {
 	s := Set{m: make(map[string]Country, len(cs))}
 	for _, c := range cs {
-		if c.Alpha2 != "" {
+		if c.Alpha2 == "" {
+			continue
+		}
+		if canon, ok := ByAlpha2(c.Alpha2); ok {
+			s.m[canon.Alpha2] = canon
+		} else {
 			s.m[c.Alpha2] = c
 		}
 	}

--- a/core/country/set.go
+++ b/core/country/set.go
@@ -11,15 +11,15 @@ import (
 // parse gate. The zero Set is a valid empty set: it contains nothing, so a
 // gate configured with it fails closed.
 type Set struct {
-	m map[string]struct{} // uppercase alpha-2 keys
+	m map[string]Country // keyed by uppercase alpha-2, valued by the Country
 }
 
 // NewSet builds a Set from Country values. Zero-value countries are ignored.
 func NewSet(cs ...Country) Set {
-	s := Set{m: make(map[string]struct{}, len(cs))}
+	s := Set{m: make(map[string]Country, len(cs))}
 	for _, c := range cs {
 		if c.Alpha2 != "" {
-			s.m[c.Alpha2] = struct{}{}
+			s.m[c.Alpha2] = c
 		}
 	}
 	return s
@@ -29,13 +29,13 @@ func NewSet(cs ...Country) Set {
 // supplies). It fails closed: an unknown code returns the zero Set wrapping
 // ErrUnknownCode.
 func NewSetFromCodes(codes ...string) (Set, error) {
-	s := Set{m: make(map[string]struct{}, len(codes))}
+	s := Set{m: make(map[string]Country, len(codes))}
 	for _, code := range codes {
 		c, ok := ByAlpha2(code)
 		if !ok {
 			return Set{}, fmt.Errorf("country: %q: %w", code, ErrUnknownCode)
 		}
-		s.m[c.Alpha2] = struct{}{}
+		s.m[c.Alpha2] = c
 	}
 	return s, nil
 }
@@ -55,10 +55,8 @@ func (s Set) ContainsCode(code string) bool {
 // All returns the set's countries sorted by Name — the filtered dropdown source.
 func (s Set) All() []Country {
 	out := make([]Country, 0, len(s.m))
-	for code := range s.m {
-		if c, ok := ByAlpha2(code); ok {
-			out = append(out, c)
-		}
+	for _, c := range s.m {
+		out = append(out, c)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out

--- a/core/country/set.go
+++ b/core/country/set.go
@@ -1,0 +1,70 @@
+package country
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Set is an explicit, immutable collection of countries — a consumer's
+// "supported countries" policy, shared by filtered UI dropdowns and phone's
+// parse gate. The zero Set is a valid empty set: it contains nothing, so a
+// gate configured with it fails closed.
+type Set struct {
+	m map[string]struct{} // uppercase alpha-2 keys
+}
+
+// NewSet builds a Set from Country values. Zero-value countries are ignored.
+func NewSet(cs ...Country) Set {
+	s := Set{m: make(map[string]struct{}, len(cs))}
+	for _, c := range cs {
+		if c.Alpha2 != "" {
+			s.m[c.Alpha2] = struct{}{}
+		}
+	}
+	return s
+}
+
+// NewSetFromCodes builds a Set from alpha-2 code strings (the form configuration
+// supplies). It fails closed: an unknown code returns the zero Set wrapping
+// ErrUnknownCode.
+func NewSetFromCodes(codes ...string) (Set, error) {
+	s := Set{m: make(map[string]struct{}, len(codes))}
+	for _, code := range codes {
+		c, ok := ByAlpha2(code)
+		if !ok {
+			return Set{}, fmt.Errorf("country: %q: %w", code, ErrUnknownCode)
+		}
+		s.m[c.Alpha2] = struct{}{}
+	}
+	return s, nil
+}
+
+// Contains reports whether c is in the set.
+func (s Set) Contains(c Country) bool {
+	_, ok := s.m[c.Alpha2]
+	return ok
+}
+
+// ContainsCode reports whether the alpha-2 code is in the set, case-insensitively.
+func (s Set) ContainsCode(code string) bool {
+	_, ok := s.m[strings.ToUpper(code)]
+	return ok
+}
+
+// All returns the set's countries sorted by Name — the filtered dropdown source.
+func (s Set) All() []Country {
+	out := make([]Country, 0, len(s.m))
+	for code := range s.m {
+		if c, ok := ByAlpha2(code); ok {
+			out = append(out, c)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// Len returns the number of countries in the set.
+func (s Set) Len() int {
+	return len(s.m)
+}

--- a/core/country/set_test.go
+++ b/core/country/set_test.go
@@ -1,7 +1,6 @@
 package country_test
 
 import (
-	"errors"
 	"sort"
 	"testing"
 
@@ -44,5 +43,4 @@ func TestSet_ZeroValueFailsClosed(t *testing.T) {
 	assert.False(t, s.Contains(country.US))
 	assert.False(t, s.ContainsCode("US"))
 	assert.Empty(t, s.All())
-	_ = errors.Is
 }

--- a/core/country/set_test.go
+++ b/core/country/set_test.go
@@ -1,0 +1,48 @@
+package country_test
+
+import (
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/country"
+)
+
+func TestNewSet_ContainsAndLen(t *testing.T) {
+	s := country.NewSet(country.US, country.GB, country.DE)
+	assert.Equal(t, 3, s.Len())
+	assert.True(t, s.Contains(country.US))
+	assert.False(t, s.Contains(country.FR))
+	assert.True(t, s.ContainsCode("gb"))
+	assert.False(t, s.ContainsCode("fr"))
+}
+
+func TestNewSetFromCodes_OKAndFailClosed(t *testing.T) {
+	s, err := country.NewSetFromCodes("US", "gb")
+	require.NoError(t, err)
+	assert.Equal(t, 2, s.Len())
+	assert.True(t, s.ContainsCode("US"))
+
+	_, err = country.NewSetFromCodes("US", "ZZ")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, country.ErrUnknownCode)
+}
+
+func TestSet_AllSorted(t *testing.T) {
+	s := country.NewSet(country.US, country.GB, country.DE)
+	all := s.All()
+	assert.Len(t, all, 3)
+	assert.True(t, sort.SliceIsSorted(all, func(i, j int) bool { return all[i].Name < all[j].Name }))
+}
+
+func TestSet_ZeroValueFailsClosed(t *testing.T) {
+	var s country.Set
+	assert.Equal(t, 0, s.Len())
+	assert.False(t, s.Contains(country.US))
+	assert.False(t, s.ContainsCode("US"))
+	assert.Empty(t, s.All())
+	_ = errors.Is
+}

--- a/core/country/set_test.go
+++ b/core/country/set_test.go
@@ -44,3 +44,20 @@ func TestSet_ZeroValueFailsClosed(t *testing.T) {
 	assert.False(t, s.ContainsCode("US"))
 	assert.Empty(t, s.All())
 }
+
+func TestNewSet_CanonicalizesAndStaysConsistent(t *testing.T) {
+	// A partially-filled recognized country is stored canonically, so All()
+	// yields full data.
+	s := country.NewSet(country.Country{Alpha2: "US"})
+	all := s.All()
+	require.Len(t, all, 1)
+	assert.Equal(t, "United States", all[0].Name)
+	assert.Equal(t, "USD", all[0].Currency)
+
+	// An unrecognized-but-nonempty alpha-2 stays consistent across Contains,
+	// Len, and All (no silent drop from All).
+	x := country.NewSet(country.Country{Alpha2: "ZZ"})
+	assert.Equal(t, 1, x.Len())
+	assert.True(t, x.ContainsCode("ZZ"))
+	assert.Len(t, x.All(), 1)
+}

--- a/core/country/set_test.go
+++ b/core/country/set_test.go
@@ -55,9 +55,14 @@ func TestNewSet_CanonicalizesAndStaysConsistent(t *testing.T) {
 	assert.Equal(t, "USD", all[0].Currency)
 
 	// An unrecognized-but-nonempty alpha-2 stays consistent across Contains,
-	// Len, and All (no silent drop from All).
-	x := country.NewSet(country.Country{Alpha2: "ZZ"})
+	// Len, and All (no silent drop from All), including when it is built from a
+	// lowercase code — the key is normalized to uppercase, so both Contains and
+	// the case-insensitive ContainsCode find it in any casing.
+	x := country.NewSet(country.Country{Alpha2: "zz"})
 	assert.Equal(t, 1, x.Len())
+	assert.True(t, x.ContainsCode("zz"))
 	assert.True(t, x.ContainsCode("ZZ"))
+	assert.True(t, x.Contains(country.Country{Alpha2: "zz"}))
+	assert.True(t, x.Contains(country.Country{Alpha2: "ZZ"}))
 	assert.Len(t, x.All(), 1)
 }

--- a/core/phone/bench_test.go
+++ b/core/phone/bench_test.go
@@ -1,0 +1,32 @@
+package phone_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/country"
+	"github.com/dmitrymomot/forge/core/phone"
+)
+
+func BenchmarkParse(b *testing.B) {
+	for b.Loop() {
+		_, _ = phone.Parse("+1 (415) 555-2671")
+	}
+}
+
+func BenchmarkParseRegion(b *testing.B) {
+	for b.Loop() {
+		_, _ = phone.ParseRegion("07911 123456", "GB")
+	}
+}
+
+func BenchmarkParserGate(b *testing.B) {
+	set := country.NewSet(country.US, country.GB, country.DE)
+	p, err := phone.New(phone.WithAllowedCountries(set))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.Parse("+44 20 7946 0018")
+	}
+}

--- a/core/phone/config.go
+++ b/core/phone/config.go
@@ -1,0 +1,9 @@
+package phone
+
+import "github.com/dmitrymomot/forge/core/country"
+
+type config struct {
+	allowed       country.Set
+	defaultRegion string
+	gate          bool
+}

--- a/core/phone/doc.go
+++ b/core/phone/doc.go
@@ -1,0 +1,38 @@
+// Package phone normalizes phone numbers to E.164 and decomposes them against
+// core/country's dial-code table. It parses messy human input into a canonical
+// Phone value, formats it back out, and gates parsing by a supported-countries
+// policy — deliberately without the libphonenumber machinery.
+//
+// Parse accepts a number that carries its own country code (a leading + or 00),
+// stripping formatting characters. ParseRegion interprets bare national input
+// using an alpha-2 region hint (stripping one leading trunk 0). A configured
+// Parser (New with WithDefaultRegion and/or WithAllowedCountries) applies a
+// default region to bare input and rejects numbers whose country is provably
+// outside a country.Set with ErrUnsupportedRegion.
+//
+// A Phone exposes E164, DialCode, NationalNumber, Country, and Candidates.
+// Because dial codes are shared (+1 covers the US, Canada, and the Caribbean),
+// Country returns a stable primary with a false ok for an unresolved shared
+// code — Candidates lists every possibility, and a region hint pins one. The
+// gate mirrors this honesty: an ambiguous number passes when any candidate is
+// supported, since it cannot be proven to belong to the unsupported one.
+//
+// Phone marshals to and from the E.164 string for SQL (Value/Scan, zero Phone
+// is NULL) and JSON (zero Phone is null). What this is NOT: no per-country
+// length/pattern validation, no line-type or carrier lookup, no pretty
+// per-country grouping, and no area-code disambiguation of shared dial codes —
+// the libphonenumber swamp stays out. Cheap E.164 shape validation lives in
+// core/validate.
+//
+// # Usage
+//
+//	p, err := phone.Parse("+1 (415) 555-2671")
+//	if err == nil {
+//		_ = p.E164()           // "+14155552671"
+//		_ = p.NationalNumber() // "4155552671"
+//	}
+//
+//	set, _ := country.NewSetFromCodes("US", "GB", "DE")
+//	parser, _ := phone.New(phone.WithDefaultRegion("US"), phone.WithAllowedCountries(set))
+//	_, err = parser.Parse("+33 6 12 34 56 78") // ErrUnsupportedRegion
+package phone

--- a/core/phone/errors.go
+++ b/core/phone/errors.go
@@ -1,0 +1,19 @@
+package phone
+
+import "errors"
+
+// ErrInvalidNumber is returned when input contains non-digit content or its
+// digit count is outside E.164 bounds (empty national number, or over 15 total).
+var ErrInvalidNumber = errors.New("phone: invalid number")
+
+// ErrMissingCountryCode is returned by Parse when input has no leading + or 00
+// and no region context supplies a dial code.
+var ErrMissingCountryCode = errors.New("phone: missing country code")
+
+// ErrUnknownDialCode is returned when the leading digits match no country
+// calling code in the bundled table.
+var ErrUnknownDialCode = errors.New("phone: unknown dial code")
+
+// ErrUnsupportedRegion is returned by a gated Parser when the resolved country
+// is provably outside the configured supported-countries Set.
+var ErrUnsupportedRegion = errors.New("phone: unsupported region")

--- a/core/phone/json.go
+++ b/core/phone/json.go
@@ -1,0 +1,35 @@
+package phone
+
+import "encoding/json"
+
+// MarshalJSON emits the E.164 string, e.g. "+14155552671". The zero Phone emits
+// JSON null.
+func (p Phone) MarshalJSON() ([]byte, error) {
+	if p.e164 == "" {
+		return []byte("null"), nil
+	}
+	return json.Marshal(p.e164)
+}
+
+// UnmarshalJSON parses the E.164 string form. JSON null or an empty string sets
+// the zero Phone; any other value is validated by Parse.
+func (p *Phone) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		*p = Phone{}
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		*p = Phone{}
+		return nil
+	}
+	parsed, err := Parse(s)
+	if err != nil {
+		return err
+	}
+	*p = parsed
+	return nil
+}

--- a/core/phone/json_test.go
+++ b/core/phone/json_test.go
@@ -36,3 +36,9 @@ func TestUnmarshalJSON_Garbage(t *testing.T) {
 	var p phone.Phone
 	assert.ErrorIs(t, json.Unmarshal([]byte(`"nope"`), &p), phone.ErrMissingCountryCode)
 }
+
+func TestUnmarshalJSON_EmptyStringIsZero(t *testing.T) {
+	var p phone.Phone
+	require.NoError(t, json.Unmarshal([]byte(`""`), &p))
+	assert.True(t, p.IsZero())
+}

--- a/core/phone/json_test.go
+++ b/core/phone/json_test.go
@@ -1,0 +1,38 @@
+package phone_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/phone"
+)
+
+func TestMarshalJSON_RoundTrip(t *testing.T) {
+	p, _ := phone.Parse("+14155552671")
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+	assert.JSONEq(t, `"+14155552671"`, string(b))
+
+	var got phone.Phone
+	require.NoError(t, json.Unmarshal(b, &got))
+	assert.Equal(t, "+14155552671", got.E164())
+}
+
+func TestMarshalJSON_ZeroIsNull(t *testing.T) {
+	var zero phone.Phone
+	b, err := json.Marshal(zero)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(b))
+
+	var got phone.Phone
+	require.NoError(t, json.Unmarshal([]byte("null"), &got))
+	assert.True(t, got.IsZero())
+}
+
+func TestUnmarshalJSON_Garbage(t *testing.T) {
+	var p phone.Phone
+	assert.ErrorIs(t, json.Unmarshal([]byte(`"nope"`), &p), phone.ErrMissingCountryCode)
+}

--- a/core/phone/options.go
+++ b/core/phone/options.go
@@ -1,0 +1,22 @@
+package phone
+
+import "github.com/dmitrymomot/forge/core/country"
+
+// Option configures a Parser.
+type Option func(*config)
+
+// WithDefaultRegion sets the alpha-2 region used to interpret bare national
+// input (numbers with no + or 00). New rejects an unknown region.
+func WithDefaultRegion(alpha2 string) Option {
+	return func(c *config) { c.defaultRegion = alpha2 }
+}
+
+// WithAllowedCountries enables the supported-countries gate: Parse rejects a
+// number whose country is provably outside the set with ErrUnsupportedRegion.
+// Passing the zero Set fails closed (rejects everything).
+func WithAllowedCountries(s country.Set) Option {
+	return func(c *config) {
+		c.allowed = s
+		c.gate = true
+	}
+}

--- a/core/phone/parser.go
+++ b/core/phone/parser.go
@@ -3,6 +3,7 @@ package phone
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/dmitrymomot/forge/core/country"
 )
@@ -35,7 +36,8 @@ func (p *Parser) Parse(input string) (Phone, error) {
 		ph  Phone
 		err error
 	)
-	if p.cfg.defaultRegion != "" {
+	s := strings.TrimSpace(input)
+	if p.cfg.defaultRegion != "" && !strings.HasPrefix(s, "+") && !strings.HasPrefix(s, "00") {
 		ph, err = ParseRegion(input, p.cfg.defaultRegion)
 	} else {
 		ph, err = Parse(input)

--- a/core/phone/parser.go
+++ b/core/phone/parser.go
@@ -2,6 +2,7 @@ package phone
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/dmitrymomot/forge/core/country"
 )
@@ -55,10 +56,5 @@ func gatePass(set country.Set, ph Phone) bool {
 	if c, ok := ph.Country(); ok {
 		return set.Contains(c)
 	}
-	for _, c := range ph.Candidates() {
-		if set.Contains(c) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(ph.Candidates(), set.Contains)
 }

--- a/core/phone/parser.go
+++ b/core/phone/parser.go
@@ -1,0 +1,64 @@
+package phone
+
+import (
+	"fmt"
+
+	"github.com/dmitrymomot/forge/core/country"
+)
+
+// Parser is a configured phone parser: an optional default region for bare
+// national input, and an optional supported-countries gate.
+type Parser struct {
+	cfg config
+}
+
+// New builds a Parser from options. It fails closed on an unknown default
+// region, returning ErrMissingCountryCode.
+func New(opts ...Option) (*Parser, error) {
+	var c config
+	for _, o := range opts {
+		o(&c)
+	}
+	if c.defaultRegion != "" {
+		if _, ok := country.ByAlpha2(c.defaultRegion); !ok {
+			return nil, fmt.Errorf("phone: unknown default region %q: %w", c.defaultRegion, ErrMissingCountryCode)
+		}
+	}
+	return &Parser{cfg: c}, nil
+}
+
+// Parse normalizes input, applying the default region (if configured) to bare
+// national numbers, then the supported-countries gate (if configured).
+func (p *Parser) Parse(input string) (Phone, error) {
+	var (
+		ph  Phone
+		err error
+	)
+	if p.cfg.defaultRegion != "" {
+		ph, err = ParseRegion(input, p.cfg.defaultRegion)
+	} else {
+		ph, err = Parse(input)
+	}
+	if err != nil {
+		return Phone{}, err
+	}
+	if p.cfg.gate && !gatePass(p.cfg.allowed, ph) {
+		return Phone{}, ErrUnsupportedRegion
+	}
+	return ph, nil
+}
+
+// gatePass reports whether ph is allowed: a resolved/unique country must be in
+// the set; an ambiguous number passes when any candidate is in the set (the
+// number cannot be proven to belong to the unsupported one).
+func gatePass(set country.Set, ph Phone) bool {
+	if c, ok := ph.Country(); ok {
+		return set.Contains(c)
+	}
+	for _, c := range ph.Candidates() {
+		if set.Contains(c) {
+			return true
+		}
+	}
+	return false
+}

--- a/core/phone/parser_test.go
+++ b/core/phone/parser_test.go
@@ -1,0 +1,54 @@
+package phone_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/country"
+	"github.com/dmitrymomot/forge/core/phone"
+)
+
+func TestNew_DefaultRegionValidated(t *testing.T) {
+	_, err := phone.New(phone.WithDefaultRegion("ZZ"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, phone.ErrMissingCountryCode)
+}
+
+func TestParser_DefaultRegionAppliesToBareInput(t *testing.T) {
+	p, err := phone.New(phone.WithDefaultRegion("US"))
+	require.NoError(t, err)
+	ph, err := p.Parse("415-555-2671")
+	require.NoError(t, err)
+	assert.Equal(t, "+14155552671", ph.E164())
+}
+
+func TestParser_GateRejectsUnsupported(t *testing.T) {
+	set := country.NewSet(country.US, country.GB)
+	p, err := phone.New(phone.WithAllowedCountries(set))
+	require.NoError(t, err)
+
+	_, err = p.Parse("+33 6 12 34 56 78") // France, unique dial code, not in set
+	assert.ErrorIs(t, err, phone.ErrUnsupportedRegion)
+
+	ph, err := p.Parse("+44 20 7946 0018") // GB, supported
+	require.NoError(t, err)
+	assert.Equal(t, "GB", func() string { c, _ := ph.Country(); return c.Alpha2 }())
+}
+
+func TestParser_GateAmbiguousPassesIfAnyCandidateSupported(t *testing.T) {
+	set := country.NewSet(country.US) // US supported, CA not
+	p, err := phone.New(phone.WithAllowedCountries(set))
+	require.NoError(t, err)
+	_, err = p.Parse("+1 415 555 2671") // ambiguous +1; US is a candidate → passes
+	assert.NoError(t, err)
+}
+
+func TestParser_ZeroSetFailsClosed(t *testing.T) {
+	var empty country.Set
+	p, err := phone.New(phone.WithAllowedCountries(empty))
+	require.NoError(t, err)
+	_, err = p.Parse("+1 415 555 2671")
+	assert.ErrorIs(t, err, phone.ErrUnsupportedRegion)
+}

--- a/core/phone/parser_test.go
+++ b/core/phone/parser_test.go
@@ -45,6 +45,32 @@ func TestParser_GateAmbiguousPassesIfAnyCandidateSupported(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestParser_DefaultRegionDoesNotPinFullyQualifiedInput(t *testing.T) {
+	set := country.NewSet(country.US) // US supported, CA not
+	p, err := phone.New(phone.WithDefaultRegion("CA"), phone.WithAllowedCountries(set))
+	require.NoError(t, err)
+
+	// Fully-qualified +1 input stays ambiguous; US is a candidate → passes,
+	// and must not be mislabeled as CA.
+	ph, err := p.Parse("+1 415 555 2671")
+	require.NoError(t, err)
+	_, resolved := ph.Country()
+	assert.False(t, resolved)
+	assert.Equal(t, "+14155552671", ph.E164())
+
+	// Bare national input still gets the default region applied (checked
+	// without the US-only gate, since a resolved CA number would otherwise
+	// be correctly rejected as unsupported).
+	p2, err := phone.New(phone.WithDefaultRegion("CA"))
+	require.NoError(t, err)
+	ph, err = p2.Parse("416 555 0199")
+	require.NoError(t, err)
+	assert.Equal(t, "+14165550199", ph.E164())
+	c, resolved := ph.Country()
+	require.True(t, resolved)
+	assert.Equal(t, "CA", c.Alpha2)
+}
+
 func TestParser_ZeroSetFailsClosed(t *testing.T) {
 	var empty country.Set
 	p, err := phone.New(phone.WithAllowedCountries(empty))

--- a/core/phone/phone.go
+++ b/core/phone/phone.go
@@ -128,3 +128,80 @@ func (p Phone) NationalNumber() string {
 
 // IsZero reports whether p is the zero Phone.
 func (p Phone) IsZero() bool { return p.e164 == "" }
+
+// ParseRegion parses a number using a region hint (an alpha-2 code). Bare
+// national input has one leading trunk 0 stripped and the region's dial code
+// prepended; input that already carries a + or 00 is parsed as-is, and the
+// region, when it is among the dial code's candidates, resolves the country.
+// An unknown region yields ErrMissingCountryCode.
+//
+// Known limitation: the single-leading-0 trunk-prefix rule is near-universal but
+// not absolute (NANP uses no trunk 0; some plans keep a significant leading 0) —
+// callers in those regions pass fully-qualified + input to Parse.
+func ParseRegion(input, alpha2 string) (Phone, error) {
+	c, ok := country.ByAlpha2(alpha2)
+	if !ok {
+		return Phone{}, ErrMissingCountryCode
+	}
+	s := strings.TrimSpace(input)
+	if strings.HasPrefix(s, "+") || strings.HasPrefix(s, "00") {
+		p, err := Parse(s)
+		if err != nil {
+			return Phone{}, err
+		}
+		for _, cand := range p.Candidates() {
+			if cand.Alpha2 == c.Alpha2 {
+				p.resolved = c.Alpha2
+				break
+			}
+		}
+		return p, nil
+	}
+	digits, err := toDigits(s, false)
+	if err != nil {
+		return Phone{}, err
+	}
+	digits = strings.TrimPrefix(digits, "0")
+	if digits == "" {
+		return Phone{}, ErrInvalidNumber
+	}
+	return build(c.DialCode+digits, c.Alpha2)
+}
+
+// Candidates returns every country sharing this number's dial code (nil for the
+// zero Phone). It is the escape hatch for the shared-dial-code case Country
+// cannot disambiguate.
+func (p Phone) Candidates() []country.Country {
+	if p.e164 == "" {
+		return nil
+	}
+	return country.ByDialCode(p.DialCode())
+}
+
+// Country returns the number's country. The bool is true when the country is
+// certain — a dial code used by exactly one country, or a region hint that
+// pinned it — and false when the dial code is shared and unresolved, in which
+// case a stable primary is still returned (use Candidates for all options).
+func (p Phone) Country() (country.Country, bool) {
+	if p.e164 == "" {
+		return country.Country{}, false
+	}
+	if p.resolved != "" {
+		c, ok := country.ByAlpha2(p.resolved)
+		return c, ok
+	}
+	cs := p.Candidates()
+	switch len(cs) {
+	case 0:
+		return country.Country{}, false
+	case 1:
+		return cs[0], true
+	default:
+		if a, ok := primaryDial[p.DialCode()]; ok {
+			if c, ok2 := country.ByAlpha2(a); ok2 {
+				return c, false
+			}
+		}
+		return cs[0], false
+	}
+}

--- a/core/phone/phone.go
+++ b/core/phone/phone.go
@@ -1,0 +1,130 @@
+package phone
+
+import (
+	"strings"
+
+	"github.com/dmitrymomot/forge/core/country"
+)
+
+// Phone is a normalized E.164 phone number. The zero Phone is the empty value
+// (IsZero reports true). It is pointer-free for low GC scan cost.
+type Phone struct {
+	e164     string // "+14155552671"
+	resolved string // alpha-2 when a region hint pinned the country; "" otherwise
+	dialLen  int    // dial-code digit count, for splitting E164 into dial + national
+}
+
+// primaryDial designates the "main" country for a shared dial code, so Country
+// can return a stable primary for an ambiguous number. Codes not listed fall
+// back to the first candidate by Name.
+var primaryDial = map[string]string{
+	"1": "US", "7": "RU", "44": "GB", "39": "IT", "61": "AU", "47": "NO", "212": "MA", "358": "FI",
+}
+
+// Parse normalizes a phone number that carries its own country code (a leading +
+// or 00). Formatting characters (spaces, dashes, parentheses, dots, slashes) are
+// stripped. It returns ErrMissingCountryCode when no + or 00 is present.
+func Parse(input string) (Phone, error) {
+	digits, err := toDigits(input, true)
+	if err != nil {
+		return Phone{}, err
+	}
+	return build(digits, "")
+}
+
+// toDigits strips a leading + or 00 and all formatting separators, returning the
+// bare digit string. When requireCC is true, absence of a + or 00 is an error.
+func toDigits(input string, requireCC bool) (string, error) {
+	s := strings.TrimSpace(input)
+	switch {
+	case strings.HasPrefix(s, "+"):
+		s = s[1:]
+	case strings.HasPrefix(s, "00"):
+		s = s[2:]
+	default:
+		if requireCC {
+			return "", ErrMissingCountryCode
+		}
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := range len(s) {
+		ch := s[i]
+		switch {
+		case ch >= '0' && ch <= '9':
+			b.WriteByte(ch)
+		case isSep(ch):
+			// drop
+		default:
+			return "", ErrInvalidNumber
+		}
+	}
+	d := b.String()
+	if d == "" {
+		return "", ErrInvalidNumber
+	}
+	return d, nil
+}
+
+func isSep(ch byte) bool {
+	switch ch {
+	case ' ', '-', '(', ')', '.', '/':
+		return true
+	}
+	return false
+}
+
+// matchDial finds the longest dial-code prefix (1–3 digits) present in country's
+// table.
+func matchDial(digits string) (string, bool) {
+	for n := 3; n >= 1; n-- {
+		if len(digits) < n {
+			continue
+		}
+		p := digits[:n]
+		if len(country.ByDialCode(p)) > 0 {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// build validates E.164 length, resolves the dial code, and constructs a Phone.
+// resolved, when non-empty, records a region hint that pinned the country.
+func build(digits, resolved string) (Phone, error) {
+	if len(digits) > 15 {
+		return Phone{}, ErrInvalidNumber
+	}
+	dial, ok := matchDial(digits)
+	if !ok {
+		return Phone{}, ErrUnknownDialCode
+	}
+	if len(digits) <= len(dial) {
+		return Phone{}, ErrInvalidNumber // national number empty
+	}
+	return Phone{e164: "+" + digits, resolved: resolved, dialLen: len(dial)}, nil
+}
+
+// E164 returns the canonical E.164 form, e.g. "+14155552671" ("" for the zero
+// Phone).
+func (p Phone) E164() string { return p.e164 }
+
+// DialCode returns the E.164 country calling code without the +, e.g. "1".
+func (p Phone) DialCode() string {
+	if p.e164 == "" {
+		return ""
+	}
+	return p.e164[1 : 1+p.dialLen]
+}
+
+// NationalNumber returns the significant number after the dial code, e.g.
+// "4155552671".
+func (p Phone) NationalNumber() string {
+	if p.e164 == "" {
+		return ""
+	}
+	return p.e164[1+p.dialLen:]
+}
+
+// IsZero reports whether p is the zero Phone.
+func (p Phone) IsZero() bool { return p.e164 == "" }

--- a/core/phone/phone.go
+++ b/core/phone/phone.go
@@ -82,7 +82,7 @@ func matchDial(digits string) (string, bool) {
 			continue
 		}
 		p := digits[:n]
-		if len(country.ByDialCode(p)) > 0 {
+		if country.HasDialCode(p) {
 			return p, true
 		}
 	}

--- a/core/phone/phone_test.go
+++ b/core/phone/phone_test.go
@@ -1,0 +1,51 @@
+package phone_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/phone"
+)
+
+func TestParse_PlusForm(t *testing.T) {
+	p, err := phone.Parse("+1 (415) 555-2671")
+	require.NoError(t, err)
+	assert.Equal(t, "+14155552671", p.E164())
+	assert.Equal(t, "1", p.DialCode())
+	assert.Equal(t, "4155552671", p.NationalNumber())
+	assert.False(t, p.IsZero())
+}
+
+func TestParse_DoubleZeroPrefix(t *testing.T) {
+	p, err := phone.Parse("0044 20 7946 0018")
+	require.NoError(t, err)
+	assert.Equal(t, "+442079460018", p.E164())
+	assert.Equal(t, "44", p.DialCode())
+}
+
+func TestParse_Errors(t *testing.T) {
+	_, err := phone.Parse("415-555-2671")
+	assert.ErrorIs(t, err, phone.ErrMissingCountryCode)
+
+	_, err = phone.Parse("+1 abc")
+	assert.ErrorIs(t, err, phone.ErrInvalidNumber)
+
+	_, err = phone.Parse("+999 12345")
+	assert.ErrorIs(t, err, phone.ErrUnknownDialCode)
+
+	_, err = phone.Parse("+1")
+	assert.ErrorIs(t, err, phone.ErrInvalidNumber) // national number empty
+
+	_, err = phone.Parse("+1 1234567890123456")
+	assert.ErrorIs(t, err, phone.ErrInvalidNumber) // > 15 digits
+}
+
+func TestParse_ZeroValue(t *testing.T) {
+	var p phone.Phone
+	assert.True(t, p.IsZero())
+	assert.Empty(t, p.E164())
+	assert.Empty(t, p.DialCode())
+	assert.Empty(t, p.NationalNumber())
+}

--- a/core/phone/phone_test.go
+++ b/core/phone/phone_test.go
@@ -40,6 +40,12 @@ func TestParse_Errors(t *testing.T) {
 
 	_, err = phone.Parse("+1 1234567890123456")
 	assert.ErrorIs(t, err, phone.ErrInvalidNumber) // > 15 digits
+
+	// An over-length number is rejected as invalid before dial-code matching,
+	// so an unknown prefix past the E.164 length cap reports ErrInvalidNumber
+	// rather than ErrUnknownDialCode.
+	_, err = phone.Parse("+9991234567890123456")
+	assert.ErrorIs(t, err, phone.ErrInvalidNumber)
 }
 
 func TestParse_ThreeDigitDialCode(t *testing.T) {

--- a/core/phone/phone_test.go
+++ b/core/phone/phone_test.go
@@ -42,6 +42,13 @@ func TestParse_Errors(t *testing.T) {
 	assert.ErrorIs(t, err, phone.ErrInvalidNumber) // > 15 digits
 }
 
+func TestParse_ThreeDigitDialCode(t *testing.T) {
+	p, err := phone.Parse("+380 44 123 4567")
+	require.NoError(t, err)
+	assert.Equal(t, "380", p.DialCode())
+	assert.Equal(t, "441234567", p.NationalNumber())
+}
+
 func TestParse_ZeroValue(t *testing.T) {
 	var p phone.Phone
 	assert.True(t, p.IsZero())

--- a/core/phone/region_test.go
+++ b/core/phone/region_test.go
@@ -1,0 +1,66 @@
+package phone_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/country"
+	"github.com/dmitrymomot/forge/core/phone"
+)
+
+func TestParseRegion_BareNationalStripsTrunkZero(t *testing.T) {
+	p, err := phone.ParseRegion("07911 123456", "GB")
+	require.NoError(t, err)
+	assert.Equal(t, "+447911123456", p.E164())
+	c, ok := p.Country()
+	assert.True(t, ok)
+	assert.Equal(t, "GB", c.Alpha2)
+}
+
+func TestParseRegion_UnknownRegion(t *testing.T) {
+	_, err := phone.ParseRegion("07911 123456", "ZZ")
+	assert.ErrorIs(t, err, phone.ErrMissingCountryCode)
+}
+
+func TestParseRegion_PlusInputResolvesSharedCode(t *testing.T) {
+	p, err := phone.ParseRegion("+1 604 555 0199", "CA")
+	require.NoError(t, err)
+	c, ok := p.Country()
+	assert.True(t, ok)
+	assert.Equal(t, "CA", c.Alpha2) // region hint pinned CA among +1 candidates
+}
+
+func TestCountry_UniqueDialCode(t *testing.T) {
+	// +44 is NOT unique in the committed country table (GB shares it with the
+	// Crown dependencies GG/IM/JE), so this uses +49 (Germany), which has no
+	// other country sharing its dial code.
+	p, _ := phone.Parse("+49 30 12345678")
+	c, ok := p.Country()
+	assert.True(t, ok)
+	assert.Equal(t, "DE", c.Alpha2)
+}
+
+func TestCountry_AmbiguousReturnsPrimaryFalse(t *testing.T) {
+	p, _ := phone.Parse("+1 415 555 2671")
+	c, ok := p.Country()
+	assert.False(t, ok) // ambiguous +1, no hint
+	assert.Equal(t, "US", c.Alpha2)
+
+	cands := p.Candidates()
+	codes := make([]string, len(cands))
+	for i, c := range cands {
+		codes[i] = c.Alpha2
+	}
+	assert.Contains(t, codes, "US")
+	assert.Contains(t, codes, "CA")
+}
+
+func TestCandidates_ZeroPhone(t *testing.T) {
+	var p phone.Phone
+	assert.Nil(t, p.Candidates())
+	_, ok := p.Country()
+	assert.False(t, ok)
+	_ = country.US
+}

--- a/core/phone/sql.go
+++ b/core/phone/sql.go
@@ -1,0 +1,46 @@
+package phone
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+)
+
+// Value implements driver.Valuer, storing the E.164 string. The zero Phone
+// stores SQL NULL.
+func (p Phone) Value() (driver.Value, error) {
+	if p.e164 == "" {
+		return nil, nil
+	}
+	return p.e164, nil
+}
+
+// Scan implements sql.Scanner for the E.164 string form. A nil or empty source
+// yields the zero Phone; any other value is re-parsed by Parse.
+func (p *Phone) Scan(src any) error {
+	switch v := src.(type) {
+	case nil:
+		*p = Phone{}
+		return nil
+	case string:
+		return p.scan(v)
+	case []byte:
+		return p.scan(string(v))
+	default:
+		return fmt.Errorf("phone: cannot scan %T: %w", src, ErrInvalidNumber)
+	}
+}
+
+func (p *Phone) scan(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		*p = Phone{}
+		return nil
+	}
+	parsed, err := Parse(s)
+	if err != nil {
+		return err
+	}
+	*p = parsed
+	return nil
+}

--- a/core/phone/sql_test.go
+++ b/core/phone/sql_test.go
@@ -1,0 +1,43 @@
+package phone_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/phone"
+)
+
+func TestValueAndScan_RoundTrip(t *testing.T) {
+	p, _ := phone.Parse("+14155552671")
+	v, err := p.Value()
+	require.NoError(t, err)
+	assert.Equal(t, "+14155552671", v)
+
+	var got phone.Phone
+	require.NoError(t, got.Scan("+14155552671"))
+	assert.Equal(t, "+14155552671", got.E164())
+
+	require.NoError(t, got.Scan([]byte("+442079460018")))
+	assert.Equal(t, "+442079460018", got.E164())
+}
+
+func TestValueAndScan_ZeroAndNull(t *testing.T) {
+	var zero phone.Phone
+	v, err := zero.Value()
+	require.NoError(t, err)
+	assert.Nil(t, v)
+
+	var got phone.Phone
+	require.NoError(t, got.Scan(nil))
+	assert.True(t, got.IsZero())
+	require.NoError(t, got.Scan(""))
+	assert.True(t, got.IsZero())
+}
+
+func TestScan_Garbage(t *testing.T) {
+	var p phone.Phone
+	assert.ErrorIs(t, p.Scan("nope"), phone.ErrMissingCountryCode)
+	assert.ErrorIs(t, p.Scan(12345), phone.ErrInvalidNumber)
+}

--- a/core/phone/sql_test.go
+++ b/core/phone/sql_test.go
@@ -21,6 +21,9 @@ func TestValueAndScan_RoundTrip(t *testing.T) {
 
 	require.NoError(t, got.Scan([]byte("+442079460018")))
 	assert.Equal(t, "+442079460018", got.E164())
+
+	require.NoError(t, got.Scan("  +14155552671  "))
+	assert.Equal(t, "+14155552671", got.E164())
 }
 
 func TestValueAndScan_ZeroAndNull(t *testing.T) {

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -15,19 +15,6 @@ tagged `(planned)` are elsewhere in this file and define build order.
 External module deps stay in the entry prose. Composition partners
 (packages a consumer wires alongside) are not deps and are not listed.
 
-## core/
-
----
-
-**core/phone**
-
-E.164 phone normalization: parse/format/validate over `core/country`'s
-dial-prefix table. Consumers: `comms/sms`, `auth/otp`, KYC forms. No
-carrier metadata, no line-type detection — the libphonenumber swamp
-stays out.
-
-Deps: `core/country` (planned).
-
 ## web/
 
 ---

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -19,17 +19,6 @@ External module deps stay in the entry prose. Composition partners
 
 ---
 
-**core/country**
-
-Curated ISO-3166 static data: alpha-2/alpha-3 codes, English names,
-default currency, and dial prefix per country — the `money` ISO-4217
-precedent applied to countries. Zero deps; consumers: registration/KYC
-forms, `geoip` enrichment, `i18n`, `core/phone`.
-
-Deps: none (stdlib only).
-
----
-
 **core/phone**
 
 E.164 phone normalization: parse/format/validate over `core/country`'s

--- a/docs/superpowers/plans/2026-07-15-core-country-phone.md
+++ b/docs/superpowers/plans/2026-07-15-core-country-phone.md
@@ -16,7 +16,7 @@
 - Tests use testify (`assert`/`require`), matching `core/money`.
 - Error sentinels are `errors.Is`-matchable, single-line, prefixed `country: ` / `phone: `.
 - Options are `type Option func(*config)` over an unexported `config` — never builders.
-- No manual line-wrapping in prose/comments/commit bodies; one line per paragraph, let it soft-wrap.
+- No manual line-wrapping in prose/markdown/PR/commit bodies; one line per paragraph, let it soft-wrap. (Go source doc comments follow existing house style — wrapped ~80 chars, as in `core/money`; do NOT unwrap them.)
 - After editing files in a package, run `just fmt ./core/<pkg>/...` (single-file `just fmt` trips a spurious betteralign error — always pass the package glob).
 - After each package is complete, `just lint` must pass clean.
 - Every package ships `bench_test.go` plus a measured optimization pass (before/after numbers) — required for the PR.

--- a/docs/superpowers/plans/2026-07-15-core-country-phone.md
+++ b/docs/superpowers/plans/2026-07-15-core-country-phone.md
@@ -1,0 +1,1696 @@
+# core/country + core/phone Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `core/country` (curated ISO-3166 static data + supported-countries `Set`) and `core/phone` (E.164 normalize/decompose value type + configured `Parser`), modeled on the `core/money` precedent.
+
+**Architecture:** `country` is a zero-dep static-data package: a `Country` value type, ~249 exported vars, map-backed lookups, and a `Set` policy value. `phone` depends on `country`: a pointer-free `Phone` value type parsed against country's dial-code table, plus a `New(...Option)` `Parser` adding a default region and a supported-countries gate. Both use only the stdlib (+ testify in tests).
+
+**Tech Stack:** Go 1.26, stdlib, `github.com/stretchr/testify` (tests). Spec: [docs/superpowers/specs/2026-07-15-core-country-phone-design.md](../specs/2026-07-15-core-country-phone-design.md).
+
+## Global Constraints
+
+- Module path `github.com/dmitrymomot/forge`; Go 1.26; single module, no sub-modules.
+- `core/country`: stdlib only, no forge deps. `core/phone`: may import `core/country` only.
+- Black-box tests only: test packages are `country_test` / `phone_test`, importing the package under test.
+- Tests use testify (`assert`/`require`), matching `core/money`.
+- Error sentinels are `errors.Is`-matchable, single-line, prefixed `country: ` / `phone: `.
+- Options are `type Option func(*config)` over an unexported `config` — never builders.
+- No manual line-wrapping in prose/comments/commit bodies; one line per paragraph, let it soft-wrap.
+- After editing files in a package, run `just fmt ./core/<pkg>/...` (single-file `just fmt` trips a spurious betteralign error — always pass the package glob).
+- After each package is complete, `just lint` must pass clean.
+- Every package ships `bench_test.go` plus a measured optimization pass (before/after numbers) — required for the PR.
+- Do NOT add any Claude/Anthropic attribution to commits.
+
+---
+
+## File Structure
+
+**`core/country/`**
+- `doc.go` — package doc + runnable example.
+- `country.go` — `Country` type, `flagEmoji`, the lookups (`ByAlpha2`/`ByAlpha3`/`ByNumeric`/`ByDialCode`/`All`), and the `init` that fills emoji + builds indexes.
+- `data.go` — the ~249 exported `Country` vars and the `all` pointer slice (generated static data with a provenance header).
+- `set.go` — the `Set` policy type.
+- `errors.go` — `ErrUnknownCode`.
+- `country_test.go`, `set_test.go`, `bench_test.go`.
+
+**`core/phone/`**
+- `doc.go` — package doc + runnable example.
+- `phone.go` — `Phone` type, `Parse`/`ParseRegion` free funcs, decomposition methods (`E164`/`DialCode`/`NationalNumber`/`Country`/`Candidates`/`IsZero`), `matchDial`, `toDigits`, `build`, `primaryDial`.
+- `parser.go` — `Parser`, `New`, `gatePass`.
+- `config.go` — unexported `config`.
+- `options.go` — `Option`, `WithDefaultRegion`, `WithAllowedCountries`.
+- `sql.go` — `Value`/`Scan`.
+- `json.go` — `MarshalJSON`/`UnmarshalJSON`.
+- `errors.go` — the four sentinels.
+- `phone_test.go`, `parser_test.go`, `sql_test.go`, `json_test.go`, `bench_test.go`.
+
+---
+
+## Task 1: `country.Country` type, seed data, and lookups
+
+**Files:**
+- Create: `core/country/country.go`, `core/country/data.go`, `core/country/errors.go`
+- Test: `core/country/country_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type Country struct { Alpha2, Alpha3, Numeric, Name, Currency, DialCode, Emoji string }`
+  - `func ByAlpha2(code string) (Country, bool)`
+  - `func ByAlpha3(code string) (Country, bool)`
+  - `func ByNumeric(code string) (Country, bool)`
+  - `func ByDialCode(code string) []Country` (internal shared slice, read-only; `nil` if none)
+  - `func All() []Country` (fresh slice, sorted by `Name`)
+  - Exported vars for the seed set: `US CA GB DE FR AU JP IN BR ZA UA NO`
+  - `var ErrUnknownCode = errors.New("country: unknown code")`
+
+- [ ] **Step 1: Write the failing test**
+
+`core/country/country_test.go`:
+```go
+package country_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/core/country"
+)
+
+func TestByAlpha2_HitAndCaseInsensitive(t *testing.T) {
+	c, ok := country.ByAlpha2("us")
+	assert.True(t, ok)
+	assert.Equal(t, "US", c.Alpha2)
+	assert.Equal(t, "USA", c.Alpha3)
+	assert.Equal(t, "840", c.Numeric)
+	assert.Equal(t, "United States", c.Name)
+	assert.Equal(t, "USD", c.Currency)
+	assert.Equal(t, "1", c.DialCode)
+	assert.Equal(t, "\U0001F1FA\U0001F1F8", c.Emoji) // 🇺🇸
+}
+
+func TestByAlpha2_Miss(t *testing.T) {
+	_, ok := country.ByAlpha2("ZZ")
+	assert.False(t, ok)
+}
+
+func TestByAlpha3AndNumeric(t *testing.T) {
+	c, ok := country.ByAlpha3("deu")
+	assert.True(t, ok)
+	assert.Equal(t, "DE", c.Alpha2)
+	c, ok = country.ByNumeric("826")
+	assert.True(t, ok)
+	assert.Equal(t, "GB", c.Alpha2)
+}
+
+func TestByDialCode_Shared(t *testing.T) {
+	cs := country.ByDialCode("1")
+	codes := make([]string, len(cs))
+	for i, c := range cs {
+		codes[i] = c.Alpha2
+	}
+	assert.Contains(t, codes, "US")
+	assert.Contains(t, codes, "CA")
+	assert.Nil(t, country.ByDialCode("999"))
+}
+
+func TestAll_SortedByName(t *testing.T) {
+	all := country.All()
+	assert.NotEmpty(t, all)
+	assert.True(t, sort.SliceIsSorted(all, func(i, j int) bool { return all[i].Name < all[j].Name }))
+}
+
+func TestVars_Populated(t *testing.T) {
+	assert.Equal(t, "GB", country.GB.Alpha2)
+	assert.Equal(t, "\U0001F1E9\U0001F1EA", country.DE.Emoji) // 🇩🇪 filled at init
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./core/country/ -run 'TestBy|TestAll|TestVars' -v`
+Expected: FAIL — package `country` does not exist / undefined symbols.
+
+- [ ] **Step 3: Write the implementation**
+
+`core/country/errors.go`:
+```go
+package country
+
+import "errors"
+
+// ErrUnknownCode is returned by NewSetFromCodes when a supplied alpha-2 code is
+// not present in the bundled ISO-3166-1 table.
+var ErrUnknownCode = errors.New("country: unknown code")
+```
+
+`core/country/country.go`:
+```go
+package country
+
+import (
+	"sort"
+	"strings"
+)
+
+// Country is one ISO-3166-1 entry: its alpha-2 (the canonical key), alpha-3, and
+// numeric-3 codes, English short name, primary official ISO-4217 currency code,
+// E.164 dial code (no leading +), and flag emoji.
+type Country struct {
+	Alpha2   string
+	Alpha3   string
+	Numeric  string
+	Name     string
+	Currency string
+	DialCode string
+	Emoji    string
+}
+
+var (
+	byAlpha2  = map[string]Country{}
+	byAlpha3  = map[string]Country{}
+	byNumeric = map[string]Country{}
+	byDial    = map[string][]Country{}
+	sorted    []Country
+)
+
+func init() {
+	for _, c := range all {
+		c.Emoji = flagEmoji(c.Alpha2)
+	}
+	sorted = make([]Country, 0, len(all))
+	for _, c := range all {
+		byAlpha2[c.Alpha2] = *c
+		byAlpha3[c.Alpha3] = *c
+		byNumeric[c.Numeric] = *c
+		byDial[c.DialCode] = append(byDial[c.DialCode], *c)
+		sorted = append(sorted, *c)
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+	for k := range byDial {
+		s := byDial[k]
+		sort.Slice(s, func(i, j int) bool { return s[i].Name < s[j].Name })
+	}
+}
+
+// flagEmoji derives a flag from an alpha-2 code by mapping each letter to its
+// Unicode regional-indicator symbol. It returns "" for non-two-letter or
+// non-A–Z input.
+func flagEmoji(alpha2 string) string {
+	if len(alpha2) != 2 {
+		return ""
+	}
+	a, b := alpha2[0], alpha2[1]
+	if a < 'A' || a > 'Z' || b < 'A' || b > 'Z' {
+		return ""
+	}
+	const base = 0x1F1E6
+	return string([]rune{rune(base + int(a-'A')), rune(base + int(b-'A'))})
+}
+
+// ByAlpha2 looks up a country by ISO-3166-1 alpha-2 code, case-insensitively.
+func ByAlpha2(code string) (Country, bool) {
+	c, ok := byAlpha2[strings.ToUpper(code)]
+	return c, ok
+}
+
+// ByAlpha3 looks up a country by ISO-3166-1 alpha-3 code, case-insensitively.
+func ByAlpha3(code string) (Country, bool) {
+	c, ok := byAlpha3[strings.ToUpper(code)]
+	return c, ok
+}
+
+// ByNumeric looks up a country by ISO-3166-1 numeric-3 code.
+func ByNumeric(code string) (Country, bool) {
+	c, ok := byNumeric[code]
+	return c, ok
+}
+
+// ByDialCode returns every country sharing an E.164 dial code (many share "1").
+// The returned slice is shared internal state sorted by Name and must not be
+// modified; it is nil when no country uses the code.
+func ByDialCode(code string) []Country {
+	return byDial[code]
+}
+
+// All returns every bundled country sorted by Name. The returned slice is a
+// fresh copy the caller may retain and modify.
+func All() []Country {
+	out := make([]Country, len(sorted))
+	copy(out, sorted)
+	return out
+}
+```
+
+`core/country/data.go` (seed set — expanded to the full table in Task 3):
+```go
+package country
+
+// ISO-3166-1 static data: alpha-2/alpha-3/numeric codes, English short name,
+// primary official ISO-4217 currency, and E.164 dial code. Curated static data
+// committed to the repo — no runtime fetch. Emoji flags are derived from the
+// alpha-2 pair at package init. Source: ISO-3166-1 (2026 edition).
+
+var (
+	AU = Country{Alpha2: "AU", Alpha3: "AUS", Numeric: "036", Name: "Australia", Currency: "AUD", DialCode: "61"}
+	BR = Country{Alpha2: "BR", Alpha3: "BRA", Numeric: "076", Name: "Brazil", Currency: "BRL", DialCode: "55"}
+	CA = Country{Alpha2: "CA", Alpha3: "CAN", Numeric: "124", Name: "Canada", Currency: "CAD", DialCode: "1"}
+	DE = Country{Alpha2: "DE", Alpha3: "DEU", Numeric: "276", Name: "Germany", Currency: "EUR", DialCode: "49"}
+	FR = Country{Alpha2: "FR", Alpha3: "FRA", Numeric: "250", Name: "France", Currency: "EUR", DialCode: "33"}
+	GB = Country{Alpha2: "GB", Alpha3: "GBR", Numeric: "826", Name: "United Kingdom", Currency: "GBP", DialCode: "44"}
+	IN = Country{Alpha2: "IN", Alpha3: "IND", Numeric: "356", Name: "India", Currency: "INR", DialCode: "91"}
+	JP = Country{Alpha2: "JP", Alpha3: "JPN", Numeric: "392", Name: "Japan", Currency: "JPY", DialCode: "81"}
+	NO = Country{Alpha2: "NO", Alpha3: "NOR", Numeric: "578", Name: "Norway", Currency: "NOK", DialCode: "47"}
+	UA = Country{Alpha2: "UA", Alpha3: "UKR", Numeric: "804", Name: "Ukraine", Currency: "UAH", DialCode: "380"}
+	US = Country{Alpha2: "US", Alpha3: "USA", Numeric: "840", Name: "United States", Currency: "USD", DialCode: "1"}
+	ZA = Country{Alpha2: "ZA", Alpha3: "ZAF", Numeric: "710", Name: "South Africa", Currency: "ZAR", DialCode: "27"}
+)
+
+// all is the bundled table as pointers into the exported vars, so the init emoji
+// fill lands on the vars themselves. Extended to the full ISO-3166-1 set in a
+// later task.
+var all = []*Country{
+	&AU, &BR, &CA, &DE, &FR, &GB, &IN, &JP, &NO, &UA, &US, &ZA,
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./core/country/ -run 'TestBy|TestAll|TestVars' -v`
+Expected: PASS (all subtests).
+
+- [ ] **Step 5: Format**
+
+Run: `just fmt ./core/country/...`
+Expected: no diff errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/country/country.go core/country/data.go core/country/errors.go core/country/country_test.go
+git commit -m "feat(core/country): Country type, seed data, and lookups"
+```
+
+---
+
+## Task 2: `country.Set` policy type
+
+**Files:**
+- Create: `core/country/set.go`
+- Test: `core/country/set_test.go`
+
+**Interfaces:**
+- Consumes: `Country`, `ByAlpha2`, `ErrUnknownCode` (Task 1).
+- Produces:
+  - `type Set struct { /* unexported */ }`
+  - `func NewSet(cs ...Country) Set`
+  - `func NewSetFromCodes(codes ...string) (Set, error)`
+  - `func (s Set) Contains(c Country) bool`
+  - `func (s Set) ContainsCode(code string) bool`
+  - `func (s Set) All() []Country` (sorted by Name)
+  - `func (s Set) Len() int`
+
+- [ ] **Step 1: Write the failing test**
+
+`core/country/set_test.go`:
+```go
+package country_test
+
+import (
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/country"
+)
+
+func TestNewSet_ContainsAndLen(t *testing.T) {
+	s := country.NewSet(country.US, country.GB, country.DE)
+	assert.Equal(t, 3, s.Len())
+	assert.True(t, s.Contains(country.US))
+	assert.False(t, s.Contains(country.FR))
+	assert.True(t, s.ContainsCode("gb"))
+	assert.False(t, s.ContainsCode("fr"))
+}
+
+func TestNewSetFromCodes_OKAndFailClosed(t *testing.T) {
+	s, err := country.NewSetFromCodes("US", "gb")
+	require.NoError(t, err)
+	assert.Equal(t, 2, s.Len())
+	assert.True(t, s.ContainsCode("US"))
+
+	_, err = country.NewSetFromCodes("US", "ZZ")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, country.ErrUnknownCode)
+}
+
+func TestSet_AllSorted(t *testing.T) {
+	s := country.NewSet(country.US, country.GB, country.DE)
+	all := s.All()
+	assert.Len(t, all, 3)
+	assert.True(t, sort.SliceIsSorted(all, func(i, j int) bool { return all[i].Name < all[j].Name }))
+}
+
+func TestSet_ZeroValueFailsClosed(t *testing.T) {
+	var s country.Set
+	assert.Equal(t, 0, s.Len())
+	assert.False(t, s.Contains(country.US))
+	assert.False(t, s.ContainsCode("US"))
+	assert.Empty(t, s.All())
+	_ = errors.Is
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./core/country/ -run 'TestNewSet|TestSet' -v`
+Expected: FAIL — `Set`, `NewSet`, `NewSetFromCodes` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+`core/country/set.go`:
+```go
+package country
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Set is an explicit, immutable collection of countries — a consumer's
+// "supported countries" policy, shared by filtered UI dropdowns and phone's
+// parse gate. The zero Set is a valid empty set: it contains nothing, so a
+// gate configured with it fails closed.
+type Set struct {
+	m map[string]struct{} // uppercase alpha-2 keys
+}
+
+// NewSet builds a Set from Country values. Zero-value countries are ignored.
+func NewSet(cs ...Country) Set {
+	s := Set{m: make(map[string]struct{}, len(cs))}
+	for _, c := range cs {
+		if c.Alpha2 != "" {
+			s.m[c.Alpha2] = struct{}{}
+		}
+	}
+	return s
+}
+
+// NewSetFromCodes builds a Set from alpha-2 code strings (the form configuration
+// supplies). It fails closed: an unknown code returns the zero Set wrapping
+// ErrUnknownCode.
+func NewSetFromCodes(codes ...string) (Set, error) {
+	s := Set{m: make(map[string]struct{}, len(codes))}
+	for _, code := range codes {
+		c, ok := ByAlpha2(code)
+		if !ok {
+			return Set{}, fmt.Errorf("country: %q: %w", code, ErrUnknownCode)
+		}
+		s.m[c.Alpha2] = struct{}{}
+	}
+	return s, nil
+}
+
+// Contains reports whether c is in the set.
+func (s Set) Contains(c Country) bool {
+	_, ok := s.m[c.Alpha2]
+	return ok
+}
+
+// ContainsCode reports whether the alpha-2 code is in the set, case-insensitively.
+func (s Set) ContainsCode(code string) bool {
+	_, ok := s.m[strings.ToUpper(code)]
+	return ok
+}
+
+// All returns the set's countries sorted by Name — the filtered dropdown source.
+func (s Set) All() []Country {
+	out := make([]Country, 0, len(s.m))
+	for code := range s.m {
+		if c, ok := ByAlpha2(code); ok {
+			out = append(out, c)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// Len returns the number of countries in the set.
+func (s Set) Len() int {
+	return len(s.m)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./core/country/ -run 'TestNewSet|TestSet' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Format**
+
+Run: `just fmt ./core/country/...`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/country/set.go core/country/set_test.go
+git commit -m "feat(core/country): supported-countries Set policy type"
+```
+
+---
+
+## Task 3: Populate the full ISO-3166-1 table
+
+**Files:**
+- Modify: `core/country/data.go` (extend to the full set)
+- Test: `core/country/data_test.go` (invariant guard)
+
+**Interfaces:**
+- Consumes: `Country`, `All`, `flagEmoji`-equivalent formula (recomputed in the test), lookups (Task 1).
+- Produces: exported vars for every ISO-3166-1 country (`country.AD` … `country.ZW`) appended to `all`; no new functions.
+
+**Note:** This is a mechanical data fill, not logic. The invariant test below is written FIRST and guards the fill (shape, uniqueness, derived emoji, dial-code digits). Populate `data.go` from the canonical ISO-3166-1 list — one exported var per country following the exact literal form from Task 1, and add each new var's address to the `all` slice. Assigned Primary currency = the country's current official ISO-4217 code. Keep entries alphabetically ordered by alpha-2 for reviewability.
+
+- [ ] **Step 1: Write the failing invariant test**
+
+`core/country/data_test.go`:
+```go
+package country_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/core/country"
+)
+
+func flag(alpha2 string) string {
+	const base = 0x1F1E6
+	return string([]rune{rune(base + int(alpha2[0]-'A')), rune(base + int(alpha2[1]-'A'))})
+}
+
+func TestTable_Invariants(t *testing.T) {
+	all := country.All()
+	assert.GreaterOrEqual(t, len(all), 240, "expected the full ISO-3166-1 set")
+
+	seenA2 := map[string]bool{}
+	seenA3 := map[string]bool{}
+	seenNum := map[string]bool{}
+	for _, c := range all {
+		assert.Len(t, c.Alpha2, 2, "alpha2 %q", c.Alpha2)
+		assert.Len(t, c.Alpha3, 3, "alpha3 %q", c.Alpha3)
+		assert.Len(t, c.Numeric, 3, "numeric %q for %s", c.Numeric, c.Alpha2)
+		assert.NotEmpty(t, c.Name, "name for %s", c.Alpha2)
+		assert.Len(t, c.Currency, 3, "currency %q for %s", c.Currency, c.Alpha2)
+		assert.NotEmpty(t, c.DialCode, "dial for %s", c.Alpha2)
+		for i := range len(c.DialCode) {
+			assert.True(t, c.DialCode[i] >= '0' && c.DialCode[i] <= '9', "dial %q not numeric", c.DialCode)
+		}
+		assert.LessOrEqual(t, len(c.DialCode), 3, "dial %q too long", c.DialCode)
+		assert.Equal(t, flag(c.Alpha2), c.Emoji, "emoji mismatch for %s", c.Alpha2)
+
+		assert.False(t, seenA2[c.Alpha2], "duplicate alpha2 %s", c.Alpha2)
+		assert.False(t, seenA3[c.Alpha3], "duplicate alpha3 %s", c.Alpha3)
+		assert.False(t, seenNum[c.Numeric], "duplicate numeric %s", c.Numeric)
+		seenA2[c.Alpha2], seenA3[c.Alpha3], seenNum[c.Numeric] = true, true, true
+	}
+}
+
+func TestTable_KnownSpotChecks(t *testing.T) {
+	for _, tc := range []struct{ code, name, cur, dial string }{
+		{"AD", "Andorra", "EUR", "376"},
+		{"CN", "China", "CNY", "86"},
+		{"EG", "Egypt", "EGP", "20"},
+		{"NZ", "New Zealand", "NZD", "64"},
+		{"ZW", "Zimbabwe", "ZWG", "263"},
+	} {
+		c, ok := country.ByAlpha2(tc.code)
+		assert.True(t, ok, tc.code)
+		assert.Equal(t, tc.name, c.Name, tc.code)
+		assert.Equal(t, tc.cur, c.Currency, tc.code)
+		assert.Equal(t, tc.dial, c.DialCode, tc.code)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./core/country/ -run TestTable -v`
+Expected: FAIL — only 12 seed rows, `GreaterOrEqual 240` fails and `AD`/`CN`/etc. lookups miss.
+
+- [ ] **Step 3: Populate `data.go` with the full ISO-3166-1 table**
+
+Extend the `var (...)` block in `core/country/data.go` with one exported var per ISO-3166-1 country (alpha-2 order), each in the exact literal form from Task 1 (`Alpha2`/`Alpha3`/`Numeric`/`Name`/`Currency`/`DialCode`; no `Emoji` — it is filled at init). Add every new var's address to the `all` slice. The invariant test is the acceptance gate. Example additions:
+```go
+	AD = Country{Alpha2: "AD", Alpha3: "AND", Numeric: "020", Name: "Andorra", Currency: "EUR", DialCode: "376"}
+	AE = Country{Alpha2: "AE", Alpha3: "ARE", Numeric: "784", Name: "United Arab Emirates", Currency: "AED", DialCode: "971"}
+	// … through …
+	ZW = Country{Alpha2: "ZW", Alpha3: "ZWE", Numeric: "716", Name: "Zimbabwe", Currency: "ZWG", DialCode: "263"}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./core/country/ -run TestTable -v && go test ./core/country/ -v`
+Expected: PASS — table + all prior tests green.
+
+- [ ] **Step 5: Format**
+
+Run: `just fmt ./core/country/...`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/country/data.go core/country/data_test.go
+git commit -m "feat(core/country): populate full ISO-3166-1 table"
+```
+
+---
+
+## Task 4: `country` doc, benchmarks, optimization pass, roadmap
+
+**Files:**
+- Create: `core/country/doc.go`, `core/country/bench_test.go`
+- Modify: `docs/packages.md` (delete the `core/country` entry)
+
+**Interfaces:**
+- Consumes: the full `country` API (Tasks 1–3).
+- Produces: no new symbols.
+
+- [ ] **Step 1: Write benchmarks**
+
+`core/country/bench_test.go`:
+```go
+package country_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/country"
+)
+
+func BenchmarkByAlpha2(b *testing.B) {
+	for b.Loop() {
+		_, _ = country.ByAlpha2("US")
+	}
+}
+
+func BenchmarkByDialCode(b *testing.B) {
+	for b.Loop() {
+		_ = country.ByDialCode("1")
+	}
+}
+
+func BenchmarkAll(b *testing.B) {
+	for b.Loop() {
+		_ = country.All()
+	}
+}
+
+func BenchmarkNewSetFromCodes(b *testing.B) {
+	for b.Loop() {
+		_, _ = country.NewSetFromCodes("US", "GB", "DE", "FR")
+	}
+}
+```
+
+- [ ] **Step 2: Run the benchmarks (record before numbers)**
+
+Run: `just bench ./core/country/...`
+Expected: results print; note ns/op and allocs/op for each. `ByAlpha2` and `ByDialCode` should be 0 allocs/op; if not, that is the optimization-pass target.
+
+- [ ] **Step 3: Write `doc.go`**
+
+`core/country/doc.go`:
+```go
+// Package country provides curated ISO-3166-1 static data — alpha-2, alpha-3,
+// and numeric codes, English short name, primary official ISO-4217 currency
+// code, E.164 dial code, and flag emoji — plus case-insensitive lookups and a
+// Set type expressing a "supported countries" policy.
+//
+// Every country is exposed as a package-level Country var (US, GB, DE, …) and
+// indexed for lookup by ByAlpha2, ByAlpha3, ByNumeric, and ByDialCode; All
+// returns the whole table sorted by Name (a dropdown source). Because many
+// countries share one dial code (+1 covers the US, Canada, and the Caribbean),
+// ByDialCode returns a slice. The data is committed static — no runtime fetch;
+// flag emoji are derived from the alpha-2 pair at package init.
+//
+// A Set is an explicit, immutable collection a consumer constructs (NewSet, or
+// NewSetFromCodes over configuration strings, which fails closed on an unknown
+// code) and passes wherever a supported-countries policy is needed — the
+// filtered All dropdown, or core/phone's parse gate. The zero Set is a valid
+// empty set that contains nothing, so a gate configured with it fails closed.
+//
+// What this is NOT: it carries only the primary official currency per country
+// (not de-facto multi-currency reality), no ISO-3166-2 subdivisions/states, no
+// translated names (that is an i18n concern), and no historical or deprecated
+// codes. Cheap shape-only validation of a country code lives in core/validate;
+// this package is the authoritative data.
+//
+// # Usage
+//
+//	c, ok := country.ByAlpha2("us")
+//	if ok {
+//		_ = c.Name     // "United States"
+//		_ = c.Currency // "USD"
+//		_ = c.Emoji    // "🇺🇸"
+//	}
+//
+//	supported, _ := country.NewSetFromCodes("US", "GB", "DE")
+//	_ = supported.ContainsCode("fr") // false
+//	_ = supported.All()              // sorted, for a filtered dropdown
+package country
+```
+
+- [ ] **Step 4: Optimization pass (only if a benchmark showed a win)**
+
+If Step 2 showed non-zero allocs on `ByAlpha2`/`ByDialCode`, or an obvious hot-path win, apply the minimal change and re-run `just bench ./core/country/...`. Record before/after in the PR description. If already optimal (0 allocs on the lookups), note "no change — lookups already 0 allocs/op" in the PR. Make no speculative changes.
+
+- [ ] **Step 5: Delete the roadmap entry**
+
+In `docs/packages.md`, remove the `**core/country**` block (heading through its `Deps:` line and the surrounding `---` separators for that entry only). Leave `core/phone` until Task 9.
+
+- [ ] **Step 6: Verify and commit**
+
+Run: `just lint`
+Expected: clean (vet, build, golangci-lint, nilaway, betteralign, modernize all pass).
+```bash
+git add core/country/doc.go core/country/bench_test.go docs/packages.md
+git commit -m "docs(core/country): doc.go, benchmarks, drop roadmap entry"
+```
+
+---
+
+## Task 5: `phone.Phone` type and `Parse`
+
+**Files:**
+- Create: `core/phone/phone.go`, `core/phone/errors.go`
+- Test: `core/phone/phone_test.go`
+
+**Interfaces:**
+- Consumes: `country.ByDialCode`, `country.ByAlpha2` (country package).
+- Produces:
+  - `type Phone struct { /* unexported: e164 string, dialLen int, resolved string */ }`
+  - `func Parse(input string) (Phone, error)`
+  - `func (p Phone) E164() string`
+  - `func (p Phone) DialCode() string`
+  - `func (p Phone) NationalNumber() string`
+  - `func (p Phone) IsZero() bool`
+  - internal: `toDigits(input string, requireCC bool) (string, error)`, `matchDial(digits string) (string, bool)`, `build(digits, resolved string) (Phone, error)`
+  - `var ErrInvalidNumber, ErrMissingCountryCode, ErrUnknownDialCode, ErrUnsupportedRegion`
+
+- [ ] **Step 1: Write the failing test**
+
+`core/phone/phone_test.go`:
+```go
+package phone_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/phone"
+)
+
+func TestParse_PlusForm(t *testing.T) {
+	p, err := phone.Parse("+1 (415) 555-2671")
+	require.NoError(t, err)
+	assert.Equal(t, "+14155552671", p.E164())
+	assert.Equal(t, "1", p.DialCode())
+	assert.Equal(t, "4155552671", p.NationalNumber())
+	assert.False(t, p.IsZero())
+}
+
+func TestParse_DoubleZeroPrefix(t *testing.T) {
+	p, err := phone.Parse("0044 20 7946 0018")
+	require.NoError(t, err)
+	assert.Equal(t, "+442079460018", p.E164())
+	assert.Equal(t, "44", p.DialCode())
+}
+
+func TestParse_Errors(t *testing.T) {
+	_, err := phone.Parse("415-555-2671")
+	assert.ErrorIs(t, err, phone.ErrMissingCountryCode)
+
+	_, err = phone.Parse("+1 abc")
+	assert.ErrorIs(t, err, phone.ErrInvalidNumber)
+
+	_, err = phone.Parse("+999 12345")
+	assert.ErrorIs(t, err, phone.ErrUnknownDialCode)
+
+	_, err = phone.Parse("+1")
+	assert.ErrorIs(t, err, phone.ErrInvalidNumber) // national number empty
+
+	_, err = phone.Parse("+1 1234567890123456")
+	assert.ErrorIs(t, err, phone.ErrInvalidNumber) // > 15 digits
+}
+
+func TestParse_ZeroValue(t *testing.T) {
+	var p phone.Phone
+	assert.True(t, p.IsZero())
+	assert.Empty(t, p.E164())
+	assert.Empty(t, p.DialCode())
+	assert.Empty(t, p.NationalNumber())
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./core/phone/ -run TestParse -v`
+Expected: FAIL — package `phone` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+`core/phone/errors.go`:
+```go
+package phone
+
+import "errors"
+
+// ErrInvalidNumber is returned when input contains non-digit content or its
+// digit count is outside E.164 bounds (empty national number, or over 15 total).
+var ErrInvalidNumber = errors.New("phone: invalid number")
+
+// ErrMissingCountryCode is returned by Parse when input has no leading + or 00
+// and no region context supplies a dial code.
+var ErrMissingCountryCode = errors.New("phone: missing country code")
+
+// ErrUnknownDialCode is returned when the leading digits match no country
+// calling code in the bundled table.
+var ErrUnknownDialCode = errors.New("phone: unknown dial code")
+
+// ErrUnsupportedRegion is returned by a gated Parser when the resolved country
+// is provably outside the configured supported-countries Set.
+var ErrUnsupportedRegion = errors.New("phone: unsupported region")
+```
+
+`core/phone/phone.go`:
+```go
+package phone
+
+import (
+	"strings"
+
+	"github.com/dmitrymomot/forge/core/country"
+)
+
+// Phone is a normalized E.164 phone number. The zero Phone is the empty value
+// (IsZero reports true). It is pointer-free for low GC scan cost.
+type Phone struct {
+	e164     string // "+14155552671"
+	resolved string // alpha-2 when a region hint pinned the country; "" otherwise
+	dialLen  int    // dial-code digit count, for splitting E164 into dial + national
+}
+
+// primaryDial designates the "main" country for a shared dial code, so Country
+// can return a stable primary for an ambiguous number. Codes not listed fall
+// back to the first candidate by Name.
+var primaryDial = map[string]string{
+	"1": "US", "7": "RU", "44": "GB", "39": "IT", "61": "AU", "47": "NO", "212": "MA", "358": "FI",
+}
+
+// Parse normalizes a phone number that carries its own country code (a leading +
+// or 00). Formatting characters (spaces, dashes, parentheses, dots, slashes) are
+// stripped. It returns ErrMissingCountryCode when no + or 00 is present.
+func Parse(input string) (Phone, error) {
+	digits, err := toDigits(input, true)
+	if err != nil {
+		return Phone{}, err
+	}
+	return build(digits, "")
+}
+
+// toDigits strips a leading + or 00 and all formatting separators, returning the
+// bare digit string. When requireCC is true, absence of a + or 00 is an error.
+func toDigits(input string, requireCC bool) (string, error) {
+	s := strings.TrimSpace(input)
+	switch {
+	case strings.HasPrefix(s, "+"):
+		s = s[1:]
+	case strings.HasPrefix(s, "00"):
+		s = s[2:]
+	default:
+		if requireCC {
+			return "", ErrMissingCountryCode
+		}
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := range len(s) {
+		ch := s[i]
+		switch {
+		case ch >= '0' && ch <= '9':
+			b.WriteByte(ch)
+		case isSep(ch):
+			// drop
+		default:
+			return "", ErrInvalidNumber
+		}
+	}
+	d := b.String()
+	if d == "" {
+		return "", ErrInvalidNumber
+	}
+	return d, nil
+}
+
+func isSep(ch byte) bool {
+	switch ch {
+	case ' ', '-', '(', ')', '.', '/':
+		return true
+	}
+	return false
+}
+
+// matchDial finds the longest dial-code prefix (1–3 digits) present in country's
+// table.
+func matchDial(digits string) (string, bool) {
+	for n := 3; n >= 1; n-- {
+		if len(digits) < n {
+			continue
+		}
+		p := digits[:n]
+		if len(country.ByDialCode(p)) > 0 {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// build validates E.164 length, resolves the dial code, and constructs a Phone.
+// resolved, when non-empty, records a region hint that pinned the country.
+func build(digits, resolved string) (Phone, error) {
+	if len(digits) > 15 {
+		return Phone{}, ErrInvalidNumber
+	}
+	dial, ok := matchDial(digits)
+	if !ok {
+		return Phone{}, ErrUnknownDialCode
+	}
+	if len(digits) <= len(dial) {
+		return Phone{}, ErrInvalidNumber // national number empty
+	}
+	return Phone{e164: "+" + digits, resolved: resolved, dialLen: len(dial)}, nil
+}
+
+// E164 returns the canonical E.164 form, e.g. "+14155552671" ("" for the zero
+// Phone).
+func (p Phone) E164() string { return p.e164 }
+
+// DialCode returns the E.164 country calling code without the +, e.g. "1".
+func (p Phone) DialCode() string {
+	if p.e164 == "" {
+		return ""
+	}
+	return p.e164[1 : 1+p.dialLen]
+}
+
+// NationalNumber returns the significant number after the dial code, e.g.
+// "4155552671".
+func (p Phone) NationalNumber() string {
+	if p.e164 == "" {
+		return ""
+	}
+	return p.e164[1+p.dialLen:]
+}
+
+// IsZero reports whether p is the zero Phone.
+func (p Phone) IsZero() bool { return p.e164 == "" }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./core/phone/ -run TestParse -v`
+Expected: PASS.
+
+- [ ] **Step 5: Format**
+
+Run: `just fmt ./core/phone/...`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/phone/phone.go core/phone/errors.go core/phone/phone_test.go
+git commit -m "feat(core/phone): Phone type and Parse"
+```
+
+---
+
+## Task 6: `ParseRegion`, `Country`, and `Candidates`
+
+**Files:**
+- Modify: `core/phone/phone.go` (add `ParseRegion`, `Country`, `Candidates`)
+- Test: `core/phone/region_test.go`
+
+**Interfaces:**
+- Consumes: `Parse`, `build`, `toDigits`, `primaryDial` (Task 5); `country.ByAlpha2`, `country.ByDialCode`.
+- Produces:
+  - `func ParseRegion(input, alpha2 string) (Phone, error)`
+  - `func (p Phone) Country() (country.Country, bool)`
+  - `func (p Phone) Candidates() []country.Country`
+
+- [ ] **Step 1: Write the failing test**
+
+`core/phone/region_test.go`:
+```go
+package phone_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/country"
+	"github.com/dmitrymomot/forge/core/phone"
+)
+
+func TestParseRegion_BareNationalStripsTrunkZero(t *testing.T) {
+	p, err := phone.ParseRegion("07911 123456", "GB")
+	require.NoError(t, err)
+	assert.Equal(t, "+447911123456", p.E164())
+	c, ok := p.Country()
+	assert.True(t, ok)
+	assert.Equal(t, "GB", c.Alpha2)
+}
+
+func TestParseRegion_UnknownRegion(t *testing.T) {
+	_, err := phone.ParseRegion("07911 123456", "ZZ")
+	assert.ErrorIs(t, err, phone.ErrMissingCountryCode)
+}
+
+func TestParseRegion_PlusInputResolvesSharedCode(t *testing.T) {
+	p, err := phone.ParseRegion("+1 604 555 0199", "CA")
+	require.NoError(t, err)
+	c, ok := p.Country()
+	assert.True(t, ok)
+	assert.Equal(t, "CA", c.Alpha2) // region hint pinned CA among +1 candidates
+}
+
+func TestCountry_UniqueDialCode(t *testing.T) {
+	p, _ := phone.Parse("+44 20 7946 0018")
+	c, ok := p.Country()
+	assert.True(t, ok)
+	assert.Equal(t, "GB", c.Alpha2)
+}
+
+func TestCountry_AmbiguousReturnsPrimaryFalse(t *testing.T) {
+	p, _ := phone.Parse("+1 415 555 2671")
+	c, ok := p.Country()
+	assert.False(t, ok) // ambiguous +1, no hint
+	assert.Equal(t, "US", c.Alpha2)
+
+	cands := p.Candidates()
+	codes := make([]string, len(cands))
+	for i, c := range cands {
+		codes[i] = c.Alpha2
+	}
+	assert.Contains(t, codes, "US")
+	assert.Contains(t, codes, "CA")
+}
+
+func TestCandidates_ZeroPhone(t *testing.T) {
+	var p phone.Phone
+	assert.Nil(t, p.Candidates())
+	_, ok := p.Country()
+	assert.False(t, ok)
+	_ = country.US
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./core/phone/ -run 'TestParseRegion|TestCountry|TestCandidates' -v`
+Expected: FAIL — `ParseRegion`, `Country`, `Candidates` undefined.
+
+- [ ] **Step 3: Add the implementation to `phone.go`**
+
+Append to `core/phone/phone.go`:
+```go
+// ParseRegion parses a number using a region hint (an alpha-2 code). Bare
+// national input has one leading trunk 0 stripped and the region's dial code
+// prepended; input that already carries a + or 00 is parsed as-is, and the
+// region, when it is among the dial code's candidates, resolves the country.
+// An unknown region yields ErrMissingCountryCode.
+//
+// Known limitation: the single-leading-0 trunk-prefix rule is near-universal but
+// not absolute (NANP uses no trunk 0; some plans keep a significant leading 0) —
+// callers in those regions pass fully-qualified + input to Parse.
+func ParseRegion(input, alpha2 string) (Phone, error) {
+	c, ok := country.ByAlpha2(alpha2)
+	if !ok {
+		return Phone{}, ErrMissingCountryCode
+	}
+	s := strings.TrimSpace(input)
+	if strings.HasPrefix(s, "+") || strings.HasPrefix(s, "00") {
+		p, err := Parse(s)
+		if err != nil {
+			return Phone{}, err
+		}
+		for _, cand := range p.Candidates() {
+			if cand.Alpha2 == c.Alpha2 {
+				p.resolved = c.Alpha2
+				break
+			}
+		}
+		return p, nil
+	}
+	digits, err := toDigits(s, false)
+	if err != nil {
+		return Phone{}, err
+	}
+	digits = strings.TrimPrefix(digits, "0")
+	if digits == "" {
+		return Phone{}, ErrInvalidNumber
+	}
+	return build(c.DialCode+digits, c.Alpha2)
+}
+
+// Candidates returns every country sharing this number's dial code (nil for the
+// zero Phone). It is the escape hatch for the shared-dial-code case Country
+// cannot disambiguate.
+func (p Phone) Candidates() []country.Country {
+	if p.e164 == "" {
+		return nil
+	}
+	return country.ByDialCode(p.DialCode())
+}
+
+// Country returns the number's country. The bool is true when the country is
+// certain — a dial code used by exactly one country, or a region hint that
+// pinned it — and false when the dial code is shared and unresolved, in which
+// case a stable primary is still returned (use Candidates for all options).
+func (p Phone) Country() (country.Country, bool) {
+	if p.e164 == "" {
+		return country.Country{}, false
+	}
+	if p.resolved != "" {
+		c, ok := country.ByAlpha2(p.resolved)
+		return c, ok
+	}
+	cs := p.Candidates()
+	switch len(cs) {
+	case 0:
+		return country.Country{}, false
+	case 1:
+		return cs[0], true
+	default:
+		if a, ok := primaryDial[p.DialCode()]; ok {
+			if c, ok2 := country.ByAlpha2(a); ok2 {
+				return c, false
+			}
+		}
+		return cs[0], false
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./core/phone/ -run 'TestParseRegion|TestCountry|TestCandidates' -v`
+Expected: PASS. (Requires `CA` in the full table from Task 3 — sharing dial code `1` with `US`.)
+
+- [ ] **Step 5: Format**
+
+Run: `just fmt ./core/phone/...`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/phone/phone.go core/phone/region_test.go
+git commit -m "feat(core/phone): ParseRegion, Country, Candidates"
+```
+
+---
+
+## Task 7: `Parser` with default region and supported-countries gate
+
+**Files:**
+- Create: `core/phone/config.go`, `core/phone/options.go`, `core/phone/parser.go`
+- Test: `core/phone/parser_test.go`
+
+**Interfaces:**
+- Consumes: `Parse`, `ParseRegion`, `Phone.Country`, `Phone.Candidates` (Tasks 5–6); `country.Set`, `country.ByAlpha2`; `ErrMissingCountryCode`, `ErrUnsupportedRegion`.
+- Produces:
+  - `type Option func(*config)`
+  - `func WithDefaultRegion(alpha2 string) Option`
+  - `func WithAllowedCountries(s country.Set) Option`
+  - `type Parser struct { /* unexported */ }`
+  - `func New(opts ...Option) (*Parser, error)`
+  - `func (p *Parser) Parse(input string) (Phone, error)`
+
+- [ ] **Step 1: Write the failing test**
+
+`core/phone/parser_test.go`:
+```go
+package phone_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/country"
+	"github.com/dmitrymomot/forge/core/phone"
+)
+
+func TestNew_DefaultRegionValidated(t *testing.T) {
+	_, err := phone.New(phone.WithDefaultRegion("ZZ"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, phone.ErrMissingCountryCode)
+}
+
+func TestParser_DefaultRegionAppliesToBareInput(t *testing.T) {
+	p, err := phone.New(phone.WithDefaultRegion("US"))
+	require.NoError(t, err)
+	ph, err := p.Parse("415-555-2671")
+	require.NoError(t, err)
+	assert.Equal(t, "+14155552671", ph.E164())
+}
+
+func TestParser_GateRejectsUnsupported(t *testing.T) {
+	set := country.NewSet(country.US, country.GB)
+	p, err := phone.New(phone.WithAllowedCountries(set))
+	require.NoError(t, err)
+
+	_, err = p.Parse("+33 6 12 34 56 78") // France, unique dial code, not in set
+	assert.ErrorIs(t, err, phone.ErrUnsupportedRegion)
+
+	ph, err := p.Parse("+44 20 7946 0018") // GB, supported
+	require.NoError(t, err)
+	assert.Equal(t, "GB", func() string { c, _ := ph.Country(); return c.Alpha2 }())
+}
+
+func TestParser_GateAmbiguousPassesIfAnyCandidateSupported(t *testing.T) {
+	set := country.NewSet(country.US) // US supported, CA not
+	p, err := phone.New(phone.WithAllowedCountries(set))
+	require.NoError(t, err)
+	_, err = p.Parse("+1 415 555 2671") // ambiguous +1; US is a candidate → passes
+	assert.NoError(t, err)
+}
+
+func TestParser_ZeroSetFailsClosed(t *testing.T) {
+	var empty country.Set
+	p, err := phone.New(phone.WithAllowedCountries(empty))
+	require.NoError(t, err)
+	_, err = p.Parse("+1 415 555 2671")
+	assert.ErrorIs(t, err, phone.ErrUnsupportedRegion)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./core/phone/ -run 'TestNew|TestParser' -v`
+Expected: FAIL — `New`, `WithDefaultRegion`, `WithAllowedCountries` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+`core/phone/config.go`:
+```go
+package phone
+
+import "github.com/dmitrymomot/forge/core/country"
+
+type config struct {
+	defaultRegion string
+	allowed       country.Set
+	gate          bool
+}
+```
+
+`core/phone/options.go`:
+```go
+package phone
+
+import "github.com/dmitrymomot/forge/core/country"
+
+// Option configures a Parser.
+type Option func(*config)
+
+// WithDefaultRegion sets the alpha-2 region used to interpret bare national
+// input (numbers with no + or 00). New rejects an unknown region.
+func WithDefaultRegion(alpha2 string) Option {
+	return func(c *config) { c.defaultRegion = alpha2 }
+}
+
+// WithAllowedCountries enables the supported-countries gate: Parse rejects a
+// number whose country is provably outside the set with ErrUnsupportedRegion.
+// Passing the zero Set fails closed (rejects everything).
+func WithAllowedCountries(s country.Set) Option {
+	return func(c *config) {
+		c.allowed = s
+		c.gate = true
+	}
+}
+```
+
+`core/phone/parser.go`:
+```go
+package phone
+
+import (
+	"fmt"
+
+	"github.com/dmitrymomot/forge/core/country"
+)
+
+// Parser is a configured phone parser: an optional default region for bare
+// national input, and an optional supported-countries gate.
+type Parser struct {
+	cfg config
+}
+
+// New builds a Parser from options. It fails closed on an unknown default
+// region, returning ErrMissingCountryCode.
+func New(opts ...Option) (*Parser, error) {
+	var c config
+	for _, o := range opts {
+		o(&c)
+	}
+	if c.defaultRegion != "" {
+		if _, ok := country.ByAlpha2(c.defaultRegion); !ok {
+			return nil, fmt.Errorf("phone: unknown default region %q: %w", c.defaultRegion, ErrMissingCountryCode)
+		}
+	}
+	return &Parser{cfg: c}, nil
+}
+
+// Parse normalizes input, applying the default region (if configured) to bare
+// national numbers, then the supported-countries gate (if configured).
+func (p *Parser) Parse(input string) (Phone, error) {
+	var (
+		ph  Phone
+		err error
+	)
+	if p.cfg.defaultRegion != "" {
+		ph, err = ParseRegion(input, p.cfg.defaultRegion)
+	} else {
+		ph, err = Parse(input)
+	}
+	if err != nil {
+		return Phone{}, err
+	}
+	if p.cfg.gate && !gatePass(p.cfg.allowed, ph) {
+		return Phone{}, ErrUnsupportedRegion
+	}
+	return ph, nil
+}
+
+// gatePass reports whether ph is allowed: a resolved/unique country must be in
+// the set; an ambiguous number passes when any candidate is in the set (the
+// number cannot be proven to belong to the unsupported one).
+func gatePass(set country.Set, ph Phone) bool {
+	if c, ok := ph.Country(); ok {
+		return set.Contains(c)
+	}
+	for _, c := range ph.Candidates() {
+		if set.Contains(c) {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./core/phone/ -run 'TestNew|TestParser' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Format**
+
+Run: `just fmt ./core/phone/...`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/phone/config.go core/phone/options.go core/phone/parser.go core/phone/parser_test.go
+git commit -m "feat(core/phone): configured Parser with default region and supported-countries gate"
+```
+
+---
+
+## Task 8: SQL and JSON marshaling
+
+**Files:**
+- Create: `core/phone/sql.go`, `core/phone/json.go`
+- Test: `core/phone/sql_test.go`, `core/phone/json_test.go`
+
+**Interfaces:**
+- Consumes: `Phone`, `Parse` (Tasks 5).
+- Produces:
+  - `func (p Phone) Value() (driver.Value, error)`
+  - `func (p *Phone) Scan(src any) error`
+  - `func (p Phone) MarshalJSON() ([]byte, error)`
+  - `func (p *Phone) UnmarshalJSON(b []byte) error`
+
+- [ ] **Step 1: Write the failing tests**
+
+`core/phone/sql_test.go`:
+```go
+package phone_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/phone"
+)
+
+func TestValueAndScan_RoundTrip(t *testing.T) {
+	p, _ := phone.Parse("+14155552671")
+	v, err := p.Value()
+	require.NoError(t, err)
+	assert.Equal(t, "+14155552671", v)
+
+	var got phone.Phone
+	require.NoError(t, got.Scan("+14155552671"))
+	assert.Equal(t, "+14155552671", got.E164())
+
+	require.NoError(t, got.Scan([]byte("+442079460018")))
+	assert.Equal(t, "+442079460018", got.E164())
+}
+
+func TestValueAndScan_ZeroAndNull(t *testing.T) {
+	var zero phone.Phone
+	v, err := zero.Value()
+	require.NoError(t, err)
+	assert.Nil(t, v)
+
+	var got phone.Phone
+	require.NoError(t, got.Scan(nil))
+	assert.True(t, got.IsZero())
+	require.NoError(t, got.Scan(""))
+	assert.True(t, got.IsZero())
+}
+
+func TestScan_Garbage(t *testing.T) {
+	var p phone.Phone
+	assert.ErrorIs(t, p.Scan("nope"), phone.ErrMissingCountryCode)
+	assert.ErrorIs(t, p.Scan(12345), phone.ErrInvalidNumber)
+}
+```
+
+`core/phone/json_test.go`:
+```go
+package phone_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/phone"
+)
+
+func TestMarshalJSON_RoundTrip(t *testing.T) {
+	p, _ := phone.Parse("+14155552671")
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+	assert.JSONEq(t, `"+14155552671"`, string(b))
+
+	var got phone.Phone
+	require.NoError(t, json.Unmarshal(b, &got))
+	assert.Equal(t, "+14155552671", got.E164())
+}
+
+func TestMarshalJSON_ZeroIsNull(t *testing.T) {
+	var zero phone.Phone
+	b, err := json.Marshal(zero)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(b))
+
+	var got phone.Phone
+	require.NoError(t, json.Unmarshal([]byte("null"), &got))
+	assert.True(t, got.IsZero())
+}
+
+func TestUnmarshalJSON_Garbage(t *testing.T) {
+	var p phone.Phone
+	assert.ErrorIs(t, json.Unmarshal([]byte(`"nope"`), &p), phone.ErrMissingCountryCode)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./core/phone/ -run 'TestValue|TestScan|TestMarshal|TestUnmarshal' -v`
+Expected: FAIL — `Value`/`Scan`/`MarshalJSON`/`UnmarshalJSON` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+`core/phone/sql.go`:
+```go
+package phone
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+)
+
+// Value implements driver.Valuer, storing the E.164 string. The zero Phone
+// stores SQL NULL.
+func (p Phone) Value() (driver.Value, error) {
+	if p.e164 == "" {
+		return nil, nil
+	}
+	return p.e164, nil
+}
+
+// Scan implements sql.Scanner for the E.164 string form. A nil or empty source
+// yields the zero Phone; any other value is re-parsed by Parse.
+func (p *Phone) Scan(src any) error {
+	switch v := src.(type) {
+	case nil:
+		*p = Phone{}
+		return nil
+	case string:
+		return p.scan(v)
+	case []byte:
+		return p.scan(string(v))
+	default:
+		return fmt.Errorf("phone: cannot scan %T: %w", src, ErrInvalidNumber)
+	}
+}
+
+func (p *Phone) scan(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		*p = Phone{}
+		return nil
+	}
+	parsed, err := Parse(s)
+	if err != nil {
+		return err
+	}
+	*p = parsed
+	return nil
+}
+```
+
+`core/phone/json.go`:
+```go
+package phone
+
+import "encoding/json"
+
+// MarshalJSON emits the E.164 string, e.g. "+14155552671". The zero Phone emits
+// JSON null.
+func (p Phone) MarshalJSON() ([]byte, error) {
+	if p.e164 == "" {
+		return []byte("null"), nil
+	}
+	return json.Marshal(p.e164)
+}
+
+// UnmarshalJSON parses the E.164 string form. JSON null or an empty string sets
+// the zero Phone; any other value is validated by Parse.
+func (p *Phone) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		*p = Phone{}
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		*p = Phone{}
+		return nil
+	}
+	parsed, err := Parse(s)
+	if err != nil {
+		return err
+	}
+	*p = parsed
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./core/phone/ -run 'TestValue|TestScan|TestMarshal|TestUnmarshal' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Format**
+
+Run: `just fmt ./core/phone/...`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/phone/sql.go core/phone/json.go core/phone/sql_test.go core/phone/json_test.go
+git commit -m "feat(core/phone): SQL and JSON marshaling"
+```
+
+---
+
+## Task 9: `phone` doc, benchmarks, optimization pass, roadmap
+
+**Files:**
+- Create: `core/phone/doc.go`, `core/phone/bench_test.go`
+- Modify: `docs/packages.md` (delete the `core/phone` entry)
+
+**Interfaces:**
+- Consumes: the full `phone` API (Tasks 5–8).
+- Produces: no new symbols.
+
+- [ ] **Step 1: Write benchmarks**
+
+`core/phone/bench_test.go`:
+```go
+package phone_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/country"
+	"github.com/dmitrymomot/forge/core/phone"
+)
+
+func BenchmarkParse(b *testing.B) {
+	for b.Loop() {
+		_, _ = phone.Parse("+1 (415) 555-2671")
+	}
+}
+
+func BenchmarkParseRegion(b *testing.B) {
+	for b.Loop() {
+		_, _ = phone.ParseRegion("07911 123456", "GB")
+	}
+}
+
+func BenchmarkParserGate(b *testing.B) {
+	set := country.NewSet(country.US, country.GB, country.DE)
+	p, _ := phone.New(phone.WithAllowedCountries(set))
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.Parse("+44 20 7946 0018")
+	}
+}
+```
+
+- [ ] **Step 2: Run the benchmarks (record before numbers)**
+
+Run: `just bench ./core/phone/...`
+Expected: results print; note ns/op and allocs/op. `Parse` allocates at least once (the stripped digit string); that is the candidate for the optimization pass.
+
+- [ ] **Step 3: Write `doc.go`**
+
+`core/phone/doc.go`:
+```go
+// Package phone normalizes phone numbers to E.164 and decomposes them against
+// core/country's dial-code table. It parses messy human input into a canonical
+// Phone value, formats it back out, and gates parsing by a supported-countries
+// policy — deliberately without the libphonenumber machinery.
+//
+// Parse accepts a number that carries its own country code (a leading + or 00),
+// stripping formatting characters. ParseRegion interprets bare national input
+// using an alpha-2 region hint (stripping one leading trunk 0). A configured
+// Parser (New with WithDefaultRegion and/or WithAllowedCountries) applies a
+// default region to bare input and rejects numbers whose country is provably
+// outside a country.Set with ErrUnsupportedRegion.
+//
+// A Phone exposes E164, DialCode, NationalNumber, Country, and Candidates.
+// Because dial codes are shared (+1 covers the US, Canada, and the Caribbean),
+// Country returns a stable primary with a false ok for an unresolved shared
+// code — Candidates lists every possibility, and a region hint pins one. The
+// gate mirrors this honesty: an ambiguous number passes when any candidate is
+// supported, since it cannot be proven to belong to the unsupported one.
+//
+// Phone marshals to and from the E.164 string for SQL (Value/Scan, zero Phone
+// is NULL) and JSON (zero Phone is null). What this is NOT: no per-country
+// length/pattern validation, no line-type or carrier lookup, no pretty
+// per-country grouping, and no area-code disambiguation of shared dial codes —
+// the libphonenumber swamp stays out. Cheap E.164 shape validation lives in
+// core/validate.
+//
+// # Usage
+//
+//	p, err := phone.Parse("+1 (415) 555-2671")
+//	if err == nil {
+//		_ = p.E164()           // "+14155552671"
+//		_ = p.NationalNumber() // "4155552671"
+//	}
+//
+//	set, _ := country.NewSetFromCodes("US", "GB", "DE")
+//	parser, _ := phone.New(phone.WithDefaultRegion("US"), phone.WithAllowedCountries(set))
+//	_, err = parser.Parse("+33 6 12 34 56 78") // ErrUnsupportedRegion
+package phone
+```
+
+- [ ] **Step 4: Optimization pass (only if a benchmark showed a win)**
+
+If `BenchmarkParse` shows an avoidable allocation (e.g., the separator-strip builder runs even when input is already clean), consider a fast path that skips the builder when no separators are present, and re-run `just bench ./core/phone/...`. Record before/after in the PR. Make no speculative changes; if the measured win is negligible, keep the simpler code and note "no change — measured win negligible".
+
+- [ ] **Step 5: Delete the roadmap entry**
+
+In `docs/packages.md`, remove the `**core/phone**` block (heading through its `Deps:` line and that entry's `---` separators). The `## core/` section header can remain if other entries exist; if `country` and `phone` were the only two, remove the now-empty `## core/` section.
+
+- [ ] **Step 6: Verify and commit**
+
+Run: `just lint && just test ./core/country/... && just test ./core/phone/...`
+Expected: lint clean; all tests pass with `-race`.
+```bash
+git add core/phone/doc.go core/phone/bench_test.go docs/packages.md
+git commit -m "docs(core/phone): doc.go, benchmarks, drop roadmap entry"
+```
+
+---
+
+## Self-Review (completed)
+
+**Spec coverage:**
+- `country` type + all 7 fields → Task 1 (shape) + Task 3 (data). ✓
+- ~249 exported vars → Task 1 (seed) + Task 3 (full). ✓
+- Lookups `ByAlpha2/Alpha3/Numeric/ByDialCode/All` → Task 1. ✓
+- `Set` (NewSet/NewSetFromCodes fail-closed/Contains/ContainsCode/All/Len) → Task 2. ✓
+- Emoji derived at init → Task 1 (`flagEmoji` + init), guarded by Task 3 invariant test. ✓
+- `Phone` type + `E164/DialCode/NationalNumber/IsZero` → Task 5. ✓
+- `Parse` (+/00, length bounds, longest-prefix, error sentinels) → Task 5. ✓
+- `ParseRegion` (trunk-0, region hint) + `Country`/`Candidates` (primary+false, resolved) → Task 6. ✓
+- `Parser` `New`/`WithDefaultRegion`/`WithAllowedCountries` + provably-unsupported gate + fail-closed zero Set → Task 7. ✓
+- SQL `Value`/`Scan`, JSON `Marshal`/`Unmarshal`, zero=NULL/null → Task 8. ✓
+- Tenancy via passed value (no seam) → realized by `Set`/`Parser` being values; covered by Task 2 + Task 7 tests. ✓
+- Perf: map-backed lookups, pointer-free `Phone`, benchmarks + optimization pass → Tasks 1/5 design + Tasks 4/9. ✓
+- Black-box tests → every test file is `country_test`/`phone_test`. ✓
+- Data provenance header → Task 1 `data.go` comment. ✓
+- Build order country→phone, roadmap deletion → Tasks 4 and 9. ✓
+
+**Placeholder scan:** No TBD/TODO; the one bulk-data step (Task 3) ships a full invariant test and an explicit canonical source, not a vague instruction. Optimization steps are conditioned on measured wins with an explicit "no change" fallback (not open-ended). ✓
+
+**Type consistency:** `Country` fields, `Set` methods, `Phone` methods, and the four `phone` sentinels are used identically across tasks. `Parse`/`ParseRegion`/`build`/`toDigits`/`matchDial`/`primaryDial`/`gatePass` names match between definition and use. `New` returns `(*Parser, error)` consistently in Task 7 tests and impl. ✓

--- a/docs/superpowers/specs/2026-07-15-core-country-phone-design.md
+++ b/docs/superpowers/specs/2026-07-15-core-country-phone-design.md
@@ -1,0 +1,133 @@
+# Design: `core/country` + `core/phone`
+
+Two roadmap packages built together (`country` first, `phone` depends on it), both modeled on the `core/money` precedent: curated static data exposed as package-level vars plus free-func lookups and small value types. Zero magic, no runtime data fetches.
+
+## Scope & boundaries
+
+- **`core/country`** — curated ISO-3166-1 static data (alpha-2/alpha-3/numeric, English name, primary currency, dial code, flag emoji), lookups, and a `Set` value type expressing a "supported countries" policy. Zero forge deps (stdlib only). Consumers: registration/KYC forms, `web/geoip` enrichment, `i18n`, `core/phone`.
+- **`core/phone`** — E.164 normalization/decomposition value type plus a configured `Parser` (default region + supported-countries gate). Deps: `core/country`. Consumers: `comms/sms`, `auth/otp`, KYC forms.
+
+**Not in scope (the libphonenumber swamp, stated explicitly):** per-country national-number length/pattern tables; line-type (mobile vs landline) or carrier detection; pretty per-country grouping (`(415) 555-2671`); disambiguating US-vs-CA (or any shared dial code) from a bare number via area-code ranges; ISO-3166-2 subdivisions/states; translated country names (that is `i18n`); historical/deprecated ISO codes; multi-currency-per-country reality (primary official currency only).
+
+**Relationship to `core/validate`:** unchanged and complementary. `validate.CountryCode` / `validate.Phone` remain cheap yes/no *shape* rules returning a `Violation` with an i18n key (they may delegate to `phone.Parse` or use a standalone `^\+[1-9]\d{6,14}$` regex). `country`/`phone` are the authoritative *data + normalization* layer that returns values, which `validate` never does. Neither package changes `validate`.
+
+## `core/country`
+
+### Type & data
+
+```go
+type Country struct {
+    Alpha2   string // "US"  — ISO-3166-1 alpha-2, the canonical key
+    Alpha3   string // "USA" — ISO-3166-1 alpha-3
+    Numeric  string // "840" — ISO-3166-1 numeric-3 (zero-padded)
+    Name     string // "United States" — English short name
+    Currency string // "USD" — primary official ISO-4217 code (string; no money import)
+    DialCode string // "1"   — E.164 country calling code, no leading +
+    Emoji    string // "🇺🇸"  — flag, derived from the alpha-2 regional-indicator pair
+}
+```
+
+- All ~249 countries exposed as exported vars (`country.US` … `country.ZW`) plus a full bundled table backing the lookups. (Two-letter alpha-2 identifiers never collide with Go keywords.)
+- `Currency` is the single primary official currency; countries with de-facto multiple currencies record only the primary, documented.
+- `DialCode` is the country's single calling code. Many countries share one code (`+1`), so the reverse lookup returns a slice.
+- `Emoji` is derived from the alpha-2 letters at data-generation time (two regional-indicator codepoints); it costs no runtime work and serves the flag-in-dropdown case.
+
+### Lookups
+
+All case-insensitive on input; unknown keys return the zero `Country` and `false`.
+
+```go
+func ByAlpha2(code string) (Country, bool)
+func ByAlpha3(code string) (Country, bool)
+func ByNumeric(code string) (Country, bool)
+func ByDialCode(code string) []Country // may be many (US, CA, JM… for "1"); nil if none
+func All() []Country                    // sorted by Name, deterministic; fresh slice per call
+```
+
+### `Set` — supported-countries policy
+
+An explicit, immutable value the consumer constructs and passes. It is the single type serving both the filtered UI dropdown and the `phone` gate. May be backed by `core/set` internally, but exposes country-aware ergonomics.
+
+```go
+func NewSet(cs ...Country) Set
+func NewSetFromCodes(codes ...string) (Set, error) // alpha-2 strings from config/env; unknown code → error (fail-closed)
+
+func (s Set) Contains(c Country) bool
+func (s Set) ContainsCode(code string) bool // case-insensitive
+func (s Set) All() []Country                // sorted by Name — the filtered dropdown source
+func (s Set) Len() int
+```
+
+### Files
+
+`doc.go` (runnable example) · `country.go` (type + lookups) · `data.go` (generated exported vars + bundled table, with a source-provenance header comment) · `set.go` · `errors.go` · tests · `bench_test.go`.
+
+## `core/phone`
+
+Value type (`money.Money` precedent) plus a configured `Parser` (the sanctioned `New(...Option)` idiom, justified because phone genuinely carries config: a default region and an optional supported-countries gate). Deps: `core/country`.
+
+### Value type
+
+```go
+type Phone struct { /* canonical E.164 digits + resolved country; pointer-free for GC */ }
+
+func (p Phone) E164() string           // "+14155552671" — canonical; what sms/otp store & send
+func (p Phone) DialCode() string       // "1"
+func (p Phone) NationalNumber() string // "4155552671" — significant number after the dial code
+func (p Phone) Country() (country.Country, bool) // primary country; bool=false when the dial code is ambiguous and no region hint resolved it
+func (p Phone) Candidates() []country.Country     // all countries sharing the dial code — the correctness escape hatch
+func (p Phone) IsZero() bool
+```
+
+**No pretty per-country grouping** — only the canonical E.164 form and the dial-code / national-number split. Localized grouping is the swamp and stays out.
+
+### Marshaling
+
+Mirrors `money`: SQL `Scan`/`Value` and JSON `MarshalJSON`/`UnmarshalJSON` all round-trip the E.164 string (`"+14155552671"`). The zero `Phone` marshals to empty/NULL; unmarshaling re-parses (fail on garbage).
+
+### Free functions (zero-config)
+
+```go
+func Parse(input string) (Phone, error)              // requires a country code: leading + or 00
+func ParseRegion(input, alpha2 string) (Phone, error) // bare national input; region supplies the dial code
+```
+
+`ParseRegion` strips a single leading trunk `0` (the near-universal national trunk-prefix convention) before prepending the region's dial code. Known limitation, documented: NANP uses no trunk `0`, and a few plans (e.g. Italian landlines) retain a significant leading `0` — callers in those regions pass fully-qualified `+` input to `Parse`.
+
+### Configured parser
+
+```go
+func New(opts ...Option) *Parser
+func WithDefaultRegion(alpha2 string) Option    // bare "415-555-2671" → +1…
+func WithAllowedCountries(s country.Set) Option  // the supported-countries gate
+
+func (p *Parser) Parse(input string) (Phone, error) // applies default region + gate
+```
+
+The gate rejects with `ErrUnsupportedRegion` only when the country is *provably* unsupported — the dial code maps to a single country, or a region hint resolved it. An ambiguous number (e.g. `+1`) with at least one supported candidate passes. Documented explicitly, because silent over-rejection would be worse than the honest gap.
+
+### Parse rules
+
+Strip formatting characters; normalize a leading `00` to `+`; match the longest dial prefix against `country`'s table; enforce E.164 bounds (≤15 total national digits, non-empty significant number). No per-country length or pattern tables. Failure modes below.
+
+### Errors
+
+`errors.Is`-matchable, single-line sentinels (`phone: …`):
+
+- `ErrInvalidNumber` — non-digit garbage, or length outside E.164 bounds.
+- `ErrMissingCountryCode` — `Parse` input has no `+`/`00` and no region context.
+- `ErrUnknownDialCode` — leading digits match no country calling code.
+- `ErrUnsupportedRegion` — resolved country is provably outside the configured `Set`.
+
+### Files
+
+`doc.go` (runnable example) · `phone.go` (type + free funcs + methods) · `parser.go` (`New` + gated `Parse`) · `config.go` · `options.go` (`type Option func(*config)`, never builders) · `sql.go` · `json.go` · `errors.go` · tests · `bench_test.go`.
+
+## Cross-cutting
+
+- **Tenancy.** No construction seam required: the supported-countries policy is a passed *value*. Single-tenant apps build one `Set`/`Parser`; multi-tenant apps resolve a per-tenant `Set` (or hold `map[TenantID]*Parser`). Zero ceremony single-tenant; fail-closed when a configured set is empty/missing.
+- **Performance.** Map-backed O(1) lookups built once at package init; zero-alloc targets for `Parse` and the lookups (`useragent`/`money` precedent — scan bytes, avoid `[]byte`↔`string` round-trips); pointer-free `Phone`/`Country` structs for low GC scan cost (field layout enforced by betteralign). Each PR ships `bench_test.go` plus a measured post-benchmark optimization pass with before/after numbers.
+- **Testing.** Black-box (`_test` external package) only; white-box only if unexported invariants demand it. Cover: every lookup hit/miss and case-folding; `Set` construction incl. fail-closed unknown code; `Parse`/`ParseRegion` happy paths, each error sentinel, `00`-prefix and trunk-`0` handling, shared-dial-code ambiguity (`Country` bool + `Candidates`); the gate's provably-unsupported vs ambiguous-passes behavior; SQL/JSON round-trips incl. zero value.
+- **Data provenance.** `data.go` is curated/generated static ISO-3166 + dial + primary-currency data committed to the repo (no runtime fetch), with the source and generation date in a header comment.
+- **Build order.** `country` (zero deps) ships first; `phone` builds on it.
+- **Roadmap.** On ship, delete the `core/country` and `core/phone` entries from `docs/packages.md` (the catalog lists only unbuilt packages).


### PR DESCRIPTION
## Summary

Two new `core/` packages built together (`country` first, `phone` depends on it), modeled on the `core/money` precedent: curated static data as package-level vars + free-func lookups + small value types. Zero magic, no runtime data fetches.

- **`core/country`** — curated ISO-3166-1 static data (249 countries: alpha-2/alpha-3/numeric, English name, primary ISO-4217 currency, E.164 dial code, flag emoji), case-insensitive lookups (`ByAlpha2`/`ByAlpha3`/`ByNumeric`/`ByDialCode`/`All`), and a `Set` "supported countries" policy value. Zero forge deps.
- **`core/phone`** — E.164 normalize/decompose value type `Phone` (`Parse`/`ParseRegion`, `E164`/`DialCode`/`NationalNumber`/`Country`/`Candidates`, SQL + JSON marshaling) plus a configured `Parser` (`New(...Option)` with `WithDefaultRegion` and a `WithAllowedCountries` gate). Depends on `core/country` only.

## Design highlights

- **Complementary to `core/validate`, not overlapping.** `validate.CountryCode`/`Phone` stay cheap yes/no shape rules; these packages are the authoritative data + normalization layer that returns values.
- **Shared-dial-code honesty.** `+1` maps to the US, Canada, and the Caribbean. `Country()` returns a stable primary with `ok=false` for an unresolved shared code; `Candidates()` lists all options; a region hint pins one. The supported-countries gate mirrors this: an ambiguous number passes when *any* candidate is supported (rejects only the provably-unsupported), since it can't be proven to belong to the unsupported one.
- **Anti-scope: the libphonenumber swamp stays out.** No per-country length/pattern tables, no line-type/carrier, no pretty grouping, no area-code disambiguation.
- **Tenancy needs no seam.** The supported-countries policy is a passed value (`Set`/`Parser`) — single-tenant pays zero ceremony, multi-tenant resolves a per-tenant `Set`; the zero `Set` fails closed.

## Data

249 rows, structural invariants test-guarded (shape, uniqueness of alpha-2/alpha-3/numeric, init-derived flag emoji, numeric dial codes ≤3). Currencies reflect current codes (CW/SX `XCG`, ZW `ZWG`, SL `SLE`, MR `MRU`, VE `VES`).

## Performance

Map-backed lookups at 0 allocs/op (`ByAlpha2` ~12ns, `ByDialCode` ~6ns); `Parse` ~81ns/2 allocs. Optimization fast-path was benchmarked and reverted (no measured win) — pointer-free `Phone`/`Country` structs.

## Testing

Black-box tests throughout; `just lint` clean repo-wide (vet, golangci-lint, nilaway, betteralign, modernize). Coverage: `core/country` 96.4%, `core/phone` 93.0%.

Specs: `docs/superpowers/specs/2026-07-15-core-country-phone-design.md` · Plan: `docs/superpowers/plans/2026-07-15-core-country-phone.md`.
