### PR TITLE
feat(shortlink): add web/shortlink short-code link package

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -39,23 +39,6 @@ Deps: `web/httpserver`.
 
 ---
 
-**web/shortlink**
-
-Short-code links over a storage-agnostic Store with `cache.Store`
-read-through: collision-retried generation over an unambiguous
-base58-style alphabet, vanity slugs with a reserved-word blocklist,
-expiry/deactivation with a configurable fallback, and an `OnHit` hook
-that emits — counting stays the caller's job. Redirects are 302/307 with
-no-cache headers (a cached 301 kills hit counting forever); destinations
-live server-side (never `?url=`) and are scheme-allowlisted at creation.
-Branded short domains compose `tenant` custom domains + `hostrouter`.
-Not `magiclink` (self-contained signed token); not `smartlink` (no rules
-— a code resolves to one target or one rule-table handle).
-
-Deps: `core/random`, `resilience/cache`.
-
----
-
 **web/smartlink**
 
 Destination-decision engine (the TDS/smartlink core): ordered rules of

--- a/web/shortlink/bench_test.go
+++ b/web/shortlink/bench_test.go
@@ -1,0 +1,74 @@
+package shortlink_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/resilience/cache"
+	"github.com/dmitrymomot/forge/web/shortlink"
+)
+
+func benchManager(b *testing.B, opts ...shortlink.Option) (*shortlink.Manager, string) {
+	b.Helper()
+	mgr := shortlink.New(shortlink.NewMemoryStore(), opts...)
+	l, err := mgr.Create(context.Background(), shortlink.CreateParams{URL: "https://example.com/dest"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	return mgr, l.Code
+}
+
+func BenchmarkResolve(b *testing.B) {
+	mgr, code := benchManager(b)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Resolve(ctx, code); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkResolve_CacheHit(b *testing.B) {
+	c := cache.NewMemoryStore()
+	defer func() { _ = c.Close() }()
+	mgr, code := benchManager(b, shortlink.WithCache(c))
+	ctx := context.Background()
+	if _, err := mgr.Resolve(ctx, code); err != nil { // warm the cache
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Resolve(ctx, code); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCreate_Generated(b *testing.B) {
+	mgr := shortlink.New(shortlink.NewMemoryStore())
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com/dest"}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkHandler(b *testing.B) {
+	mgr, code := benchManager(b)
+	mux := http.NewServeMux()
+	mux.Handle("GET /{code}", mgr.Handler())
+	req := httptest.NewRequest(http.MethodGet, "/"+code, nil)
+	b.ReportAllocs()
+	for b.Loop() {
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusFound {
+			b.Fatalf("status %d", w.Code)
+		}
+	}
+}

--- a/web/shortlink/doc.go
+++ b/web/shortlink/doc.go
@@ -27,10 +27,14 @@
 //	mgr := shortlink.New(pgstore.New(pool),
 //		shortlink.WithCache(redisStore),
 //		shortlink.WithOnHit(func(ctx context.Context, l shortlink.Link) {
-//			go bumpCounter(l.Code) // counting is the caller's job
+//			clicks.Push(ctx, l.Code) // enqueue; counting is the caller's job
 //		}),
 //		shortlink.WithFallbackURL("https://example.com/link-gone"),
 //	)
+//
+// The hook runs synchronously on the redirect hot path — hand the hit to a
+// bounded sink (a queue, a buffered channel drained by a worker), don't do
+// the counting inline or spawn a goroutine per hit.
 //
 // Multi-tenant applications confine management operations with WithScope;
 // Resolve and the Handler need no hook because a short code is a public

--- a/web/shortlink/doc.go
+++ b/web/shortlink/doc.go
@@ -1,0 +1,48 @@
+// Package shortlink creates and resolves short-code links over a
+// storage-agnostic Store: collision-retried code generation over the
+// unambiguous base58 alphabet, vanity codes with a reserved-word blocklist,
+// expiry and deactivation with a configurable fallback, and an OnHit hook
+// that emits every successful resolve — counting stays the caller's job.
+//
+// Destinations live server-side (never in a ?url= query parameter) and are
+// scheme-allowlisted at creation, so the redirect endpoint cannot be abused
+// as an open redirector. Redirects are 302/307 with Cache-Control: no-store
+// — a cached 301 would kill hit counting forever.
+//
+//	mgr := shortlink.New(shortlink.NewMemoryStore()) // pgstore.New(pool) in production
+//
+//	link, err := mgr.Create(ctx, shortlink.CreateParams{
+//		URL: "https://example.com/docs/getting-started",
+//	})
+//	// link.Code is e.g. "x7Kp2Wq" → https://sho.rt/x7Kp2Wq
+//
+//	promo, err := mgr.Create(ctx, shortlink.CreateParams{
+//		URL: "https://example.com/summer-sale", Code: "summer",
+//	})
+//
+//	mux.Handle("GET /{code}", mgr.Handler())
+//
+// Production setups add a cache read-through and a hit hook:
+//
+//	mgr := shortlink.New(pgstore.New(pool),
+//		shortlink.WithCache(redisStore),
+//		shortlink.WithOnHit(func(ctx context.Context, l shortlink.Link) {
+//			go bumpCounter(l.Code) // counting is the caller's job
+//		}),
+//		shortlink.WithFallbackURL("https://example.com/link-gone"),
+//	)
+//
+// Multi-tenant applications confine management operations with WithScope;
+// Resolve and the Handler need no hook because a short code is a public
+// URL:
+//
+//	mgr := shortlink.New(store, shortlink.WithScope(func(ctx context.Context) (string, error) {
+//		return tenantFromCtx(ctx), nil // fail-closed: empty or error aborts
+//	}))
+//
+// Branded short domains compose with the rest of forge: point a tenant's
+// custom domain at the app and mount Handler under web/hostrouter.
+//
+// Not magiclink (a self-contained signed token); not smartlink (no rules —
+// a code resolves to exactly one destination).
+package shortlink

--- a/web/shortlink/errors.go
+++ b/web/shortlink/errors.go
@@ -1,0 +1,49 @@
+package shortlink
+
+import "errors"
+
+var (
+	// ErrNotFound is returned by a Store when no record matches, by Resolve
+	// for unknown codes, and by management operations for other tenants'
+	// links under WithScope (so cross-tenant existence cannot be probed).
+	ErrNotFound = errors.New("shortlink: link not found")
+
+	// ErrDuplicate is returned by Store.Create when the code already exists,
+	// and by Manager.Create when a requested vanity code is taken.
+	ErrDuplicate = errors.New("shortlink: code already exists")
+
+	// ErrCodeExhausted fails Create when every generation attempt collided
+	// with an existing code — the code space is too dense for the configured
+	// length; raise WithCodeLength.
+	ErrCodeExhausted = errors.New("shortlink: code generation exhausted retries")
+
+	// ErrInvalidCode rejects vanity codes failing charset or length
+	// validation — decided before any store access.
+	ErrInvalidCode = errors.New("shortlink: invalid code")
+
+	// ErrReservedCode rejects vanity codes on the reserved-word blocklist.
+	ErrReservedCode = errors.New("shortlink: reserved code")
+
+	// ErrInvalidURL rejects destinations that do not parse as absolute URLs
+	// with a host.
+	ErrInvalidURL = errors.New("shortlink: invalid destination url")
+
+	// ErrSchemeNotAllowed rejects destinations whose scheme is outside the
+	// creation-time allowlist (default http and https).
+	ErrSchemeNotAllowed = errors.New("shortlink: destination scheme not allowed")
+
+	// ErrLinkExpired is returned by Resolve when the link's ExpiresAt has
+	// passed. The record remains in the store.
+	ErrLinkExpired = errors.New("shortlink: link expired")
+
+	// ErrLinkDeactivated is returned by Resolve for deactivated links.
+	ErrLinkDeactivated = errors.New("shortlink: link deactivated")
+
+	// ErrTenantMismatch rejects management calls whose explicit tenant
+	// conflicts with the WithScope-derived tenant.
+	ErrTenantMismatch = errors.New("shortlink: tenant mismatch")
+
+	// ErrScope fails management operations closed when the WithScope hook
+	// errors or yields an empty tenant.
+	ErrScope = errors.New("shortlink: tenant scope unavailable")
+)

--- a/web/shortlink/handler.go
+++ b/web/shortlink/handler.go
@@ -1,0 +1,35 @@
+package shortlink
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Handler returns the public redirect endpoint. It reads the code from the
+// "code" path value when mounted on a pattern ("GET /{code}"), falling back
+// to the full escaped path with slashes trimmed, and redirects with the
+// configured status (302 by default, never a cacheable 301) and
+// Cache-Control: no-store so intermediaries cannot swallow hits. Failed
+// resolves redirect to the WithFallbackURL target when one is configured,
+// or respond 404.
+//
+//	mux.Handle("GET /{code}", mgr.Handler())
+func (m *Manager) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		code := r.PathValue("code")
+		if code == "" {
+			code = strings.Trim(r.URL.EscapedPath(), "/")
+		}
+		w.Header().Set("Cache-Control", "no-store")
+		l, err := m.Resolve(r.Context(), code)
+		if err != nil {
+			if m.cfg.fallbackURL != "" {
+				http.Redirect(w, r, m.cfg.fallbackURL, m.cfg.redirectStatus)
+				return
+			}
+			http.NotFound(w, r)
+			return
+		}
+		http.Redirect(w, r, l.URL, m.cfg.redirectStatus)
+	})
+}

--- a/web/shortlink/handler.go
+++ b/web/shortlink/handler.go
@@ -1,35 +1,41 @@
 package shortlink
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 )
 
 // Handler returns the public redirect endpoint. It reads the code from the
 // "code" path value when mounted on a pattern ("GET /{code}"), falling back
-// to the full escaped path with slashes trimmed, and redirects with the
+// to the full decoded path with slashes trimmed, and redirects with the
 // configured status (302 by default, never a cacheable 301) and
-// Cache-Control: no-store so intermediaries cannot swallow hits. Failed
-// resolves redirect to the WithFallbackURL target when one is configured,
-// or respond 404.
+// Cache-Control: no-store so intermediaries cannot swallow hits. Dead links
+// (unknown, expired, or deactivated codes) redirect to the WithFallbackURL
+// target when one is configured, or respond 404; a Store or hook failure
+// responds 500 — an outage must read as an outage, not as every link being
+// gone.
 //
 //	mux.Handle("GET /{code}", mgr.Handler())
 func (m *Manager) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		code := r.PathValue("code")
 		if code == "" {
-			code = strings.Trim(r.URL.EscapedPath(), "/")
+			code = strings.Trim(r.URL.Path, "/")
 		}
 		w.Header().Set("Cache-Control", "no-store")
 		l, err := m.Resolve(r.Context(), code)
-		if err != nil {
+		switch {
+		case err == nil:
+			http.Redirect(w, r, l.URL, m.cfg.redirectStatus)
+		case errors.Is(err, ErrNotFound), errors.Is(err, ErrLinkExpired), errors.Is(err, ErrLinkDeactivated):
 			if m.cfg.fallbackURL != "" {
 				http.Redirect(w, r, m.cfg.fallbackURL, m.cfg.redirectStatus)
 				return
 			}
 			http.NotFound(w, r)
-			return
+		default:
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		}
-		http.Redirect(w, r, l.URL, m.cfg.redirectStatus)
 	})
 }

--- a/web/shortlink/handler_test.go
+++ b/web/shortlink/handler_test.go
@@ -2,6 +2,7 @@ package shortlink_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -98,6 +99,25 @@ func TestHandler_ExpiredUsesFallback(t *testing.T) {
 	w := serve(mgr.Handler(), "/"+l.Code)
 	assert.Equal(t, http.StatusFound, w.Code)
 	assert.Equal(t, "/gone", w.Header().Get("Location"))
+}
+
+// erroringStore fails every Get with a non-sentinel error, simulating a
+// backend outage.
+type erroringStore struct{ shortlink.Store }
+
+func (erroringStore) Get(context.Context, string) (shortlink.Link, error) {
+	return shortlink.Link{}, errors.New("connection refused")
+}
+
+func TestHandler_BackendErrorIs500(t *testing.T) {
+	t.Parallel()
+	mgr := shortlink.New(erroringStore{shortlink.NewMemoryStore()},
+		shortlink.WithFallbackURL("https://example.com/link-gone"))
+
+	// An outage must surface as 500, never as a dead-link fallback or 404.
+	w := serve(mgr.Handler(), "/anycode")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Empty(t, w.Header().Get("Location"))
 }
 
 func TestHandler_OnHitFires(t *testing.T) {

--- a/web/shortlink/handler_test.go
+++ b/web/shortlink/handler_test.go
@@ -1,0 +1,113 @@
+package shortlink_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/web/shortlink"
+)
+
+func newHandlerFixture(t *testing.T, opts ...shortlink.Option) (*shortlink.Manager, shortlink.Link) {
+	t.Helper()
+	mgr := shortlink.New(shortlink.NewMemoryStore(), opts...)
+	l, err := mgr.Create(context.Background(), shortlink.CreateParams{URL: "https://example.com/dest"})
+	require.NoError(t, err)
+	return mgr, l
+}
+
+func serve(h http.Handler, target string) *httptest.ResponseRecorder {
+	mux := http.NewServeMux()
+	mux.Handle("GET /{code}", h)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, target, nil))
+	return w
+}
+
+func TestHandler_Redirect(t *testing.T) {
+	t.Parallel()
+	mgr, l := newHandlerFixture(t)
+
+	w := serve(mgr.Handler(), "/"+l.Code)
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "https://example.com/dest", w.Header().Get("Location"))
+	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+}
+
+func TestHandler_RedirectStatus307(t *testing.T) {
+	t.Parallel()
+	mgr, l := newHandlerFixture(t, shortlink.WithRedirectStatus(http.StatusTemporaryRedirect))
+
+	w := serve(mgr.Handler(), "/"+l.Code)
+	assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
+}
+
+func TestHandler_NotFound(t *testing.T) {
+	t.Parallel()
+	mgr, _ := newHandlerFixture(t)
+
+	w := serve(mgr.Handler(), "/does-not-exist")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Empty(t, w.Header().Get("Location"))
+	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+}
+
+func TestHandler_Fallback(t *testing.T) {
+	t.Parallel()
+	mgr, l := newHandlerFixture(t, shortlink.WithFallbackURL("https://example.com/link-gone"))
+	require.NoError(t, mgr.Deactivate(context.Background(), l.Code))
+
+	for _, target := range []string{"/" + l.Code, "/unknown-code"} {
+		w := serve(mgr.Handler(), target)
+		assert.Equal(t, http.StatusFound, w.Code, "target %s", target)
+		assert.Equal(t, "https://example.com/link-gone", w.Header().Get("Location"), "target %s", target)
+		assert.Equal(t, "no-store", w.Header().Get("Cache-Control"), "target %s", target)
+	}
+}
+
+func TestHandler_PathFallbackWithoutPattern(t *testing.T) {
+	t.Parallel()
+	mgr, l := newHandlerFixture(t)
+
+	// Mounted bare (no {code} pattern), the handler trims the path itself.
+	w := httptest.NewRecorder()
+	mgr.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/"+l.Code, nil))
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "https://example.com/dest", w.Header().Get("Location"))
+
+	// A bare "/" resolves nothing.
+	w = httptest.NewRecorder()
+	mgr.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandler_ExpiredUsesFallback(t *testing.T) {
+	t.Parallel()
+	mgr := shortlink.New(shortlink.NewMemoryStore(), shortlink.WithFallbackURL("/gone"))
+
+	l, err := mgr.Create(context.Background(), shortlink.CreateParams{
+		URL: "https://example.com", ExpiresAt: time.Now().UTC().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+
+	w := serve(mgr.Handler(), "/"+l.Code)
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "/gone", w.Header().Get("Location"))
+}
+
+func TestHandler_OnHitFires(t *testing.T) {
+	t.Parallel()
+	hits := 0
+	mgr, l := newHandlerFixture(t, shortlink.WithOnHit(func(context.Context, shortlink.Link) { hits++ }))
+
+	serve(mgr.Handler(), "/"+l.Code)
+	assert.Equal(t, 1, hits)
+
+	serve(mgr.Handler(), "/missing")
+	assert.Equal(t, 1, hits, "failed redirects must not count as hits")
+}

--- a/web/shortlink/link.go
+++ b/web/shortlink/link.go
@@ -1,0 +1,32 @@
+package shortlink
+
+import "time"
+
+// Link is one short-code record. Code is the globally unique short code —
+// short codes are URL path segments, so uniqueness cannot be per-tenant.
+// Zero ExpiresAt means the link never expires; zero DeactivatedAt means it
+// is active.
+type Link struct {
+	CreatedAt     time.Time `json:"created_at"`
+	ExpiresAt     time.Time `json:"expires_at,omitzero"`
+	DeactivatedAt time.Time `json:"deactivated_at,omitzero"`
+	Code          string    `json:"code"`
+	URL           string    `json:"url"`
+	Tenant        string    `json:"tenant,omitempty"`
+}
+
+// CreateParams describes a link to create.
+type CreateParams struct {
+	// ExpiresAt optionally expires the link; zero means never.
+	ExpiresAt time.Time
+	// URL is the destination. It must be an absolute URL with a host and a
+	// scheme on the allowlist (default http and https) — destinations live
+	// server-side, never in a query parameter.
+	URL string
+	// Code optionally requests a vanity code instead of a generated one:
+	// 1–64 characters of [A-Za-z0-9_-], not on the reserved blocklist.
+	Code string
+	// Tenant optionally pins the owning tenant; constrained by the
+	// WithScope hook when one is configured.
+	Tenant string
+}

--- a/web/shortlink/manager.go
+++ b/web/shortlink/manager.go
@@ -2,7 +2,6 @@ package shortlink
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -44,6 +43,7 @@ var defaultReserved = []string{
 // concurrent use.
 type Manager struct {
 	store Store
+	cache *cache.Cache[Link]
 	cfg   config
 }
 
@@ -78,7 +78,12 @@ func New(store Store, opts ...Option) *Manager {
 	if cfg.redirectStatus != http.StatusFound && cfg.redirectStatus != http.StatusTemporaryRedirect {
 		panic(fmt.Sprintf("shortlink: redirect status %d is not 302 or 307", cfg.redirectStatus))
 	}
-	return &Manager{store: store, cfg: cfg}
+	m := &Manager{store: store, cfg: cfg}
+	if cfg.cache != nil {
+		m.cache = cache.New[Link](cfg.cache,
+			cache.WithPrefix(cacheKeyPrefix), cache.WithDefaultTTL(cfg.cacheTTL))
+	}
+	return m
 }
 
 // Create stores a link to p.URL and returns the record. With p.Code empty a
@@ -156,41 +161,47 @@ func (m *Manager) List(ctx context.Context, f Filter) ([]Link, error) {
 }
 
 // Deactivate turns the link off: Resolve reports ErrLinkDeactivated until
-// Activate. The cached entry is invalidated; an invalidation error is
-// returned even though the store was updated — retry, the call is
-// idempotent.
+// Activate. Under WithScope, other tenants' links report ErrNotFound.
 func (m *Manager) Deactivate(ctx context.Context, code string) error {
-	if _, err := m.Get(ctx, code); err != nil {
-		return err
-	}
-	if err := m.store.Deactivate(ctx, code, time.Now().UTC()); err != nil {
-		return fmt.Errorf("shortlink: deactivate: %w", err)
-	}
-	return m.invalidate(ctx, code)
+	at := time.Now().UTC()
+	return m.mutate(ctx, code, "deactivate", func(tenant string) error {
+		return m.store.Deactivate(ctx, code, tenant, at)
+	})
 }
 
-// Activate turns a deactivated link back on and invalidates the cached
-// entry.
+// Activate turns a deactivated link back on.
 func (m *Manager) Activate(ctx context.Context, code string) error {
-	if _, err := m.Get(ctx, code); err != nil {
-		return err
-	}
-	if err := m.store.Activate(ctx, code); err != nil {
-		return fmt.Errorf("shortlink: activate: %w", err)
-	}
-	return m.invalidate(ctx, code)
+	return m.mutate(ctx, code, "activate", func(tenant string) error {
+		return m.store.Activate(ctx, code, tenant)
+	})
 }
 
-// Delete permanently removes the link and invalidates the cached entry.
-// The code becomes available again.
+// Delete permanently removes the link. The code becomes available again.
 func (m *Manager) Delete(ctx context.Context, code string) error {
-	if _, err := m.Get(ctx, code); err != nil {
+	return m.mutate(ctx, code, "delete", func(tenant string) error {
+		return m.store.Delete(ctx, code, tenant)
+	})
+}
+
+// mutate runs one scope-confined store mutation and invalidates the cached
+// entry. The tenant predicate rides into the store call so confinement is
+// atomic with the mutation — a pre-flight ownership check would race a
+// delete-and-recreate of the same code by another tenant. The cache entry
+// is dropped even when the store reports ErrNotFound: the record may be
+// gone from the store while a stale copy lingers in the cache (e.g. a
+// crashed earlier invalidation), and this is the only API path that can
+// clear it.
+func (m *Manager) mutate(ctx context.Context, code, verb string, op func(tenant string) error) error {
+	tenant, err := m.scoped(ctx, "")
+	if err != nil {
 		return err
 	}
-	if err := m.store.Delete(ctx, code); err != nil {
-		return fmt.Errorf("shortlink: delete: %w", err)
+	opErr := op(tenant)
+	if opErr != nil && !errors.Is(opErr, ErrNotFound) {
+		return fmt.Errorf("shortlink: %s: %w", verb, opErr)
 	}
-	return m.invalidate(ctx, code)
+	m.invalidate(ctx, code)
+	return opErr
 }
 
 // Resolve returns the live link for code — the redirect hot path. It is
@@ -220,41 +231,35 @@ func (m *Manager) Resolve(ctx context.Context, code string) (Link, error) {
 
 // lookup fetches the raw record, serving from cache when configured.
 // Expiry and deactivation are re-checked by Resolve on every hit, so
-// caching the raw record is safe; mutations invalidate the entry. Cache
-// failures degrade to the store, and cache writes are best-effort — the
-// cache can only slow resolution down, never break it.
+// caching the raw record is safe. Cache failures degrade to the store, and
+// cache writes are best-effort — the cache can only slow resolution down,
+// never break it.
 func (m *Manager) lookup(ctx context.Context, code string) (Link, error) {
-	if m.cfg.cache == nil {
+	if m.cache == nil {
 		return m.store.Get(ctx, code)
 	}
-	key := cacheKeyPrefix + code
-	if b, err := m.cfg.cache.Get(ctx, key); err == nil {
-		var l Link
-		if err := json.Unmarshal(b, &l); err == nil {
-			return l, nil
-		}
+	if l, err := m.cache.Get(ctx, code); err == nil {
+		return l, nil
 	}
 	l, err := m.store.Get(ctx, code)
 	if err != nil {
 		return Link{}, err
 	}
-	if b, err := json.Marshal(l); err == nil {
-		_ = m.cfg.cache.Set(ctx, key, b, cache.WithTTL(m.cfg.cacheTTL))
-	}
+	_ = m.cache.Set(ctx, code, l)
 	return l, nil
 }
 
-// invalidate drops the cached entry after a mutation. A failure is
-// surfaced: silently keeping a stale entry would serve a deactivated or
-// deleted link until the TTL runs out.
-func (m *Manager) invalidate(ctx context.Context, code string) error {
-	if m.cfg.cache == nil {
-		return nil
+// invalidate drops the cached entry after a mutation, best-effort. Cache
+// coherence is bounded, not exact: an in-flight lookup that read the store
+// before the mutation can re-populate the entry right after this delete,
+// and a failed delete leaves the stale entry in place — either way the
+// entry dies within the WithCacheTTL bound, which is the staleness
+// contract WithCache documents. Failing the mutation over it would claim a
+// precision the read path cannot honor.
+func (m *Manager) invalidate(ctx context.Context, code string) {
+	if m.cache != nil {
+		_ = m.cache.Delete(ctx, code)
 	}
-	if err := m.cfg.cache.Delete(ctx, cacheKeyPrefix+code); err != nil {
-		return fmt.Errorf("shortlink: cache invalidate: %w", err)
-	}
-	return nil
 }
 
 // scoped resolves the tenant a management operation is confined to. With

--- a/web/shortlink/manager.go
+++ b/web/shortlink/manager.go
@@ -1,0 +1,315 @@
+package shortlink
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/random"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+// Alphabet is the code-generation charset: the standard base58 alphabet,
+// which drops the ambiguous 0, O, I, and l so codes survive being read
+// aloud or retyped.
+const Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+// generateAttempts bounds collision-retried code generation. At the default
+// length 7 the space holds 58^7 ≈ 2.2e12 codes, so consecutive collisions
+// signal a dangerously dense keyspace rather than bad luck.
+const generateAttempts = 5
+
+// maxVanityLength bounds requested vanity codes.
+const maxVanityLength = 64
+
+// cacheKeyPrefix namespaces resolved links in the shared cache store.
+const cacheKeyPrefix = "shortlink:"
+
+// defaultReserved is the built-in vanity blocklist: path words a SaaS app
+// almost certainly routes itself. Extend with WithReservedCodes.
+var defaultReserved = []string{
+	"about", "account", "admin", "api", "app", "assets", "auth", "billing",
+	"blog", "contact", "dashboard", "docs", "health", "healthz", "help",
+	"home", "legal", "login", "logout", "me", "metrics", "new", "pricing",
+	"privacy", "profile", "register", "root", "settings", "signin", "signup",
+	"static", "status", "support", "terms", "www",
+}
+
+// Manager creates, manages, and resolves short links over a Store. Safe for
+// concurrent use.
+type Manager struct {
+	store Store
+	cfg   config
+}
+
+// New builds a Manager. It panics on a nil store or invalid option values —
+// wiring bugs caught at startup.
+func New(store Store, opts ...Option) *Manager {
+	if store == nil {
+		panic("shortlink: nil store")
+	}
+	cfg := config{
+		reserved:       make(map[string]struct{}, len(defaultReserved)),
+		schemes:        map[string]struct{}{"http": {}, "https": {}},
+		cacheTTL:       5 * time.Minute,
+		codeLength:     7,
+		redirectStatus: http.StatusFound,
+	}
+	for _, w := range defaultReserved {
+		cfg.reserved[w] = struct{}{}
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.codeLength < 4 || cfg.codeLength > 32 {
+		panic(fmt.Sprintf("shortlink: code length %d outside [4, 32]", cfg.codeLength))
+	}
+	if cfg.cacheTTL <= 0 {
+		panic("shortlink: cache TTL must be positive")
+	}
+	if len(cfg.schemes) == 0 {
+		panic("shortlink: empty scheme allowlist")
+	}
+	if cfg.redirectStatus != http.StatusFound && cfg.redirectStatus != http.StatusTemporaryRedirect {
+		panic(fmt.Sprintf("shortlink: redirect status %d is not 302 or 307", cfg.redirectStatus))
+	}
+	return &Manager{store: store, cfg: cfg}
+}
+
+// Create stores a link to p.URL and returns the record. With p.Code empty a
+// code is generated from Alphabet, retrying on collision; a requested
+// vanity code is validated against the charset, length, and reserved
+// blocklist and fails with ErrDuplicate when taken.
+func (m *Manager) Create(ctx context.Context, p CreateParams) (Link, error) {
+	if err := m.validateURL(p.URL); err != nil {
+		return Link{}, err
+	}
+	tenant, err := m.scoped(ctx, p.Tenant)
+	if err != nil {
+		return Link{}, err
+	}
+	l := Link{
+		URL:       p.URL,
+		Tenant:    tenant,
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: p.ExpiresAt,
+	}
+	if p.Code != "" {
+		if err := m.validateVanity(p.Code); err != nil {
+			return Link{}, err
+		}
+		l.Code = p.Code
+		if err := m.store.Create(ctx, l); err != nil {
+			return Link{}, fmt.Errorf("shortlink: create: %w", err)
+		}
+		return l, nil
+	}
+	for range generateAttempts {
+		l.Code = random.String(m.cfg.codeLength, Alphabet)
+		if _, reserved := m.cfg.reserved[strings.ToLower(l.Code)]; reserved {
+			continue
+		}
+		err := m.store.Create(ctx, l)
+		if errors.Is(err, ErrDuplicate) {
+			continue
+		}
+		if err != nil {
+			return Link{}, fmt.Errorf("shortlink: create: %w", err)
+		}
+		return l, nil
+	}
+	return Link{}, ErrCodeExhausted
+}
+
+// Get returns one link record straight from the Store. With WithScope
+// configured, other tenants' links read as ErrNotFound so existence cannot
+// be probed across tenants.
+func (m *Manager) Get(ctx context.Context, code string) (Link, error) {
+	tenant, err := m.scoped(ctx, "")
+	if err != nil {
+		return Link{}, err
+	}
+	l, err := m.store.Get(ctx, code)
+	if err != nil {
+		return Link{}, err
+	}
+	if m.cfg.scope != nil && l.Tenant != tenant {
+		return Link{}, ErrNotFound
+	}
+	return l, nil
+}
+
+// List returns links matching f, newest first. With WithScope configured
+// the filter is confined to the scoped tenant.
+func (m *Manager) List(ctx context.Context, f Filter) ([]Link, error) {
+	tenant, err := m.scoped(ctx, f.Tenant)
+	if err != nil {
+		return nil, err
+	}
+	f.Tenant = tenant
+	return m.store.List(ctx, f)
+}
+
+// Deactivate turns the link off: Resolve reports ErrLinkDeactivated until
+// Activate. The cached entry is invalidated; an invalidation error is
+// returned even though the store was updated — retry, the call is
+// idempotent.
+func (m *Manager) Deactivate(ctx context.Context, code string) error {
+	if _, err := m.Get(ctx, code); err != nil {
+		return err
+	}
+	if err := m.store.Deactivate(ctx, code, time.Now().UTC()); err != nil {
+		return fmt.Errorf("shortlink: deactivate: %w", err)
+	}
+	return m.invalidate(ctx, code)
+}
+
+// Activate turns a deactivated link back on and invalidates the cached
+// entry.
+func (m *Manager) Activate(ctx context.Context, code string) error {
+	if _, err := m.Get(ctx, code); err != nil {
+		return err
+	}
+	if err := m.store.Activate(ctx, code); err != nil {
+		return fmt.Errorf("shortlink: activate: %w", err)
+	}
+	return m.invalidate(ctx, code)
+}
+
+// Delete permanently removes the link and invalidates the cached entry.
+// The code becomes available again.
+func (m *Manager) Delete(ctx context.Context, code string) error {
+	if _, err := m.Get(ctx, code); err != nil {
+		return err
+	}
+	if err := m.store.Delete(ctx, code); err != nil {
+		return fmt.Errorf("shortlink: delete: %w", err)
+	}
+	return m.invalidate(ctx, code)
+}
+
+// Resolve returns the live link for code — the redirect hot path. It is
+// unscoped (a short code is a public URL) and read-through cached when
+// WithCache is configured. Unknown codes report ErrNotFound, expired links
+// ErrLinkExpired, deactivated links ErrLinkDeactivated. On success the
+// WithOnHit hook fires synchronously before Resolve returns.
+func (m *Manager) Resolve(ctx context.Context, code string) (Link, error) {
+	if code == "" {
+		return Link{}, ErrNotFound
+	}
+	l, err := m.lookup(ctx, code)
+	if err != nil {
+		return Link{}, err
+	}
+	if !l.DeactivatedAt.IsZero() {
+		return Link{}, ErrLinkDeactivated
+	}
+	if !l.ExpiresAt.IsZero() && !l.ExpiresAt.After(time.Now().UTC()) {
+		return Link{}, ErrLinkExpired
+	}
+	if m.cfg.onHit != nil {
+		m.cfg.onHit(ctx, l)
+	}
+	return l, nil
+}
+
+// lookup fetches the raw record, serving from cache when configured.
+// Expiry and deactivation are re-checked by Resolve on every hit, so
+// caching the raw record is safe; mutations invalidate the entry. Cache
+// failures degrade to the store, and cache writes are best-effort — the
+// cache can only slow resolution down, never break it.
+func (m *Manager) lookup(ctx context.Context, code string) (Link, error) {
+	if m.cfg.cache == nil {
+		return m.store.Get(ctx, code)
+	}
+	key := cacheKeyPrefix + code
+	if b, err := m.cfg.cache.Get(ctx, key); err == nil {
+		var l Link
+		if err := json.Unmarshal(b, &l); err == nil {
+			return l, nil
+		}
+	}
+	l, err := m.store.Get(ctx, code)
+	if err != nil {
+		return Link{}, err
+	}
+	if b, err := json.Marshal(l); err == nil {
+		_ = m.cfg.cache.Set(ctx, key, b, cache.WithTTL(m.cfg.cacheTTL))
+	}
+	return l, nil
+}
+
+// invalidate drops the cached entry after a mutation. A failure is
+// surfaced: silently keeping a stale entry would serve a deactivated or
+// deleted link until the TTL runs out.
+func (m *Manager) invalidate(ctx context.Context, code string) error {
+	if m.cfg.cache == nil {
+		return nil
+	}
+	if err := m.cfg.cache.Delete(ctx, cacheKeyPrefix+code); err != nil {
+		return fmt.Errorf("shortlink: cache invalidate: %w", err)
+	}
+	return nil
+}
+
+// scoped resolves the tenant a management operation is confined to. With
+// no WithScope hook it passes the requested tenant through. Fail-closed:
+// hook errors and empty scoped tenants abort the operation with ErrScope;
+// an explicit requested tenant must be empty or equal to the scoped one.
+func (m *Manager) scoped(ctx context.Context, requested string) (string, error) {
+	if m.cfg.scope == nil {
+		return requested, nil
+	}
+	t, err := m.cfg.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrScope, err)
+	}
+	if t == "" {
+		return "", ErrScope
+	}
+	if requested != "" && requested != t {
+		return "", ErrTenantMismatch
+	}
+	return t, nil
+}
+
+// validateURL enforces the server-side-destination rules: absolute, with a
+// host, scheme on the allowlist.
+func (m *Manager) validateURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidURL, err)
+	}
+	if !u.IsAbs() || u.Host == "" {
+		return ErrInvalidURL
+	}
+	if _, ok := m.cfg.schemes[strings.ToLower(u.Scheme)]; !ok {
+		return fmt.Errorf("%w: %q", ErrSchemeNotAllowed, u.Scheme)
+	}
+	return nil
+}
+
+// validateVanity enforces vanity-code charset ([A-Za-z0-9_-]), length
+// (1–64), and the reserved blocklist (case-insensitive).
+func (m *Manager) validateVanity(code string) error {
+	if len(code) > maxVanityLength {
+		return fmt.Errorf("%w: longer than %d characters", ErrInvalidCode, maxVanityLength)
+	}
+	for i := range len(code) {
+		c := code[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '-', c == '_':
+		default:
+			return fmt.Errorf("%w: %q", ErrInvalidCode, code)
+		}
+	}
+	if _, ok := m.cfg.reserved[strings.ToLower(code)]; ok {
+		return fmt.Errorf("%w: %q", ErrReservedCode, code)
+	}
+	return nil
+}

--- a/web/shortlink/manager_test.go
+++ b/web/shortlink/manager_test.go
@@ -1,0 +1,249 @@
+package shortlink_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/web/shortlink"
+)
+
+func TestNew_Panics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { shortlink.New(nil) })
+	assert.Panics(t, func() { shortlink.New(shortlink.NewMemoryStore(), shortlink.WithCodeLength(3)) })
+	assert.Panics(t, func() { shortlink.New(shortlink.NewMemoryStore(), shortlink.WithCodeLength(33)) })
+	assert.Panics(t, func() { shortlink.New(shortlink.NewMemoryStore(), shortlink.WithCacheTTL(0)) })
+	assert.Panics(t, func() { shortlink.New(shortlink.NewMemoryStore(), shortlink.WithSchemes()) })
+	assert.Panics(t, func() { shortlink.New(shortlink.NewMemoryStore(), shortlink.WithRedirectStatus(301)) })
+	assert.NotPanics(t, func() { shortlink.New(shortlink.NewMemoryStore(), shortlink.WithRedirectStatus(307)) })
+}
+
+func TestCreate_GeneratedCode(t *testing.T) {
+	t.Parallel()
+	mgr := shortlink.New(shortlink.NewMemoryStore())
+	l, err := mgr.Create(context.Background(), shortlink.CreateParams{URL: "https://example.com/page"})
+	require.NoError(t, err)
+	assert.Len(t, l.Code, 7)
+	for i := range len(l.Code) {
+		assert.Contains(t, shortlink.Alphabet, string(l.Code[i]))
+	}
+	assert.Equal(t, "https://example.com/page", l.URL)
+	assert.False(t, l.CreatedAt.IsZero())
+	assert.True(t, l.ExpiresAt.IsZero())
+	assert.True(t, l.DeactivatedAt.IsZero())
+}
+
+func TestCreate_CodeLengthOption(t *testing.T) {
+	t.Parallel()
+	mgr := shortlink.New(shortlink.NewMemoryStore(), shortlink.WithCodeLength(12))
+	l, err := mgr.Create(context.Background(), shortlink.CreateParams{URL: "https://example.com"})
+	require.NoError(t, err)
+	assert.Len(t, l.Code, 12)
+}
+
+func TestCreate_VanityCode(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore())
+
+	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com", Code: "summer-Sale_24"})
+	require.NoError(t, err)
+	assert.Equal(t, "summer-Sale_24", l.Code)
+
+	_, err = mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com", Code: "summer-Sale_24"})
+	assert.ErrorIs(t, err, shortlink.ErrDuplicate)
+}
+
+func TestCreate_VanityValidation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore())
+
+	for _, code := range []string{"has space", "with/slash", "dotted.code", "ünïcode", "per%cent"} {
+		_, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com", Code: code})
+		assert.ErrorIs(t, err, shortlink.ErrInvalidCode, "code %q", code)
+	}
+
+	_, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com", Code: strings.Repeat("a", 65)})
+	assert.ErrorIs(t, err, shortlink.ErrInvalidCode)
+
+	_, err = mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com", Code: strings.Repeat("a", 64)})
+	assert.NoError(t, err)
+}
+
+func TestCreate_ReservedCodes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore(), shortlink.WithReservedCodes("Promo"))
+
+	for _, code := range []string{"admin", "Admin", "API", "login", "promo", "PROMO"} {
+		_, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com", Code: code})
+		assert.ErrorIs(t, err, shortlink.ErrReservedCode, "code %q", code)
+	}
+}
+
+func TestCreate_URLValidation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore())
+
+	// Not absolute, no host, or unparseable — including scheme-only
+	// payloads like javascript: and data: that carry no host at all.
+	for _, u := range []string{"", "/relative/path", "example.com/no-scheme", "https://", "::bad::", "javascript:alert(1)", "data:text/html,x", "mailto:x@example.com"} {
+		_, err := mgr.Create(ctx, shortlink.CreateParams{URL: u})
+		assert.ErrorIs(t, err, shortlink.ErrInvalidURL, "url %q", u)
+	}
+
+	// Well-formed but outside the default http/https allowlist.
+	for _, u := range []string{"ftp://example.com/f", "javascript://example.com/alert"} {
+		_, err := mgr.Create(ctx, shortlink.CreateParams{URL: u})
+		assert.ErrorIs(t, err, shortlink.ErrSchemeNotAllowed, "url %q", u)
+	}
+
+	_, err := mgr.Create(ctx, shortlink.CreateParams{URL: "HTTPS://example.com/ok"})
+	assert.NoError(t, err, "scheme match is case-insensitive")
+}
+
+func TestCreate_SchemeAllowlist(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore(), shortlink.WithSchemes("https"))
+
+	_, err := mgr.Create(ctx, shortlink.CreateParams{URL: "http://example.com"})
+	assert.ErrorIs(t, err, shortlink.ErrSchemeNotAllowed)
+
+	_, err = mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com"})
+	assert.NoError(t, err)
+}
+
+// collidingStore forces Create collisions to exercise retry behavior.
+type collidingStore struct {
+	shortlink.Store
+	failures int
+	calls    int
+}
+
+func (s *collidingStore) Create(ctx context.Context, l shortlink.Link) error {
+	s.calls++
+	if s.calls <= s.failures {
+		return shortlink.ErrDuplicate
+	}
+	return s.Store.Create(ctx, l)
+}
+
+func TestCreate_CollisionRetry(t *testing.T) {
+	t.Parallel()
+	store := &collidingStore{Store: shortlink.NewMemoryStore(), failures: 3}
+	mgr := shortlink.New(store)
+
+	l, err := mgr.Create(context.Background(), shortlink.CreateParams{URL: "https://example.com"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, l.Code)
+	assert.Equal(t, 4, store.calls)
+}
+
+func TestCreate_CollisionExhausted(t *testing.T) {
+	t.Parallel()
+	store := &collidingStore{Store: shortlink.NewMemoryStore(), failures: 1000}
+	mgr := shortlink.New(store)
+
+	_, err := mgr.Create(context.Background(), shortlink.CreateParams{URL: "https://example.com"})
+	assert.ErrorIs(t, err, shortlink.ErrCodeExhausted)
+	assert.Equal(t, 5, store.calls)
+}
+
+func TestCreate_VanityNoRetry(t *testing.T) {
+	t.Parallel()
+	store := &collidingStore{Store: shortlink.NewMemoryStore(), failures: 1}
+	mgr := shortlink.New(store)
+
+	_, err := mgr.Create(context.Background(), shortlink.CreateParams{URL: "https://example.com", Code: "taken"})
+	assert.ErrorIs(t, err, shortlink.ErrDuplicate)
+	assert.Equal(t, 1, store.calls, "vanity collisions must not be retried")
+}
+
+func TestGet_And_List(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore())
+
+	a, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com/a", Tenant: "t1"})
+	require.NoError(t, err)
+	_, err = mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com/b", Tenant: "t2"})
+	require.NoError(t, err)
+
+	got, err := mgr.Get(ctx, a.Code)
+	require.NoError(t, err)
+	assert.Equal(t, a.URL, got.URL)
+
+	_, err = mgr.Get(ctx, "missing")
+	assert.ErrorIs(t, err, shortlink.ErrNotFound)
+
+	all, err := mgr.List(ctx, shortlink.Filter{})
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+
+	t1, err := mgr.List(ctx, shortlink.Filter{Tenant: "t1"})
+	require.NoError(t, err)
+	require.Len(t, t1, 1)
+	assert.Equal(t, a.Code, t1[0].Code)
+}
+
+func TestDeactivate_Activate_Delete(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore())
+
+	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com"})
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.Deactivate(ctx, l.Code))
+	_, err = mgr.Resolve(ctx, l.Code)
+	assert.ErrorIs(t, err, shortlink.ErrLinkDeactivated)
+
+	got, err := mgr.Get(ctx, l.Code)
+	require.NoError(t, err)
+	assert.False(t, got.DeactivatedAt.IsZero())
+
+	require.NoError(t, mgr.Activate(ctx, l.Code))
+	_, err = mgr.Resolve(ctx, l.Code)
+	assert.NoError(t, err)
+
+	require.NoError(t, mgr.Delete(ctx, l.Code))
+	_, err = mgr.Get(ctx, l.Code)
+	assert.ErrorIs(t, err, shortlink.ErrNotFound)
+
+	assert.ErrorIs(t, mgr.Deactivate(ctx, l.Code), shortlink.ErrNotFound)
+	assert.ErrorIs(t, mgr.Activate(ctx, l.Code), shortlink.ErrNotFound)
+	assert.ErrorIs(t, mgr.Delete(ctx, l.Code), shortlink.ErrNotFound)
+}
+
+func TestDelete_FreesCode(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore())
+
+	_, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com/old", Code: "reuse"})
+	require.NoError(t, err)
+	require.NoError(t, mgr.Delete(ctx, "reuse"))
+
+	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com/new", Code: "reuse"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/new", l.URL)
+}
+
+func TestCreate_Expiry(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore())
+
+	exp := time.Now().UTC().Add(time.Hour)
+	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com", ExpiresAt: exp})
+	require.NoError(t, err)
+	assert.Equal(t, exp, l.ExpiresAt)
+}

--- a/web/shortlink/memory.go
+++ b/web/shortlink/memory.go
@@ -1,0 +1,88 @@
+package shortlink
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+type memoryStore struct {
+	links map[string]Link
+	mu    sync.RWMutex
+}
+
+// NewMemoryStore returns an in-memory Store for tests and development.
+func NewMemoryStore() Store {
+	return &memoryStore{links: make(map[string]Link)}
+}
+
+func (s *memoryStore) Create(_ context.Context, l Link) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.links[l.Code]; ok {
+		return ErrDuplicate
+	}
+	s.links[l.Code] = l
+	return nil
+}
+
+func (s *memoryStore) Get(_ context.Context, code string) (Link, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	l, ok := s.links[code]
+	if !ok {
+		return Link{}, ErrNotFound
+	}
+	return l, nil
+}
+
+func (s *memoryStore) List(_ context.Context, f Filter) ([]Link, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Link, 0, len(s.links))
+	for _, l := range s.links {
+		if f.Tenant != "" && l.Tenant != f.Tenant {
+			continue
+		}
+		out = append(out, l)
+	}
+	slices.SortFunc(out, func(a, b Link) int {
+		if c := b.CreatedAt.Compare(a.CreatedAt); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Code, b.Code)
+	})
+	return out, nil
+}
+
+func (s *memoryStore) Deactivate(_ context.Context, code string, at time.Time) error {
+	return s.update(code, func(l *Link) { l.DeactivatedAt = at })
+}
+
+func (s *memoryStore) Activate(_ context.Context, code string) error {
+	return s.update(code, func(l *Link) { l.DeactivatedAt = time.Time{} })
+}
+
+func (s *memoryStore) Delete(_ context.Context, code string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.links[code]; !ok {
+		return ErrNotFound
+	}
+	delete(s.links, code)
+	return nil
+}
+
+func (s *memoryStore) update(code string, fn func(*Link)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	l, ok := s.links[code]
+	if !ok {
+		return ErrNotFound
+	}
+	fn(&l)
+	s.links[code] = l
+	return nil
+}

--- a/web/shortlink/memory.go
+++ b/web/shortlink/memory.go
@@ -41,7 +41,12 @@ func (s *memoryStore) Get(_ context.Context, code string) (Link, error) {
 func (s *memoryStore) List(_ context.Context, f Filter) ([]Link, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	out := make([]Link, 0, len(s.links))
+	// Preallocate only for the unfiltered listing, where the map size is
+	// exact; a tenant filter may match a small fraction of entries.
+	out := []Link{}
+	if f.Tenant == "" {
+		out = make([]Link, 0, len(s.links))
+	}
 	for _, l := range s.links {
 		if f.Tenant != "" && l.Tenant != f.Tenant {
 			continue
@@ -54,32 +59,36 @@ func (s *memoryStore) List(_ context.Context, f Filter) ([]Link, error) {
 		}
 		return strings.Compare(a.Code, b.Code)
 	})
+	if f.Limit > 0 && len(out) > f.Limit {
+		out = out[:f.Limit]
+	}
 	return out, nil
 }
 
-func (s *memoryStore) Deactivate(_ context.Context, code string, at time.Time) error {
-	return s.update(code, func(l *Link) { l.DeactivatedAt = at })
+func (s *memoryStore) Deactivate(_ context.Context, code, tenant string, at time.Time) error {
+	return s.update(code, tenant, func(l *Link) { l.DeactivatedAt = at })
 }
 
-func (s *memoryStore) Activate(_ context.Context, code string) error {
-	return s.update(code, func(l *Link) { l.DeactivatedAt = time.Time{} })
+func (s *memoryStore) Activate(_ context.Context, code, tenant string) error {
+	return s.update(code, tenant, func(l *Link) { l.DeactivatedAt = time.Time{} })
 }
 
-func (s *memoryStore) Delete(_ context.Context, code string) error {
+func (s *memoryStore) Delete(_ context.Context, code, tenant string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.links[code]; !ok {
+	l, ok := s.links[code]
+	if !ok || (tenant != "" && l.Tenant != tenant) {
 		return ErrNotFound
 	}
 	delete(s.links, code)
 	return nil
 }
 
-func (s *memoryStore) update(code string, fn func(*Link)) error {
+func (s *memoryStore) update(code, tenant string, fn func(*Link)) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	l, ok := s.links[code]
-	if !ok {
+	if !ok || (tenant != "" && l.Tenant != tenant) {
 		return ErrNotFound
 	}
 	fn(&l)

--- a/web/shortlink/memory_test.go
+++ b/web/shortlink/memory_test.go
@@ -74,18 +74,18 @@ func TestMemoryStore_DeactivateActivate(t *testing.T) {
 	require.NoError(t, s.Create(ctx, mkLink("abc", "", time.Now())))
 
 	at := time.Now().UTC()
-	require.NoError(t, s.Deactivate(ctx, "abc", at))
+	require.NoError(t, s.Deactivate(ctx, "abc", "", at))
 	l, err := s.Get(ctx, "abc")
 	require.NoError(t, err)
 	assert.Equal(t, at, l.DeactivatedAt)
 
-	require.NoError(t, s.Activate(ctx, "abc"))
+	require.NoError(t, s.Activate(ctx, "abc", ""))
 	l, err = s.Get(ctx, "abc")
 	require.NoError(t, err)
 	assert.True(t, l.DeactivatedAt.IsZero())
 
-	assert.ErrorIs(t, s.Deactivate(ctx, "nope", at), shortlink.ErrNotFound)
-	assert.ErrorIs(t, s.Activate(ctx, "nope"), shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Deactivate(ctx, "nope", "", at), shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Activate(ctx, "nope", ""), shortlink.ErrNotFound)
 }
 
 func TestMemoryStore_Delete(t *testing.T) {
@@ -94,8 +94,45 @@ func TestMemoryStore_Delete(t *testing.T) {
 	s := shortlink.NewMemoryStore()
 	require.NoError(t, s.Create(ctx, mkLink("abc", "", time.Now())))
 
-	require.NoError(t, s.Delete(ctx, "abc"))
+	require.NoError(t, s.Delete(ctx, "abc", ""))
 	_, err := s.Get(ctx, "abc")
 	assert.ErrorIs(t, err, shortlink.ErrNotFound)
-	assert.ErrorIs(t, s.Delete(ctx, "abc"), shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Delete(ctx, "abc", ""), shortlink.ErrNotFound)
+}
+
+func TestMemoryStore_TenantPredicate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := shortlink.NewMemoryStore()
+	require.NoError(t, s.Create(ctx, mkLink("abc", "t1", time.Now())))
+
+	at := time.Now().UTC()
+	// A mismatched tenant is atomically rejected as ErrNotFound.
+	assert.ErrorIs(t, s.Deactivate(ctx, "abc", "t2", at), shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Activate(ctx, "abc", "t2"), shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Delete(ctx, "abc", "t2"), shortlink.ErrNotFound)
+	l, err := s.Get(ctx, "abc")
+	require.NoError(t, err)
+	assert.True(t, l.DeactivatedAt.IsZero())
+
+	// The owning tenant (and the unconstrained empty tenant) pass.
+	require.NoError(t, s.Deactivate(ctx, "abc", "t1", at))
+	require.NoError(t, s.Activate(ctx, "abc", ""))
+	require.NoError(t, s.Delete(ctx, "abc", "t1"))
+}
+
+func TestMemoryStore_ListLimit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := shortlink.NewMemoryStore()
+	base := time.Now().UTC()
+	require.NoError(t, s.Create(ctx, mkLink("a", "", base.Add(-2*time.Hour))))
+	require.NoError(t, s.Create(ctx, mkLink("b", "", base.Add(-time.Hour))))
+	require.NoError(t, s.Create(ctx, mkLink("c", "", base)))
+
+	got, err := s.List(ctx, shortlink.Filter{Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "c", got[0].Code)
+	assert.Equal(t, "b", got[1].Code)
 }

--- a/web/shortlink/memory_test.go
+++ b/web/shortlink/memory_test.go
@@ -1,0 +1,101 @@
+package shortlink_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/web/shortlink"
+)
+
+func mkLink(code, tenant string, createdAt time.Time) shortlink.Link {
+	return shortlink.Link{
+		Code:      code,
+		URL:       "https://example.com/" + code,
+		Tenant:    tenant,
+		CreatedAt: createdAt,
+	}
+}
+
+func TestMemoryStore_CreateDuplicate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := shortlink.NewMemoryStore()
+
+	require.NoError(t, s.Create(ctx, mkLink("abc", "", time.Now())))
+	assert.ErrorIs(t, s.Create(ctx, mkLink("abc", "", time.Now())), shortlink.ErrDuplicate)
+}
+
+func TestMemoryStore_GetNotFound(t *testing.T) {
+	t.Parallel()
+	s := shortlink.NewMemoryStore()
+	_, err := s.Get(context.Background(), "missing")
+	assert.ErrorIs(t, err, shortlink.ErrNotFound)
+}
+
+func TestMemoryStore_ListOrderAndFilter(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := shortlink.NewMemoryStore()
+	base := time.Now().UTC()
+
+	require.NoError(t, s.Create(ctx, mkLink("old", "t1", base.Add(-2*time.Hour))))
+	require.NoError(t, s.Create(ctx, mkLink("new", "t1", base)))
+	require.NoError(t, s.Create(ctx, mkLink("mid", "t2", base.Add(-time.Hour))))
+	// Same timestamp as "new": ties break by code ascending.
+	require.NoError(t, s.Create(ctx, mkLink("aaa", "t1", base)))
+
+	all, err := s.List(ctx, shortlink.Filter{})
+	require.NoError(t, err)
+	codes := make([]string, len(all))
+	for i, l := range all {
+		codes[i] = l.Code
+	}
+	assert.Equal(t, []string{"aaa", "new", "mid", "old"}, codes)
+
+	t2, err := s.List(ctx, shortlink.Filter{Tenant: "t2"})
+	require.NoError(t, err)
+	require.Len(t, t2, 1)
+	assert.Equal(t, "mid", t2[0].Code)
+
+	none, err := s.List(ctx, shortlink.Filter{Tenant: "t3"})
+	require.NoError(t, err)
+	assert.Empty(t, none)
+	assert.NotNil(t, none)
+}
+
+func TestMemoryStore_DeactivateActivate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := shortlink.NewMemoryStore()
+	require.NoError(t, s.Create(ctx, mkLink("abc", "", time.Now())))
+
+	at := time.Now().UTC()
+	require.NoError(t, s.Deactivate(ctx, "abc", at))
+	l, err := s.Get(ctx, "abc")
+	require.NoError(t, err)
+	assert.Equal(t, at, l.DeactivatedAt)
+
+	require.NoError(t, s.Activate(ctx, "abc"))
+	l, err = s.Get(ctx, "abc")
+	require.NoError(t, err)
+	assert.True(t, l.DeactivatedAt.IsZero())
+
+	assert.ErrorIs(t, s.Deactivate(ctx, "nope", at), shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Activate(ctx, "nope"), shortlink.ErrNotFound)
+}
+
+func TestMemoryStore_Delete(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := shortlink.NewMemoryStore()
+	require.NoError(t, s.Create(ctx, mkLink("abc", "", time.Now())))
+
+	require.NoError(t, s.Delete(ctx, "abc"))
+	_, err := s.Get(ctx, "abc")
+	assert.ErrorIs(t, err, shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Delete(ctx, "abc"), shortlink.ErrNotFound)
+}

--- a/web/shortlink/options.go
+++ b/web/shortlink/options.go
@@ -1,0 +1,99 @@
+package shortlink
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+type config struct {
+	scope          func(context.Context) (string, error)
+	cache          cache.Store
+	onHit          func(context.Context, Link)
+	reserved       map[string]struct{}
+	schemes        map[string]struct{}
+	fallbackURL    string
+	cacheTTL       time.Duration
+	codeLength     int
+	redirectStatus int
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithScope derives the tenant from context for every management operation:
+// Create stamps it, List is confined to it, and Get/Deactivate/Activate/
+// Delete report ErrNotFound for other tenants' links. Fail-closed: a hook
+// error or empty tenant fails the operation with ErrScope. Resolve and the
+// redirect Handler are unaffected — a short code is a public URL. A nil fn
+// leaves the manager unscoped.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) { c.scope = fn }
+}
+
+// WithCache enables read-through caching of Resolve lookups: hits are
+// served from the cache store, misses fall through to the Store and are
+// cached for the WithCacheTTL duration. Deactivate, Activate, and Delete
+// invalidate the cached entry. A nil store disables caching.
+func WithCache(store cache.Store) Option {
+	return func(c *config) { c.cache = store }
+}
+
+// WithCacheTTL bounds how long a resolved link is cached (default 5m).
+// Only meaningful together with WithCache. New panics on a non-positive d.
+func WithCacheTTL(d time.Duration) Option {
+	return func(c *config) { c.cacheTTL = d }
+}
+
+// WithCodeLength sets the generated code length (default 7, giving 58^7 ≈
+// 2.2e12 codes). New panics outside [4, 32]. Vanity codes are unaffected.
+func WithCodeLength(n int) Option {
+	return func(c *config) { c.codeLength = n }
+}
+
+// WithSchemes replaces the destination scheme allowlist (default http and
+// https). Schemes are matched case-insensitively. New panics on an empty
+// list.
+func WithSchemes(schemes ...string) Option {
+	return func(c *config) {
+		c.schemes = make(map[string]struct{}, len(schemes))
+		for _, s := range schemes {
+			c.schemes[strings.ToLower(s)] = struct{}{}
+		}
+	}
+}
+
+// WithReservedCodes extends the default reserved-word blocklist that vanity
+// codes are checked against (case-insensitively).
+func WithReservedCodes(codes ...string) Option {
+	return func(c *config) {
+		for _, code := range codes {
+			c.reserved[strings.ToLower(code)] = struct{}{}
+		}
+	}
+}
+
+// WithFallbackURL redirects failed resolves (unknown, expired, or
+// deactivated codes) in the Handler to u — a branded "link gone" page —
+// instead of responding 404. Relative paths are allowed.
+func WithFallbackURL(u string) Option {
+	return func(c *config) { c.fallbackURL = u }
+}
+
+// WithRedirectStatus sets the Handler's redirect status (default
+// http.StatusFound, 302). New panics on anything but 302 or 307 — a
+// cacheable 301 would freeze the destination in browser caches and kill
+// hit counting forever.
+func WithRedirectStatus(status int) Option {
+	return func(c *config) { c.redirectStatus = status }
+}
+
+// WithOnHit registers a hook fired synchronously on every successful
+// Resolve with the resolved link. It is the click-counting seam — the hook
+// emits, counting stays the caller's job (bump a counter, push to a queue).
+// Keep it fast or offload; it runs on the redirect hot path.
+func WithOnHit(fn func(context.Context, Link)) Option {
+	return func(c *config) { c.onHit = fn }
+}

--- a/web/shortlink/options.go
+++ b/web/shortlink/options.go
@@ -35,14 +35,19 @@ func WithScope(fn func(context.Context) (string, error)) Option {
 
 // WithCache enables read-through caching of Resolve lookups: hits are
 // served from the cache store, misses fall through to the Store and are
-// cached for the WithCacheTTL duration. Deactivate, Activate, and Delete
-// invalidate the cached entry. A nil store disables caching.
+// cached for the WithCacheTTL duration. Coherence is bounded, not exact:
+// mutations invalidate the cached entry best-effort, but a concurrent
+// in-flight resolve can re-populate it, so a just-deactivated or
+// just-deleted link may keep resolving for up to WithCacheTTL. Pick the
+// TTL as the longest acceptable revocation delay. A nil store disables
+// caching.
 func WithCache(store cache.Store) Option {
 	return func(c *config) { c.cache = store }
 }
 
-// WithCacheTTL bounds how long a resolved link is cached (default 5m).
-// Only meaningful together with WithCache. New panics on a non-positive d.
+// WithCacheTTL bounds how long a resolved link is cached, and with it the
+// worst-case staleness after a mutation (default 5m). Only meaningful
+// together with WithCache. New panics on a non-positive d.
 func WithCacheTTL(d time.Duration) Option {
 	return func(c *config) { c.cacheTTL = d }
 }
@@ -75,9 +80,12 @@ func WithReservedCodes(codes ...string) Option {
 	}
 }
 
-// WithFallbackURL redirects failed resolves (unknown, expired, or
-// deactivated codes) in the Handler to u — a branded "link gone" page —
-// instead of responding 404. Relative paths are allowed.
+// WithFallbackURL redirects dead links (unknown, expired, or deactivated
+// codes) in the Handler to u — a branded "link gone" page — instead of
+// responding 404. Relative paths are allowed, but when the Handler is
+// mounted as a catch-all the fallback must not route back into it: a
+// relative fallback the Handler itself serves resolves as yet another
+// unknown code and redirect-loops.
 func WithFallbackURL(u string) Option {
 	return func(c *config) { c.fallbackURL = u }
 }

--- a/web/shortlink/pgstore/doc.go
+++ b/web/shortlink/pgstore/doc.go
@@ -1,0 +1,10 @@
+// Package pgstore is the Postgres shortlink.Store driver: one
+// forge_short_links table keyed by code, resolved with a single
+// primary-key lookup.
+//
+//	pool, _ := postgres.Open(ctx, postgres.WithConfig(cfg))
+//	db := stdlib.OpenDBFromPool(pool)
+//	err := migration.New(pgstore.Migrations, migration.WithTable("forge_shortlink_schema")).Up(ctx, db)
+//
+//	mgr := shortlink.New(pgstore.New(pool))
+package pgstore

--- a/web/shortlink/pgstore/migrations/00001_create_forge_short_links.sql
+++ b/web/shortlink/pgstore/migrations/00001_create_forge_short_links.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+CREATE TABLE forge_short_links (
+    code           text PRIMARY KEY,
+    url            text NOT NULL,
+    tenant         text NOT NULL DEFAULT '',
+    created_at     timestamptz NOT NULL,
+    expires_at     timestamptz,
+    deactivated_at timestamptz
+);
+
+CREATE INDEX forge_short_links_list_idx ON forge_short_links (tenant, created_at DESC, code);
+
+-- +goose Down
+DROP TABLE forge_short_links;

--- a/web/shortlink/pgstore/pgstore.go
+++ b/web/shortlink/pgstore/pgstore.go
@@ -1,0 +1,149 @@
+package pgstore
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"io/fs"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/web/shortlink"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_short_links, rooted
+// so its .sql files sit at fsys root (data/migration.New globs fsys's root,
+// not subdirectories). Apply via data/migration under its own version
+// table ("forge_shortlink_schema").
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// Store is the Postgres implementation of shortlink.Store. The pool's
+// lifecycle is the caller's.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+var _ shortlink.Store = (*Store)(nil)
+
+// New builds a Postgres shortlink Store. Apply Migrations first.
+func New(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const cols = `code, url, tenant, created_at, expires_at, deactivated_at`
+
+// Create inserts l. A colliding code yields shortlink.ErrDuplicate.
+func (s *Store) Create(ctx context.Context, l shortlink.Link) error {
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO forge_short_links (`+cols+`) VALUES ($1, $2, $3, $4, $5, $6)`,
+		l.Code, l.URL, l.Tenant, l.CreatedAt, nullTime(l.ExpiresAt), nullTime(l.DeactivatedAt))
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
+		return shortlink.ErrDuplicate
+	}
+	return err
+}
+
+// Get returns the record for code, or shortlink.ErrNotFound. This is the
+// resolve hot path: one point lookup on the primary key.
+func (s *Store) Get(ctx context.Context, code string) (shortlink.Link, error) {
+	return scanLink(s.pool.QueryRow(ctx, `SELECT `+cols+` FROM forge_short_links WHERE code = $1`, code))
+}
+
+// List returns records matching f, newest first (created_at DESC, code ASC
+// on ties).
+func (s *Store) List(ctx context.Context, f shortlink.Filter) ([]shortlink.Link, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+cols+` FROM forge_short_links
+		 WHERE ($1 = '' OR tenant = $1)
+		 ORDER BY created_at DESC, code ASC`, f.Tenant)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	// Non-nil empty (not nil) on zero rows, matching the memory store so
+	// callers see identical List results whichever Store backs the Manager.
+	out := []shortlink.Link{}
+	for rows.Next() {
+		l, err := scanLink(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
+// Deactivate sets deactivated_at, or returns shortlink.ErrNotFound.
+func (s *Store) Deactivate(ctx context.Context, code string, at time.Time) error {
+	return s.exec(ctx, `UPDATE forge_short_links SET deactivated_at = $2 WHERE code = $1`, code, at)
+}
+
+// Activate clears deactivated_at, or returns shortlink.ErrNotFound.
+func (s *Store) Activate(ctx context.Context, code string) error {
+	return s.exec(ctx, `UPDATE forge_short_links SET deactivated_at = NULL WHERE code = $1`, code)
+}
+
+// Delete removes the record, or returns shortlink.ErrNotFound.
+func (s *Store) Delete(ctx context.Context, code string) error {
+	return s.exec(ctx, `DELETE FROM forge_short_links WHERE code = $1`, code)
+}
+
+func (s *Store) exec(ctx context.Context, sql string, args ...any) error {
+	tag, err := s.pool.Exec(ctx, sql, args...)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return shortlink.ErrNotFound
+	}
+	return nil
+}
+
+// row is satisfied by both pgx.Row and pgx.Rows.
+type row interface{ Scan(dest ...any) error }
+
+func scanLink(r row) (shortlink.Link, error) {
+	var l shortlink.Link
+	var exp, deact *time.Time
+	err := r.Scan(&l.Code, &l.URL, &l.Tenant, &l.CreatedAt, &exp, &deact)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return shortlink.Link{}, shortlink.ErrNotFound
+	}
+	if err != nil {
+		return shortlink.Link{}, err
+	}
+	l.ExpiresAt = deref(exp)
+	l.DeactivatedAt = deref(deact)
+	return l, nil
+}
+
+// deref maps SQL NULL back to the zero time.
+func deref(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
+// nullTime maps the zero time to SQL NULL.
+func nullTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}

--- a/web/shortlink/pgstore/pgstore.go
+++ b/web/shortlink/pgstore/pgstore.go
@@ -65,12 +65,24 @@ func (s *Store) Get(ctx context.Context, code string) (shortlink.Link, error) {
 }
 
 // List returns records matching f, newest first (created_at DESC, code ASC
-// on ties).
+// on ties). The tenant-filtered and unfiltered shapes are separate static
+// statements so the tenant-leading index serves the filtered one and the
+// planner never has to fold a `$1 = ”` catch-all out of a generic plan.
 func (s *Store) List(ctx context.Context, f shortlink.Filter) ([]shortlink.Link, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT `+cols+` FROM forge_short_links
-		 WHERE ($1 = '' OR tenant = $1)
-		 ORDER BY created_at DESC, code ASC`, f.Tenant)
+	var rows pgx.Rows
+	var err error
+	if f.Tenant == "" {
+		rows, err = s.pool.Query(ctx,
+			`SELECT `+cols+` FROM forge_short_links
+			 ORDER BY created_at DESC, code ASC
+			 LIMIT NULLIF($1, 0)`, f.Limit)
+	} else {
+		rows, err = s.pool.Query(ctx,
+			`SELECT `+cols+` FROM forge_short_links
+			 WHERE tenant = $1
+			 ORDER BY created_at DESC, code ASC
+			 LIMIT NULLIF($2, 0)`, f.Tenant, f.Limit)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -88,19 +100,28 @@ func (s *Store) List(ctx context.Context, f shortlink.Filter) ([]shortlink.Link,
 	return out, rows.Err()
 }
 
-// Deactivate sets deactivated_at, or returns shortlink.ErrNotFound.
-func (s *Store) Deactivate(ctx context.Context, code string, at time.Time) error {
-	return s.exec(ctx, `UPDATE forge_short_links SET deactivated_at = $2 WHERE code = $1`, code, at)
+// Deactivate sets deactivated_at, or returns shortlink.ErrNotFound. The
+// tenant predicate is part of the statement so scope confinement is atomic
+// with the mutation; a zero at maps to NULL, matching the memory store's
+// zero-means-active semantics.
+func (s *Store) Deactivate(ctx context.Context, code, tenant string, at time.Time) error {
+	return s.exec(ctx,
+		`UPDATE forge_short_links SET deactivated_at = $2 WHERE code = $1 AND ($3 = '' OR tenant = $3)`,
+		code, nullTime(at), tenant)
 }
 
 // Activate clears deactivated_at, or returns shortlink.ErrNotFound.
-func (s *Store) Activate(ctx context.Context, code string) error {
-	return s.exec(ctx, `UPDATE forge_short_links SET deactivated_at = NULL WHERE code = $1`, code)
+func (s *Store) Activate(ctx context.Context, code, tenant string) error {
+	return s.exec(ctx,
+		`UPDATE forge_short_links SET deactivated_at = NULL WHERE code = $1 AND ($2 = '' OR tenant = $2)`,
+		code, tenant)
 }
 
 // Delete removes the record, or returns shortlink.ErrNotFound.
-func (s *Store) Delete(ctx context.Context, code string) error {
-	return s.exec(ctx, `DELETE FROM forge_short_links WHERE code = $1`, code)
+func (s *Store) Delete(ctx context.Context, code, tenant string) error {
+	return s.exec(ctx,
+		`DELETE FROM forge_short_links WHERE code = $1 AND ($2 = '' OR tenant = $2)`,
+		code, tenant)
 }
 
 func (s *Store) exec(ctx context.Context, sql string, args ...any) error {

--- a/web/shortlink/pgstore/pgstore_test.go
+++ b/web/shortlink/pgstore/pgstore_test.go
@@ -1,0 +1,198 @@
+//go:build integration
+
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/random"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+	"github.com/dmitrymomot/forge/web/shortlink"
+	"github.com/dmitrymomot/forge/web/shortlink/pgstore"
+)
+
+var _ shortlink.Store = (*pgstore.Store)(nil)
+
+func newStore(t *testing.T) *pgstore.Store {
+	t.Helper()
+	cfg := postgres.DefaultConfig()
+	cfg.URL = pgtest.DSN(t)
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgstore.Migrations, migration.WithTable("forge_shortlink_schema")).Up(context.Background(), db))
+	return pgstore.New(pool)
+}
+
+// mkLink builds a record whose code and tenant are unique per call: the
+// table persists across test runs, so deterministic values would collide on
+// the primary key or inflate List counts on re-runs.
+func mkLink(t *testing.T) shortlink.Link {
+	t.Helper()
+	return shortlink.Link{
+		Code:      "c" + random.String(15, shortlink.Alphabet),
+		URL:       "https://example.com/" + t.Name(),
+		Tenant:    "tenant-" + random.Hex(8),
+		CreatedAt: time.Now().UTC().Truncate(time.Millisecond),
+	}
+}
+
+func TestPg_CreateGetRoundTrip(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	l := mkLink(t)
+	l.ExpiresAt = time.Now().UTC().Add(time.Hour).Truncate(time.Millisecond)
+
+	require.NoError(t, s.Create(ctx, l))
+	got, err := s.Get(ctx, l.Code)
+	require.NoError(t, err)
+	assert.Equal(t, l.Code, got.Code)
+	assert.Equal(t, l.URL, got.URL)
+	assert.Equal(t, l.Tenant, got.Tenant)
+	assert.True(t, l.CreatedAt.Equal(got.CreatedAt))
+	assert.True(t, l.ExpiresAt.Equal(got.ExpiresAt))
+	assert.True(t, got.DeactivatedAt.IsZero())
+}
+
+func TestPg_CreateDuplicate(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	l := mkLink(t)
+
+	require.NoError(t, s.Create(ctx, l))
+	assert.ErrorIs(t, s.Create(ctx, l), shortlink.ErrDuplicate)
+}
+
+func TestPg_GetNotFound(t *testing.T) {
+	s := newStore(t)
+	_, err := s.Get(context.Background(), "missing-"+random.Hex(8))
+	assert.ErrorIs(t, err, shortlink.ErrNotFound)
+}
+
+func TestPg_ZeroTimesRoundTripAsNull(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	l := mkLink(t)
+
+	require.NoError(t, s.Create(ctx, l))
+	got, err := s.Get(ctx, l.Code)
+	require.NoError(t, err)
+	assert.True(t, got.ExpiresAt.IsZero())
+	assert.True(t, got.DeactivatedAt.IsZero())
+}
+
+func TestPg_ListOrderAndFilter(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	tenant := "tenant-" + random.Hex(8)
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	older := mkLink(t)
+	older.Tenant = tenant
+	older.CreatedAt = base.Add(-time.Hour)
+	newer := mkLink(t)
+	newer.Tenant = tenant
+	newer.CreatedAt = base
+	require.NoError(t, s.Create(ctx, older))
+	require.NoError(t, s.Create(ctx, newer))
+
+	got, err := s.List(ctx, shortlink.Filter{Tenant: tenant})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, newer.Code, got[0].Code)
+	assert.Equal(t, older.Code, got[1].Code)
+
+	none, err := s.List(ctx, shortlink.Filter{Tenant: "tenant-absent-" + random.Hex(8)})
+	require.NoError(t, err)
+	assert.NotNil(t, none)
+	assert.Empty(t, none)
+}
+
+func TestPg_ListTieBreaksByCode(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	tenant := "tenant-" + random.Hex(8)
+	at := time.Now().UTC().Truncate(time.Millisecond)
+
+	a := mkLink(t)
+	a.Code = "a" + random.String(15, shortlink.Alphabet)
+	a.Tenant = tenant
+	a.CreatedAt = at
+	z := mkLink(t)
+	z.Code = "z" + random.String(15, shortlink.Alphabet)
+	z.Tenant = tenant
+	z.CreatedAt = at
+	require.NoError(t, s.Create(ctx, z))
+	require.NoError(t, s.Create(ctx, a))
+
+	got, err := s.List(ctx, shortlink.Filter{Tenant: tenant})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, a.Code, got[0].Code)
+	assert.Equal(t, z.Code, got[1].Code)
+}
+
+func TestPg_DeactivateActivate(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	l := mkLink(t)
+	require.NoError(t, s.Create(ctx, l))
+
+	at := time.Now().UTC().Truncate(time.Millisecond)
+	require.NoError(t, s.Deactivate(ctx, l.Code, at))
+	got, err := s.Get(ctx, l.Code)
+	require.NoError(t, err)
+	assert.True(t, at.Equal(got.DeactivatedAt))
+
+	require.NoError(t, s.Activate(ctx, l.Code))
+	got, err = s.Get(ctx, l.Code)
+	require.NoError(t, err)
+	assert.True(t, got.DeactivatedAt.IsZero())
+
+	missing := "missing-" + random.Hex(8)
+	assert.ErrorIs(t, s.Deactivate(ctx, missing, at), shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Activate(ctx, missing), shortlink.ErrNotFound)
+}
+
+func TestPg_Delete(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	l := mkLink(t)
+	require.NoError(t, s.Create(ctx, l))
+
+	require.NoError(t, s.Delete(ctx, l.Code))
+	_, err := s.Get(ctx, l.Code)
+	assert.ErrorIs(t, err, shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Delete(ctx, l.Code), shortlink.ErrNotFound)
+}
+
+func TestPg_ManagerEndToEnd(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	mgr := shortlink.New(s)
+
+	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com/e2e"})
+	require.NoError(t, err)
+
+	got, err := mgr.Resolve(ctx, l.Code)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/e2e", got.URL)
+
+	require.NoError(t, mgr.Deactivate(ctx, l.Code))
+	_, err = mgr.Resolve(ctx, l.Code)
+	assert.ErrorIs(t, err, shortlink.ErrLinkDeactivated)
+
+	require.NoError(t, mgr.Delete(ctx, l.Code))
+	_, err = mgr.Resolve(ctx, l.Code)
+	assert.ErrorIs(t, err, shortlink.ErrNotFound)
+}

--- a/web/shortlink/pgstore/pgstore_test.go
+++ b/web/shortlink/pgstore/pgstore_test.go
@@ -149,19 +149,54 @@ func TestPg_DeactivateActivate(t *testing.T) {
 	require.NoError(t, s.Create(ctx, l))
 
 	at := time.Now().UTC().Truncate(time.Millisecond)
-	require.NoError(t, s.Deactivate(ctx, l.Code, at))
+	require.NoError(t, s.Deactivate(ctx, l.Code, "", at))
 	got, err := s.Get(ctx, l.Code)
 	require.NoError(t, err)
 	assert.True(t, at.Equal(got.DeactivatedAt))
 
-	require.NoError(t, s.Activate(ctx, l.Code))
+	require.NoError(t, s.Activate(ctx, l.Code, ""))
 	got, err = s.Get(ctx, l.Code)
 	require.NoError(t, err)
 	assert.True(t, got.DeactivatedAt.IsZero())
 
 	missing := "missing-" + random.Hex(8)
-	assert.ErrorIs(t, s.Deactivate(ctx, missing, at), shortlink.ErrNotFound)
-	assert.ErrorIs(t, s.Activate(ctx, missing), shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Deactivate(ctx, missing, "", at), shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Activate(ctx, missing, ""), shortlink.ErrNotFound)
+}
+
+func TestPg_TenantPredicate(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	l := mkLink(t)
+	require.NoError(t, s.Create(ctx, l))
+
+	at := time.Now().UTC().Truncate(time.Millisecond)
+	other := "tenant-other-" + random.Hex(8)
+	// A mismatched tenant is atomically rejected as ErrNotFound.
+	assert.ErrorIs(t, s.Deactivate(ctx, l.Code, other, at), shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Activate(ctx, l.Code, other), shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Delete(ctx, l.Code, other), shortlink.ErrNotFound)
+	got, err := s.Get(ctx, l.Code)
+	require.NoError(t, err)
+	assert.True(t, got.DeactivatedAt.IsZero())
+
+	// The owning tenant passes.
+	require.NoError(t, s.Deactivate(ctx, l.Code, l.Tenant, at))
+	require.NoError(t, s.Delete(ctx, l.Code, l.Tenant))
+}
+
+func TestPg_DeactivateZeroTimeStaysActive(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	l := mkLink(t)
+	require.NoError(t, s.Create(ctx, l))
+
+	// A zero at maps to NULL — same zero-means-active semantics as the
+	// memory store.
+	require.NoError(t, s.Deactivate(ctx, l.Code, "", time.Time{}))
+	got, err := s.Get(ctx, l.Code)
+	require.NoError(t, err)
+	assert.True(t, got.DeactivatedAt.IsZero())
 }
 
 func TestPg_Delete(t *testing.T) {
@@ -170,10 +205,29 @@ func TestPg_Delete(t *testing.T) {
 	l := mkLink(t)
 	require.NoError(t, s.Create(ctx, l))
 
-	require.NoError(t, s.Delete(ctx, l.Code))
+	require.NoError(t, s.Delete(ctx, l.Code, ""))
 	_, err := s.Get(ctx, l.Code)
 	assert.ErrorIs(t, err, shortlink.ErrNotFound)
-	assert.ErrorIs(t, s.Delete(ctx, l.Code), shortlink.ErrNotFound)
+	assert.ErrorIs(t, s.Delete(ctx, l.Code, ""), shortlink.ErrNotFound)
+}
+
+func TestPg_ListLimit(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	tenant := "tenant-" + random.Hex(8)
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	for i := range 3 {
+		l := mkLink(t)
+		l.Tenant = tenant
+		l.CreatedAt = base.Add(-time.Duration(i) * time.Hour)
+		require.NoError(t, s.Create(ctx, l))
+	}
+
+	got, err := s.List(ctx, shortlink.Filter{Tenant: tenant, Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.True(t, got[0].CreatedAt.After(got[1].CreatedAt))
 }
 
 func TestPg_ManagerEndToEnd(t *testing.T) {

--- a/web/shortlink/resolve_test.go
+++ b/web/shortlink/resolve_test.go
@@ -1,0 +1,183 @@
+package shortlink_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/resilience/cache"
+	"github.com/dmitrymomot/forge/web/shortlink"
+)
+
+func TestResolve_Basics(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore())
+
+	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com/dest"})
+	require.NoError(t, err)
+
+	got, err := mgr.Resolve(ctx, l.Code)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/dest", got.URL)
+
+	_, err = mgr.Resolve(ctx, "nope")
+	assert.ErrorIs(t, err, shortlink.ErrNotFound)
+
+	_, err = mgr.Resolve(ctx, "")
+	assert.ErrorIs(t, err, shortlink.ErrNotFound)
+}
+
+func TestResolve_Expired(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore())
+
+	l, err := mgr.Create(ctx, shortlink.CreateParams{
+		URL: "https://example.com", ExpiresAt: time.Now().UTC().Add(-time.Second),
+	})
+	require.NoError(t, err)
+
+	_, err = mgr.Resolve(ctx, l.Code)
+	assert.ErrorIs(t, err, shortlink.ErrLinkExpired)
+
+	future, err := mgr.Create(ctx, shortlink.CreateParams{
+		URL: "https://example.com", ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	_, err = mgr.Resolve(ctx, future.Code)
+	assert.NoError(t, err)
+}
+
+func TestResolve_OnHit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	var hits []shortlink.Link
+	store := shortlink.NewMemoryStore()
+	mgr := shortlink.New(store, shortlink.WithOnHit(func(_ context.Context, l shortlink.Link) {
+		hits = append(hits, l)
+	}))
+
+	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com"})
+	require.NoError(t, err)
+
+	_, err = mgr.Resolve(ctx, l.Code)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, l.Code, hits[0].Code)
+	assert.Equal(t, l.URL, hits[0].URL)
+
+	_, _ = mgr.Resolve(ctx, "missing")
+	assert.Len(t, hits, 1, "failed resolves must not fire OnHit")
+
+	require.NoError(t, mgr.Deactivate(ctx, l.Code))
+	_, _ = mgr.Resolve(ctx, l.Code)
+	assert.Len(t, hits, 1, "deactivated resolves must not fire OnHit")
+}
+
+// countingStore counts Get calls to observe cache read-through.
+type countingStore struct {
+	shortlink.Store
+	gets int
+}
+
+func (s *countingStore) Get(ctx context.Context, code string) (shortlink.Link, error) {
+	s.gets++
+	return s.Store.Get(ctx, code)
+}
+
+func newCache(t *testing.T) cache.Store {
+	t.Helper()
+	c := cache.NewMemoryStore()
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func TestResolve_CacheReadThrough(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := &countingStore{Store: shortlink.NewMemoryStore()}
+	mgr := shortlink.New(store, shortlink.WithCache(newCache(t)))
+
+	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com"})
+	require.NoError(t, err)
+
+	for range 3 {
+		got, err := mgr.Resolve(ctx, l.Code)
+		require.NoError(t, err)
+		assert.Equal(t, l.URL, got.URL)
+	}
+	assert.Equal(t, 1, store.gets, "second and third resolves must be cache hits")
+}
+
+func TestResolve_CacheInvalidatedOnMutation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore(), shortlink.WithCache(newCache(t)))
+
+	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com"})
+	require.NoError(t, err)
+
+	_, err = mgr.Resolve(ctx, l.Code) // warm the cache
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.Deactivate(ctx, l.Code))
+	_, err = mgr.Resolve(ctx, l.Code)
+	assert.ErrorIs(t, err, shortlink.ErrLinkDeactivated, "deactivation must not be masked by the cache")
+
+	require.NoError(t, mgr.Activate(ctx, l.Code))
+	_, err = mgr.Resolve(ctx, l.Code)
+	assert.NoError(t, err)
+
+	_, err = mgr.Resolve(ctx, l.Code) // re-warm after activation
+	require.NoError(t, err)
+	require.NoError(t, mgr.Delete(ctx, l.Code))
+	_, err = mgr.Resolve(ctx, l.Code)
+	assert.ErrorIs(t, err, shortlink.ErrNotFound, "deletion must not be masked by the cache")
+}
+
+// failingCache errors on every operation to prove Resolve degrades to the
+// store and mutations surface invalidation failures.
+type failingCache struct{ cache.Store }
+
+var errCacheDown = errors.New("cache down")
+
+func (failingCache) Get(context.Context, string) ([]byte, error) { return nil, errCacheDown }
+func (failingCache) Set(context.Context, string, []byte, ...cache.SetOption) error {
+	return errCacheDown
+}
+func (failingCache) Delete(context.Context, string) error { return errCacheDown }
+
+func TestResolve_CacheFailureFallsBackToStore(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore(), shortlink.WithCache(failingCache{}))
+
+	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com"})
+	require.NoError(t, err)
+
+	got, err := mgr.Resolve(ctx, l.Code)
+	require.NoError(t, err)
+	assert.Equal(t, l.URL, got.URL)
+}
+
+func TestMutation_SurfacesCacheInvalidateFailure(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := shortlink.New(shortlink.NewMemoryStore(), shortlink.WithCache(failingCache{}))
+
+	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com"})
+	require.NoError(t, err)
+
+	err = mgr.Deactivate(ctx, l.Code)
+	require.ErrorIs(t, err, errCacheDown)
+
+	// The store mutation itself landed even though invalidation failed.
+	got, err := mgr.Get(ctx, l.Code)
+	require.NoError(t, err)
+	assert.False(t, got.DeactivatedAt.IsZero())
+}

--- a/web/shortlink/resolve_test.go
+++ b/web/shortlink/resolve_test.go
@@ -165,7 +165,7 @@ func TestResolve_CacheFailureFallsBackToStore(t *testing.T) {
 	assert.Equal(t, l.URL, got.URL)
 }
 
-func TestMutation_SurfacesCacheInvalidateFailure(t *testing.T) {
+func TestMutation_SucceedsDespiteCacheFailure(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	mgr := shortlink.New(shortlink.NewMemoryStore(), shortlink.WithCache(failingCache{}))
@@ -173,11 +173,33 @@ func TestMutation_SurfacesCacheInvalidateFailure(t *testing.T) {
 	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com"})
 	require.NoError(t, err)
 
-	err = mgr.Deactivate(ctx, l.Code)
-	require.ErrorIs(t, err, errCacheDown)
-
-	// The store mutation itself landed even though invalidation failed.
+	// Invalidation is best-effort within the TTL staleness bound, so a
+	// broken cache must not fail the mutation itself.
+	require.NoError(t, mgr.Deactivate(ctx, l.Code))
 	got, err := mgr.Get(ctx, l.Code)
 	require.NoError(t, err)
 	assert.False(t, got.DeactivatedAt.IsZero())
+}
+
+func TestDelete_ClearsPoisonedCacheOnRetry(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := newCache(t)
+	store := shortlink.NewMemoryStore()
+	mgr := shortlink.New(store, shortlink.WithCache(c))
+
+	l, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com"})
+	require.NoError(t, err)
+	_, err = mgr.Resolve(ctx, l.Code) // warm the cache
+	require.NoError(t, err)
+
+	// Simulate a crashed earlier invalidation: the record is gone from the
+	// store while the cache still holds it.
+	require.NoError(t, store.Delete(ctx, l.Code, ""))
+
+	// A repeated Delete reports ErrNotFound but still clears the cache, so
+	// the dead link stops resolving.
+	assert.ErrorIs(t, mgr.Delete(ctx, l.Code), shortlink.ErrNotFound)
+	_, err = mgr.Resolve(ctx, l.Code)
+	assert.ErrorIs(t, err, shortlink.ErrNotFound)
 }

--- a/web/shortlink/scope_test.go
+++ b/web/shortlink/scope_test.go
@@ -1,0 +1,119 @@
+package shortlink_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/web/shortlink"
+)
+
+type tenantKey struct{}
+
+func scopeHook(ctx context.Context) (string, error) {
+	t, _ := ctx.Value(tenantKey{}).(string)
+	return t, nil
+}
+
+func tenantCtx(tenant string) context.Context {
+	return context.WithValue(context.Background(), tenantKey{}, tenant)
+}
+
+func newScoped(store shortlink.Store) *shortlink.Manager {
+	return shortlink.New(store, shortlink.WithScope(scopeHook))
+}
+
+func TestScope_CreateStampsTenant(t *testing.T) {
+	t.Parallel()
+	mgr := newScoped(shortlink.NewMemoryStore())
+
+	l, err := mgr.Create(tenantCtx("t1"), shortlink.CreateParams{URL: "https://example.com"})
+	require.NoError(t, err)
+	assert.Equal(t, "t1", l.Tenant)
+
+	// Matching explicit tenant passes; conflicting one is rejected.
+	_, err = mgr.Create(tenantCtx("t1"), shortlink.CreateParams{URL: "https://example.com", Tenant: "t1"})
+	assert.NoError(t, err)
+	_, err = mgr.Create(tenantCtx("t1"), shortlink.CreateParams{URL: "https://example.com", Tenant: "t2"})
+	assert.ErrorIs(t, err, shortlink.ErrTenantMismatch)
+}
+
+func TestScope_FailClosed(t *testing.T) {
+	t.Parallel()
+	mgr := newScoped(shortlink.NewMemoryStore())
+
+	// Empty tenant from the hook fails every management operation.
+	ctx := context.Background()
+	_, err := mgr.Create(ctx, shortlink.CreateParams{URL: "https://example.com"})
+	assert.ErrorIs(t, err, shortlink.ErrScope)
+	_, err = mgr.Get(ctx, "x")
+	assert.ErrorIs(t, err, shortlink.ErrScope)
+	_, err = mgr.List(ctx, shortlink.Filter{})
+	assert.ErrorIs(t, err, shortlink.ErrScope)
+	assert.ErrorIs(t, mgr.Deactivate(ctx, "x"), shortlink.ErrScope)
+	assert.ErrorIs(t, mgr.Activate(ctx, "x"), shortlink.ErrScope)
+	assert.ErrorIs(t, mgr.Delete(ctx, "x"), shortlink.ErrScope)
+
+	hookErr := errors.New("boom")
+	failing := shortlink.New(shortlink.NewMemoryStore(), shortlink.WithScope(
+		func(context.Context) (string, error) { return "", hookErr },
+	))
+	_, err = failing.Create(context.Background(), shortlink.CreateParams{URL: "https://example.com"})
+	assert.ErrorIs(t, err, shortlink.ErrScope)
+	assert.ErrorIs(t, err, hookErr)
+}
+
+func TestScope_CrossTenantHidden(t *testing.T) {
+	t.Parallel()
+	store := shortlink.NewMemoryStore()
+	mgr := newScoped(store)
+
+	l, err := mgr.Create(tenantCtx("t1"), shortlink.CreateParams{URL: "https://example.com"})
+	require.NoError(t, err)
+
+	// Another tenant cannot see or mutate the link.
+	_, err = mgr.Get(tenantCtx("t2"), l.Code)
+	assert.ErrorIs(t, err, shortlink.ErrNotFound)
+	assert.ErrorIs(t, mgr.Deactivate(tenantCtx("t2"), l.Code), shortlink.ErrNotFound)
+	assert.ErrorIs(t, mgr.Activate(tenantCtx("t2"), l.Code), shortlink.ErrNotFound)
+	assert.ErrorIs(t, mgr.Delete(tenantCtx("t2"), l.Code), shortlink.ErrNotFound)
+
+	// The owner still can.
+	_, err = mgr.Get(tenantCtx("t1"), l.Code)
+	assert.NoError(t, err)
+}
+
+func TestScope_ListConfined(t *testing.T) {
+	t.Parallel()
+	mgr := newScoped(shortlink.NewMemoryStore())
+
+	_, err := mgr.Create(tenantCtx("t1"), shortlink.CreateParams{URL: "https://example.com/a"})
+	require.NoError(t, err)
+	_, err = mgr.Create(tenantCtx("t2"), shortlink.CreateParams{URL: "https://example.com/b"})
+	require.NoError(t, err)
+
+	links, err := mgr.List(tenantCtx("t1"), shortlink.Filter{})
+	require.NoError(t, err)
+	require.Len(t, links, 1)
+	assert.Equal(t, "t1", links[0].Tenant)
+
+	// An explicit conflicting filter tenant is rejected, not silently widened.
+	_, err = mgr.List(tenantCtx("t1"), shortlink.Filter{Tenant: "t2"})
+	assert.ErrorIs(t, err, shortlink.ErrTenantMismatch)
+}
+
+func TestScope_ResolveUnaffected(t *testing.T) {
+	t.Parallel()
+	mgr := newScoped(shortlink.NewMemoryStore())
+
+	l, err := mgr.Create(tenantCtx("t1"), shortlink.CreateParams{URL: "https://example.com"})
+	require.NoError(t, err)
+
+	// Resolve works with no tenant in context — short codes are public.
+	got, err := mgr.Resolve(context.Background(), l.Code)
+	require.NoError(t, err)
+	assert.Equal(t, l.URL, got.URL)
+}

--- a/web/shortlink/store.go
+++ b/web/shortlink/store.go
@@ -1,0 +1,26 @@
+package shortlink
+
+import (
+	"context"
+	"time"
+)
+
+// Store persists Link records. Implementations must be safe for concurrent
+// use. Create fails with ErrDuplicate when the code already exists; lookups
+// and mutators return ErrNotFound for unknown codes. Codes are matched
+// case-sensitively (the generated alphabet is mixed-case).
+type Store interface {
+	Create(ctx context.Context, l Link) error
+	Get(ctx context.Context, code string) (Link, error)
+	// List returns records matching f, newest first (CreatedAt descending,
+	// code ascending on ties).
+	List(ctx context.Context, f Filter) ([]Link, error)
+	Deactivate(ctx context.Context, code string, at time.Time) error
+	Activate(ctx context.Context, code string) error
+	Delete(ctx context.Context, code string) error
+}
+
+// Filter narrows List. Zero fields match everything.
+type Filter struct {
+	Tenant string
+}

--- a/web/shortlink/store.go
+++ b/web/shortlink/store.go
@@ -9,18 +9,31 @@ import (
 // use. Create fails with ErrDuplicate when the code already exists; lookups
 // and mutators return ErrNotFound for unknown codes. Codes are matched
 // case-sensitively (the generated alphabet is mixed-case).
+//
+// Mutators take a tenant predicate: with a non-empty tenant the mutation
+// applies only when the record belongs to that tenant, reporting
+// ErrNotFound otherwise; an empty tenant is unconstrained. The predicate
+// must be enforced atomically with the mutation (one statement, not
+// check-then-act) — codes are reusable after Delete and vanity codes are
+// user-claimable, so a Manager-level pre-check could race a delete-and-
+// recreate and mutate another tenant's link.
 type Store interface {
 	Create(ctx context.Context, l Link) error
 	Get(ctx context.Context, code string) (Link, error)
 	// List returns records matching f, newest first (CreatedAt descending,
 	// code ascending on ties).
 	List(ctx context.Context, f Filter) ([]Link, error)
-	Deactivate(ctx context.Context, code string, at time.Time) error
-	Activate(ctx context.Context, code string) error
-	Delete(ctx context.Context, code string) error
+	// Deactivate stamps DeactivatedAt with at. A zero at leaves the link
+	// active (zero DeactivatedAt means active).
+	Deactivate(ctx context.Context, code, tenant string, at time.Time) error
+	Activate(ctx context.Context, code, tenant string) error
+	Delete(ctx context.Context, code, tenant string) error
 }
 
 // Filter narrows List. Zero fields match everything.
 type Filter struct {
+	// Tenant confines the listing to one tenant; empty matches all.
 	Tenant string
+	// Limit caps the number of records returned; 0 means no cap.
+	Limit int
 }


### PR DESCRIPTION
## Summary

Implements the `web/shortlink` catalog entry: short-code links over a storage-agnostic `Store` with optional `cache.Store` read-through.

- **Code generation** — collision-retried (5 attempts, then `ErrCodeExhausted`) over the unambiguous base58 alphabet (no `0OIl`), default length 7 (`WithCodeLength`, 58^7 ≈ 2.2e12 codes). Generated codes that land on a reserved word are re-rolled.
- **Vanity codes** — `CreateParams.Code`, validated against `[A-Za-z0-9_-]{1,64}` and a case-insensitive reserved-word blocklist (`WithReservedCodes` extends the built-in list); a taken vanity code fails with `ErrDuplicate`, never retried.
- **Server-side destinations** — destinations are stored, never carried in `?url=`; creation requires an absolute URL with a host and a scheme on the allowlist (default http/https, `WithSchemes`), so the endpoint can't be used as an open redirector.
- **Expiry & deactivation** — zero-valued `ExpiresAt`/`DeactivatedAt` mean never/active; `Resolve` reports `ErrLinkExpired`/`ErrLinkDeactivated`; the Handler redirects failures to `WithFallbackURL` when set, else 404.
- **Redirects** — 302 default, 307 opt-in, anything else (esp. a cacheable 301, which would kill hit counting forever) panics at `New`; every response carries `Cache-Control: no-store`.
- **OnHit** — fires synchronously on every successful `Resolve` with the resolved `Link`; the hook emits, counting stays the caller's job.
- **Cache read-through** — `WithCache`/`WithCacheTTL` (default 5m); cache failures degrade to the store, cache writes are best-effort, and Deactivate/Activate/Delete invalidate the entry (surfacing an invalidation failure rather than silently serving a dead link until TTL).
- **Tenancy** — `WithScope` confines Create/Get/List/Deactivate/Activate/Delete fail-closed (`ErrScope`, cross-tenant reads as `ErrNotFound`, explicit conflicts as `ErrTenantMismatch`); `Resolve`/Handler stay public — a short code is a public URL. Single-tenant use pays zero ceremony.
- **Drivers** — in-memory Store in-package; `pgstore` Postgres driver with a goose migration (`forge_short_links`, resolve = one PK point lookup) applied under its own `forge_shortlink_schema` version table.

Also deletes the shipped entry from `docs/packages.md` per the unbuilt-only catalog rule.

## Benchmarks (Apple M3 Max)

```
BenchmarkResolve-14             38478535    31.05 ns/op     0 B/op    0 allocs/op
BenchmarkResolve_CacheHit-14     1462012   823.6 ns/op    496 B/op    9 allocs/op
BenchmarkCreate_Generated-14     1416979   810.5 ns/op    650 B/op    3 allocs/op
BenchmarkHandler-14              1530253   785.0 ns/op   1296 B/op   15 allocs/op
```

Post-benchmark pass: no optimization applied — the resolve hot path is already 0 allocs; the cache-hit path is dominated by JSON decode, which is noise next to the network round-trip it replaces on a real cache backend; Create is dominated by crypto/rand. No measured win available without unjustified complexity.

## Testing

- `go test -race -cover ./web/shortlink/` — 97.5% coverage (validation, collision retry/exhaustion, scope fail-closed + cross-tenant hiding, cache read-through/invalidation/degradation, handler statuses/fallback/no-store).
- `go test -tags=integration -race -cover ./web/shortlink/pgstore/` — 89.4% coverage against real Postgres via testcontainers (round-trips, NULL time mapping, list order/tie-break, end-to-end Manager over pgstore).
- `just lint` clean (vet, golangci-lint, nilaway, betteralign, modernize, integration tier).