### PR TITLE
feat(attribution): web/attribution — marketing-touch capture package

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -73,20 +73,6 @@ filtering stay consumer-side.
 
 Deps: `core/clock`.
 
----
-
-**web/attribution**
-
-Marketing-touch capture: middleware records a configured param set
-(`utm_*`, click IDs, sub-IDs) into a signed cookie (`cookie` + `sign`)
-under first-touch or last-touch policy with an attribution window, and
-hands the stored touch back at conversion time. Includes a
-tracking-pixel endpoint (correct 1×1 GIF + no-cache). The "where did
-this signup come from" answer every SaaS wants and every affiliate
-platform requires; multi-touch models stay out.
-
-Deps: `web/cookie`, `crypto/sign`.
-
 ## view/
 
 ---

--- a/web/attribution/attribution.go
+++ b/web/attribution/attribution.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/dmitrymomot/forge/core/ctxkey"
@@ -59,10 +60,12 @@ type Tracker struct {
 	cfg   config
 }
 
-// New builds a Tracker over codec. New panics if codec is nil — that is a
-// wiring bug, not a runtime condition. The default policy is LastTouch with
-// a 30-day window over DefaultParams, stored in a "__Host-attribution"
-// cookie ("attribution" when the codec policy can't satisfy __Host-).
+// New builds a Tracker over codec. New panics on wiring bugs — a nil codec,
+// or a custom __Host- cookie name the codec policy can't satisfy (which
+// would otherwise fail every capture silently, since capture is
+// best-effort). The default policy is LastTouch with a 30-day window over
+// DefaultParams, stored in a "__Host-attribution" cookie ("attribution"
+// when the codec policy can't satisfy __Host-).
 func New(codec *cookie.Codec, opts ...Option) *Tracker {
 	if codec == nil {
 		panic("attribution: nil cookie codec")
@@ -71,14 +74,18 @@ func New(codec *cookie.Codec, opts ...Option) *Tracker {
 	if cfg.cookieName == defaultCookieName && !codec.SupportsHostPrefix() {
 		cfg.cookieName = "attribution"
 	}
+	if strings.HasPrefix(cfg.cookieName, "__Host-") && !codec.SupportsHostPrefix() {
+		panic("attribution: cookie name " + cfg.cookieName + " requires a codec with Secure, Path=/, and no Domain")
+	}
 	return &Tracker{codec: codec, cfg: cfg}
 }
 
 // Middleware captures configured params from the request query into the
 // touch cookie and exposes the effective touch to the handler chain via
 // Touch. Requests without campaign params pass through untouched — no
-// cookie read, no allocation. Capture is best-effort and never fails the
-// request.
+// cookie read or write; a request with no query string at all skips even
+// the query parse (zero allocations). Capture is best-effort and never
+// fails the request.
 func (t *Tracker) Middleware() middleware.Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/web/attribution/attribution.go
+++ b/web/attribution/attribution.go
@@ -1,0 +1,178 @@
+package attribution
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/ctxkey"
+	"github.com/dmitrymomot/forge/web/cookie"
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+var touchKey = ctxkey.New[Touch]("attribution_touch")
+
+// maxValueLen caps a single captured param value. Real click IDs stay well
+// under it; anything longer is garbage or abuse and is dropped so it cannot
+// crowd the 4 KiB cookie limit out from under the legitimate params.
+const maxValueLen = 512
+
+// Policy selects which touch wins when a visitor arrives with campaign
+// params while a valid touch is already stored.
+type Policy int
+
+const (
+	// LastTouch overwrites the stored touch on every new campaign visit —
+	// the touch closest to conversion wins (the common analytics default).
+	LastTouch Policy = iota
+	// FirstTouch keeps the original stored touch until it expires — the
+	// touch that acquired the visitor wins.
+	FirstTouch
+)
+
+// Touch is one captured marketing touch: the configured params present on
+// the visit and when it happened.
+type Touch struct {
+	// Params holds the captured query params (e.g. "utm_source" → "google").
+	Params map[string]string
+	// At is the capture time, second precision, UTC.
+	At time.Time
+}
+
+// IsZero reports whether t is the zero Touch (nothing captured).
+func (t Touch) IsZero() bool { return t.At.IsZero() }
+
+// Get returns the named param, or "" when absent.
+func (t Touch) Get(name string) string { return t.Params[name] }
+
+// wireTouch is the compact cookie payload.
+type wireTouch struct {
+	Params map[string]string `json:"p"`
+	At     int64             `json:"at"`
+}
+
+// Tracker captures marketing touches into a signed cookie and hands them
+// back at conversion time.
+type Tracker struct {
+	codec *cookie.Codec
+	cfg   config
+}
+
+// New builds a Tracker over codec. New panics if codec is nil — that is a
+// wiring bug, not a runtime condition. The default policy is LastTouch with
+// a 30-day window over DefaultParams, stored in a "__Host-attribution"
+// cookie ("attribution" when the codec policy can't satisfy __Host-).
+func New(codec *cookie.Codec, opts ...Option) *Tracker {
+	if codec == nil {
+		panic("attribution: nil cookie codec")
+	}
+	cfg := newConfig(opts...)
+	if cfg.cookieName == defaultCookieName && !codec.SupportsHostPrefix() {
+		cfg.cookieName = "attribution"
+	}
+	return &Tracker{codec: codec, cfg: cfg}
+}
+
+// Middleware captures configured params from the request query into the
+// touch cookie and exposes the effective touch to the handler chain via
+// Touch. Requests without campaign params pass through untouched — no
+// cookie read, no allocation. Capture is best-effort and never fails the
+// request.
+func (t *Tracker) Middleware() middleware.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if touch := t.capture(w, r); !touch.IsZero() {
+				r = r.WithContext(touchKey.With(r.Context(), touch))
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// Touch returns the stored touch at conversion time: the touch captured on
+// this very request (via Middleware or Pixel wiring) or the verified cookie
+// from an earlier visit. Absent, tampered, or expired touches return
+// ErrNoTouch.
+func (t *Tracker) Touch(r *http.Request) (Touch, error) {
+	if touch, ok := touchKey.From(r.Context()); ok {
+		return touch, nil
+	}
+	return t.read(r)
+}
+
+// Clear expires the touch cookie — call it after the conversion is recorded
+// so the same touch is not attributed twice.
+func (t *Tracker) Clear(w http.ResponseWriter) { t.codec.Delete(w, t.cfg.cookieName) }
+
+// capture records the request's campaign params per the policy and returns
+// the effective touch — the zero Touch when the request carries no
+// configured params or nothing valid is stored.
+func (t *Tracker) capture(w http.ResponseWriter, r *http.Request) Touch {
+	params := t.collect(r)
+	if params == nil {
+		return Touch{}
+	}
+	existing, err := t.read(r)
+	if err == nil && t.cfg.policy == FirstTouch {
+		return existing
+	}
+	touch := Touch{Params: params, At: t.cfg.clk.Now().UTC().Truncate(time.Second)}
+	if werr := t.write(w, touch); werr != nil {
+		t.cfg.log.DebugContext(r.Context(), "attribution: touch cookie write failed", slog.Any("error", werr))
+		if err == nil {
+			return existing
+		}
+		return Touch{}
+	}
+	return touch
+}
+
+// collect extracts the configured params from the request query. It returns
+// nil when none are present.
+func (t *Tracker) collect(r *http.Request) map[string]string {
+	if r.URL.RawQuery == "" {
+		return nil
+	}
+	query := r.URL.Query()
+	var out map[string]string
+	for _, name := range t.cfg.params {
+		vs, ok := query[name]
+		if !ok || len(vs) == 0 || vs[0] == "" {
+			continue
+		}
+		if len(vs[0]) > maxValueLen {
+			t.cfg.log.DebugContext(r.Context(), "attribution: param value too long, dropped", slog.String("param", name), slog.Int("len", len(vs[0])))
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string, len(t.cfg.params))
+		}
+		out[name] = vs[0]
+	}
+	return out
+}
+
+func (t *Tracker) read(r *http.Request) (Touch, error) {
+	raw, err := t.codec.GetSigned(r, t.cfg.cookieName)
+	if err != nil {
+		return Touch{}, ErrNoTouch
+	}
+	var wt wireTouch
+	if err := json.Unmarshal([]byte(raw), &wt); err != nil || wt.At <= 0 || len(wt.Params) == 0 {
+		return Touch{}, ErrNoTouch
+	}
+	at := time.Unix(wt.At, 0).UTC()
+	if t.cfg.clk.Now().Sub(at) > t.cfg.window {
+		return Touch{}, ErrNoTouch
+	}
+	return Touch{Params: wt.Params, At: at}, nil
+}
+
+func (t *Tracker) write(w http.ResponseWriter, touch Touch) error {
+	b, err := json.Marshal(wireTouch{At: touch.At.Unix(), Params: touch.Params})
+	if err != nil {
+		return err
+	}
+	return t.codec.SetSigned(w, t.cfg.cookieName, string(b), cookie.WithWriteMaxAge(t.cfg.window))
+}

--- a/web/attribution/attribution_test.go
+++ b/web/attribution/attribution_test.go
@@ -312,6 +312,35 @@ func TestNewPanicsOnNilCodec(t *testing.T) {
 	attribution.New(nil)
 }
 
+func TestNewPanicsOnIncompatibleHostPrefixName(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("custom __Host- name on a Domain-scoped codec must panic")
+		}
+	}()
+	attribution.New(newCodec(t, cookie.WithDomain("example.com")), attribution.WithCookieName("__Host-touch"))
+}
+
+func TestParamOptionsDoNotAliasCallerSlice(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	base := make([]string, 1, 2) // spare capacity invites in-place append
+	base[0] = "aff_id"
+
+	tr := attribution.New(codec, attribution.WithParams(base...), attribution.WithExtraParams("sub1"))
+	if base[:cap(base)][1] == "sub1" {
+		t.Fatal("WithExtraParams wrote into the caller's backing array")
+	}
+	_, seen, err := visit(t, tr, "/?aff_id=42&sub1=x", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen.Get("aff_id") != "42" || seen.Get("sub1") != "x" {
+		t.Fatalf("capture = %v", seen.Params)
+	}
+}
+
 func TestTouchZeroValue(t *testing.T) {
 	t.Parallel()
 	var zero attribution.Touch

--- a/web/attribution/attribution_test.go
+++ b/web/attribution/attribution_test.go
@@ -1,0 +1,324 @@
+package attribution_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+	"github.com/dmitrymomot/forge/web/attribution"
+	"github.com/dmitrymomot/forge/web/cookie"
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+func newCodec(t *testing.T, opts ...cookie.Option) *cookie.Codec {
+	t.Helper()
+	ks, err := keyset.New(keyset.WithPrimary(1, make([]byte, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := cookie.New(ks, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// visit sends a request with cookies through the tracker middleware and
+// returns the response recorder plus the touch the handler observed.
+func visit(t *testing.T, tr *attribution.Tracker, target string, cookies []*http.Cookie) (*httptest.ResponseRecorder, attribution.Touch, error) {
+	t.Helper()
+	var (
+		seen    attribution.Touch
+		seenErr error
+	)
+	h := middleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen, seenErr = tr.Touch(r)
+	}), tr.Middleware())
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	for _, ck := range cookies {
+		req.AddCookie(ck)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec, seen, seenErr
+}
+
+func TestCaptureAndConvert(t *testing.T) {
+	t.Parallel()
+	tr := attribution.New(newCodec(t))
+
+	rec, seen, err := visit(t, tr, "/?utm_source=google&utm_medium=cpc&gclid=abc123", nil)
+	if err != nil {
+		t.Fatalf("Touch on capture request: %v", err)
+	}
+	if seen.Get("utm_source") != "google" || seen.Get("utm_medium") != "cpc" || seen.Get("gclid") != "abc123" {
+		t.Fatalf("captured params = %v", seen.Params)
+	}
+	if seen.IsZero() || seen.At.IsZero() {
+		t.Fatal("captured touch has no timestamp")
+	}
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != "__Host-attribution" {
+		t.Fatalf("cookies = %v", cookies)
+	}
+
+	// Conversion on a later request: cookie round-trip, no middleware needed.
+	req := httptest.NewRequest(http.MethodPost, "/signup", nil)
+	req.AddCookie(cookies[0])
+	got, err := tr.Touch(req)
+	if err != nil {
+		t.Fatalf("Touch at conversion: %v", err)
+	}
+	if got.Get("utm_source") != "google" || !got.At.Equal(seen.At) {
+		t.Fatalf("stored touch = %+v, want %+v", got, seen)
+	}
+}
+
+func TestNoParamsNoCookie(t *testing.T) {
+	t.Parallel()
+	tr := attribution.New(newCodec(t))
+	for _, target := range []string{"/", "/?page=2&sort=asc"} {
+		rec, _, err := visit(t, tr, target, nil)
+		if !errors.Is(err, attribution.ErrNoTouch) {
+			t.Fatalf("%s: Touch err = %v, want ErrNoTouch", target, err)
+		}
+		if len(rec.Result().Cookies()) != 0 {
+			t.Fatalf("%s: unexpected cookie written", target)
+		}
+	}
+}
+
+func TestLastTouchOverwrites(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC))
+	tr := attribution.New(newCodec(t), attribution.WithClock(clk))
+
+	rec, _, _ := visit(t, tr, "/?utm_source=google", nil)
+	first := rec.Result().Cookies()
+
+	clk.Advance(time.Hour)
+	rec, seen, err := visit(t, tr, "/?utm_source=newsletter&utm_campaign=july", first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen.Get("utm_source") != "newsletter" || seen.Get("utm_campaign") != "july" {
+		t.Fatalf("last-touch params = %v", seen.Params)
+	}
+	if len(rec.Result().Cookies()) != 1 {
+		t.Fatal("last-touch visit must rewrite the cookie")
+	}
+
+	// The old touch's params are fully replaced, not merged.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(rec.Result().Cookies()[0])
+	got, err := tr.Touch(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Get("utm_source") != "newsletter" || len(got.Params) != 2 {
+		t.Fatalf("stored touch after overwrite = %v", got.Params)
+	}
+}
+
+func TestFirstTouchKeepsOriginal(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC))
+	tr := attribution.New(newCodec(t), attribution.WithPolicy(attribution.FirstTouch), attribution.WithClock(clk))
+
+	rec, _, _ := visit(t, tr, "/?utm_source=google", nil)
+	first := rec.Result().Cookies()
+
+	clk.Advance(time.Hour)
+	rec, seen, err := visit(t, tr, "/?utm_source=newsletter", first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen.Get("utm_source") != "google" {
+		t.Fatalf("first-touch source = %q, want original", seen.Get("utm_source"))
+	}
+	if len(rec.Result().Cookies()) != 0 {
+		t.Fatal("first-touch keep must not rewrite the cookie")
+	}
+}
+
+func TestFirstTouchExpiredRecaptures(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC))
+	tr := attribution.New(newCodec(t), attribution.WithPolicy(attribution.FirstTouch), attribution.WithWindow(24*time.Hour), attribution.WithClock(clk))
+
+	rec, _, _ := visit(t, tr, "/?utm_source=google", nil)
+	first := rec.Result().Cookies()
+
+	clk.Advance(25 * time.Hour)
+	_, seen, err := visit(t, tr, "/?utm_source=newsletter", first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen.Get("utm_source") != "newsletter" {
+		t.Fatalf("expired first touch must be replaced, got %q", seen.Get("utm_source"))
+	}
+}
+
+func TestWindowExpiry(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC))
+	tr := attribution.New(newCodec(t), attribution.WithWindow(24*time.Hour), attribution.WithClock(clk))
+
+	rec, _, _ := visit(t, tr, "/?utm_source=google", nil)
+	ck := rec.Result().Cookies()[0]
+	if ck.MaxAge != int((24 * time.Hour).Seconds()) {
+		t.Fatalf("cookie MaxAge = %d, want window", ck.MaxAge)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(ck)
+
+	clk.Advance(23 * time.Hour)
+	if _, err := tr.Touch(req); err != nil {
+		t.Fatalf("inside window: %v", err)
+	}
+	clk.Advance(2 * time.Hour)
+	if _, err := tr.Touch(req); !errors.Is(err, attribution.ErrNoTouch) {
+		t.Fatalf("outside window err = %v, want ErrNoTouch", err)
+	}
+}
+
+func TestTamperedCookieRejected(t *testing.T) {
+	t.Parallel()
+	tr := attribution.New(newCodec(t))
+	rec, _, _ := visit(t, tr, "/?utm_source=google", nil)
+	ck := rec.Result().Cookies()[0]
+
+	tampered := *ck
+	tampered.Value = strings.Replace(ck.Value, ck.Value[:4], "AAAA", 1)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&tampered)
+	if _, err := tr.Touch(req); !errors.Is(err, attribution.ErrNoTouch) {
+		t.Fatalf("tampered cookie err = %v, want ErrNoTouch", err)
+	}
+}
+
+func TestClear(t *testing.T) {
+	t.Parallel()
+	tr := attribution.New(newCodec(t))
+	rec := httptest.NewRecorder()
+	tr.Clear(rec)
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != "__Host-attribution" || cookies[0].MaxAge >= 0 {
+		t.Fatalf("Clear cookies = %v", cookies)
+	}
+}
+
+func TestParamHygiene(t *testing.T) {
+	t.Parallel()
+	tr := attribution.New(newCodec(t))
+
+	long := strings.Repeat("x", 600)
+	_, seen, err := visit(t, tr, "/?utm_source=google&utm_content="+long+"&utm_medium=&utm_term=a&utm_term=b", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen.Get("utm_content") != "" {
+		t.Fatal("oversized value must be dropped")
+	}
+	if seen.Get("utm_medium") != "" {
+		t.Fatal("empty value must be skipped")
+	}
+	if seen.Get("utm_term") != "a" {
+		t.Fatalf("repeated param = %q, want first value", seen.Get("utm_term"))
+	}
+	if seen.Get("utm_source") != "google" {
+		t.Fatal("valid params must survive hygiene drops")
+	}
+}
+
+func TestConfiguredParams(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+
+	replaced := attribution.New(codec, attribution.WithParams("aff_id", "sub1"))
+	_, seen, err := visit(t, replaced, "/?utm_source=google&aff_id=42&sub1=x", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen.Get("utm_source") != "" || seen.Get("aff_id") != "42" || seen.Get("sub1") != "x" {
+		t.Fatalf("WithParams capture = %v", seen.Params)
+	}
+
+	extended := attribution.New(codec, attribution.WithExtraParams("ref"))
+	_, seen, err = visit(t, extended, "/?utm_source=google&ref=friend", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen.Get("utm_source") != "google" || seen.Get("ref") != "friend" {
+		t.Fatalf("WithExtraParams capture = %v", seen.Params)
+	}
+}
+
+func TestCookieNameFallback(t *testing.T) {
+	t.Parallel()
+	// A codec with a Domain can't satisfy __Host-; the default name falls back.
+	tr := attribution.New(newCodec(t, cookie.WithDomain("example.com")))
+	rec, _, _ := visit(t, tr, "/?utm_source=google", nil)
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != "attribution" {
+		t.Fatalf("cookies = %v, want fallback name", cookies)
+	}
+
+	named := attribution.New(newCodec(t), attribution.WithCookieName("touch"))
+	rec, _, _ = visit(t, named, "/?utm_source=google", nil)
+	if cookies := rec.Result().Cookies(); len(cookies) != 1 || cookies[0].Name != "touch" {
+		t.Fatalf("cookies = %v, want custom name", cookies)
+	}
+}
+
+func TestOversizedTouchIsBestEffort(t *testing.T) {
+	t.Parallel()
+	// 17 default params near the per-value cap blow past the 4 KiB cookie
+	// limit; capture must drop the touch and never fail the request.
+	tr := attribution.New(newCodec(t))
+	var sb strings.Builder
+	for i, name := range attribution.DefaultParams() {
+		if i > 0 {
+			sb.WriteByte('&')
+		}
+		sb.WriteString(name)
+		sb.WriteByte('=')
+		sb.WriteString(strings.Repeat("v", 500))
+	}
+	rec, _, err := visit(t, tr, "/?"+sb.String(), nil)
+	// The handler observed ErrNoTouch — proof the request reached it despite
+	// the dropped write.
+	if !errors.Is(err, attribution.ErrNoTouch) {
+		t.Fatalf("Touch err = %v, want ErrNoTouch after dropped write", err)
+	}
+	if len(rec.Result().Cookies()) != 0 {
+		t.Fatal("failed write must not set a cookie")
+	}
+}
+
+func TestNewPanicsOnNilCodec(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("New(nil) must panic")
+		}
+	}()
+	attribution.New(nil)
+}
+
+func TestTouchZeroValue(t *testing.T) {
+	t.Parallel()
+	var zero attribution.Touch
+	if !zero.IsZero() {
+		t.Fatal("zero Touch must report IsZero")
+	}
+	if zero.Get("utm_source") != "" {
+		t.Fatal("Get on zero Touch must return empty")
+	}
+}

--- a/web/attribution/bench_test.go
+++ b/web/attribution/bench_test.go
@@ -1,0 +1,82 @@
+package attribution_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/crypto/keyset"
+	"github.com/dmitrymomot/forge/web/attribution"
+	"github.com/dmitrymomot/forge/web/cookie"
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+func benchTracker(b *testing.B) *attribution.Tracker {
+	b.Helper()
+	ks, err := keyset.New(keyset.WithPrimary(1, make([]byte, 32)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	codec, err := cookie.New(ks)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return attribution.New(codec)
+}
+
+var benchNoop = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+func BenchmarkMiddleware_NoQuery(b *testing.B) {
+	h := middleware.Wrap(benchNoop, benchTracker(b).Middleware())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	b.ReportAllocs()
+	for b.Loop() {
+		h.ServeHTTP(rec, req)
+	}
+}
+
+func BenchmarkMiddleware_UnrelatedQuery(b *testing.B) {
+	h := middleware.Wrap(benchNoop, benchTracker(b).Middleware())
+	req := httptest.NewRequest(http.MethodGet, "/?page=2&sort=asc&q=shoes", nil)
+	rec := httptest.NewRecorder()
+	b.ReportAllocs()
+	for b.Loop() {
+		h.ServeHTTP(rec, req)
+	}
+}
+
+func BenchmarkMiddleware_Capture(b *testing.B) {
+	h := middleware.Wrap(benchNoop, benchTracker(b).Middleware())
+	req := httptest.NewRequest(http.MethodGet, "/?utm_source=google&utm_medium=cpc&utm_campaign=launch&gclid=CjkKCQjw", nil)
+	b.ReportAllocs()
+	for b.Loop() {
+		h.ServeHTTP(httptest.NewRecorder(), req)
+	}
+}
+
+func BenchmarkTouch_CookieRead(b *testing.B) {
+	tr := benchTracker(b)
+	rec := httptest.NewRecorder()
+	h := middleware.Wrap(benchNoop, tr.Middleware())
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/?utm_source=google&utm_medium=cpc&gclid=CjkKCQjw", nil))
+	req := httptest.NewRequest(http.MethodPost, "/signup", nil)
+	for _, ck := range rec.Result().Cookies() {
+		req.AddCookie(ck)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := tr.Touch(req); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPixel(b *testing.B) {
+	h := benchTracker(b).Pixel()
+	req := httptest.NewRequest(http.MethodGet, "/pixel.gif?utm_source=email", nil)
+	b.ReportAllocs()
+	for b.Loop() {
+		h.ServeHTTP(httptest.NewRecorder(), req)
+	}
+}

--- a/web/attribution/doc.go
+++ b/web/attribution/doc.go
@@ -10,8 +10,9 @@
 // overwrite the stored touch; FirstTouch keeps the original until it
 // expires. The attribution window (default 30 days) bounds both the cookie
 // lifetime and a server-side timestamp check, so an expired touch never
-// counts even if the browser kept the cookie. Requests without campaign
-// params pass through with zero overhead.
+// counts even if the browser kept the cookie. Requests with no query string
+// pass through with zero overhead; an unrelated query string costs one
+// parse and no cookie work.
 //
 // At conversion (signup, purchase), Touch returns the stored touch —
 // persist its params with the conversion, then Clear the cookie so the

--- a/web/attribution/doc.go
+++ b/web/attribution/doc.go
@@ -1,0 +1,43 @@
+// Package attribution captures marketing touches — utm_* params, ad-platform
+// click IDs, affiliate sub-IDs — into a signed cookie and hands them back at
+// conversion time. It answers "where did this signup come from" with a
+// single stored touch per visitor.
+//
+// Middleware watches every request: when the query string carries any
+// configured param, the set is recorded as a Touch in a signed cookie
+// (web/cookie SetSigned — tamper-proof, client-readable). Which visit wins
+// is the Policy: LastTouch (default) lets every new campaign visit
+// overwrite the stored touch; FirstTouch keeps the original until it
+// expires. The attribution window (default 30 days) bounds both the cookie
+// lifetime and a server-side timestamp check, so an expired touch never
+// counts even if the browser kept the cookie. Requests without campaign
+// params pass through with zero overhead.
+//
+// At conversion (signup, purchase), Touch returns the stored touch —
+// persist its params with the conversion, then Clear the cookie so the
+// same touch is not counted twice. Pixel serves a 1×1 transparent GIF with
+// caching disabled, capturing params from the pixel URL for pages the
+// middleware can't wrap.
+//
+// # Non-goals
+//
+//   - No multi-touch models: exactly one stored touch, first or last.
+//   - No server-side touch storage or identity stitching — the cookie is
+//     the store; persisting touches against users at conversion is the
+//     consumer's insert.
+//   - No bot filtering: wrap Pixel or the middleware chain with your own
+//     gate if crawler traffic skews numbers.
+//
+// # Usage
+//
+//	codec, _ := cookie.New(ks)
+//	tracker := attribution.New(codec, attribution.WithExtraParams("ref", "aff_sub"))
+//	handler := middleware.Wrap(mux, tracker.Middleware())
+//	mux.Handle("GET /pixel.gif", tracker.Pixel())
+//
+//	// At conversion:
+//	if touch, err := tracker.Touch(r); err == nil {
+//		saveSignupSource(user, touch.Params)
+//		tracker.Clear(w)
+//	}
+package attribution

--- a/web/attribution/errors.go
+++ b/web/attribution/errors.go
@@ -1,0 +1,7 @@
+package attribution
+
+import "errors"
+
+// ErrNoTouch means no valid touch is stored: the cookie is absent,
+// tampered with, malformed, or outside the attribution window.
+var ErrNoTouch = errors.New("attribution: no touch")

--- a/web/attribution/example_test.go
+++ b/web/attribution/example_test.go
@@ -1,0 +1,36 @@
+package attribution_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/dmitrymomot/forge/crypto/keyset"
+	"github.com/dmitrymomot/forge/web/attribution"
+	"github.com/dmitrymomot/forge/web/cookie"
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+func Example() {
+	ks, _ := keyset.New(keyset.WithPrimary(1, make([]byte, 32)))
+	codec, _ := cookie.New(ks)
+	tracker := attribution.New(codec)
+
+	// The campaign landing: middleware records the touch into a signed cookie.
+	landing := middleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}), tracker.Middleware())
+	rec := httptest.NewRecorder()
+	landing.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/?utm_source=google&utm_campaign=launch", nil))
+
+	// The conversion, days later: the browser sends the cookie back.
+	signup := httptest.NewRequest(http.MethodPost, "/signup", nil)
+	for _, ck := range rec.Result().Cookies() {
+		signup.AddCookie(ck)
+	}
+	touch, err := tracker.Touch(signup)
+	if err != nil {
+		fmt.Println("organic signup")
+		return
+	}
+	fmt.Println(touch.Get("utm_source"), touch.Get("utm_campaign"))
+	// Output: google launch
+}

--- a/web/attribution/options.go
+++ b/web/attribution/options.go
@@ -1,0 +1,117 @@
+package attribution
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+const defaultCookieName = "__Host-attribution"
+
+// DefaultParams returns the params captured out of the box: the utm_* set
+// plus the click IDs of the major ad platforms (Google, Microsoft, Meta,
+// TikTok, X, LinkedIn, Pinterest, Reddit). Append affiliate sub-IDs via
+// WithExtraParams or replace the set entirely via WithParams.
+func DefaultParams() []string {
+	return []string{
+		"utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "utm_id",
+		"gclid", "gbraid", "wbraid", "dclid",
+		"msclkid",
+		"fbclid",
+		"ttclid",
+		"twclid",
+		"li_fat_id",
+		"epik",
+		"rdt_cid",
+	}
+}
+
+type config struct {
+	clk        clock.Clock
+	log        *slog.Logger
+	cookieName string
+	params     []string
+	window     time.Duration
+	policy     Policy
+}
+
+// Option configures the Tracker.
+type Option func(*config)
+
+func newConfig(opts ...Option) config {
+	cfg := config{
+		cookieName: defaultCookieName,
+		params:     DefaultParams(),
+		window:     30 * 24 * time.Hour,
+		policy:     LastTouch,
+		clk:        clock.System(),
+		log:        logger.NewNope(),
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return cfg
+}
+
+// WithPolicy selects first-touch or last-touch (default LastTouch). Values
+// other than FirstTouch behave as LastTouch.
+func WithPolicy(p Policy) Option { return func(c *config) { c.policy = p } }
+
+// WithWindow sets the attribution window (default 30 days): both the cookie
+// lifetime and the server-side cutoff past which a stored touch no longer
+// counts. Non-positive values are ignored.
+func WithWindow(d time.Duration) Option {
+	return func(c *config) {
+		if d > 0 {
+			c.window = d
+		}
+	}
+}
+
+// WithCookieName overrides the touch cookie name (default
+// "__Host-attribution", falling back to "attribution" when the codec policy
+// can't satisfy __Host-). Empty names are ignored.
+func WithCookieName(name string) Option {
+	return func(c *config) {
+		if name != "" {
+			c.cookieName = name
+		}
+	}
+}
+
+// WithParams replaces the captured param set. Empty calls are ignored.
+func WithParams(names ...string) Option {
+	return func(c *config) {
+		if len(names) > 0 {
+			c.params = names
+		}
+	}
+}
+
+// WithExtraParams appends names (e.g. affiliate sub-IDs) to the captured
+// param set.
+func WithExtraParams(names ...string) Option {
+	return func(c *config) { c.params = append(c.params, names...) }
+}
+
+// WithClock overrides the time source (default the system clock). Nil is
+// ignored.
+func WithClock(clk clock.Clock) Option {
+	return func(c *config) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+// WithLogger sets the logger for best-effort capture failures, logged at
+// Debug (default discards). Nil is ignored.
+func WithLogger(l *slog.Logger) Option {
+	return func(c *config) {
+		if l != nil {
+			c.log = l
+		}
+	}
+}

--- a/web/attribution/options.go
+++ b/web/attribution/options.go
@@ -2,6 +2,7 @@ package attribution
 
 import (
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/dmitrymomot/forge/core/clock"
@@ -72,7 +73,9 @@ func WithWindow(d time.Duration) Option {
 
 // WithCookieName overrides the touch cookie name (default
 // "__Host-attribution", falling back to "attribution" when the codec policy
-// can't satisfy __Host-). Empty names are ignored.
+// can't satisfy __Host-). A custom __Host- name on a codec that can't
+// satisfy the prefix rules panics in New — otherwise every best-effort
+// capture would fail silently. Empty names are ignored.
 func WithCookieName(name string) Option {
 	return func(c *config) {
 		if name != "" {
@@ -81,19 +84,21 @@ func WithCookieName(name string) Option {
 	}
 }
 
-// WithParams replaces the captured param set. Empty calls are ignored.
+// WithParams replaces the captured param set. The names are copied, so a
+// slice expanded into the call can be reused freely. Empty calls are
+// ignored.
 func WithParams(names ...string) Option {
 	return func(c *config) {
 		if len(names) > 0 {
-			c.params = names
+			c.params = slices.Clone(names)
 		}
 	}
 }
 
 // WithExtraParams appends names (e.g. affiliate sub-IDs) to the captured
-// param set.
+// param set without mutating any caller-owned backing array.
 func WithExtraParams(names ...string) Option {
-	return func(c *config) { c.params = append(c.params, names...) }
+	return func(c *config) { c.params = append(slices.Clip(c.params), names...) }
 }
 
 // WithClock overrides the time source (default the system clock). Nil is

--- a/web/attribution/pixel.go
+++ b/web/attribution/pixel.go
@@ -1,0 +1,39 @@
+package attribution
+
+import (
+	"net/http"
+	"strconv"
+)
+
+// pixelGIF is a 1×1 fully transparent GIF89a — the canonical 43-byte
+// tracking pixel.
+var pixelGIF = []byte{
+	0x47, 0x49, 0x46, 0x38, 0x39, 0x61, // header "GIF89a"
+	0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00, // 1×1 logical screen, 2-color global palette
+	0x00, 0x00, 0x00, 0xff, 0xff, 0xff, // palette: black, white
+	0x21, 0xf9, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00, // graphic control: color 0 transparent
+	0x2c, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, // 1×1 image descriptor
+	0x02, 0x02, 0x44, 0x01, 0x00, // LZW image data: one transparent pixel
+	0x3b, // trailer
+}
+
+// Pixel returns the tracking-pixel endpoint: it captures campaign params
+// from the pixel URL exactly like Middleware, then serves a 1×1 transparent
+// GIF with caching disabled so every impression reaches the server. Embed
+// it where the capture middleware can't run — emails don't carry cookies to
+// this endpoint, but marketing pages served off a static host do.
+func (t *Tracker) Pixel() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.capture(w, r)
+		h := w.Header()
+		h.Set("Content-Type", "image/gif")
+		h.Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+		h.Set("Pragma", "no-cache")
+		h.Set("Expires", "0")
+		h.Set("Content-Length", strconv.Itoa(len(pixelGIF)))
+		w.WriteHeader(http.StatusOK)
+		if r.Method != http.MethodHead {
+			_, _ = w.Write(pixelGIF)
+		}
+	})
+}

--- a/web/attribution/pixel_test.go
+++ b/web/attribution/pixel_test.go
@@ -1,0 +1,78 @@
+package attribution_test
+
+import (
+	"bytes"
+	"image/gif"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/attribution"
+)
+
+func TestPixelServesValidGIF(t *testing.T) {
+	t.Parallel()
+	tr := attribution.New(newCodec(t))
+	rec := httptest.NewRecorder()
+	tr.Pixel().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/pixel.gif", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "image/gif" {
+		t.Fatalf("Content-Type = %q", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store, no-cache, must-revalidate, max-age=0" {
+		t.Fatalf("Cache-Control = %q", cc)
+	}
+	if rec.Header().Get("Pragma") != "no-cache" || rec.Header().Get("Expires") != "0" {
+		t.Fatal("legacy no-cache headers missing")
+	}
+	body := rec.Body.Bytes()
+	if cl := rec.Header().Get("Content-Length"); cl != strconv.Itoa(len(body)) {
+		t.Fatalf("Content-Length = %q, body %d bytes", cl, len(body))
+	}
+	img, err := gif.Decode(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("body is not a valid GIF: %v", err)
+	}
+	if b := img.Bounds(); b.Dx() != 1 || b.Dy() != 1 {
+		t.Fatalf("pixel bounds = %v, want 1x1", b)
+	}
+}
+
+func TestPixelCapturesParams(t *testing.T) {
+	t.Parallel()
+	tr := attribution.New(newCodec(t))
+	rec := httptest.NewRecorder()
+	tr.Pixel().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/pixel.gif?utm_source=email&utm_campaign=july", nil))
+
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("cookies = %v", cookies)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(cookies[0])
+	touch, err := tr.Touch(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if touch.Get("utm_source") != "email" || touch.Get("utm_campaign") != "july" {
+		t.Fatalf("pixel-captured params = %v", touch.Params)
+	}
+}
+
+func TestPixelHeadOmitsBody(t *testing.T) {
+	t.Parallel()
+	tr := attribution.New(newCodec(t))
+	rec := httptest.NewRecorder()
+	tr.Pixel().ServeHTTP(rec, httptest.NewRequest(http.MethodHead, "/pixel.gif", nil))
+
+	if rec.Body.Len() != 0 {
+		t.Fatalf("HEAD body = %d bytes, want none", rec.Body.Len())
+	}
+	if rec.Header().Get("Content-Type") != "image/gif" || rec.Header().Get("Content-Length") == "" {
+		t.Fatal("HEAD must still carry the GIF headers")
+	}
+}


### PR DESCRIPTION
## Summary

New `web/attribution` package: captures marketing touches — `utm_*` params, ad-platform click IDs, affiliate sub-IDs — into a signed cookie and hands them back at conversion time. Answers "where did this signup come from" with exactly one stored touch per visitor; multi-touch models stay out.

- **Middleware** watches every request; when the query carries any configured param, the set is stored as a `Touch` in a signed cookie (`cookie.SetSigned`, tamper-proof). Capture is best-effort and never fails the request.
- **Policy**: `LastTouch` (default) overwrites on every new campaign visit; `FirstTouch` keeps the original until it expires. Expired first touches are replaced.
- **Attribution window** (default 30 days) bounds both the cookie `Max-Age` and a server-side timestamp check inside the signed payload, so a replayed or clock-gamed cookie past the window never counts.
- **`Touch(r)`** returns the stored touch at conversion (context first for same-request capture, verified cookie otherwise); **`Clear(w)`** expires the cookie so one touch isn't attributed twice.
- **`Pixel()`** serves the canonical 43-byte 1×1 transparent GIF with full no-cache headers (validated by `image/gif` decode in tests), capturing params from the pixel URL.
- Default param set: `utm_*` (6) + click IDs for Google (`gclid`/`gbraid`/`wbraid`/`dclid`), Microsoft, Meta, TikTok, X, LinkedIn, Pinterest, Reddit; `WithParams` replaces, `WithExtraParams` appends (sub-IDs).
- Hygiene: first value wins on repeated params, empty values skipped, values >512 bytes dropped (so junk can't crowd the 4 KiB cookie limit out from under real click IDs).
- Default cookie `__Host-attribution`, falling back to `attribution` when the codec policy can't satisfy `__Host-` (csrf precedent).
- Removes the shipped entry from `docs/packages.md` (catalog lists unbuilt packages only).

Tenancy note: like `csrf`/`cookie`, the touch cookie is inherently browser+domain scoped, so no `WithScope` seam applies (same precedent as the other web boundary packages).

## Benchmarks (Apple M3 Max)

```
BenchmarkMiddleware_NoQuery-14         192501620    6.196 ns/op       0 B/op    0 allocs/op
BenchmarkMiddleware_UnrelatedQuery-14    3237378    369.1 ns/op     448 B/op    5 allocs/op
BenchmarkMiddleware_Capture-14            382160     3165 ns/op    5259 B/op   47 allocs/op
BenchmarkTouch_CookieRead-14              471522     2588 ns/op    3016 B/op   45 allocs/op
BenchmarkPixel-14                         457978     2559 ns/op    4587 B/op   44 allocs/op
```

The hot path (no query string — the overwhelming majority of requests) is 0 allocs / ~6 ns. Capture and conversion reads run once per campaign landing / signup, dominated by HMAC verify + JSON — no perf-motivated complexity warranted (numbers above are the post-benchmark pass; the fast-path `RawQuery == ""` early return is the one measured win, taking the common case from ~370 ns/5 allocs to 6 ns/0 allocs).

## Test plan

- [x] `go test -race -cover ./web/attribution/...` — 93.6% coverage, black-box only
- [x] Capture→conversion round-trip, last-touch overwrite (full replace, no merge), first-touch keep (no cookie rewrite), expired-first-touch recapture
- [x] Window expiry server-side check, tampered-cookie rejection, oversized-touch best-effort drop (request still succeeds)
- [x] Pixel: valid 1×1 GIF (decoded), no-cache headers, HEAD omits body, params captured from pixel URL
- [x] `just lint` clean (vet, golangci-lint, nilaway, betteralign, modernize, integration tier)