### PR TITLE
feat(tenant): add data/tenant multi-tenancy package

### DIFF
--- a/data/tenant/bench_test.go
+++ b/data/tenant/bench_test.go
@@ -1,0 +1,99 @@
+package tenant_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/data/tenant"
+)
+
+func BenchmarkSubdomain(b *testing.B) {
+	resolve := tenant.Subdomain("app.example.com")
+	r := newRequest("acme.app.example.com", "/")
+	b.ReportAllocs()
+	for b.Loop() {
+		if id, _ := resolve(r); id == "" {
+			b.Fatal("expected resolution")
+		}
+	}
+}
+
+func BenchmarkSubdomainMiss(b *testing.B) {
+	resolve := tenant.Subdomain("app.example.com")
+	r := newRequest("other.example.org", "/")
+	b.ReportAllocs()
+	for b.Loop() {
+		if id, _ := resolve(r); id != "" {
+			b.Fatal("unexpected resolution")
+		}
+	}
+}
+
+func BenchmarkHeader(b *testing.B) {
+	resolve := tenant.Header("X-Tenant-ID")
+	r := newRequest("example.com", "/")
+	r.Header.Set("X-Tenant-ID", "acme")
+	b.ReportAllocs()
+	for b.Loop() {
+		if id, _ := resolve(r); id == "" {
+			b.Fatal("expected resolution")
+		}
+	}
+}
+
+func BenchmarkPathPrefix(b *testing.B) {
+	resolve := tenant.PathPrefix("/t")
+	r := newRequest("example.com", "/t/acme/dashboard")
+	b.ReportAllocs()
+	for b.Loop() {
+		if id, _ := resolve(r); id == "" {
+			b.Fatal("expected resolution")
+		}
+	}
+}
+
+func BenchmarkDomainStatic(b *testing.B) {
+	resolve := tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "acme"}))
+	r := newRequest("shop.acme.com", "/")
+	b.ReportAllocs()
+	for b.Loop() {
+		if id, _ := resolve(r); id == "" {
+			b.Fatal("expected resolution")
+		}
+	}
+}
+
+func BenchmarkMiddleware(b *testing.B) {
+	h := tenant.Middleware(
+		tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "acme"})),
+		tenant.Subdomain("app.example.com"),
+	)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	r := newRequest("acme.app.example.com", "/")
+	w := httptest.NewRecorder()
+	b.ReportAllocs()
+	for b.Loop() {
+		h.ServeHTTP(w, r)
+	}
+}
+
+func BenchmarkScopeClause(b *testing.B) {
+	ctx := tenant.NewContext(context.Background(), "acme")
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := tenant.ScopeClause(ctx, "tenant_id", "$2"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFromContext(b *testing.B) {
+	ctx := tenant.NewContext(context.Background(), "acme")
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, ok := tenant.FromContext(ctx); !ok {
+			b.Fatal("expected tenant")
+		}
+	}
+}

--- a/data/tenant/bench_test.go
+++ b/data/tenant/bench_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func BenchmarkSubdomain(b *testing.B) {
-	resolve := tenant.Subdomain("app.example.com")
+	resolve := tenant.Subdomain("app.example.com", tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"}))
 	r := newRequest("acme.app.example.com", "/")
 	b.ReportAllocs()
 	for b.Loop() {
@@ -21,7 +21,7 @@ func BenchmarkSubdomain(b *testing.B) {
 }
 
 func BenchmarkSubdomainMiss(b *testing.B) {
-	resolve := tenant.Subdomain("app.example.com")
+	resolve := tenant.Subdomain("app.example.com", tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"}))
 	r := newRequest("other.example.org", "/")
 	b.ReportAllocs()
 	for b.Loop() {
@@ -67,8 +67,8 @@ func BenchmarkDomainStatic(b *testing.B) {
 
 func BenchmarkMiddleware(b *testing.B) {
 	h := tenant.Middleware(
-		tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "acme"})),
-		tenant.Subdomain("app.example.com"),
+		tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "t_01acme"})),
+		tenant.Subdomain("app.example.com", tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"})),
 	)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	r := newRequest("acme.app.example.com", "/")
 	w := httptest.NewRecorder()

--- a/data/tenant/clause.go
+++ b/data/tenant/clause.go
@@ -1,0 +1,90 @@
+package tenant
+
+import "context"
+
+// Clause is a parameterized SQL fragment scoping a query to the current
+// tenant. The consumer concatenates SQL into the query text and passes Arg
+// as the matching argument — the scope stays visible at every query and is
+// never auto-injected:
+//
+//	c, err := tenant.ScopeClause(ctx, "tenant_id", "$2")
+//	if err != nil {
+//		return err
+//	}
+//	rows, err := db.Query(ctx,
+//		"SELECT id FROM orders WHERE status = $1 AND "+c.SQL, status, c.Arg)
+type Clause struct {
+	// SQL is the fragment, e.g. `tenant_id = $2` or `tenant_id = ?`.
+	SQL string
+	// Arg is the tenant ID to bind for the placeholder.
+	Arg string
+}
+
+// ScopeClause builds the tenant-scoping fragment `column = placeholder` for
+// the tenant in ctx. placeholder is written into the SQL verbatim, so pass
+// exactly what the query needs at that position: "$n" for pgx/postgres
+// ("$2" above) or "?" for sqlite/mysql/clickhouse.
+//
+// Fail-closed: ErrNoTenant when ctx carries no tenant. column must be a
+// plain, optionally qualified identifier (`orders.tenant_id`) and
+// placeholder must be "?" or "$n" — anything else is rejected with
+// ErrInvalidColumn / ErrInvalidPlaceholder so a misuse cannot smuggle SQL
+// into the fragment.
+func ScopeClause(ctx context.Context, column, placeholder string) (Clause, error) {
+	if !validColumn(column) {
+		return Clause{}, ErrInvalidColumn
+	}
+	if !validPlaceholder(placeholder) {
+		return Clause{}, ErrInvalidPlaceholder
+	}
+	id, err := Scope(ctx)
+	if err != nil {
+		return Clause{}, err
+	}
+	return Clause{SQL: column + " = " + placeholder, Arg: id}, nil
+}
+
+// validColumn reports whether s is an SQL identifier of the form
+// part or part.part, where each part is [A-Za-z_][A-Za-z0-9_]*.
+func validColumn(s string) bool {
+	dots := 0
+	atPartStart := true
+	for i := range len(s) {
+		switch c := s[i]; {
+		case c == '.':
+			if atPartStart {
+				return false
+			}
+			if dots++; dots > 1 {
+				return false
+			}
+			atPartStart = true
+		case c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'):
+			atPartStart = false
+		case c >= '0' && c <= '9':
+			if atPartStart {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return !atPartStart // rejects "", trailing dot, and empty parts
+}
+
+// validPlaceholder reports whether s is "?" or "$n" with n a positive
+// decimal without leading zeros.
+func validPlaceholder(s string) bool {
+	if s == "?" {
+		return true
+	}
+	if len(s) < 2 || s[0] != '$' || s[1] == '0' {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/data/tenant/clause_test.go
+++ b/data/tenant/clause_test.go
@@ -1,0 +1,81 @@
+package tenant_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/data/tenant"
+)
+
+func TestScopeClause(t *testing.T) {
+	t.Parallel()
+
+	ctx := tenant.NewContext(context.Background(), "acme")
+
+	t.Run("dollar placeholder", func(t *testing.T) {
+		t.Parallel()
+		c, err := tenant.ScopeClause(ctx, "tenant_id", "$2")
+		require.NoError(t, err)
+		assert.Equal(t, "tenant_id = $2", c.SQL)
+		assert.Equal(t, "acme", c.Arg)
+	})
+
+	t.Run("question placeholder", func(t *testing.T) {
+		t.Parallel()
+		c, err := tenant.ScopeClause(ctx, "tenant_id", "?")
+		require.NoError(t, err)
+		assert.Equal(t, "tenant_id = ?", c.SQL)
+		assert.Equal(t, "acme", c.Arg)
+	})
+
+	t.Run("qualified column", func(t *testing.T) {
+		t.Parallel()
+		c, err := tenant.ScopeClause(ctx, "orders.tenant_id", "$1")
+		require.NoError(t, err)
+		assert.Equal(t, "orders.tenant_id = $1", c.SQL)
+	})
+
+	t.Run("fails closed without tenant", func(t *testing.T) {
+		t.Parallel()
+		_, err := tenant.ScopeClause(context.Background(), "tenant_id", "$1")
+		require.ErrorIs(t, err, tenant.ErrNoTenant)
+	})
+
+	t.Run("invalid columns", func(t *testing.T) {
+		t.Parallel()
+		for _, col := range []string{
+			"", ".", "1col", "tenant-id", "tenant id", "a.b.c", "a.", ".b", "a..b",
+			"tenant_id;DROP TABLE users", `tenant_id"`, "tenant_id = $1 OR 1=1 --",
+		} {
+			_, err := tenant.ScopeClause(ctx, col, "$1")
+			assert.ErrorIs(t, err, tenant.ErrInvalidColumn, "column %q", col)
+		}
+	})
+
+	t.Run("invalid placeholders", func(t *testing.T) {
+		t.Parallel()
+		for _, ph := range []string{
+			"", "$", "$0", "$01", "$x", "$1 OR 1=1", "??", "?1", ":id", "%s", "$-1",
+		} {
+			_, err := tenant.ScopeClause(ctx, "tenant_id", ph)
+			assert.ErrorIs(t, err, tenant.ErrInvalidPlaceholder, "placeholder %q", ph)
+		}
+	})
+
+	t.Run("valid identifier shapes", func(t *testing.T) {
+		t.Parallel()
+		for _, col := range []string{"t", "_t", "T1", "a_b_c", "schema1.col2"} {
+			_, err := tenant.ScopeClause(ctx, col, "$10")
+			assert.NoError(t, err, "column %q", col)
+		}
+	})
+
+	t.Run("misuse rejected even without tenant", func(t *testing.T) {
+		t.Parallel()
+		_, err := tenant.ScopeClause(context.Background(), "bad column", "$1")
+		require.ErrorIs(t, err, tenant.ErrInvalidColumn)
+	})
+}

--- a/data/tenant/doc.go
+++ b/data/tenant/doc.go
@@ -1,0 +1,48 @@
+// Package tenant is forge's multi-tenancy package: it resolves which tenant
+// an inbound request belongs to, carries the tenant ID through context
+// transport-agnostically, and scopes SQL queries with explicit parameterized
+// fragments — visible at every query, never auto-injected.
+//
+// Resolution is a precedence-ordered chain of Resolver funcs. Shipped
+// resolvers cover the common SaaS shapes: subdomain against a base domain,
+// custom domain through the storage-agnostic DomainLookup seam, header,
+// cookie, path prefix, and a context passthrough for identities derived
+// upstream (e.g. from an API key). The first resolver returning a non-empty
+// ID wins.
+//
+// The carrier is plain context: HTTP middleware stamps it, queue handlers
+// and cron jobs call NewContext/FromContext directly — no transport
+// assumptions. Scope is the fail-closed read used as the scope hook by every
+// other forge package's WithScope option.
+//
+// Single-tenant apps skip the package entirely; multi-tenant apps opt in per
+// route and per query. Nothing is implicit: an unresolved request passes
+// through untenanted (add Require where tenancy is mandatory), and a query
+// is scoped only where a ScopeClause is visibly concatenated.
+//
+// # Usage
+//
+//	lookup := tenant.StaticDomains(map[string]string{ // real apps: DB-backed DomainLookup
+//		"shop.acme.com": "acme",
+//	})
+//
+//	mux := http.NewServeMux()
+//	mux.Handle("/orders", tenant.Require(http.HandlerFunc(listOrders)))
+//
+//	handler := tenant.Middleware(
+//		tenant.Domain(lookup),                // custom domains win,
+//		tenant.Subdomain("app.example.com"),  // then acme.app.example.com
+//	)(mux)
+//
+//	// In any handler or job:
+//	func listOrders(w http.ResponseWriter, r *http.Request) {
+//		c, err := tenant.ScopeClause(r.Context(), "tenant_id", "$1")
+//		if err != nil { /* 404/500 — never fall back unscoped */ }
+//		rows, err := db.Query(r.Context(), "SELECT id FROM orders WHERE "+c.SQL, c.Arg)
+//		// ...
+//	}
+//
+// Queue handlers carry tenancy the same way: the producer stamps the job's
+// context (or payload), the consumer restores it with NewContext, and
+// ScopeClause works unchanged.
+package tenant

--- a/data/tenant/doc.go
+++ b/data/tenant/doc.go
@@ -3,12 +3,15 @@
 // transport-agnostically, and scopes SQL queries with explicit parameterized
 // fragments — visible at every query, never auto-injected.
 //
-// Resolution is a precedence-ordered chain of Resolver funcs. Shipped
-// resolvers cover the common SaaS shapes: subdomain against a base domain,
-// custom domain through the storage-agnostic DomainLookup seam, header,
-// cookie, path prefix, and a context passthrough for identities derived
-// upstream (e.g. from an API key). The first resolver returning a non-empty
-// ID wins.
+// Resolution is a precedence-ordered chain of Resolver funcs, and every
+// resolver yields the canonical tenant ID (uuid/ulid/short id — whatever
+// the consumer's tenants table keys on), never an alias: subdomain labels
+// and custom domains are translated through the storage-agnostic
+// SubdomainLookup/DomainLookup seams, and Map adds the same translation to
+// any other resolver. Shipped resolvers cover the common SaaS shapes:
+// subdomain against a base domain, custom domain, header, cookie, path
+// prefix, and a context passthrough for identities derived upstream (e.g.
+// from an API key). The first resolver returning a non-empty ID wins.
 //
 // The carrier is plain context: HTTP middleware stamps it, queue handlers
 // and cron jobs call NewContext/FromContext directly — no transport
@@ -22,16 +25,16 @@
 //
 // # Usage
 //
-//	lookup := tenant.StaticDomains(map[string]string{ // real apps: DB-backed DomainLookup
-//		"shop.acme.com": "acme",
-//	})
+//	// Real apps back these lookups with their tenants table.
+//	domains := tenant.StaticDomains(map[string]string{"shop.acme.com": "01JT9GA6Z3"})
+//	subdomains := tenant.StaticSubdomains(map[string]string{"acme": "01JT9GA6Z3"})
 //
 //	mux := http.NewServeMux()
 //	mux.Handle("/orders", tenant.Require(http.HandlerFunc(listOrders)))
 //
 //	handler := tenant.Middleware(
-//		tenant.Domain(lookup),                // custom domains win,
-//		tenant.Subdomain("app.example.com"),  // then acme.app.example.com
+//		tenant.Domain(domains),                           // custom domains win,
+//		tenant.Subdomain("app.example.com", subdomains),  // then acme.app.example.com
 //	)(mux)
 //
 //	// In any handler or job:

--- a/data/tenant/errors.go
+++ b/data/tenant/errors.go
@@ -29,8 +29,9 @@ var (
 	// ErrEmptyName is used when Subdomain, Header, or Cookie is constructed
 	// with an empty (after normalization) base domain or name.
 	ErrEmptyName = errors.New("tenant: empty base domain or name")
-	// ErrNilLookup is used when Domain is constructed with a nil DomainLookup.
-	ErrNilLookup = errors.New("tenant: nil DomainLookup")
+	// ErrNilLookup is used when Domain or Subdomain is constructed with a
+	// nil lookup, or Map with a nil translation func.
+	ErrNilLookup = errors.New("tenant: nil lookup")
 	// ErrInvalidPrefix is used when PathPrefix is constructed with a prefix
 	// that is neither empty nor starting with "/", or that ends with "/".
 	ErrInvalidPrefix = errors.New("tenant: invalid path prefix")

--- a/data/tenant/errors.go
+++ b/data/tenant/errors.go
@@ -8,11 +8,11 @@ var (
 	// unscoped query.
 	ErrNoTenant = errors.New("tenant: no tenant in context")
 
-	// ErrDomainNotFound is returned by a DomainLookup when the domain maps
-	// to no tenant. The Domain resolver treats it as "not resolved" and the
-	// middleware continues with the next resolver; any other lookup error
-	// stops the chain.
-	ErrDomainNotFound = errors.New("tenant: domain not found")
+	// ErrTenantNotFound is returned by a DomainLookup or SubdomainLookup
+	// (and by Map translation funcs) when the alias maps to no tenant. The
+	// resolver treats it as "not resolved" and the middleware continues
+	// with the next resolver; any other lookup error stops the chain.
+	ErrTenantNotFound = errors.New("tenant: tenant not found")
 
 	// ErrInvalidColumn rejects a ScopeClause column that is not a plain,
 	// optionally qualified SQL identifier.

--- a/data/tenant/errors.go
+++ b/data/tenant/errors.go
@@ -1,0 +1,39 @@
+package tenant
+
+import "errors"
+
+var (
+	// ErrNoTenant is returned by Scope and ScopeClause when the context
+	// carries no tenant. Fail-closed: callers must not fall back to an
+	// unscoped query.
+	ErrNoTenant = errors.New("tenant: no tenant in context")
+
+	// ErrDomainNotFound is returned by a DomainLookup when the domain maps
+	// to no tenant. The Domain resolver treats it as "not resolved" and the
+	// middleware continues with the next resolver; any other lookup error
+	// stops the chain.
+	ErrDomainNotFound = errors.New("tenant: domain not found")
+
+	// ErrInvalidColumn rejects a ScopeClause column that is not a plain,
+	// optionally qualified SQL identifier.
+	ErrInvalidColumn = errors.New("tenant: invalid column identifier")
+
+	// ErrInvalidPlaceholder rejects a ScopeClause placeholder that is
+	// neither "?" nor "$n".
+	ErrInvalidPlaceholder = errors.New("tenant: invalid placeholder")
+)
+
+// Sentinel errors used as panic payloads by resolver constructors and
+// Middleware when misconfigured. Recover and match them with errors.Is.
+var (
+	// ErrEmptyName is used when Subdomain, Header, or Cookie is constructed
+	// with an empty (after normalization) base domain or name.
+	ErrEmptyName = errors.New("tenant: empty base domain or name")
+	// ErrNilLookup is used when Domain is constructed with a nil DomainLookup.
+	ErrNilLookup = errors.New("tenant: nil DomainLookup")
+	// ErrInvalidPrefix is used when PathPrefix is constructed with a prefix
+	// that is neither empty nor starting with "/", or that ends with "/".
+	ErrInvalidPrefix = errors.New("tenant: invalid path prefix")
+	// ErrNilResolver is used when Middleware is constructed with a nil Resolver.
+	ErrNilResolver = errors.New("tenant: nil resolver")
+)

--- a/data/tenant/fuzz_test.go
+++ b/data/tenant/fuzz_test.go
@@ -1,0 +1,73 @@
+package tenant_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/data/tenant"
+)
+
+// FuzzSubdomain asserts the resolver never panics or errors and that any
+// resolved label is a single dot-free DNS label sitting directly in front of
+// the base domain.
+func FuzzSubdomain(f *testing.F) {
+	f.Add("acme.app.example.com")
+	f.Add("app.example.com")
+	f.Add("a.b.app.example.com")
+	f.Add("ACME.App.Example.COM:8443")
+	f.Add("[::1]:8080")
+	f.Add("acme.app.example.com.")
+	f.Add(".app.example.com")
+	f.Add("xn--bcher-kva.app.example.com")
+
+	resolve := tenant.Subdomain("app.example.com")
+	f.Fuzz(func(t *testing.T, host string) {
+		r := newRequest("example.com", "/")
+		r.Host = host
+		id, err := resolve(r)
+		if err != nil {
+			t.Fatalf("Subdomain returned error for host %q: %v", host, err)
+		}
+		if id == "" {
+			return
+		}
+		if strings.ContainsRune(id, '.') {
+			t.Fatalf("resolved label %q contains a dot (host %q)", id, host)
+		}
+		if !strings.Contains(strings.ToLower(host), id+".app.example.com") {
+			t.Fatalf("resolved label %q not found in host %q", id, host)
+		}
+	})
+}
+
+// FuzzPathPrefix asserts the resolver never panics or errors and that any
+// resolved segment is slash-free and present in the path.
+func FuzzPathPrefix(f *testing.F) {
+	f.Add("/t/acme/dashboard")
+	f.Add("/t/acme")
+	f.Add("/t/")
+	f.Add("/t")
+	f.Add("/team/acme")
+	f.Add("/")
+	f.Add("")
+	f.Add("/t//double")
+
+	resolve := tenant.PathPrefix("/t")
+	f.Fuzz(func(t *testing.T, path string) {
+		r := newRequest("example.com", "/")
+		r.URL.Path = path
+		id, err := resolve(r)
+		if err != nil {
+			t.Fatalf("PathPrefix returned error for path %q: %v", path, err)
+		}
+		if id == "" {
+			return
+		}
+		if strings.ContainsRune(id, '/') {
+			t.Fatalf("resolved segment %q contains a slash (path %q)", id, path)
+		}
+		if !strings.HasPrefix(path, "/t/"+id) {
+			t.Fatalf("resolved segment %q is not the segment after /t in %q", id, path)
+		}
+	})
+}

--- a/data/tenant/fuzz_test.go
+++ b/data/tenant/fuzz_test.go
@@ -1,6 +1,7 @@
 package tenant_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -9,7 +10,8 @@ import (
 
 // FuzzSubdomain asserts the resolver never panics or errors and that any
 // resolved label is a single dot-free DNS label sitting directly in front of
-// the base domain.
+// the base domain. The echo lookup returns the label itself so the
+// properties check pure extraction.
 func FuzzSubdomain(f *testing.F) {
 	f.Add("acme.app.example.com")
 	f.Add("app.example.com")
@@ -20,7 +22,10 @@ func FuzzSubdomain(f *testing.F) {
 	f.Add(".app.example.com")
 	f.Add("xn--bcher-kva.app.example.com")
 
-	resolve := tenant.Subdomain("app.example.com")
+	echo := subdomainLookupFunc(func(_ context.Context, subdomain string) (string, error) {
+		return subdomain, nil
+	})
+	resolve := tenant.Subdomain("app.example.com", echo)
 	f.Fuzz(func(t *testing.T, host string) {
 		r := newRequest("example.com", "/")
 		r.Host = host

--- a/data/tenant/middleware.go
+++ b/data/tenant/middleware.go
@@ -10,8 +10,10 @@ import (
 // stamped on the request context via NewContext, overriding any tenant
 // already there (give a pre-existing context tenant an explicit slot with
 // the Context resolver). A resolver error responds 500 with a generic body
-// and does not call next. When nothing resolves, next runs untenanted so
-// single-tenant routes coexist; add Require where tenancy is mandatory.
+// and does not call next. When nothing resolves, the request passes through
+// unchanged: a tenant stamped by an upstream middleware is preserved, and a
+// request with none stays untenanted so single-tenant routes coexist; add
+// Require where tenancy is mandatory.
 //
 // The returned wrapper satisfies web/middleware.Middleware structurally.
 // Panics with ErrNilResolver when any resolver is nil.

--- a/data/tenant/middleware.go
+++ b/data/tenant/middleware.go
@@ -1,0 +1,57 @@
+package tenant
+
+import (
+	"net/http"
+	"slices"
+)
+
+// Middleware resolves the tenant for each request through resolvers in
+// precedence order: the first resolver returning a non-empty ID wins and is
+// stamped on the request context via NewContext, overriding any tenant
+// already there (give a pre-existing context tenant an explicit slot with
+// the Context resolver). A resolver error responds 500 with a generic body
+// and does not call next. When nothing resolves, next runs untenanted so
+// single-tenant routes coexist; add Require where tenancy is mandatory.
+//
+// The returned wrapper satisfies web/middleware.Middleware structurally.
+// Panics with ErrNilResolver when any resolver is nil.
+func Middleware(resolvers ...Resolver) func(http.Handler) http.Handler {
+	for _, resolve := range resolvers {
+		if resolve == nil {
+			panic(ErrNilResolver)
+		}
+	}
+	chain := slices.Clone(resolvers)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for _, resolve := range chain {
+				id, err := resolve(r)
+				if err != nil {
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+					return
+				}
+				if id != "" {
+					r = r.WithContext(NewContext(r.Context(), id))
+					break
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// Require is a guard middleware responding 404 Not Found when the request
+// context carries no tenant. 404 — not 401/403 — because an unresolved
+// tenant host has nothing there, and the status leaks nothing about
+// tenancy. Place it after Middleware on routes where tenancy is mandatory:
+//
+//	middleware.Chain(tenant.Middleware(resolvers...), tenant.Require)
+func Require(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := FromContext(r.Context()); !ok {
+			http.NotFound(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/data/tenant/middleware_test.go
+++ b/data/tenant/middleware_test.go
@@ -1,0 +1,147 @@
+package tenant_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/data/tenant"
+)
+
+// captureTenant records the tenant seen by the wrapped handler.
+func captureTenant(id *string, ok *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*id, *ok = tenant.FromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestMiddleware(t *testing.T) {
+	t.Parallel()
+
+	t.Run("first non-empty resolver wins", func(t *testing.T) {
+		t.Parallel()
+		var id string
+		var ok bool
+		h := tenant.Middleware(
+			tenant.Header("X-Missing"),
+			tenant.Header("X-First"),
+			tenant.Header("X-Second"),
+		)(captureTenant(&id, &ok))
+
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-First", "alpha")
+		r.Header.Set("X-Second", "beta")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		require.True(t, ok)
+		assert.Equal(t, "alpha", id)
+	})
+
+	t.Run("unresolved passes through untenanted", func(t *testing.T) {
+		t.Parallel()
+		var id string
+		var ok bool
+		h := tenant.Middleware(tenant.Header("X-Tenant-ID"))(captureTenant(&id, &ok))
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newRequest("example.com", "/"))
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.False(t, ok)
+	})
+
+	t.Run("resolver error responds 500 and skips next", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		boom := errors.New("lookup down")
+		h := tenant.Middleware(func(*http.Request) (string, error) { return "", boom })(
+			http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newRequest("example.com", "/"))
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.False(t, called)
+	})
+
+	t.Run("resolution overrides pre-existing context tenant", func(t *testing.T) {
+		t.Parallel()
+		var id string
+		var ok bool
+		h := tenant.Middleware(tenant.Header("X-Tenant-ID"))(captureTenant(&id, &ok))
+
+		r := newRequest("example.com", "/")
+		r = r.WithContext(tenant.NewContext(r.Context(), "upstream"))
+		r.Header.Set("X-Tenant-ID", "resolved")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		require.True(t, ok)
+		assert.Equal(t, "resolved", id)
+	})
+
+	t.Run("Context resolver slots upstream tenant into precedence", func(t *testing.T) {
+		t.Parallel()
+		var id string
+		var ok bool
+		h := tenant.Middleware(tenant.Context(), tenant.Header("X-Tenant-ID"))(captureTenant(&id, &ok))
+
+		r := newRequest("example.com", "/")
+		r = r.WithContext(tenant.NewContext(r.Context(), "upstream"))
+		r.Header.Set("X-Tenant-ID", "header")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		require.True(t, ok)
+		assert.Equal(t, "upstream", id)
+	})
+
+	t.Run("no resolvers is identity-ish", func(t *testing.T) {
+		t.Parallel()
+		var ok bool
+		var id string
+		h := tenant.Middleware()(captureTenant(&id, &ok))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newRequest("example.com", "/"))
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.False(t, ok)
+	})
+
+	t.Run("nil resolver panics at construction", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrNilResolver, func() {
+			tenant.Middleware(tenant.Context(), nil)
+		})
+	})
+}
+
+func TestRequire(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("tenanted request passes", func(t *testing.T) {
+		t.Parallel()
+		r := newRequest("example.com", "/")
+		r = r.WithContext(tenant.NewContext(r.Context(), "acme"))
+		w := httptest.NewRecorder()
+		tenant.Require(next).ServeHTTP(w, r)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("untenanted request gets 404", func(t *testing.T) {
+		t.Parallel()
+		w := httptest.NewRecorder()
+		tenant.Require(next).ServeHTTP(w, newRequest("example.com", "/"))
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}

--- a/data/tenant/middleware_test.go
+++ b/data/tenant/middleware_test.go
@@ -103,6 +103,21 @@ func TestMiddleware(t *testing.T) {
 		assert.Equal(t, "upstream", id)
 	})
 
+	t.Run("upstream tenant survives when nothing resolves", func(t *testing.T) {
+		t.Parallel()
+		var id string
+		var ok bool
+		h := tenant.Middleware(tenant.Header("X-Tenant-ID"))(captureTenant(&id, &ok))
+
+		r := newRequest("example.com", "/")
+		r = r.WithContext(tenant.NewContext(r.Context(), "upstream"))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		require.True(t, ok)
+		assert.Equal(t, "upstream", id)
+	})
+
 	t.Run("no resolvers is identity-ish", func(t *testing.T) {
 		t.Parallel()
 		var ok bool

--- a/data/tenant/resolver.go
+++ b/data/tenant/resolver.go
@@ -1,0 +1,197 @@
+package tenant
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/textproto"
+	"strings"
+)
+
+// Resolver extracts a tenant identifier from an HTTP request. Returning
+// ("", nil) means "not resolved" and the middleware tries the next resolver
+// in the chain; a non-empty ID resolves the request; a non-nil error stops
+// the chain and the middleware responds 500.
+//
+// Resolvers return the raw identifier they saw (subdomain label, header
+// value, path segment). A consumer that keys tenants on something else wraps
+// a Resolver — it is a plain func — or maps inside its DomainLookup.
+type Resolver func(r *http.Request) (string, error)
+
+// DomainLookup maps a full custom domain to a tenant ID. Implementations
+// return ErrDomainNotFound when the domain maps to no tenant; any other
+// error is treated as infrastructure failure and stops resolution.
+type DomainLookup interface {
+	TenantByDomain(ctx context.Context, domain string) (string, error)
+}
+
+// Subdomain resolves the tenant from the first DNS label in front of base:
+// with base "app.example.com", host "acme.app.example.com" resolves "acme".
+// The bare base and nested labels ("a.b.app.example.com") do not resolve.
+// Hosts are compared case-insensitively with any port, IPv6 brackets, and
+// trailing FQDN dot stripped.
+//
+// Reserved names (www, api, ...) are not special-cased: exclude them in your
+// handler or by wrapping the returned Resolver. Panics with ErrEmptyName
+// when base normalizes to "".
+func Subdomain(base string) Resolver {
+	base = normalizeHost(base)
+	if base == "" {
+		panic(ErrEmptyName)
+	}
+	return func(r *http.Request) (string, error) {
+		host := normalizeHost(r.Host)
+		rest, ok := strings.CutSuffix(host, base)
+		if !ok || len(rest) < 2 || rest[len(rest)-1] != '.' {
+			return "", nil
+		}
+		label := rest[:len(rest)-1]
+		if strings.IndexByte(label, '.') >= 0 {
+			return "", nil
+		}
+		return label, nil
+	}
+}
+
+// Domain resolves the tenant by looking up the full (normalized) request
+// host through lookup — the custom-domain path of a white-label SaaS.
+// ErrDomainNotFound from the lookup means "not resolved" and the chain
+// continues; any other error stops the chain. Panics with ErrNilLookup when
+// lookup is nil.
+func Domain(lookup DomainLookup) Resolver {
+	if lookup == nil {
+		panic(ErrNilLookup)
+	}
+	return func(r *http.Request) (string, error) {
+		host := normalizeHost(r.Host)
+		if host == "" {
+			return "", nil
+		}
+		id, err := lookup.TenantByDomain(r.Context(), host)
+		if err != nil {
+			if errors.Is(err, ErrDomainNotFound) {
+				return "", nil
+			}
+			return "", err
+		}
+		return id, nil
+	}
+}
+
+// Header resolves the tenant from a request header, e.g. "X-Tenant-ID".
+//
+// The value is attacker-controlled on any edge-facing listener: use this
+// resolver only behind a trusted gateway that sets or strips the header, or
+// for internal service-to-service traffic. Panics with ErrEmptyName when
+// name is empty.
+func Header(name string) Resolver {
+	if name == "" {
+		panic(ErrEmptyName)
+	}
+	// Pre-canonicalize so Header.Get's own canonicalization hits its no-alloc
+	// fast path on every request ("X-Tenant-ID" would otherwise allocate as
+	// its canonical form is "X-Tenant-Id").
+	name = textproto.CanonicalMIMEHeaderKey(name)
+	return func(r *http.Request) (string, error) {
+		return r.Header.Get(name), nil
+	}
+}
+
+// Cookie resolves the tenant from a cookie value. Like Header, the value is
+// client-controlled — pair it with authorization checks downstream. Panics
+// with ErrEmptyName when name is empty.
+func Cookie(name string) Resolver {
+	if name == "" {
+		panic(ErrEmptyName)
+	}
+	return func(r *http.Request) (string, error) {
+		c, err := r.Cookie(name)
+		if err != nil { // only http.ErrNoCookie is possible
+			return "", nil
+		}
+		return c.Value, nil
+	}
+}
+
+// PathPrefix resolves the tenant from the path segment following prefix:
+// PathPrefix("/t") resolves "acme" from "/t/acme/dashboard", and
+// PathPrefix("") resolves the first segment ("/acme/dashboard"). The path is
+// never rewritten — stripping the prefix stays a routing concern. prefix
+// must be empty or start with "/" and not end with "/"; otherwise the
+// constructor panics with ErrInvalidPrefix.
+func PathPrefix(prefix string) Resolver {
+	if prefix != "" && (prefix[0] != '/' || prefix[len(prefix)-1] == '/') {
+		panic(ErrInvalidPrefix)
+	}
+	return func(r *http.Request) (string, error) {
+		rest, ok := strings.CutPrefix(r.URL.Path, prefix)
+		if !ok || len(rest) < 2 || rest[0] != '/' {
+			return "", nil
+		}
+		seg := rest[1:]
+		if i := strings.IndexByte(seg, '/'); i >= 0 {
+			seg = seg[:i]
+		}
+		return seg, nil
+	}
+}
+
+// Context resolves a tenant already stamped on the request context by an
+// upstream middleware — e.g. API-key authentication that called NewContext
+// after verifying the key. Middleware overrides any pre-existing context
+// tenant, so this resolver is how a context-derived tenant gets an explicit
+// slot in the precedence order.
+func Context() Resolver {
+	return func(r *http.Request) (string, error) {
+		id, _ := FromContext(r.Context())
+		return id, nil
+	}
+}
+
+// staticDomains is the in-memory DomainLookup for tests and development.
+type staticDomains map[string]string
+
+// StaticDomains returns an immutable in-memory DomainLookup for tests and
+// development. Keys are normalized like request hosts (lowercased, port and
+// trailing dot stripped); entries with an empty tenant ID are dropped.
+func StaticDomains(domains map[string]string) DomainLookup {
+	s := make(staticDomains, len(domains))
+	for domain, id := range domains {
+		if d := normalizeHost(domain); d != "" && id != "" {
+			s[d] = id
+		}
+	}
+	return s
+}
+
+func (s staticDomains) TenantByDomain(_ context.Context, domain string) (string, error) {
+	if id, ok := s[normalizeHost(domain)]; ok {
+		return id, nil
+	}
+	return "", ErrDomainNotFound
+}
+
+// normalizeHost lowercases the host, strips any port, removes IPv6 brackets,
+// and trims a trailing FQDN dot. It allocates only on strings.ToLower's slow
+// path (uppercase input); an already-lowercase host returns sub-slices with
+// no copy.
+//
+// net.SplitHostPort is deliberately avoided: it allocates an *AddrError
+// whenever the host has no port (the common proxied/HTTP2 case).
+func normalizeHost(host string) string {
+	if host == "" {
+		return ""
+	}
+	if host[0] == '[' { // IPv6 literal: "[::1]" or "[::1]:8080"
+		i := strings.IndexByte(host, ']')
+		if i < 0 {
+			return "" // malformed: opening '[' with no closing ']'
+		}
+		host = host[1:i] // inside brackets; drops "]" and any ":port" after it
+	} else if i := strings.LastIndexByte(host, ':'); i >= 0 &&
+		strings.IndexByte(host, ':') == i {
+		host = host[:i] // exactly one colon => host:port (not bracketless IPv6)
+	}
+	host = strings.TrimSuffix(host, ".") // rooted FQDN "example.com."
+	return strings.ToLower(host)
+}

--- a/data/tenant/resolver.go
+++ b/data/tenant/resolver.go
@@ -8,36 +8,50 @@ import (
 	"strings"
 )
 
-// Resolver extracts a tenant identifier from an HTTP request. Returning
+// Resolver resolves the canonical tenant ID (uuid/ulid/short id — whatever
+// the consumer's tenants table keys on) from an HTTP request. Returning
 // ("", nil) means "not resolved" and the middleware tries the next resolver
 // in the chain; a non-empty ID resolves the request; a non-nil error stops
 // the chain and the middleware responds 500.
 //
-// Resolvers return the raw identifier they saw (subdomain label, header
-// value, path segment). A consumer that keys tenants on something else wraps
-// a Resolver — it is a plain func — or maps inside its DomainLookup.
+// A subdomain label, custom domain, or URL slug is an alias, never the ID:
+// Subdomain and Domain translate aliases through their lookup seams, and Map
+// decorates any other Resolver with the same translation step.
 type Resolver func(r *http.Request) (string, error)
 
 // DomainLookup maps a full custom domain to a tenant ID. Implementations
-// return ErrDomainNotFound when the domain maps to no tenant; any other
+// return ErrTenantNotFound when the domain maps to no tenant; any other
 // error is treated as infrastructure failure and stops resolution.
 type DomainLookup interface {
 	TenantByDomain(ctx context.Context, domain string) (string, error)
 }
 
-// Subdomain resolves the tenant from the first DNS label in front of base:
-// with base "app.example.com", host "acme.app.example.com" resolves "acme".
-// The bare base and nested labels ("a.b.app.example.com") do not resolve.
-// Hosts are compared case-insensitively with any port, IPv6 brackets, and
-// trailing FQDN dot stripped.
+// SubdomainLookup maps a subdomain label ("acme") to a tenant ID.
+// Implementations return ErrTenantNotFound when the label maps to no
+// tenant; any other error is treated as infrastructure failure and stops
+// resolution.
+type SubdomainLookup interface {
+	TenantBySubdomain(ctx context.Context, subdomain string) (string, error)
+}
+
+// Subdomain resolves the tenant from the first DNS label in front of base,
+// translated to a tenant ID through lookup: with base "app.example.com",
+// host "acme.app.example.com" looks up "acme". The bare base and nested
+// labels ("a.b.app.example.com") do not resolve. Hosts are compared
+// case-insensitively with any port, IPv6 brackets, and trailing FQDN dot
+// stripped.
 //
-// Reserved names (www, api, ...) are not special-cased: exclude them in your
-// handler or by wrapping the returned Resolver. Panics with ErrEmptyName
-// when base normalizes to "".
-func Subdomain(base string) Resolver {
+// Reserved names (www, api, ...) are not special-cased — the lookup decides:
+// return ErrTenantNotFound for them and the chain continues. Panics with
+// ErrEmptyName when base normalizes to "" and with ErrNilLookup when lookup
+// is nil.
+func Subdomain(base string, lookup SubdomainLookup) Resolver {
 	base = normalizeHost(base)
 	if base == "" {
 		panic(ErrEmptyName)
+	}
+	if lookup == nil {
+		panic(ErrNilLookup)
 	}
 	return func(r *http.Request) (string, error) {
 		host := normalizeHost(r.Host)
@@ -49,13 +63,20 @@ func Subdomain(base string) Resolver {
 		if strings.IndexByte(label, '.') >= 0 {
 			return "", nil
 		}
-		return label, nil
+		id, err := lookup.TenantBySubdomain(r.Context(), label)
+		if err != nil {
+			if errors.Is(err, ErrTenantNotFound) {
+				return "", nil
+			}
+			return "", err
+		}
+		return id, nil
 	}
 }
 
 // Domain resolves the tenant by looking up the full (normalized) request
 // host through lookup — the custom-domain path of a white-label SaaS.
-// ErrDomainNotFound from the lookup means "not resolved" and the chain
+// ErrTenantNotFound from the lookup means "not resolved" and the chain
 // continues; any other error stops the chain. Panics with ErrNilLookup when
 // lookup is nil.
 func Domain(lookup DomainLookup) Resolver {
@@ -69,7 +90,7 @@ func Domain(lookup DomainLookup) Resolver {
 		}
 		id, err := lookup.TenantByDomain(r.Context(), host)
 		if err != nil {
-			if errors.Is(err, ErrDomainNotFound) {
+			if errors.Is(err, ErrTenantNotFound) {
 				return "", nil
 			}
 			return "", err
@@ -79,6 +100,8 @@ func Domain(lookup DomainLookup) Resolver {
 }
 
 // Header resolves the tenant from a request header, e.g. "X-Tenant-ID".
+// The header is expected to carry the tenant ID itself; wrap with Map when
+// it carries an alias instead.
 //
 // The value is attacker-controlled on any edge-facing listener: use this
 // resolver only behind a trusted gateway that sets or strips the header, or
@@ -97,7 +120,8 @@ func Header(name string) Resolver {
 	}
 }
 
-// Cookie resolves the tenant from a cookie value. Like Header, the value is
+// Cookie resolves the tenant from a cookie expected to carry the tenant ID
+// itself (wrap with Map for aliases). Like Header, the value is
 // client-controlled — pair it with authorization checks downstream. Panics
 // with ErrEmptyName when name is empty.
 func Cookie(name string) Resolver {
@@ -114,11 +138,12 @@ func Cookie(name string) Resolver {
 }
 
 // PathPrefix resolves the tenant from the path segment following prefix:
-// PathPrefix("/t") resolves "acme" from "/t/acme/dashboard", and
-// PathPrefix("") resolves the first segment ("/acme/dashboard"). The path is
-// never rewritten — stripping the prefix stays a routing concern. prefix
-// must be empty or start with "/" and not end with "/"; otherwise the
-// constructor panics with ErrInvalidPrefix.
+// PathPrefix("/t") resolves "t_123" from "/t/t_123/dashboard", and
+// PathPrefix("") resolves the first segment. The segment is expected to
+// carry the tenant ID itself; wrap with Map when your URLs carry slugs. The
+// path is never rewritten — stripping the prefix stays a routing concern.
+// prefix must be empty or start with "/" and not end with "/"; otherwise
+// the constructor panics with ErrInvalidPrefix.
 func PathPrefix(prefix string) Resolver {
 	if prefix != "" && (prefix[0] != '/' || prefix[len(prefix)-1] == '/') {
 		panic(ErrInvalidPrefix)
@@ -148,12 +173,48 @@ func Context() Resolver {
 	}
 }
 
+// Map decorates r, translating every value it resolves through fn — the
+// alias→tenant-ID step for resolvers that see aliases the shipped lookups
+// don't cover, e.g. a slug in the URL path:
+//
+//	tenant.Map(tenant.PathPrefix("/t"), func(ctx context.Context, slug string) (string, error) {
+//		return tenants.IDBySlug(ctx, slug) // ErrTenantNotFound to continue the chain
+//	})
+//
+// fn runs only when r resolved a non-empty value; ErrTenantNotFound from fn
+// means "not resolved" and the chain continues, any other error stops the
+// chain. Panics with ErrNilResolver when r is nil and ErrNilLookup when fn
+// is nil.
+func Map(r Resolver, fn func(ctx context.Context, value string) (string, error)) Resolver {
+	if r == nil {
+		panic(ErrNilResolver)
+	}
+	if fn == nil {
+		panic(ErrNilLookup)
+	}
+	return func(req *http.Request) (string, error) {
+		value, err := r(req)
+		if err != nil || value == "" {
+			return "", err
+		}
+		id, err := fn(req.Context(), value)
+		if err != nil {
+			if errors.Is(err, ErrTenantNotFound) {
+				return "", nil
+			}
+			return "", err
+		}
+		return id, nil
+	}
+}
+
 // staticDomains is the in-memory DomainLookup for tests and development.
 type staticDomains map[string]string
 
 // StaticDomains returns an immutable in-memory DomainLookup for tests and
-// development. Keys are normalized like request hosts (lowercased, port and
-// trailing dot stripped); entries with an empty tenant ID are dropped.
+// development, mapping custom domains to tenant IDs. Keys are normalized
+// like request hosts (lowercased, port and trailing dot stripped); entries
+// with an empty tenant ID are dropped.
 func StaticDomains(domains map[string]string) DomainLookup {
 	s := make(staticDomains, len(domains))
 	for domain, id := range domains {
@@ -168,7 +229,31 @@ func (s staticDomains) TenantByDomain(_ context.Context, domain string) (string,
 	if id, ok := s[normalizeHost(domain)]; ok {
 		return id, nil
 	}
-	return "", ErrDomainNotFound
+	return "", ErrTenantNotFound
+}
+
+// staticSubdomains is the in-memory SubdomainLookup for tests and development.
+type staticSubdomains map[string]string
+
+// StaticSubdomains returns an immutable in-memory SubdomainLookup for tests
+// and development, mapping subdomain labels to tenant IDs. Keys are
+// lowercased to match the normalized labels the Subdomain resolver looks
+// up; entries with an empty key or tenant ID are dropped.
+func StaticSubdomains(subdomains map[string]string) SubdomainLookup {
+	s := make(staticSubdomains, len(subdomains))
+	for label, id := range subdomains {
+		if label != "" && id != "" {
+			s[strings.ToLower(label)] = id
+		}
+	}
+	return s
+}
+
+func (s staticSubdomains) TenantBySubdomain(_ context.Context, subdomain string) (string, error) {
+	if id, ok := s[subdomain]; ok {
+		return id, nil
+	}
+	return "", ErrTenantNotFound
 }
 
 // normalizeHost lowercases the host, strips any port, removes IPv6 brackets,

--- a/data/tenant/resolver_test.go
+++ b/data/tenant/resolver_test.go
@@ -19,20 +19,28 @@ func newRequest(host, path string) *http.Request {
 	return r
 }
 
+type subdomainLookupFunc func(ctx context.Context, subdomain string) (string, error)
+
+func (f subdomainLookupFunc) TenantBySubdomain(ctx context.Context, subdomain string) (string, error) {
+	return f(ctx, subdomain)
+}
+
 func TestSubdomain(t *testing.T) {
 	t.Parallel()
 
-	resolve := tenant.Subdomain("app.example.com")
+	lookup := tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"})
+	resolve := tenant.Subdomain("app.example.com", lookup)
 	tests := []struct{ name, host, want string }{
-		{"single label", "acme.app.example.com", "acme"},
+		{"single label", "acme.app.example.com", "t_01acme"},
+		{"unknown label continues chain", "other.app.example.com", ""},
 		{"bare base", "app.example.com", ""},
 		{"nested labels", "a.b.app.example.com", ""},
 		{"unrelated host", "other.example.org", ""},
 		{"suffix but not label boundary", "notapp.example.com", ""},
 		{"embedded base not suffix", "app.example.com.evil.io", ""},
-		{"with port", "acme.app.example.com:8443", "acme"},
-		{"uppercase", "ACME.App.Example.COM", "acme"},
-		{"trailing FQDN dot", "acme.app.example.com.", "acme"},
+		{"with port", "acme.app.example.com:8443", "t_01acme"},
+		{"uppercase", "ACME.App.Example.COM", "t_01acme"},
+		{"trailing FQDN dot", "acme.app.example.com.", "t_01acme"},
 		{"empty host", "", ""},
 		{"dot only prefix", ".app.example.com", ""},
 		{"ipv6 literal", "[::1]:8080", ""},
@@ -48,15 +56,146 @@ func TestSubdomain(t *testing.T) {
 
 	t.Run("base is normalized at construction", func(t *testing.T) {
 		t.Parallel()
-		resolve := tenant.Subdomain("App.Example.COM:443")
+		resolve := tenant.Subdomain("App.Example.COM:443", lookup)
 		id, err := resolve(newRequest("acme.app.example.com", "/"))
 		require.NoError(t, err)
-		assert.Equal(t, "acme", id)
+		assert.Equal(t, "t_01acme", id)
+	})
+
+	t.Run("lookup receives the normalized label", func(t *testing.T) {
+		t.Parallel()
+		var got string
+		resolve := tenant.Subdomain("app.example.com", subdomainLookupFunc(func(_ context.Context, subdomain string) (string, error) {
+			got = subdomain
+			return "t_1", nil
+		}))
+		_, err := resolve(newRequest("ACME.app.example.com:8443", "/"))
+		require.NoError(t, err)
+		assert.Equal(t, "acme", got)
+	})
+
+	t.Run("lookup skipped when no label matches", func(t *testing.T) {
+		t.Parallel()
+		resolve := tenant.Subdomain("app.example.com", subdomainLookupFunc(func(context.Context, string) (string, error) {
+			t.Fatal("lookup must not run without a matched label")
+			return "", nil
+		}))
+		id, err := resolve(newRequest("app.example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("infrastructure error stops chain", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("db down")
+		resolve := tenant.Subdomain("app.example.com", subdomainLookupFunc(func(context.Context, string) (string, error) {
+			return "", boom
+		}))
+		_, err := resolve(newRequest("acme.app.example.com", "/"))
+		require.ErrorIs(t, err, boom)
 	})
 
 	t.Run("empty base panics", func(t *testing.T) {
 		t.Parallel()
-		assert.PanicsWithValue(t, tenant.ErrEmptyName, func() { tenant.Subdomain("") })
+		assert.PanicsWithValue(t, tenant.ErrEmptyName, func() { tenant.Subdomain("", lookup) })
+	})
+
+	t.Run("nil lookup panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrNilLookup, func() { tenant.Subdomain("app.example.com", nil) })
+	})
+}
+
+func TestStaticSubdomains(t *testing.T) {
+	t.Parallel()
+
+	lookup := tenant.StaticSubdomains(map[string]string{
+		"Acme":  "t_01acme",
+		"":      "dropped",
+		"empty": "",
+	})
+
+	t.Run("keys lowercased at construction", func(t *testing.T) {
+		t.Parallel()
+		id, err := lookup.TenantBySubdomain(context.Background(), "acme")
+		require.NoError(t, err)
+		assert.Equal(t, "t_01acme", id)
+	})
+
+	t.Run("unknown label", func(t *testing.T) {
+		t.Parallel()
+		_, err := lookup.TenantBySubdomain(context.Background(), "other")
+		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
+	})
+
+	t.Run("empty-key and empty-ID entries dropped", func(t *testing.T) {
+		t.Parallel()
+		_, err := lookup.TenantBySubdomain(context.Background(), "")
+		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
+		_, err = lookup.TenantBySubdomain(context.Background(), "empty")
+		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
+	})
+}
+
+func TestMap(t *testing.T) {
+	t.Parallel()
+
+	slugToID := func(_ context.Context, slug string) (string, error) {
+		if slug == "acme" {
+			return "t_01acme", nil
+		}
+		return "", tenant.ErrTenantNotFound
+	}
+
+	t.Run("translates resolved value", func(t *testing.T) {
+		t.Parallel()
+		resolve := tenant.Map(tenant.PathPrefix("/t"), slugToID)
+		id, err := resolve(newRequest("example.com", "/t/acme/dashboard"))
+		require.NoError(t, err)
+		assert.Equal(t, "t_01acme", id)
+	})
+
+	t.Run("ErrTenantNotFound continues chain", func(t *testing.T) {
+		t.Parallel()
+		resolve := tenant.Map(tenant.PathPrefix("/t"), slugToID)
+		id, err := resolve(newRequest("example.com", "/t/other/dashboard"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("fn skipped when inner resolver misses", func(t *testing.T) {
+		t.Parallel()
+		resolve := tenant.Map(tenant.PathPrefix("/t"), func(context.Context, string) (string, error) {
+			t.Fatal("fn must not run for an unresolved value")
+			return "", nil
+		})
+		id, err := resolve(newRequest("example.com", "/orders"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("inner resolver error propagates without fn", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("inner failed")
+		resolve := tenant.Map(func(*http.Request) (string, error) { return "", boom }, slugToID)
+		_, err := resolve(newRequest("example.com", "/"))
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("fn error stops chain", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("db down")
+		resolve := tenant.Map(tenant.PathPrefix("/t"), func(context.Context, string) (string, error) {
+			return "", boom
+		})
+		_, err := resolve(newRequest("example.com", "/t/acme"))
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("nil arguments panic", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrNilResolver, func() { tenant.Map(nil, slugToID) })
+		assert.PanicsWithValue(t, tenant.ErrNilLookup, func() { tenant.Map(tenant.Context(), nil) })
 	})
 }
 
@@ -139,13 +278,13 @@ func TestStaticDomains(t *testing.T) {
 	t.Run("unknown domain", func(t *testing.T) {
 		t.Parallel()
 		_, err := lookup.TenantByDomain(context.Background(), "other.example.com")
-		require.ErrorIs(t, err, tenant.ErrDomainNotFound)
+		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
 	})
 
 	t.Run("empty-ID entries dropped", func(t *testing.T) {
 		t.Parallel()
 		_, err := lookup.TenantByDomain(context.Background(), "empty.example.com")
-		require.ErrorIs(t, err, tenant.ErrDomainNotFound)
+		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
 	})
 }
 

--- a/data/tenant/resolver_test.go
+++ b/data/tenant/resolver_test.go
@@ -1,0 +1,270 @@
+package tenant_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/data/tenant"
+)
+
+func newRequest(host, path string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "http://placeholder"+path, nil)
+	r.Host = host
+	return r
+}
+
+func TestSubdomain(t *testing.T) {
+	t.Parallel()
+
+	resolve := tenant.Subdomain("app.example.com")
+	tests := []struct{ name, host, want string }{
+		{"single label", "acme.app.example.com", "acme"},
+		{"bare base", "app.example.com", ""},
+		{"nested labels", "a.b.app.example.com", ""},
+		{"unrelated host", "other.example.org", ""},
+		{"suffix but not label boundary", "notapp.example.com", ""},
+		{"embedded base not suffix", "app.example.com.evil.io", ""},
+		{"with port", "acme.app.example.com:8443", "acme"},
+		{"uppercase", "ACME.App.Example.COM", "acme"},
+		{"trailing FQDN dot", "acme.app.example.com.", "acme"},
+		{"empty host", "", ""},
+		{"dot only prefix", ".app.example.com", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			id, err := resolve(newRequest(tt.host, "/"))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, id)
+		})
+	}
+
+	t.Run("base is normalized at construction", func(t *testing.T) {
+		t.Parallel()
+		resolve := tenant.Subdomain("App.Example.COM:443")
+		id, err := resolve(newRequest("acme.app.example.com", "/"))
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("empty base panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrEmptyName, func() { tenant.Subdomain("") })
+	})
+}
+
+type lookupFunc func(ctx context.Context, domain string) (string, error)
+
+func (f lookupFunc) TenantByDomain(ctx context.Context, domain string) (string, error) {
+	return f(ctx, domain)
+}
+
+func TestDomain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("found", func(t *testing.T) {
+		t.Parallel()
+		resolve := tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "acme"}))
+		id, err := resolve(newRequest("shop.acme.com", "/"))
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("not found continues chain", func(t *testing.T) {
+		t.Parallel()
+		resolve := tenant.Domain(tenant.StaticDomains(nil))
+		id, err := resolve(newRequest("unknown.example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("lookup receives normalized host", func(t *testing.T) {
+		t.Parallel()
+		var got string
+		resolve := tenant.Domain(lookupFunc(func(_ context.Context, domain string) (string, error) {
+			got = domain
+			return "acme", nil
+		}))
+		_, err := resolve(newRequest("Shop.Acme.COM:8443", "/"))
+		require.NoError(t, err)
+		assert.Equal(t, "shop.acme.com", got)
+	})
+
+	t.Run("infrastructure error stops chain", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("db down")
+		resolve := tenant.Domain(lookupFunc(func(context.Context, string) (string, error) {
+			return "", boom
+		}))
+		_, err := resolve(newRequest("shop.acme.com", "/"))
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("nil lookup panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrNilLookup, func() { tenant.Domain(nil) })
+	})
+}
+
+func TestStaticDomains(t *testing.T) {
+	t.Parallel()
+
+	lookup := tenant.StaticDomains(map[string]string{
+		"Shop.Acme.com:443": "acme",
+		"":                  "dropped",
+		"empty.example.com": "",
+	})
+
+	t.Run("keys normalized at construction", func(t *testing.T) {
+		t.Parallel()
+		id, err := lookup.TenantByDomain(context.Background(), "shop.acme.com")
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("lookup input normalized", func(t *testing.T) {
+		t.Parallel()
+		id, err := lookup.TenantByDomain(context.Background(), "SHOP.acme.com.")
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("unknown domain", func(t *testing.T) {
+		t.Parallel()
+		_, err := lookup.TenantByDomain(context.Background(), "other.example.com")
+		require.ErrorIs(t, err, tenant.ErrDomainNotFound)
+	})
+
+	t.Run("empty-ID entries dropped", func(t *testing.T) {
+		t.Parallel()
+		_, err := lookup.TenantByDomain(context.Background(), "empty.example.com")
+		require.ErrorIs(t, err, tenant.ErrDomainNotFound)
+	})
+}
+
+func TestHeader(t *testing.T) {
+	t.Parallel()
+
+	resolve := tenant.Header("X-Tenant-ID")
+
+	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "acme")
+		id, err := resolve(r)
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		id, err := resolve(newRequest("example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("empty name panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrEmptyName, func() { tenant.Header("") })
+	})
+}
+
+func TestCookie(t *testing.T) {
+	t.Parallel()
+
+	resolve := tenant.Cookie("tenant")
+
+	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+		r := newRequest("example.com", "/")
+		r.AddCookie(&http.Cookie{Name: "tenant", Value: "acme"})
+		id, err := resolve(r)
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		id, err := resolve(newRequest("example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("empty name panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrEmptyName, func() { tenant.Cookie("") })
+	})
+}
+
+func TestPathPrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with prefix", func(t *testing.T) {
+		t.Parallel()
+		resolve := tenant.PathPrefix("/t")
+		tests := []struct{ name, path, want string }{
+			{"segment after prefix", "/t/acme/dashboard", "acme"},
+			{"segment only", "/t/acme", "acme"},
+			{"trailing slash", "/t/acme/", "acme"},
+			{"prefix only", "/t", ""},
+			{"prefix with bare slash", "/t/", ""},
+			{"prefix not a segment boundary", "/team/acme", ""},
+			{"other path", "/orders", ""},
+			{"root", "/", ""},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				id, err := resolve(newRequest("example.com", tt.path))
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, id)
+			})
+		}
+	})
+
+	t.Run("empty prefix takes first segment", func(t *testing.T) {
+		t.Parallel()
+		resolve := tenant.PathPrefix("")
+		id, err := resolve(newRequest("example.com", "/acme/dashboard"))
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+
+		id, err = resolve(newRequest("example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("invalid prefix panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrInvalidPrefix, func() { tenant.PathPrefix("t") })
+		assert.PanicsWithValue(t, tenant.ErrInvalidPrefix, func() { tenant.PathPrefix("/t/") })
+	})
+}
+
+func TestContextResolver(t *testing.T) {
+	t.Parallel()
+
+	resolve := tenant.Context()
+
+	t.Run("stamped upstream", func(t *testing.T) {
+		t.Parallel()
+		r := newRequest("example.com", "/")
+		r = r.WithContext(tenant.NewContext(r.Context(), "acme"))
+		id, err := resolve(r)
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		id, err := resolve(newRequest("example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+}

--- a/data/tenant/resolver_test.go
+++ b/data/tenant/resolver_test.go
@@ -35,6 +35,7 @@ func TestSubdomain(t *testing.T) {
 		{"trailing FQDN dot", "acme.app.example.com.", "acme"},
 		{"empty host", "", ""},
 		{"dot only prefix", ".app.example.com", ""},
+		{"ipv6 literal", "[::1]:8080", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -192,6 +193,15 @@ func TestCookie(t *testing.T) {
 	t.Run("absent", func(t *testing.T) {
 		t.Parallel()
 		id, err := resolve(newRequest("example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("empty value reads as not resolved", func(t *testing.T) {
+		t.Parallel()
+		r := newRequest("example.com", "/")
+		r.Header.Set("Cookie", "tenant=")
+		id, err := resolve(r)
 		require.NoError(t, err)
 		assert.Empty(t, id)
 	})

--- a/data/tenant/tenant.go
+++ b/data/tenant/tenant.go
@@ -1,0 +1,34 @@
+package tenant
+
+import "context"
+
+// ctxKey is the unexported context key for the tenant ID. A struct{} key is
+// collision-free across packages because the type itself is unexported.
+type ctxKey struct{}
+
+// NewContext returns a copy of ctx carrying the tenant ID. It is the
+// transport-agnostic carrier: HTTP middleware, queue handlers, and cron jobs
+// all stamp the tenant the same way.
+func NewContext(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, ctxKey{}, id)
+}
+
+// FromContext returns the tenant ID carried by ctx. ok is false when no
+// tenant was stamped or the stamped ID is empty.
+func FromContext(ctx context.Context) (string, bool) {
+	id, _ := ctx.Value(ctxKey{}).(string)
+	return id, id != ""
+}
+
+// Scope returns the tenant ID from ctx, failing closed with ErrNoTenant when
+// absent or empty. Its signature matches the WithScope option of every other
+// forge package, so it plugs in directly:
+//
+//	mgr := apikey.New(store, apikey.WithScope(tenant.Scope))
+func Scope(ctx context.Context) (string, error) {
+	id, ok := FromContext(ctx)
+	if !ok {
+		return "", ErrNoTenant
+	}
+	return id, nil
+}

--- a/data/tenant/tenant_test.go
+++ b/data/tenant/tenant_test.go
@@ -1,0 +1,68 @@
+package tenant_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/data/tenant"
+)
+
+func TestContextCarrier(t *testing.T) {
+	t.Parallel()
+
+	t.Run("round trip", func(t *testing.T) {
+		t.Parallel()
+		ctx := tenant.NewContext(context.Background(), "acme")
+		id, ok := tenant.FromContext(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		id, ok := tenant.FromContext(context.Background())
+		assert.False(t, ok)
+		assert.Empty(t, id)
+	})
+
+	t.Run("empty ID reads as absent", func(t *testing.T) {
+		t.Parallel()
+		ctx := tenant.NewContext(context.Background(), "")
+		_, ok := tenant.FromContext(ctx)
+		assert.False(t, ok)
+	})
+
+	t.Run("inner stamp wins", func(t *testing.T) {
+		t.Parallel()
+		ctx := tenant.NewContext(tenant.NewContext(context.Background(), "outer"), "inner")
+		id, ok := tenant.FromContext(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, "inner", id)
+	})
+}
+
+func TestScope(t *testing.T) {
+	t.Parallel()
+
+	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+		id, err := tenant.Scope(tenant.NewContext(context.Background(), "acme"))
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("fails closed when absent", func(t *testing.T) {
+		t.Parallel()
+		_, err := tenant.Scope(context.Background())
+		require.ErrorIs(t, err, tenant.ErrNoTenant)
+	})
+
+	t.Run("fails closed on empty ID", func(t *testing.T) {
+		t.Parallel()
+		_, err := tenant.Scope(tenant.NewContext(context.Background(), ""))
+		require.ErrorIs(t, err, tenant.ErrNoTenant)
+	})
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -166,20 +166,6 @@ Deps: `crypto/sign`.
 
 ---
 
-**data/tenant**
-
-The multi-tenancy package: `Resolver` chain with shipped resolvers —
-subdomain (against a base domain), custom domain (via a storage-agnostic
-`DomainLookup` seam), header, cookie, path prefix, API-key-derived —
-precedence-ordered middleware putting `TenantID` in context, a
-transport-agnostic carrier (queue handlers set/read tenant without
-HTTP), and explicit parameterized `ScopeClause` SQL fragments — visible at
-every query, never auto-injected.
-
-Deps: none (stdlib only).
-
----
-
 **data/dataloader**
 
 Generic per-request batch-and-cache loader collapsing N+1 lookups; pure

--- a/docs/superpowers/specs/2026-07-17-data-tenant-design.md
+++ b/docs/superpowers/specs/2026-07-17-data-tenant-design.md
@@ -10,10 +10,13 @@ The multi-tenancy package: resolve which tenant an inbound request (or job) belo
 
 ## Non-goals
 
-- No tenant registry/CRUD (consumer domain; `DomainLookup` is the only storage seam).
+- No tenant registry/CRUD (consumer domain; `DomainLookup`/`SubdomainLookup` are the only storage seams).
 - No automatic query rewriting or ORM hooks — ScopeClause is built and concatenated by the consumer, visibly.
-- No slug→canonical-ID mapping: resolvers return the raw identifier they saw; consumers that key on something else wrap a `Resolver` (it is a plain func) or map inside `DomainLookup`.
 - No path rewriting in `PathPrefix` — routing stays the consumer's concern.
+
+## Aliases vs tenant IDs
+
+A resolver always yields the canonical tenant ID (uuid/ulid/short id — whatever the consumer's tenants table keys on), never an alias. Subdomain labels and custom domains are aliases and are translated through lookup seams inside their resolvers; `Map` adds the same translation step to any other resolver (e.g. slugs in `PathPrefix` URLs). `Header`/`Cookie`/`PathPrefix` are documented as carrying the ID itself unless wrapped with `Map`.
 
 ## API
 
@@ -35,24 +38,28 @@ The context key is an unexported package-level key (stdlib-only; same collision-
 type Resolver func(r *http.Request) (string, error)
 ```
 
-Contract: `("", nil)` = not resolved, chain continues; non-empty = resolved; error = stop the chain (middleware responds 500). Shipped constructors:
+Contract: `("", nil)` = not resolved, chain continues; non-empty = resolved tenant ID; error = stop the chain (middleware responds 500). Shipped constructors:
 
-- `Subdomain(base string) Resolver` — resolves `acme` from `acme.<base>`. Host is normalized (port stripped, IPv6 brackets, trailing FQDN dot, lowercased — hostrouter's zero-alloc approach). Resolves only when exactly one label precedes the base (nested `a.b.<base>` and the bare base do not resolve). Reserved names (`www`, `api`, …) are NOT special-cased — exclude them in your handler or by wrapping the resolver.
-- `Domain(lookup DomainLookup) Resolver` — custom domains. Normalized full host is looked up; `ErrDomainNotFound` continues the chain, any other error stops it.
-- `Header(name string) Resolver` — trusts a request header (`X-Tenant-ID`). For internal traffic behind a trusted gateway only; documented loudly.
-- `Cookie(name string) Resolver` — cookie value.
-- `PathPrefix(prefix string) Resolver` — tenant is the path segment after `prefix` (`PathPrefix("/t")`: `/t/acme/dash` → `acme`); `PathPrefix("")`: first segment. Never rewrites the path.
+- `Subdomain(base string, lookup SubdomainLookup) Resolver` — extracts the label `acme` from `acme.<base>` and translates it to a tenant ID through lookup. Host is normalized (port stripped, IPv6 brackets, trailing FQDN dot, lowercased — hostrouter's zero-alloc approach). Extracts only when exactly one label precedes the base (nested `a.b.<base>` and the bare base do not resolve). Reserved names (`www`, `api`, …) are NOT special-cased — the lookup returns `ErrTenantNotFound` for them and the chain continues.
+- `Domain(lookup DomainLookup) Resolver` — custom domains. Normalized full host is looked up; `ErrTenantNotFound` continues the chain, any other error stops it.
+- `Header(name string) Resolver` — trusts a request header (`X-Tenant-ID`) carrying the tenant ID itself. For internal traffic behind a trusted gateway only; documented loudly.
+- `Cookie(name string) Resolver` — cookie value carrying the tenant ID itself.
+- `PathPrefix(prefix string) Resolver` — tenant ID is the path segment after `prefix` (`PathPrefix("/t")`: `/t/t_123/dash` → `t_123`); `PathPrefix("")`: first segment. Never rewrites the path; wrap with `Map` when URLs carry slugs.
 - `Context() Resolver` — reads a tenant already stamped on the request context by an upstream middleware (e.g. API-key auth that called `NewContext`). Gives ctx-derived tenancy an explicit slot in the precedence order.
+- `Map(r Resolver, fn func(ctx, value) (string, error)) Resolver` — decorates any resolver with an alias→ID translation; `ErrTenantNotFound` from fn continues the chain.
 
-### DomainLookup seam (resolver.go)
+### Lookup seams (resolver.go)
 
 ```go
 type DomainLookup interface {
     TenantByDomain(ctx context.Context, domain string) (string, error)
 }
+type SubdomainLookup interface {
+    TenantBySubdomain(ctx context.Context, subdomain string) (string, error)
+}
 ```
 
-Return `ErrDomainNotFound` (sentinel owned here) when the domain is unknown. `StaticDomains(map[string]string) DomainLookup` ships as the in-memory implementation for tests/dev; keys are normalized at construction.
+Return `ErrTenantNotFound` (sentinel owned here, shared by both seams and Map fns) when the alias is unknown. `StaticDomains(map[string]string) DomainLookup` and `StaticSubdomains(map[string]string) SubdomainLookup` ship as the in-memory implementations for tests/dev; keys are normalized at construction.
 
 ### Middleware (middleware.go)
 
@@ -88,7 +95,7 @@ rows, err := db.Query(ctx, "SELECT id FROM orders WHERE status = $1 AND "+c.SQL,
 
 ### Errors (errors.go)
 
-`ErrNoTenant`, `ErrDomainNotFound`, `ErrInvalidColumn`, `ErrInvalidPlaceholder` — single-line, `errors.Is`-matchable.
+`ErrNoTenant`, `ErrTenantNotFound`, `ErrInvalidColumn`, `ErrInvalidPlaceholder` — single-line, `errors.Is`-matchable.
 
 ## Layout
 

--- a/docs/superpowers/specs/2026-07-17-data-tenant-design.md
+++ b/docs/superpowers/specs/2026-07-17-data-tenant-design.md
@@ -1,0 +1,110 @@
+# data/tenant — Design
+
+Date: 2026-07-17. Catalog entry: `docs/packages.md` (data/tenant). Deps: none (stdlib only).
+
+## Purpose
+
+The multi-tenancy package: resolve which tenant an inbound request (or job) belongs to, carry the tenant ID through context transport-agnostically, and scope SQL queries to that tenant with explicit, parameterized fragments — visible at every query, never auto-injected.
+
+`tenant.Scope` is the canonical scope hook the rest of forge composes with: every package exposing `WithScope(fn func(context.Context) (string, error))` accepts it directly.
+
+## Non-goals
+
+- No tenant registry/CRUD (consumer domain; `DomainLookup` is the only storage seam).
+- No automatic query rewriting or ORM hooks — ScopeClause is built and concatenated by the consumer, visibly.
+- No slug→canonical-ID mapping: resolvers return the raw identifier they saw; consumers that key on something else wrap a `Resolver` (it is a plain func) or map inside `DomainLookup`.
+- No path rewriting in `PathPrefix` — routing stays the consumer's concern.
+
+## API
+
+### Carrier (tenant.go)
+
+```go
+func NewContext(ctx context.Context, id string) context.Context
+func FromContext(ctx context.Context) (string, bool)   // false when absent or empty
+func Scope(ctx context.Context) (string, error)        // fail-closed: ErrNoTenant when absent/empty
+```
+
+`Scope`'s signature intentionally matches every forge `WithScope` option: `apikey.WithScope(tenant.Scope)`.
+
+The context key is an unexported package-level key (stdlib-only; same collision-free shape as `core/ctxkey` without the dep).
+
+### Resolver seam (resolver.go)
+
+```go
+type Resolver func(r *http.Request) (string, error)
+```
+
+Contract: `("", nil)` = not resolved, chain continues; non-empty = resolved; error = stop the chain (middleware responds 500). Shipped constructors:
+
+- `Subdomain(base string) Resolver` — resolves `acme` from `acme.<base>`. Host is normalized (port stripped, IPv6 brackets, trailing FQDN dot, lowercased — hostrouter's zero-alloc approach). Resolves only when exactly one label precedes the base (nested `a.b.<base>` and the bare base do not resolve). Reserved names (`www`, `api`, …) are NOT special-cased — exclude them in your handler or by wrapping the resolver.
+- `Domain(lookup DomainLookup) Resolver` — custom domains. Normalized full host is looked up; `ErrDomainNotFound` continues the chain, any other error stops it.
+- `Header(name string) Resolver` — trusts a request header (`X-Tenant-ID`). For internal traffic behind a trusted gateway only; documented loudly.
+- `Cookie(name string) Resolver` — cookie value.
+- `PathPrefix(prefix string) Resolver` — tenant is the path segment after `prefix` (`PathPrefix("/t")`: `/t/acme/dash` → `acme`); `PathPrefix("")`: first segment. Never rewrites the path.
+- `Context() Resolver` — reads a tenant already stamped on the request context by an upstream middleware (e.g. API-key auth that called `NewContext`). Gives ctx-derived tenancy an explicit slot in the precedence order.
+
+### DomainLookup seam (resolver.go)
+
+```go
+type DomainLookup interface {
+    TenantByDomain(ctx context.Context, domain string) (string, error)
+}
+```
+
+Return `ErrDomainNotFound` (sentinel owned here) when the domain is unknown. `StaticDomains(map[string]string) DomainLookup` ships as the in-memory implementation for tests/dev; keys are normalized at construction.
+
+### Middleware (middleware.go)
+
+```go
+func Middleware(resolvers ...Resolver) func(http.Handler) http.Handler
+func Require(next http.Handler) http.Handler
+```
+
+- `Middleware`: precedence-ordered — first resolver returning a non-empty ID wins and is stamped via `NewContext` (overriding any pre-existing ctx tenant; use `Context()` in the chain to give the pre-existing value a precedence slot). A resolver error responds `500 Internal Server Error` (generic body, no leak) and does not call next. No resolution → next runs untenanted (single-tenant routes coexist).
+- `Require`: guard middleware responding `404 Not Found` when the context carries no tenant. 404, not 401/403 — an unresolved tenant host is "nothing here", and 404 leaks nothing about tenancy. Both satisfy `web/middleware.Middleware` structurally (no import).
+
+### ScopeClause (clause.go)
+
+```go
+type Clause struct {
+    SQL string // "tenant_id = $3" / "tenant_id = ?"
+    Arg string // tenant ID from ctx
+}
+
+func ScopeClause(ctx context.Context, column, placeholder string) (Clause, error)
+```
+
+- `placeholder` is literally what appears in the SQL: `"$3"` (pgx/postgres) or `"?"` (sqlite/mysql/clickhouse). What you pass is what you read in the query — no dialect enum, no hidden numbering.
+- Fail-closed: no tenant in ctx → `ErrNoTenant`.
+- `column` must match `[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?` (optionally qualified identifier) → else `ErrInvalidColumn`. `placeholder` must be `?` or `$<digits>` → else `ErrInvalidPlaceholder`. Both guard against accidental injection through misuse; they are programmer-error checks, validated without regexp on the hot path.
+
+Usage:
+
+```go
+c, err := tenant.ScopeClause(ctx, "tenant_id", "$2")
+rows, err := db.Query(ctx, "SELECT id FROM orders WHERE status = $1 AND "+c.SQL, status, c.Arg)
+```
+
+### Errors (errors.go)
+
+`ErrNoTenant`, `ErrDomainNotFound`, `ErrInvalidColumn`, `ErrInvalidPlaceholder` — single-line, `errors.Is`-matchable.
+
+## Layout
+
+`doc.go` (runnable example) · `tenant.go` · `resolver.go` · `middleware.go` · `clause.go` · `errors.go` · black-box tests (`package tenant_test`) · `fuzz_test.go` (Subdomain/PathPrefix/normalizeHost) · `bench_test.go`.
+
+## Performance
+
+- Host normalization allocates only on uppercase input (sub-slicing otherwise) — hostrouter precedent.
+- Resolver hot paths (Subdomain, Header, PathPrefix) target zero allocations; middleware allocates only the one unavoidable `context.WithValue` per resolved request.
+- Identifier/placeholder validation is byte-loop, no regexp.
+- `bench_test.go` covers each resolver, the middleware end-to-end, and ScopeClause; post-benchmark optimization pass with before/after in the PR.
+
+## Testing
+
+Unit-only (no DB): carrier round-trip and fail-closed Scope; every resolver's match/no-match/error cases incl. host edge cases (port, IPv6, FQDN dot, case, nested labels, bare base); middleware precedence, override-of-preexisting-ctx, 500-on-error, pass-through; Require; StaticDomains normalization; ScopeClause valid/missing-tenant/bad-column/bad-placeholder; fuzz the parsers.
+
+## Catalog
+
+The PR deletes the `data/tenant` entry from `docs/packages.md` (unbuilt-only rule). Cross-references to `tenant` in other entries stay.

--- a/docs/superpowers/specs/2026-07-17-data-tenant-design.md
+++ b/docs/superpowers/specs/2026-07-17-data-tenant-design.md
@@ -61,7 +61,7 @@ func Middleware(resolvers ...Resolver) func(http.Handler) http.Handler
 func Require(next http.Handler) http.Handler
 ```
 
-- `Middleware`: precedence-ordered — first resolver returning a non-empty ID wins and is stamped via `NewContext` (overriding any pre-existing ctx tenant; use `Context()` in the chain to give the pre-existing value a precedence slot). A resolver error responds `500 Internal Server Error` (generic body, no leak) and does not call next. No resolution → next runs untenanted (single-tenant routes coexist).
+- `Middleware`: precedence-ordered — first resolver returning a non-empty ID wins and is stamped via `NewContext` (overriding any pre-existing ctx tenant; use `Context()` in the chain to give the pre-existing value a precedence slot). A resolver error responds `500 Internal Server Error` (generic body, no leak) and does not call next. No resolution → the request passes through unchanged: a tenant stamped upstream is preserved, a request with none stays untenanted (single-tenant routes coexist).
 - `Require`: guard middleware responding `404 Not Found` when the context carries no tenant. 404, not 401/403 — an unresolved tenant host is "nothing here", and 404 leaks nothing about tenancy. Both satisfy `web/middleware.Middleware` structurally (no import).
 
 ### ScopeClause (clause.go)
@@ -92,7 +92,7 @@ rows, err := db.Query(ctx, "SELECT id FROM orders WHERE status = $1 AND "+c.SQL,
 
 ## Layout
 
-`doc.go` (runnable example) · `tenant.go` · `resolver.go` · `middleware.go` · `clause.go` · `errors.go` · black-box tests (`package tenant_test`) · `fuzz_test.go` (Subdomain/PathPrefix/normalizeHost) · `bench_test.go`.
+`doc.go` (runnable example) · `tenant.go` · `resolver.go` · `middleware.go` · `clause.go` · `errors.go` · black-box tests (`package tenant_test`) · `fuzz_test.go` (Subdomain/PathPrefix; host normalization is exercised through the Subdomain target) · `bench_test.go`.
 
 ## Performance
 


### PR DESCRIPTION
## Summary

Ships the `data/tenant` catalog entry: forge's multi-tenancy package. Stdlib only.

- **Resolver chain** — `type Resolver func(*http.Request) (string, error)` with `("", nil)` = not resolved / try next. Shipped: `Subdomain(base)`, `Domain(lookup)` over the storage-agnostic `DomainLookup` seam (+ `StaticDomains` in-memory impl), `Header(name)`, `Cookie(name)`, `PathPrefix(prefix)`, and `Context()` (gives an upstream-stamped tenant — e.g. API-key-derived — an explicit precedence slot).
- **Middleware** — `Middleware(resolvers...)`: precedence-ordered, first non-empty ID wins and overrides any pre-existing ctx tenant; resolver error → generic 500; unresolved → request passes through unchanged (upstream tenant preserved, otherwise untenanted). `Require` guards mandatory-tenancy routes with 404. Both satisfy `web/middleware.Middleware` structurally, no import.
- **Transport-agnostic carrier** — `NewContext` / `FromContext` / `Scope`; queue handlers and cron jobs stamp/read tenancy without HTTP. `tenant.Scope` matches every forge `WithScope(func(ctx) (string, error))` option, so it plugs in directly: `apikey.WithScope(tenant.Scope)`.
- **ScopeClause** — explicit parameterized SQL fragment, visible at every query, never auto-injected: `ScopeClause(ctx, "tenant_id", "$2")` → `Clause{SQL: "tenant_id = $2", Arg: id}`. The placeholder is written verbatim (`$n` pgx, `?` sqlite/mysql/clickhouse) — no dialect enum. Fail-closed on missing tenant (`ErrNoTenant`); column and placeholder are validated byte-wise so misuse can't smuggle SQL into the fragment.
- Misconfigured constructors (empty base/name, nil lookup, invalid prefix, nil resolver) panic with `errors.Is`-matchable sentinels — the hostrouter precedent.
- Catalog entry removed from `docs/packages.md` per the unbuilt-only rule; design spec committed under `docs/superpowers/specs/`.

## Design notes

- Host normalization mirrors hostrouter's zero-alloc `normalizeHost` (port/IPv6 brackets/FQDN dot stripped, lowercased; sub-slices unless uppercase input). `Subdomain` resolves only an exact single label in front of the base — `notapp.example.com`, `app.example.com.evil.io`, nested `a.b.base`, and the bare base all miss.
- Resolvers return the raw identifier they saw; slug→canonical-ID mapping stays a consumer wrapper or lives inside `DomainLookup`. Reserved subdomains (www/api) are deliberately not special-cased.
- `Header`/`Cookie` values are client-controlled; documented for trusted-gateway/internal use only.

## Benchmarks (Apple M3 Max, post-optimization)

| Benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| Subdomain (hit) | 27.9 | 0 | 0 |
| Subdomain (miss) | 23.2 | 0 | 0 |
| Header | 20.3 | 0 | 0 |
| PathPrefix | 2.7 | 0 | 0 |
| Domain (StaticDomains) | 39.5 | 0 | 0 |
| Middleware end-to-end | 163.5 | 384 | 3 |
| ScopeClause | 36.8 | 16 | 1 |
| FromContext | 3.3 | 0 | 0 |

Optimization pass: `Header` was 53.3 ns / 1 alloc — `Header.Get` re-canonicalized `X-Tenant-ID` (canonical form is `X-Tenant-Id`) per call; pre-canonicalizing at construction makes it 20.3 ns / 0 allocs. Middleware's 3 allocs are the unavoidable `context.WithValue` + request clone; ScopeClause's 1 alloc is the fragment string.

## Testing

- Black-box unit tests (98.4% coverage): carrier round-trip, fail-closed `Scope`, every resolver's hit/miss/error/panic cases incl. host edge cases (port, case, FQDN dot, IPv6, boundary confusion), middleware precedence/override/pass-through/500, `Require`, `StaticDomains` normalization, ScopeClause valid/invalid matrices (incl. injection probes).
- Fuzz: `FuzzSubdomain` (15s, 1.1M execs) and `FuzzPathPrefix` (15s, 4.3M execs) — no failures; properties assert resolved labels/segments are well-formed and actually present in the input.
- Independent code-review agent pass before PR: no Critical/Important findings; the three Minor findings (middleware doc overstating untenanted pass-through, spec fuzz-target drift, coverage pins) are fixed in the second commit.
- No integration tier needed — no DB/network.