### PR TITLE
feat(smartlink): unified link engine — decision core + short-code manager + redirect pipeline (absorbs shortlink)

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -39,39 +39,40 @@ Deps: `web/httpserver`.
 
 ---
 
-**web/shortlink**
-
-Short-code links over a storage-agnostic Store with `cache.Store`
-read-through: collision-retried generation over an unambiguous
-base58-style alphabet, vanity slugs with a reserved-word blocklist,
-expiry/deactivation with a configurable fallback, and an `OnHit` hook
-that emits — counting stays the caller's job. Redirects are 302/307 with
-no-cache headers (a cached 301 kills hit counting forever); destinations
-live server-side (never `?url=`) and are scheme-allowlisted at creation.
-Branded short domains compose `tenant` custom domains + `hostrouter`.
-Not `magiclink` (self-contained signed token); not `smartlink` (no rules
-— a code resolves to one target or one rule-table handle).
-
-Deps: `core/random`, `resilience/cache`.
-
----
-
 **web/smartlink**
 
-Destination-decision engine (the TDS/smartlink core): ordered rules of
-typed matchers — `Geo`, `Device`, `Locale`, `ParamEquals`, `TimeWindow`,
-`Percent` — evaluated over a caller-built visit context (no net/http
-import), first match wins, mandatory default target. Weighted splits
-bucket deterministically by hash of a caller-supplied sticky key, never
-RNG. The decision returns the matched rule and the final URL — template
-macros from the visit context, param merge policy — and is what the
-caller emits as the click event. Rule values are consumer data hydrated
-into the typed vocabulary; no DSL. Not `featureflag` ("is X on for
-subject"); not `hostrouter` (inbound hosts) — this selects outbound
-destinations. Rule storage/admin, target health checks, and bot
+The link package: a destination-decision engine plus a storage-backed
+manager and redirect handler on top of it. The engine compiles ordered
+rules of typed matchers — `Geo`, `Device`, `Locale`, `ParamEquals`,
+`TimeWindow`, `Percent` — evaluated over a caller-built visit context (no
+net/http import), first match wins, mandatory default target. Weighted
+splits bucket deterministically by hash of a caller-supplied sticky key,
+never RNG. The decision returns the matched rule and the final URL —
+template macros from the visit context, param merge policy — and is what
+the caller emits as the click event. Rule values are consumer data
+hydrated into the typed vocabulary; no DSL.
+
+The manager mints short codes over a storage-agnostic `Store` (`pgstore`
+driver + migration ships with the package) with `cache.Store`
+read-through: collision-retried generation, vanity codes with a
+reserved-word blocklist, expiry/deactivation, and metadata stamping. A
+uniform per-click pipeline serves both a fixed-destination link (a
+compiled degenerate spec — no rules) and a rule-driven one (a
+consumer-supplied resolver) identically: build the visit, merge the
+link's metadata, decide, redirect 302/307 with no-store (never 301 — it
+would kill hit observation forever), then hand the hit to a synchronous
+`OnHit` observer for the caller to log or count. Sync decorators
+(fraud diversion, A/B overrides, metrics) wrap the decision itself;
+`WithScope` fail-closed tenancy applies to management operations only —
+resolving a code and serving it stay public, and codes are globally
+unique. Not `featureflag` ("is X on for subject"); not `hostrouter`
+(inbound hosts); not `magiclink` (self-contained signed token, not a
+redirect) — this selects and serves outbound destinations from a stored
+code. Rule storage/admin, target health checks, click counting, and bot
 filtering stay consumer-side.
 
-Deps: `core/clock`.
+Deps: `core/clock`, `core/id`, `core/random`, `resilience/cache`,
+`ops/logger` (+ pgx in the pgstore driver).
 
 ---
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -60,7 +60,7 @@ uniform per-click pipeline serves both a fixed-destination link (a
 compiled degenerate spec — no rules) and a rule-driven one (a
 consumer-supplied resolver) identically: build the visit, merge the
 link's metadata, decide, redirect 302/307 with no-store (never 301 — it
-would kill hit observation forever), then hand the hit to a synchronous
+would kill hit observation forever), then hand the hit to a post-redirect
 `OnHit` observer for the caller to log or count. Sync decorators
 (fraud diversion, A/B overrides, metrics) wrap the decision itself;
 `WithScope` fail-closed tenancy applies to management operations only —

--- a/docs/superpowers/plans/2026-07-18-smartlink-bench-after.txt
+++ b/docs/superpowers/plans/2026-07-18-smartlink-bench-after.txt
@@ -1,0 +1,16 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/dmitrymomot/forge/web/smartlink
+cpu: Apple M3 Max
+BenchmarkDecideLiteral-14          	45882049	        25.99 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecideSplit-14            	77655662	        15.59 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecideMacro-14            	20483116	        58.54 ns/op	      80 B/op	       1 allocs/op
+BenchmarkDecideMerge-14            	 2109642	       569.4 ns/op	     760 B/op	      11 allocs/op
+BenchmarkDecideBare-14             	135071242	         8.869 ns/op	       0 B/op	       0 allocs/op
+BenchmarkChain3-14                 	31010488	        38.51 ns/op	       0 B/op	       0 allocs/op
+BenchmarkMemoryStoreGet-14         	10967788	       110.6 ns/op	     336 B/op	       2 allocs/op
+BenchmarkHandlerTarget-14          	  359868	      3263 ns/op	    9124 B/op	      51 allocs/op
+BenchmarkResolveDecideTarget-14    	 1302829	       921.7 ns/op	    1464 B/op	      17 allocs/op
+BenchmarkHandlerRef-14             	  555216	      2109 ns/op	    7393 B/op	      34 allocs/op
+PASS
+ok  	github.com/dmitrymomot/forge/web/smartlink	12.149s

--- a/docs/superpowers/plans/2026-07-18-smartlink-bench-after.txt
+++ b/docs/superpowers/plans/2026-07-18-smartlink-bench-after.txt
@@ -2,15 +2,15 @@ goos: darwin
 goarch: arm64
 pkg: github.com/dmitrymomot/forge/web/smartlink
 cpu: Apple M3 Max
-BenchmarkDecideLiteral-14          	45882049	        25.99 ns/op	       0 B/op	       0 allocs/op
-BenchmarkDecideSplit-14            	77655662	        15.59 ns/op	       0 B/op	       0 allocs/op
-BenchmarkDecideMacro-14            	20483116	        58.54 ns/op	      80 B/op	       1 allocs/op
-BenchmarkDecideMerge-14            	 2109642	       569.4 ns/op	     760 B/op	      11 allocs/op
-BenchmarkDecideBare-14             	135071242	         8.869 ns/op	       0 B/op	       0 allocs/op
-BenchmarkChain3-14                 	31010488	        38.51 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMemoryStoreGet-14         	10967788	       110.6 ns/op	     336 B/op	       2 allocs/op
-BenchmarkHandlerTarget-14          	  359868	      3263 ns/op	    9124 B/op	      51 allocs/op
-BenchmarkResolveDecideTarget-14    	 1302829	       921.7 ns/op	    1464 B/op	      17 allocs/op
-BenchmarkHandlerRef-14             	  555216	      2109 ns/op	    7393 B/op	      34 allocs/op
+BenchmarkDecideLiteral-14          	44891208	        25.55 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecideSplit-14            	77207446	        15.50 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecideMacro-14            	20849108	        58.04 ns/op	      80 B/op	       1 allocs/op
+BenchmarkDecideMerge-14            	 2122904	       564.3 ns/op	     760 B/op	      11 allocs/op
+BenchmarkDecideBare-14             	138616789	         8.679 ns/op	       0 B/op	       0 allocs/op
+BenchmarkChain3-14                 	31744491	        37.86 ns/op	       0 B/op	       0 allocs/op
+BenchmarkMemoryStoreGet-14         	10683732	       112.9 ns/op	     336 B/op	       2 allocs/op
+BenchmarkHandlerTarget-14          	  366050	      3284 ns/op	    9124 B/op	      51 allocs/op
+BenchmarkResolveDecideTarget-14    	 1000000	      1044 ns/op	    1560 B/op	      19 allocs/op
+BenchmarkHandlerRef-14             	  573590	      2138 ns/op	    7393 B/op	      34 allocs/op
 PASS
-ok  	github.com/dmitrymomot/forge/web/smartlink	12.149s
+ok  	github.com/dmitrymomot/forge/web/smartlink	12.015s

--- a/docs/superpowers/plans/2026-07-18-smartlink-bench-baseline.txt
+++ b/docs/superpowers/plans/2026-07-18-smartlink-bench-baseline.txt
@@ -1,0 +1,16 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/dmitrymomot/forge/web/smartlink
+cpu: Apple M3 Max
+BenchmarkDecideLiteral-14          	45892886	        25.85 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecideSplit-14            	77301735	        15.48 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecideMacro-14            	20422982	        58.20 ns/op	      80 B/op	       1 allocs/op
+BenchmarkDecideMerge-14            	 2232692	       536.6 ns/op	     760 B/op	      11 allocs/op
+BenchmarkDecideBare-14             	134317682	         8.934 ns/op	       0 B/op	       0 allocs/op
+BenchmarkChain3-14                 	30684160	        39.21 ns/op	       0 B/op	       0 allocs/op
+BenchmarkMemoryStoreGet-14         	11201762	       108.1 ns/op	     336 B/op	       2 allocs/op
+BenchmarkHandlerTarget-14          	  383238	      3109 ns/op	    9124 B/op	      51 allocs/op
+BenchmarkResolveDecideTarget-14    	 1358593	       886.2 ns/op	    1464 B/op	      17 allocs/op
+BenchmarkHandlerRef-14             	  601191	      2024 ns/op	    7393 B/op	      34 allocs/op
+PASS
+ok  	github.com/dmitrymomot/forge/web/smartlink	12.213s

--- a/docs/superpowers/plans/2026-07-18-smartlink-unified.md
+++ b/docs/superpowers/plans/2026-07-18-smartlink-unified.md
@@ -1,0 +1,277 @@
+# web/smartlink Unified Link Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `web/smartlink` into the single link package — engine (seeded verbatim from the #64 branch) + storage-backed link Manager + redirect Handler with one uniform per-click pipeline for both inline-URL and offer-ref links.
+
+**Architecture:** Engine stays a pure decision core (`Spec`→`Compile`→`Compiled.Decide`); a `Decider`/`Chain` decorator seam and a compile `Cache` sit on top of it; the Manager owns short codes over a `Store` seam (memory + `pgstore`) and serves clicks through a Handler: lookup → Visit build/enrich → metadata merge → decorated Decide → redirect → async `OnHit`. Spec: `docs/superpowers/specs/2026-07-17-smartlink-unified-design.md` — read it before starting; it is the source of truth. Plans are direction, not transcription: implement the behavior, don't copy sketches verbatim.
+
+**Tech Stack:** Go stdlib + forge-internal deps only: `core/clock` (engine), `core/id` + `core/random` (codes), `resilience/cache` (read-through seam), `ops/logger` (nope default), `data/migration` + pgx (pgstore only).
+
+## Global Constraints
+
+- Branch: work on `dm/smartlink-shortlink-consolidation-25c16a` (current worktree branch, already holds the spec). Never switch branches.
+- Do NOT re-read the #65 (shortlink) diff — the spec encodes everything worth keeping from it.
+- `just fmt ./web/smartlink/...` after file changes (never single-file fmt — betteralign quirk); `just lint` when a task finishes.
+- Tests: black-box (`package smartlink_test`) unless unexported state demands white-box. Default `go test` tier must stay Docker-free; pgstore tests behind `//go:build integration`.
+- Optional `*slog.Logger` defaults to `logger.NewNope()`, never `slog.Default()`.
+- Go 1.26: use `new(expr)`, run modernize via `just lint`.
+- `bench_test.go` required; before/after numbers go in the PR body.
+- Redirects: 302 default, 307 allowed, 301 rejected at construction. `Cache-Control: no-store` on every handler response.
+- No manual line-wrapping in any prose/PR/commit body.
+
+---
+
+### Task 1: Seed engine from #64 and rename Link→Compiled
+
+**Files:**
+- Create (verbatim from branch): `web/smartlink/{compile,decide,errors,matcher,options,rule,template,visit,doc}.go` + `{compile,decide}_test.go`, `bench_test.go`, `matcher` tests — whatever `git ls-tree origin/dm/web-smartlink-package-e1168c -- web/smartlink` lists.
+- Modify: all seeded files (rename only).
+
+**Interfaces (produced):** engine API used by every later task — `Compile(Spec, ...Option) (*Compiled, error)`, `(*Compiled).Decide(Visit) Decision`, `Spec{Rules, Default, Params ParamPolicy}`, `Rule{Name, When []Matcher, Targets []Target}`, `Target{URL string, Weight int}`, `Visit{At, Params map[string]string, Country, Device, Locale, StickyKey}`, `Decision{Rule, URL string, Target Target}`, `ParamsDrop/ParamsFill/ParamsOverride`, matchers `Geo/Device/Locale/ParamEquals/TimeWindow/Percent`, `WithClock`, errors `ErrNoDefault/ErrInvalidRule/ErrInvalidTarget/ErrInvalidMatcher/ErrInvalidTemplate/ErrUnknownMacro`.
+
+- [ ] **Step 1: Seed the files** — `git fetch origin dm/web-smartlink-package-e1168c && git checkout origin/dm/web-smartlink-package-e1168c -- web/smartlink` (one mechanical commit; do not hand-edit while seeding).
+- [ ] **Step 2: Verify seed builds and tests pass** — `go test ./web/smartlink/...` → PASS. Commit: `feat(smartlink): seed decision engine from PR #64 branch`.
+- [ ] **Step 3: Rename** the compiled artifact: `type Link` → `type Compiled` in `compile.go`, all `*Link` receivers/returns in `compile.go`/`decide.go`, all test references, and the doc.go mention. Mechanical: `gofmt -r 'Link -> Compiled'` is WRONG here (would rename unrelated idents) — use grep-guided manual edits; `git grep -n '\bLink\b' web/smartlink` must return zero hits afterwards.
+- [ ] **Step 4: Test + fmt** — `go test ./web/smartlink/...` PASS, `just fmt ./web/smartlink/...`.
+- [ ] **Step 5: Commit** — `refactor(smartlink): rename compiled Link to Compiled, freeing Link for the stored record`.
+
+### Task 2: Decider, DecideFunc, Decorator, Chain
+
+**Files:**
+- Create: `web/smartlink/decider.go`, Test: `web/smartlink/decider_test.go`
+
+**Interfaces:**
+- Consumes: `Visit`, `Decision`, `*Compiled` (Task 1).
+- Produces: `type Decider interface{ Decide(Visit) Decision }`; `type DecideFunc func(Visit) Decision` (implements Decider); `type Decorator func(Decider) Decider`; `func Chain(ds ...Decorator) Decorator` with `Chain(A,B,C)(d) == A(B(C(d)))`.
+
+- [ ] **Step 1: Failing tests** (black-box): `TestCompiledIsDecider` (`var _ smartlink.Decider = (*smartlink.Compiled)(nil)` + a compiled link decides through the interface); `TestChainOrder` — decorators A, B, C each append their tag to `Decision.Rule` before delegating; assert application order A(B(C(d))) i.e. innermost C runs closest to d and A sees the final result; `TestChainEmpty` — `Chain()(d)` returns d's decisions unchanged.
+- [ ] **Step 2: Run, verify FAIL** (`go test ./web/smartlink/ -run 'Decider|Chain'`).
+- [ ] **Step 3: Implement** — ~15 lines: DecideFunc method, Chain loops `for i := len(ds)-1; i >= 0; i--`.
+- [ ] **Step 4: Run tests → PASS; `just fmt ./web/smartlink/...`.**
+- [ ] **Step 5: Commit** — `feat(smartlink): Decider seam with DecideFunc adapter and Chain decorator composition`.
+
+### Task 3: Stored record, errors, Store seam, memory store
+
+**Files:**
+- Create: `web/smartlink/link.go` (record + CreateParams + Filter), `web/smartlink/store.go` (Store interface), `web/smartlink/memory.go`, `web/smartlink/manage_errors.go` (or extend `errors.go`)
+- Test: `web/smartlink/memory_test.go`
+
+**Interfaces:**
+- Produces:
+
+```go
+type Link struct { // json tags per spec; ShortURL derived, never persisted
+	CreatedAt, ExpiresAt, DeactivatedAt time.Time
+	Code, Target, Ref string
+	Metadata map[string]string
+	Tenant, ShortURL string
+}
+type CreateParams struct {
+	ExpiresAt time.Time
+	Target, Ref, Code string
+	Metadata map[string]string
+	Tenant string
+	SkipRefCheck bool
+}
+type Filter struct{ Tenant string; Limit int }
+type Store interface {
+	Create(ctx context.Context, l Link) error                                // ErrDuplicate on existing code
+	Get(ctx context.Context, code string) (Link, error)                      // ErrNotFound
+	List(ctx context.Context, f Filter) ([]Link, error)                      // CreatedAt desc, code asc ties
+	Deactivate(ctx context.Context, code, tenant string, at time.Time) error // atomic tenant predicate
+	Activate(ctx context.Context, code, tenant string) error
+	Delete(ctx context.Context, code, tenant string) error
+}
+func NewMemoryStore() *MemoryStore
+```
+
+- Errors: `ErrNotFound`, `ErrDuplicate`, `ErrLinkExpired`, `ErrLinkDeactivated`, `ErrNoTarget`, `ErrInvalidLink`, `ErrCodeReserved`, `ErrScope` — all `errors.New("smartlink: ...")`.
+
+**Store contract notes (from spec):** mutators with non-empty tenant apply only when the record belongs to that tenant, else `ErrNotFound`; empty tenant unconstrained; predicate atomic with the mutation (codes are reusable after Delete, vanity codes user-claimable — a pre-check races delete-and-recreate). Codes case-sensitive. Memory store: `map[string]Link` + `sync.RWMutex`, clone Metadata maps on both write and read (no aliasing), zero `at` in Deactivate leaves the link active.
+
+- [ ] **Step 1: Failing tests** — `TestMemoryStoreCreateGet` (roundtrip, ErrDuplicate on same code), `TestMemoryStoreGetUnknown` (ErrNotFound), `TestMemoryStoreListOrder` (newest first, code-asc ties, tenant filter, limit), `TestMemoryStoreTenantPredicate` (deactivate/activate/delete with wrong tenant → ErrNotFound + record untouched; empty tenant → applies), `TestMemoryStoreMetadataAliasing` (mutating caller's map after Create and returned map after Get doesn't change stored state), `TestMemoryStoreDeleteRecreate` (delete then create same code succeeds).
+- [ ] **Step 2: Run → FAIL.** **Step 3: Implement.** **Step 4: Run → PASS; fmt.**
+- [ ] **Step 5: Commit** — `feat(smartlink): stored Link record, Store seam, in-memory store`.
+
+### Task 4: Compile cache + Resolver type
+
+**Files:**
+- Create: `web/smartlink/cache.go`, Test: `web/smartlink/cache_test.go`
+
+**Interfaces:**
+- Consumes: `Spec`, `Compile`, `*Compiled`, `Decider`, `Decorator`, `Chain` (Tasks 1–2), `Link`, `ErrNoTarget` (Task 3).
+- Produces:
+
+```go
+type Resolver func(ctx context.Context, l Link) (Decider, error)
+func NewCache(load func(ctx context.Context, ref string) (Spec, error), compileOpts ...Option) *Cache
+func (c *Cache) Get(ctx context.Context, ref string) (*Compiled, error)
+func (c *Cache) Invalidate(ref string)
+func (c *Cache) Resolver(ds ...Decorator) Resolver // Get(l.Ref), wrap with Chain(ds...); load error wrapped, not cached
+```
+
+Behavior: RLock fast path; on miss, load + Compile outside the write lock, then store (concurrent double-compile is benign — document on NewCache). Errors (load or compile) are never cached; next Get retries. `Resolver` returns the decorated decider; it does not special-case ErrNoTarget — the consumer's load func returns `ErrNoTarget` (wrapped ok) for a paused/deleted offer and the Manager maps that to dead-link handling (Task 6).
+
+- [ ] **Step 1: Failing tests** — `TestCacheGetCompilesOnce` (counting load func; two Gets, one load), `TestCacheInvalidate` (Get, Invalidate, Get → two loads), `TestCacheLoadErrorNotCached` (first load errors, second succeeds), `TestCacheCompileErrorPropagates` (invalid Spec → error wrapping the Compile error), `TestCacheResolver` (Resolver with a tagging Decorator resolves a Link{Ref:...} and decides through the decoration).
+- [ ] **Step 2: FAIL.** **Step 3: Implement.** **Step 4: PASS; fmt.**
+- [ ] **Step 5: Commit** — `feat(smartlink): lazy compile cache with invalidation and ready-made Resolver`.
+
+### Task 5: Manager — construction, codegen, Create, lifecycle, scope
+
+**Files:**
+- Create: `web/smartlink/manager.go`, `web/smartlink/manager_options.go`, `web/smartlink/codes.go`
+- Test: `web/smartlink/manager_test.go`, `web/smartlink/scope_test.go`
+
+**Interfaces:**
+- Consumes: Store/Link/CreateParams/Filter/errors (Task 3), Resolver (Task 4), engine Compile for Target validation (Task 1).
+- Produces:
+
+```go
+func NewManager(store Store, opts ...ManagerOption) (*Manager, error)
+type ManagerOption func(*managerConfig)
+func WithCodeFunc(f func() string) ManagerOption            // default: func() string { return id.NewShort().StringLower() }
+func RandomCode(n int) func() string                        // base58 alphabet "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz" via random.String
+func WithBaseURL(u string) ManagerOption                    // trailing-slash normalized; validated absolute http(s)
+func WithSchemes(s ...string) ManagerOption                 // default http, https
+func WithReservedCodes(codes ...string) ManagerOption       // extends default blocklist
+func WithScope(f func(ctx context.Context) (string, error)) ManagerOption
+func WithLinkParamPolicy(p ParamPolicy) ManagerOption       // default ParamsFill (see spec — zero value ParamsDrop would break forwarding)
+func WithResolver(r Resolver) ManagerOption
+func WithVisitFunc(f VisitFunc) ManagerOption               // declare here: type VisitFunc func(*http.Request, Visit) Visit
+func WithOnHit(f func(context.Context, Hit)) ManagerOption  // declare here: type Hit struct{ Link Link; Visit Visit; Decision Decision }
+func WithCache(cs cache.Store, ttl time.Duration) ManagerOption
+func WithFallbackURL(u string) ManagerOption
+func WithRedirectStatus(code int) ManagerOption             // 302/307 only; 301 or anything else → NewManager error
+func WithLogger(l *slog.Logger) ManagerOption               // default logger.NewNope()
+
+func (m *Manager) Create(ctx context.Context, p CreateParams) (Link, error)
+func (m *Manager) Get(ctx context.Context, code string) (Link, error)      // management read: scope-filtered
+func (m *Manager) List(ctx context.Context, f Filter) ([]Link, error)
+func (m *Manager) Deactivate(ctx context.Context, code string) error
+func (m *Manager) Activate(ctx context.Context, code string) error
+func (m *Manager) Delete(ctx context.Context, code string) error
+func (m *Manager) ShortURL(code string) string                              // "" without WithBaseURL
+```
+
+**Create semantics:** exactly one of Target/Ref set, else `ErrInvalidLink`. Vanity Code: 1–64 chars of `[A-Za-z0-9_-]` (`ErrInvalidLink`), not in blocklist (`ErrCodeReserved`), `ErrDuplicate` surfaces. Generated code: call codeFunc, retry on `ErrDuplicate` up to 5 times, then give up with a wrapped error. Target: compile `Spec{Default: []Target{{URL: p.Target}}, Params: cfg.linkParamPolicy}` — compile error → wrapped `ErrInvalidLink`; then scheme check: macro-elide the raw target (strip `{...}` spans), `url.Parse`, scheme must be on the allowlist and non-empty; require non-empty host only when the authority contains no macro (dynamic-host templates stay legal). Ref + Resolver configured + !SkipRefCheck: call `cfg.resolver(ctx, candidate)` once, error → wrapped `ErrInvalidLink` (warms consumer cache for free). Metadata cloned. `CreatedAt` set via `time.Now().UTC()`. Returned Link gets ShortURL populated.
+
+**Scope semantics** (fail-closed, management ops only): when WithScope is set, every management method calls it; error or empty string → `ErrScope`. Create: empty `p.Tenant` → scope tenant; non-empty and different → `ErrScope`. Get: fetch then compare record.Tenant, mismatch → `ErrNotFound`. List: force `f.Tenant` to scope tenant. Deactivate/Activate/Delete: pass scope tenant as the store predicate. Without WithScope: tenant strings pass through verbatim (single-tenant zero ceremony).
+
+Default reserved codes: `api, admin, app, assets, static, health, healthz, metrics, favicon.ico, robots.txt, login, logout, signup, docs, status, www, .well-known`.
+
+- [ ] **Step 1: Failing tests** — construction: `TestNewManagerRejects301`, `TestNewManagerBadBaseURL`; create: `TestCreateTargetXorRef` (both/neither → ErrInvalidLink), `TestCreateGeneratedCodeDefault` (16-char lowercase Crockford, parses via `id.ParseShort`), `TestCreateCollisionRetry` (stubbed codeFunc returning a taken code twice then fresh — succeeds; always-colliding → error), `TestCreateVanity` (valid, invalid chars, >64, reserved → ErrCodeReserved, duplicate → ErrDuplicate), `TestCreateTargetValidation` (bad template, disallowed scheme, scheme-relative, macro-host allowed, plain host required), `TestCreateRefValidation` (resolver error → ErrInvalidLink; SkipRefCheck bypasses; no resolver configured → no check), `TestCreateMetadataCloned`, `TestShortURL` (with/without base, slash normalization, populated on Create result); lifecycle: `TestLifecycle` (deactivate/activate/delete via manager reach the store); scope (scope_test.go): `TestScopeFailClosed` (hook error / empty → ErrScope on every management op), `TestScopeCreateTenantMismatch`, `TestScopeGetForeignTenant` (→ ErrNotFound), `TestScopeListForced`, `TestScopeMutatorsUsePredicate` (foreign record untouched), `TestUnscopedPassthrough`; codes: `TestRandomCode` (length, alphabet).
+- [ ] **Step 2: FAIL.** **Step 3: Implement.** **Step 4: PASS; fmt.**
+- [ ] **Step 5: Commit** — `feat(smartlink): link Manager — codegen, create-time validation, lifecycle, fail-closed scope`.
+
+### Task 6: Resolve, cache read-through, Handler pipeline, Hit
+
+**Files:**
+- Create: `web/smartlink/resolve.go`, `web/smartlink/handler.go`
+- Test: `web/smartlink/resolve_test.go`, `web/smartlink/handler_test.go`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces:
+
+```go
+// VisitFunc and Hit are declared in Task 5's options file; this task implements their behavior.
+func (m *Manager) Resolve(ctx context.Context, code string) (Link, error) // public read: cache read-through + liveness checks
+func (m *Manager) Handler() http.Handler
+```
+
+**Resolve:** cache read-through when WithCache set — key `"smartlink:code:" + code`, JSON round-trip of Link, `cache.WithTTL(ttl)`; hit → decode; miss/any cache error → store Get, best-effort Set (log at debug on cache errors, never fail the resolve). Then liveness: `DeactivatedAt` non-zero → `ErrLinkDeactivated`; `ExpiresAt` non-zero and `<= now` → `ErrLinkExpired`. Bounded staleness documented: lifecycle mutations best-effort `Delete` the cache key (add that to Task 5's Deactivate/Activate/Delete — do it in this task as a small modify of manager.go), so a stale active record lives at most ttl. No negative caching.
+
+**Handler pipeline** (per spec, uniform for Target/Ref):
+
+```go
+code := r.PathValue("code"); if code == "" { code = strings.Trim(r.URL.Path, "/") }
+w.Header().Set("Cache-Control", "no-store")
+l, err := m.Resolve(r.Context(), code)
+// dead: ErrNotFound/ErrLinkExpired/ErrLinkDeactivated → fallback redirect or 404
+// any other err → 500 (outage reads as outage), log error
+v := Visit{Params: firstValues(r.URL.Query())}      // first value per key
+if cfg.visitFunc != nil { v = cfg.visitFunc(r, v) }
+for k, val := range l.Metadata { if v.Params == nil {...}; v.Params[k] = val } // metadata wins
+var d Decider
+switch {
+case l.Target != "": d, err = m.compileTarget(l)     // per-hit degenerate compile; err "unreachable" (validated at Create) → 500 + log
+case cfg.resolver == nil: 500 + log "Ref link with no resolver configured"
+default: d, err = cfg.resolver(r.Context(), l)
+    // errors.Is(err, ErrNoTarget) → dead-link path (fallback/404); other err → 500 + log
+}
+dec := d.Decide(v)
+http.Redirect(w, r, dec.URL, cfg.redirectStatus)
+if cfg.onHit != nil { cfg.onHit(r.Context(), Hit{Link: l, Visit: v, Decision: dec}) } // sync, after redirect written
+```
+
+`compileTarget` = `Compile(Spec{Default: []Target{{URL: l.Target}}, Params: cfg.linkParamPolicy})` — no caching in v1 (spec §perf note; bench in Task 9 decides if an LRU is ever warranted).
+
+- [ ] **Step 1: Failing tests** — resolve: `TestResolveLiveness` (active ok; expired/deactivated sentinels; unknown ErrNotFound), `TestResolveCacheReadThrough` (fake cache.Store: second Resolve served from cache, store not hit), `TestResolveCacheErrorFallsThrough` (failing cache → store still serves), `TestLifecycleInvalidatesCache` (deactivate → cache key deleted); handler (httptest): `TestHandlerTargetRedirect` (302, Location, no-store header), `TestHandlerParamForwarding` (incoming `?click_id=x` lands in final URL under default ParamsFill; target's own param wins on collision), `TestHandlerMetadataWins` (link Metadata overrides same-key query param, reaches macros `{param.affiliate_id}`), `TestHandlerVisitFuncEnriches` (geo rule matches only when VisitFunc sets Country; without VisitFunc falls to default target), `TestHandlerRefResolves` (resolver + Cache from Task 4 end-to-end), `TestHandlerRefNoTarget` (resolver returns wrapped ErrNoTarget → fallback URL when set, else 404), `TestHandlerRefNoResolver` (→ 500), `TestHandlerDeadLink` (unknown/expired/deactivated → fallback or 404), `TestHandlerStoreOutage` (erroring store → 500), `TestHandlerOnHit` (Hit carries Link.Metadata, merged Visit, final Decision; fires only on successful redirect), `TestHandler307` (WithRedirectStatus(307)), `TestHandlerPathFallback` (mounted without pattern, path-trim extraction).
+- [ ] **Step 2: FAIL.** **Step 3: Implement** (resolve.go + handler.go + small manager.go modify for cache invalidation). **Step 4: PASS; fmt.**
+- [ ] **Step 5: Commit** — `feat(smartlink): public Resolve with cache read-through and the uniform redirect Handler pipeline`.
+
+### Task 7: pgstore driver + migration + integration tests
+
+**Files:**
+- Create: `web/smartlink/pgstore/doc.go`, `web/smartlink/pgstore/pgstore.go`, `web/smartlink/pgstore/migrations/00001_create_forge_smart_links.sql`
+- Test: `web/smartlink/pgstore/pgstore_test.go` (`//go:build integration`)
+
+**Interfaces:**
+- Consumes: `smartlink.Store` contract, `smartlink.Link/Filter`, sentinel errors (Task 3).
+- Produces: `pgstore.New(pool *pgxpool.Pool) *Store` (implements `smartlink.Store`), `pgstore.Migrations fs.FS`.
+
+Follow the repo pgstore idiom exactly (see `auth/apikey/pgstore`): `//go:embed migrations/*.sql` + `fs.Sub` root (data/migration globs fsys root), version table `forge_smartlink_schema`, pool lifecycle is the caller's, `pgconn.PgError` 23505 → `ErrDuplicate`, `pgx.ErrNoRows` → `ErrNotFound`.
+
+Migration:
+
+```sql
+-- +goose Up
+CREATE TABLE forge_smart_links (
+    code           text PRIMARY KEY,
+    target         text NOT NULL DEFAULT '',
+    ref            text NOT NULL DEFAULT '',
+    metadata       jsonb NOT NULL DEFAULT '{}',
+    tenant         text NOT NULL DEFAULT '',
+    created_at     timestamptz NOT NULL,
+    expires_at     timestamptz,
+    deactivated_at timestamptz
+);
+CREATE INDEX forge_smart_links_tenant_created_idx ON forge_smart_links (tenant, created_at DESC, code);
+-- +goose Down
+DROP TABLE forge_smart_links;
+```
+
+Mutators are single statements with the tenant predicate inline, e.g. `UPDATE forge_smart_links SET deactivated_at = $3 WHERE code = $1 AND ($2 = '' OR tenant = $2)` → `RowsAffected() == 0` ⇒ `ErrNotFound`. NULL timestamptz ↔ zero `time.Time` via the nullable-scan helpers idiom. List: `ORDER BY created_at DESC, code ASC`, optional `tenant =` filter, `LIMIT` when > 0.
+
+- [ ] **Step 1: Write integration tests first** (mirror the memory_test.go suite: roundtrip/duplicate/not-found/list order+filter+limit/tenant-predicate mutators/delete-recreate/metadata fidelity incl. nil vs empty map, zero vs set timestamps). Setup via `testkit/pgtest.DSN(t)` + `data/postgres.Open` + `data/migration` applying `pgstore.Migrations` (copy the `newStore` helper shape from `auth/apikey/pgstore/pgstore_test.go`).
+- [ ] **Step 2: Run → FAIL** (`just test-integration ./web/smartlink/...`).
+- [ ] **Step 3: Implement pgstore.** **Step 4: `just test-integration ./web/smartlink/...` → PASS; fmt.**
+- [ ] **Step 5: Commit** — `feat(smartlink/pgstore): postgres Store driver with goose migration`.
+
+### Task 8: doc.go rewrite, catalog update, lint sweep
+
+**Files:**
+- Modify: `web/smartlink/doc.go`, `docs/packages.md`
+
+- [ ] **Step 1: Rewrite doc.go** — keep the engine paragraphs (updated for `Compiled`), add the manager/handler story: unified record (Target template XOR Ref), uniform pipeline, hooks contract (decorators sync, OnHit bounded-sink), tenancy (WithScope management-only, codes globally unique), the `Visit.StickyKey` doubles-as-fingerprint-carrier note (spec §Visit facts — add it to the StickyKey field comment in visit.go too), `Example` (engine-only, existing) + `Example_manager` (memory store, Create fixed link, Handler over httptest — runnable). Godoc conventions per repo.
+- [ ] **Step 2: packages.md** — delete the whole `web/shortlink` entry; rewrite `web/smartlink` entry: engine + link manager + pipeline, one short paragraph each; Deps line: `core/clock`, `core/id`, `core/random`, `resilience/cache`, `ops/logger`. `grep -rn shortlink docs/ --include='*.md' | grep -v superpowers` must show zero remaining refs (specs/plans stay).
+- [ ] **Step 3: Full check** — `go test ./web/smartlink/...`, `just lint` (fix everything), `just fmt ./web/smartlink/...`.
+- [ ] **Step 4: Commit** — `docs(smartlink): unified package docs; drop web/shortlink from catalog`.
+
+### Task 9: Benchmarks + measured optimization pass
+
+**Files:**
+- Modify: `web/smartlink/bench_test.go` (engine benches exist from seed — add manager/handler benches)
+
+- [ ] **Step 1: Add benches** — `BenchmarkHandlerTarget` (memory store, fixed link, httptest.NewRecorder loop: full lookup→compile-per-hit→decide→redirect), `BenchmarkHandlerRef` (Cache-backed resolver hit path), `BenchmarkChain3` (3 no-op decorators vs bare Decide), `BenchmarkMemoryStoreGet`. Report allocs (`b.ReportAllocs()`).
+- [ ] **Step 2: Baseline** — `go test ./web/smartlink/ -bench . -benchmem -run xxx | tee /tmp/smartlink-bench-before.txt` (save numbers for PR body).
+- [ ] **Step 3: Optimization pass, measured wins only** — expected hotspots: per-hit degenerate compile in `BenchmarkHandlerTarget` (if it dominates, the spec sanctions a bounded LRU — only add with before/after numbers), Visit params map allocs, JSON round-trip in cache path. Skip anything the numbers don't justify; readable first.
+- [ ] **Step 4: After-numbers** — rerun, save; both files' numbers go in the PR body. Commit: `perf(smartlink): benchmark manager/handler paths` (+ any measured opt commits separately).
+
+### Task 10: Ship — push, PR, close #64/#65, CI/review loop
+
+- [ ] **Step 1: Final verification** — `go test ./web/smartlink/...`, `just test-integration ./web/smartlink/...` (Docker up), `just lint` — all green, then `git status` clean.
+- [ ] **Step 2: Push + PR** — `git push -u origin dm/smartlink-shortlink-consolidation-25c16a`; `gh pr create` titled `feat(smartlink): unified link engine — decision core + short-code manager + redirect pipeline (absorbs shortlink)`; body: summary, design/spec link, what was seeded from #64 vs written new, bench before/after, test tiers. NO Claude attribution lines anywhere.
+- [ ] **Step 3: Close the superseded PRs** — comment + close: #64 (`superseded: engine landed verbatim as the seed commits of <new PR url>; Link renamed Compiled per the unified design`) and #65 (`superseded by the unified web/smartlink design (docs/superpowers/specs/2026-07-17-smartlink-unified-design.md); behaviors ported per spec, code not merged`). `gh pr close 64 --comment "..."`, same for 65.
+- [ ] **Step 4: CI/review loop per CLAUDE.md** — wait for all CI; fix failures; read Claude's review (note: the review workflow can time out silently on big PRs — if it posts nothing, run a local review pass instead); fix all real findings, resolve fixed threads, commit, repeat until clean.

--- a/docs/superpowers/specs/2026-07-17-smartlink-unified-design.md
+++ b/docs/superpowers/specs/2026-07-17-smartlink-unified-design.md
@@ -1,0 +1,180 @@
+# web/smartlink unified link engine — Design
+
+Date: 2026-07-17. Status: approved for planning.
+
+## Summary
+
+`web/smartlink` grows from a pure destination-decision engine into the single link package: engine (unchanged) + a storage-backed link manager + a redirect handler with a uniform per-click pipeline. A stored link is a short code pointing at either an inline URL template (`Target`) or a consumer-side offer reference (`Ref`); both resolve through the same flow — Visit build, metadata merge, decorated `Decide`, redirect, async hit observer — so a "simple short link" is just the degenerate case (single default target, no rules) with every ability (macros, param forwarding, metadata stamping, hooks) intact.
+
+This supersedes `web/shortlink` (PR #65, unmerged): its mechanics (Store contract with atomic tenant-predicate mutators, vanity codes + reserved blocklist, expiry/deactivation, scheme allowlist, cache read-through, fallback/no-store/never-301 handler behavior, pgstore + migration) are ported into the manager layer; the package itself is dropped from the catalog. PR #65 closes without merging. The engine PR #64 merges first as-is; this work lands as a new PR on top.
+
+## Why one package
+
+- A fixed-destination short link is a `Spec` with only `Default` — shortlink was a strict subset of smartlink, and keeping both meant catalog redundancy plus composition friction (a resolver seam in shortlink would have to import smartlink anyway).
+- Hooks (fraud guard, visit tracking, postbacks) are wanted identically for one-target links and rule links; one pipeline serves both.
+- Precedent: `async/queue` — one substantial package = engine + seams in the root, drivers isolated in subpackages (`smartlink/pgstore`). Stays within design.md layout rules.
+
+## Package layout
+
+```
+web/smartlink/           engine (existing) + Decider/Chain + Cache helper
+                         + Manager, Store seam, memory store, Handler, Hit
+web/smartlink/pgstore/   postgres Store driver + migration
+```
+
+## Engine additions (root package, no new deps)
+
+The existing engine (`Spec`/`Compile`/`Link.Decide`, matchers, templates, `ParamPolicy`) is untouched. Added on top:
+
+```go
+type Decider interface{ Decide(Visit) Decision }
+type DecideFunc func(Visit) Decision            // adapter; implements Decider
+type Decorator func(Decider) Decider            // middleware
+
+// Chain composes left-to-right in application order: Chain(A,B,C)(d) == A(B(C(d))).
+func Chain(ds ...Decorator) Decorator
+```
+
+The compiled artifact (`*Compiled` after the rename in §Stored record) already has `Decide(Visit) Decision` and satisfies `Decider` for free. Decorators cover sync concerns that must affect the current click: fraud/dup diversion (short-circuit with an alternative `Decision`), A/B overrides, metrics. Async concerns go through the handler's `OnHit` observer instead.
+
+### Compile cache helper
+
+Every consumer with `Ref` links writes the same lazy compile-with-invalidation cache, so the package ships it (pure engine level, stdlib only):
+
+```go
+func NewCache(load func(ctx context.Context, ref string) (Spec, error)) *Cache
+
+func (c *Cache) Get(ctx context.Context, ref string) (*Compiled, error) // lazy load+Compile, cached
+func (c *Cache) Invalidate(ref string)                              // called from the consumer's offer-save path
+func (c *Cache) Resolver(ds ...Decorator) Resolver                  // ready-made Manager resolver, decorators applied
+```
+
+`sync.RWMutex` copy-on-read; a concurrent miss may compile twice (benign, documented). Load errors are not cached — the next click retries. Rule storage/admin stays consumer-side, as the engine doc already mandates.
+
+### Visit facts
+
+No new `Visit` fields. `StickyKey` doubles as the fingerprint carrier: the consumer sets it to their fingerprint digest, so weighted-split stickiness and fraud identity agree by construction. Documented on `Visit.StickyKey`.
+
+## Stored record
+
+```go
+type Link struct {
+	CreatedAt     time.Time         `json:"created_at"`
+	ExpiresAt     time.Time         `json:"expires_at,omitzero"`     // zero = never
+	DeactivatedAt time.Time         `json:"deactivated_at,omitzero"` // zero = active
+	Code          string            `json:"code"`                    // globally unique path segment
+	Target        string            `json:"target,omitempty"`        // inline URL template; "" when Ref set
+	Ref           string            `json:"ref,omitempty"`           // consumer offer reference; "" when Target set
+	Metadata      map[string]string `json:"metadata,omitempty"`      // fixed per-link params (affiliate/team identity)
+	Tenant        string            `json:"tenant,omitempty"`
+	ShortURL      string            `json:"short_url,omitempty"`     // derived (WithBaseURL), never stored
+}
+```
+
+Name collision note: the engine's compiled `*Link` is renamed to avoid two `Link` types in one package — the compiled artifact becomes `*Compiled` (`Compile(Spec) (*Compiled, error)`), and the stored record owns the `Link` name. This is a rename inside unmerged #64 surface; no released API breaks. (Chosen over renaming the record, because "link" is what consumers store and list; the compiled artifact is an internal-feeling handle.)
+
+Exactly one of `Target`/`Ref` is set — enforced at `Create`. Records are immutable except lifecycle (deactivate/activate/delete): destination changes happen consumer-side for `Ref` links (edit the offer, invalidate the cache) or by re-creating for `Target` links.
+
+```go
+type CreateParams struct {
+	ExpiresAt time.Time
+	Target    string            // inline URL template: absolute, host required, scheme on allowlist; macros compile-checked
+	Ref       string            // consumer reference; validated via Resolver at create (see below)
+	Code      string            // optional vanity code: 1–64 chars [A-Za-z0-9_-], not on the reserved blocklist
+	Metadata  map[string]string
+	Tenant    string            // constrained by WithScope when configured
+	// SkipRefCheck skips create-time Resolver validation of Ref, for
+	// offers that will exist later.
+	SkipRefCheck bool
+}
+```
+
+## Manager
+
+```go
+func NewManager(store Store, opts ...Option) (*Manager, error)
+```
+
+Ported from #65 semantics: collision-retried code generation, vanity codes + reserved-word blocklist, expiry/deactivation, `WithScope` fail-closed tenancy on management ops (public resolve needs no scope — a code is a public URL), optional cache read-through with the bounded-staleness contract, delete-then-retry cache handling.
+
+Options:
+
+- `WithCodeFunc(func() string)` — code generator seam. **Default: `id.Short` lowercase** (16-char Crockford base32, URL-safe, collision-free by construction, sortable; creation-time leak documented). `RandomCode(n int) func() string` ships as a base58 alternative for 7–8 char pretty codes (collision-retried against `ErrDuplicate`, as in #65).
+- `WithBaseURL(string)` — populates `Link.ShortURL` on returned records.
+- `WithSchemes(...string)` — `Target` scheme allowlist, default http/https.
+- `WithReservedCodes(...string)` — extends the vanity blocklist.
+- `WithScope(func(ctx) (string, error))` — tenant hook, fail-closed (error or empty aborts), management ops only.
+- `WithCache(cache.Store)` — read-through for resolve; #65 bounded-staleness contract carries over.
+- `WithLinkParamPolicy(ParamPolicy)` — policy for the degenerate specs compiled from `Target` links. **Default `ParamsFill`** (incoming params forwarded, target's own params win) — the engine zero value `ParamsDrop` would silently break param forwarding for the simple case this design exists to serve. `Ref` links carry their policy in the consumer's `Spec`.
+- `WithVisitFunc(func(*http.Request, Visit) Visit)` — enricher, not builder: the handler pre-fills `Visit.Params` from the query string (first value per key), the consumer adds country/device/sticky-key from their own middleware (geoip, useragent, fingerprint — smartlink imports none of them). Optional: without it, param-only Visits still work and geo/device rules fall through to defaults.
+- `WithResolver(Resolver)` where `type Resolver func(ctx context.Context, l Link) (Decider, error)` — required before any `Ref` link resolves; returning `ErrNoTarget` marks the link dead (fallback/404), any other error is an outage (500).
+- `WithOnHit(func(ctx context.Context, h Hit))` — post-redirect observer, called synchronously; hand the Hit to a bounded sink (queue push, buffered channel), never do work inline or spawn per-hit goroutines. Same contract #65 documented.
+- `WithFallbackURL(string)`, `WithRedirectStatus(int)` — dead-link fallback and 302/307 choice; 301 is rejected (a cached 301 kills hit observation forever).
+- `WithLogger(*slog.Logger)` — default `logger.NewNope()`.
+
+Create-time `Ref` validation: when a Resolver is configured, `Create` calls it once — a typo'd ref fails at mint time (and warms the compile cache) instead of 404ing on the affiliate's first click. `CreateParams`-level opt-out flag (`SkipRefCheck bool`) for offers that will exist later.
+
+```go
+type Hit struct {
+	Link     Link     // includes Metadata → attribution for postback/tracking
+	Visit    Visit    // as decided (metadata already merged into Params)
+	Decision Decision // final URL + matched rule
+}
+```
+
+## Store seam
+
+The #65 contract verbatim, with the record fields above (`Target`/`Ref`/`Metadata` replace `URL`):
+
+```go
+type Store interface {
+	Create(ctx context.Context, l Link) error                              // ErrDuplicate on existing code
+	Get(ctx context.Context, code string) (Link, error)                    // ErrNotFound
+	List(ctx context.Context, f Filter) ([]Link, error)                    // newest first
+	Deactivate(ctx context.Context, code, tenant string, at time.Time) error
+	Activate(ctx context.Context, code, tenant string) error
+	Delete(ctx context.Context, code, tenant string) error
+}
+```
+
+Mutators keep the atomic tenant-predicate rule (one statement, not check-then-act — codes are reusable after delete and vanity codes user-claimable, so a pre-check could race a delete-and-recreate and mutate another tenant's link). Codes match case-sensitively. `NewMemoryStore()` ships in the root for tests/dev; `pgstore` is the production driver (`forge_smart_links` table: code PK, target, ref, metadata jsonb, tenant, timestamps; goose migration via `migration.Migration`).
+
+## Per-click pipeline (uniform for both modes)
+
+```
+lookup code (cache read-through)
+→ expired/deactivated/unknown? → WithFallbackURL redirect, else 404
+→ Visit{Params: query} → VisitFunc enrich
+→ merge link.Metadata into Visit.Params (metadata wins — it identifies the link, not the click)
+→ Decider: Target → compile degenerate Spec{Default, WithLinkParamPolicy}   (per-hit; see perf note)
+           Ref    → Resolver(ctx, link)                                     (consumer cache + Chain)
+→ Decide → redirect (302/307, Cache-Control: no-store)
+→ OnHit(ctx, Hit)
+```
+
+Error semantics (from #65): store/cache failure or resolver failure (other than `ErrNoTarget`) → 500 — an outage must read as an outage, not as every link being gone. Missing Resolver with a `Ref` link is a configuration error → 500 and an error log.
+
+Perf note: degenerate `Target` specs are compiled per hit in v1 — a single-template compile is a few µs and an unbounded per-code compiled-link cache is a memory liability at affiliate-code cardinality. The required `bench_test.go` covers the full resolve→redirect path; a bounded LRU is added only if the benchmark proves the compile matters (design.md §Performance: readable first, optimize proven-hot paths with numbers in the PR).
+
+Metadata merge happens before `Decide`, so `ParamEquals` rules can branch per-affiliate, and merged params flow into macros (`{param.affiliate_id}`), the final URL (per policy), and `Hit`.
+
+## Anti-scope
+
+- No fraud/bot/dup detection — that's a consumer decorator (sync divert) or OnHit consumer (async scoring feeding a denylist the decorator reads).
+- No postback delivery, no click counting, no analytics storage — `Hit` hands the consumer everything; `comms/postback` (catalog) owns tracker postbacks.
+- No offer/spec persistence — rule storage/admin stays consumer-side; `NewCache` only caches compiles.
+- No QR codes, no link-in-bio, no preview pages.
+
+## Catalog & PR mechanics
+
+- packages.md: rewrite the `web/smartlink` entry (engine + link manager + pipeline), delete the `web/shortlink` entry, fix cross-references (`magiclink`, `attribution`, engine doc "not shortlink" notes).
+- PR #64 (engine) merges first, unchanged except the `Link`→`Compiled` rename noted above (amended on that branch before merge, or as the first commit of the new PR — decided at planning).
+- PR #65 (shortlink) closes without merging, with a comment pointing at this design.
+- This design lands as one new PR: engine additions + manager + memory store + pgstore + catalog updates. Benchmarks (engine ones exist in #64; manager/handler added) + before/after numbers per repo policy.
+
+## Testing
+
+- Black-box (`smartlink_test`) throughout; white-box only where unexported state demands (compile cache internals).
+- Unit tier (default `go test`, Docker-free): engine additions, Chain semantics, Cache invalidation/error-not-cached, manager over memory store, handler pipeline incl. metadata-wins merge, fallback/status/no-store, Ref-without-resolver 500, create-time ref validation, vanity/blocklist, code collision retry, scope fail-closed.
+- Integration tier (`//go:build integration`, testcontainers pg16): pgstore conformance incl. atomic tenant-predicate mutators and delete-recreate race shape.
+- Bench: resolve→redirect for `Target` (compile-per-hit) and `Ref` (cache hit) paths, `Chain` overhead, memory-store ops.

--- a/docs/superpowers/specs/2026-07-17-smartlink-unified-design.md
+++ b/docs/superpowers/specs/2026-07-17-smartlink-unified-design.md
@@ -168,9 +168,10 @@ Metadata merge happens before `Decide`, so `ParamEquals` rules can branch per-af
 ## Catalog & PR mechanics
 
 - packages.md: rewrite the `web/smartlink` entry (engine + link manager + pipeline), delete the `web/shortlink` entry, fix cross-references (`magiclink`, `attribution`, engine doc "not shortlink" notes).
-- PR #64 (engine) merges first, unchanged except the `Link`→`Compiled` rename noted above (amended on that branch before merge, or as the first commit of the new PR — decided at planning).
-- PR #65 (shortlink) closes without merging, with a comment pointing at this design.
-- This design lands as one new PR: engine additions + manager + memory store + pgstore + catalog updates. Benchmarks (engine ones exist in #64; manager/handler added) + before/after numbers per repo policy.
+- Both PRs close without merging, each with a comment pointing at this design. Everything lands as ONE fresh PR from main.
+- The engine is NOT re-implemented: the first commit of the new branch takes the `web/smartlink` files verbatim from the #64 branch (`git checkout origin/dm/web-smartlink-package-e1168c -- web/smartlink`) — that code is review-hardened (authority-macro fail-closed escaping, zero-alloc matcher) and re-deriving it would risk losing that. The `Link`→`Compiled` rename is the second commit. Engine tests/benches come along in the seed commit.
+- The #65 code is not ported file-wise — the manager/store/handler are written fresh against this spec, which encodes the #65 behaviors worth keeping (atomic tenant-predicate mutators, fallback/no-store/never-301, blocklist, bounded-staleness cache contract). Do not re-read the #65 diff during implementation.
+- Benchmarks: engine ones arrive with the seed commit; manager/handler benches added new; before/after numbers in the PR per repo policy.
 
 ## Testing
 

--- a/web/smartlink/bench_test.go
+++ b/web/smartlink/bench_test.go
@@ -215,8 +215,8 @@ func BenchmarkResolveDecideTarget(b *testing.B) {
 }
 
 // BenchmarkHandlerRef is the same full ServeHTTP loop for a Ref-backed Link
-// resolved through a warm [smartlink.Cache] Resolver — the hit path of
-// Task 4's compile cache, not the load-and-compile miss path.
+// resolved through a warm [smartlink.Cache] Resolver — the compile cache's
+// hit path, not the load-and-compile miss path.
 func BenchmarkHandlerRef(b *testing.B) {
 	c := smartlink.NewCache(func(_ context.Context, ref string) (smartlink.Spec, error) {
 		return smartlink.Spec{Default: []smartlink.Target{{URL: "https://offer.example.com/" + ref}}}, nil

--- a/web/smartlink/bench_test.go
+++ b/web/smartlink/bench_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/dmitrymomot/forge/web/smartlink"
 )
 
-func benchLink(b *testing.B, spec smartlink.Spec) *smartlink.Link {
+func benchLink(b *testing.B, spec smartlink.Spec) *smartlink.Compiled {
 	b.Helper()
 	link, err := smartlink.Compile(spec)
 	if err != nil {

--- a/web/smartlink/bench_test.go
+++ b/web/smartlink/bench_test.go
@@ -184,7 +184,10 @@ func BenchmarkHandlerTarget(b *testing.B) {
 // from ServeHTTP/httptest scaffolding (request-line parsing, header
 // cloning, response recording, mux routing): Resolve against MemoryStore
 // plus the same per-hit degenerate Compile+Decide [Manager.decider] runs,
-// with no net/http request/response machinery in the loop.
+// with no net/http request/response machinery in the loop. The Visit
+// carries the two query params plus the Link.Metadata entry the handler
+// merges into Visit.Params before Decide, so Decide sees the same three
+// params it would through ServeHTTP.
 func BenchmarkResolveDecideTarget(b *testing.B) {
 	m, err := smartlink.NewManager(smartlink.NewMemoryStore())
 	if err != nil {
@@ -198,7 +201,9 @@ func BenchmarkResolveDecideTarget(b *testing.B) {
 		b.Fatalf("Create() error = %v", err)
 	}
 	ctx := context.Background()
-	visit := smartlink.Visit{Params: map[string]string{"click_id": "abc123", "sub1": "x"}}
+	// click_id and sub1 mirror the query string; aff mirrors the handler's
+	// Link.Metadata merge.
+	visit := smartlink.Visit{Params: map[string]string{"click_id": "abc123", "sub1": "x", "aff": "abc123"}}
 
 	b.ReportAllocs()
 	for b.Loop() {

--- a/web/smartlink/bench_test.go
+++ b/web/smartlink/bench_test.go
@@ -1,6 +1,10 @@
 package smartlink_test
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dmitrymomot/forge/web/smartlink"
@@ -84,5 +88,160 @@ func BenchmarkDecideMerge(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		link.Decide(visit)
+	}
+}
+
+// BenchmarkDecideBare is the floor: a single literal default target, no
+// rules, no macros, no merge — everything above this is a matcher, macro, or
+// merge cost layered on top.
+func BenchmarkDecideBare(b *testing.B) {
+	link := benchLink(b, smartlink.Spec{Default: []smartlink.Target{{URL: "https://example.com/"}}})
+	visit := smartlink.Visit{StickyKey: "visitor-42"}
+	b.ReportAllocs()
+	for b.Loop() {
+		link.Decide(visit)
+	}
+}
+
+// noopDecorator wraps d without altering the decision — isolates Chain/call
+// overhead from any decorator's own work.
+func noopDecorator(d smartlink.Decider) smartlink.Decider {
+	return smartlink.DecideFunc(func(v smartlink.Visit) smartlink.Decision {
+		return d.Decide(v)
+	})
+}
+
+// BenchmarkChain3 measures three no-op decorators wrapping a compiled link,
+// against BenchmarkDecideBare's bare Decide — the delta is pure Chain/closure
+// overhead.
+func BenchmarkChain3(b *testing.B) {
+	link := benchLink(b, smartlink.Spec{Default: []smartlink.Target{{URL: "https://example.com/"}}})
+	chained := smartlink.Chain(noopDecorator, noopDecorator, noopDecorator)(link)
+	visit := smartlink.Visit{StickyKey: "visitor-42"}
+	b.ReportAllocs()
+	for b.Loop() {
+		chained.Decide(visit)
+	}
+}
+
+// BenchmarkMemoryStoreGet is the store hot loop at ~1000 links: MemoryStore.Get
+// clones Metadata on every read, so this isolates that cost from the rest of
+// the resolve/decide pipeline.
+func BenchmarkMemoryStoreGet(b *testing.B) {
+	store := smartlink.NewMemoryStore()
+	const n = 1000
+	codes := make([]string, n)
+	ctx := context.Background()
+	for i := range codes {
+		code := fmt.Sprintf("code-%04d", i)
+		codes[i] = code
+		l := smartlink.Link{Code: code, Target: "https://example.com/", Metadata: map[string]string{"aff": "abc"}}
+		if err := store.Create(ctx, l); err != nil {
+			b.Fatalf("Create() error = %v", err)
+		}
+	}
+
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		if _, err := store.Get(ctx, codes[i%n]); err != nil {
+			b.Fatalf("Get() error = %v", err)
+		}
+		i++
+	}
+}
+
+// BenchmarkHandlerTarget is the full ServeHTTP loop for a Target-backed
+// Link: path/query parse, cache-less lookup against MemoryStore, the per-hit
+// degenerate compile ([Manager.decider]), Visit build, Decide, and redirect.
+// The recorder and request are recreated inside the loop since
+// httptest.ResponseRecorder accumulates header/body state across writes.
+func BenchmarkHandlerTarget(b *testing.B) {
+	m, err := smartlink.NewManager(smartlink.NewMemoryStore())
+	if err != nil {
+		b.Fatalf("NewManager() error = %v", err)
+	}
+	l, err := m.Create(context.Background(), smartlink.CreateParams{
+		Target:   "https://dest.example.com/lp?keep=orig",
+		Metadata: map[string]string{"aff": "abc123"},
+	})
+	if err != nil {
+		b.Fatalf("Create() error = %v", err)
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/r/{code}", m.Handler())
+	target := "/r/" + l.Code + "?click_id=abc123&sub1=x"
+
+	b.ReportAllocs()
+	for b.Loop() {
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+	}
+}
+
+// BenchmarkResolveDecideTarget isolates the Target path's product-side cost
+// from ServeHTTP/httptest scaffolding (request-line parsing, header
+// cloning, response recording, mux routing): Resolve against MemoryStore
+// plus the same per-hit degenerate Compile+Decide [Manager.decider] runs,
+// with no net/http request/response machinery in the loop.
+func BenchmarkResolveDecideTarget(b *testing.B) {
+	m, err := smartlink.NewManager(smartlink.NewMemoryStore())
+	if err != nil {
+		b.Fatalf("NewManager() error = %v", err)
+	}
+	l, err := m.Create(context.Background(), smartlink.CreateParams{
+		Target:   "https://dest.example.com/lp?keep=orig",
+		Metadata: map[string]string{"aff": "abc123"},
+	})
+	if err != nil {
+		b.Fatalf("Create() error = %v", err)
+	}
+	ctx := context.Background()
+	visit := smartlink.Visit{Params: map[string]string{"click_id": "abc123", "sub1": "x"}}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		resolved, err := m.Resolve(ctx, l.Code)
+		if err != nil {
+			b.Fatalf("Resolve() error = %v", err)
+		}
+		compiled, err := smartlink.Compile(smartlink.Spec{Default: []smartlink.Target{{URL: resolved.Target}}, Params: smartlink.ParamsFill})
+		if err != nil {
+			b.Fatalf("Compile() error = %v", err)
+		}
+		compiled.Decide(visit)
+	}
+}
+
+// BenchmarkHandlerRef is the same full ServeHTTP loop for a Ref-backed Link
+// resolved through a warm [smartlink.Cache] Resolver — the hit path of
+// Task 4's compile cache, not the load-and-compile miss path.
+func BenchmarkHandlerRef(b *testing.B) {
+	c := smartlink.NewCache(func(_ context.Context, ref string) (smartlink.Spec, error) {
+		return smartlink.Spec{Default: []smartlink.Target{{URL: "https://offer.example.com/" + ref}}}, nil
+	})
+	m, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithResolver(c.Resolver()))
+	if err != nil {
+		b.Fatalf("NewManager() error = %v", err)
+	}
+	l, err := m.Create(context.Background(), smartlink.CreateParams{Ref: "offer-42"})
+	if err != nil {
+		b.Fatalf("Create() error = %v", err)
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/r/{code}", m.Handler())
+	target := "/r/" + l.Code + "?click_id=abc123&sub1=x"
+
+	// Warm the Cache's compiled entry so the timed loop only exercises the
+	// RLock hit path, not the load+Compile miss path.
+	warmup := httptest.NewRequest(http.MethodGet, target, nil)
+	mux.ServeHTTP(httptest.NewRecorder(), warmup)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
 	}
 }

--- a/web/smartlink/bench_test.go
+++ b/web/smartlink/bench_test.go
@@ -1,0 +1,88 @@
+package smartlink_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+func benchLink(b *testing.B, spec smartlink.Spec) *smartlink.Link {
+	b.Helper()
+	link, err := smartlink.Compile(spec)
+	if err != nil {
+		b.Fatalf("Compile() error = %v", err)
+	}
+	return link
+}
+
+// BenchmarkDecideLiteral is the hot path: matcher walk + literal target, no
+// rendering, no merge.
+func BenchmarkDecideLiteral(b *testing.B) {
+	link := benchLink(b, smartlink.Spec{
+		Rules: []smartlink.Rule{{
+			Name: "de-mobile",
+			When: []smartlink.Matcher{
+				smartlink.Geo{Countries: []string{"AT", "CH", "DE"}},
+				smartlink.Device{Devices: []string{"mobile", "tablet"}},
+			},
+			Targets: []smartlink.Target{{URL: "https://a.example.com/lp"}},
+		}},
+		Default: []smartlink.Target{{URL: "https://example.com/"}},
+	})
+	visit := smartlink.Visit{Country: "de", Device: "mobile", StickyKey: "visitor-42"}
+	b.ReportAllocs()
+	for b.Loop() {
+		link.Decide(visit)
+	}
+}
+
+// BenchmarkDecideSplit adds a Percent gate and a weighted split — two hash
+// buckets per decision.
+func BenchmarkDecideSplit(b *testing.B) {
+	link := benchLink(b, smartlink.Spec{
+		Rules: []smartlink.Rule{{
+			Name: "gate",
+			When: []smartlink.Matcher{smartlink.Percent{Share: 90}},
+			Targets: []smartlink.Target{
+				{URL: "https://a.example.com/", Weight: 70},
+				{URL: "https://b.example.com/", Weight: 30},
+			},
+		}},
+		Default: []smartlink.Target{{URL: "https://example.com/"}},
+	})
+	visit := smartlink.Visit{StickyKey: "visitor-42"}
+	b.ReportAllocs()
+	for b.Loop() {
+		link.Decide(visit)
+	}
+}
+
+// BenchmarkDecideMacro renders a three-macro template.
+func BenchmarkDecideMacro(b *testing.B) {
+	link := benchLink(b, smartlink.Spec{
+		Default: []smartlink.Target{{URL: "https://a.example.com/{country}/lp?d={device}&c={param.click_id}"}},
+	})
+	visit := smartlink.Visit{
+		Country: "DE",
+		Device:  "mobile",
+		Params:  map[string]string{"click_id": "abc123"},
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		link.Decide(visit)
+	}
+}
+
+// BenchmarkDecideMerge renders plus re-parses the URL for a ParamsFill merge —
+// the most expensive configuration.
+func BenchmarkDecideMerge(b *testing.B) {
+	link := benchLink(b, smartlink.Spec{
+		Default: []smartlink.Target{{URL: "https://a.example.com/lp?keep=orig"}},
+		Params:  smartlink.ParamsFill,
+	})
+	visit := smartlink.Visit{Params: map[string]string{"sub1": "x", "sub2": "y"}}
+	b.ReportAllocs()
+	for b.Loop() {
+		link.Decide(visit)
+	}
+}

--- a/web/smartlink/cache.go
+++ b/web/smartlink/cache.go
@@ -1,0 +1,92 @@
+package smartlink
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Resolver resolves a Ref-backed Link to a Decider ready for a click decision.
+// [Cache.Resolver] returns a ready-made one; a Manager (a later task) is the
+// seam's consumer. Resolver does not special-case ErrNoTarget: when the
+// consumer's load func returns it for a paused or deleted offer, Resolver
+// propagates the wrapped error and leaves the mapping to dead-link handling
+// to the caller.
+type Resolver func(ctx context.Context, l Link) (Decider, error)
+
+// Cache is a lazy compile cache for Ref-backed Links. Offers live in the
+// consumer's own database as [Spec] values; Cache loads and compiles them on
+// demand, keyed by ref string, and the consumer invalidates an entry from its
+// offer-save path. Safe for concurrent use.
+type Cache struct {
+	load    func(ctx context.Context, ref string) (Spec, error)
+	entries map[string]*Compiled
+	opts    []Option
+
+	mu sync.RWMutex
+}
+
+// NewCache returns a Cache that loads a Spec via load and compiles it with
+// compileOpts on a cache miss.
+//
+// Get takes an RLock fast path; on a miss it calls load and Compile outside
+// the write lock, then stores the result under a short write lock. Two
+// goroutines that miss on the same ref concurrently may both load and
+// compile — the redundant work is benign because Compiled values for the
+// same Spec are interchangeable, so the second store just overwrites the
+// first with an equivalent result. Errors from load or Compile are never
+// cached, so the next Get retries.
+func NewCache(load func(ctx context.Context, ref string) (Spec, error), compileOpts ...Option) *Cache {
+	return &Cache{
+		load:    load,
+		opts:    compileOpts,
+		entries: make(map[string]*Compiled),
+	}
+}
+
+// Get returns the Compiled engine for ref, loading and compiling it on a
+// cache miss. Errors from load or Compile are wrapped, not cached.
+func (c *Cache) Get(ctx context.Context, ref string) (*Compiled, error) {
+	c.mu.RLock()
+	compiled, ok := c.entries[ref]
+	c.mu.RUnlock()
+	if ok {
+		return compiled, nil
+	}
+
+	spec, err := c.load(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("smartlink: load ref %q: %w", ref, err)
+	}
+	compiled, err = Compile(spec, c.opts...)
+	if err != nil {
+		return nil, fmt.Errorf("smartlink: compile ref %q: %w", ref, err)
+	}
+
+	c.mu.Lock()
+	c.entries[ref] = compiled
+	c.mu.Unlock()
+	return compiled, nil
+}
+
+// Invalidate evicts ref's cached entry, if any, so the next Get reloads and
+// recompiles it. Call this from the consumer's offer-save path.
+func (c *Cache) Invalidate(ref string) {
+	c.mu.Lock()
+	delete(c.entries, ref)
+	c.mu.Unlock()
+}
+
+// Resolver returns a ready-made Resolver backed by c: it looks up l.Ref via
+// Get and wraps the result with Chain(ds...). A load or compile error
+// propagates wrapped, as returned by Get.
+func (c *Cache) Resolver(ds ...Decorator) Resolver {
+	chain := Chain(ds...)
+	return func(ctx context.Context, l Link) (Decider, error) {
+		compiled, err := c.Get(ctx, l.Ref)
+		if err != nil {
+			return nil, err
+		}
+		return chain(compiled), nil
+	}
+}

--- a/web/smartlink/cache.go
+++ b/web/smartlink/cache.go
@@ -21,7 +21,11 @@ type Resolver func(ctx context.Context, l Link) (Decider, error)
 type Cache struct {
 	load    func(ctx context.Context, ref string) (Spec, error)
 	entries map[string]*Compiled
-	opts    []Option
+	// gens counts Invalidate calls per ref. Get stores a loaded result only
+	// when the generation it observed on the miss is still current, so a
+	// stale in-flight load can never overwrite a post-Invalidate entry.
+	gens map[string]uint64
+	opts []Option
 
 	mu sync.RWMutex
 }
@@ -34,13 +38,17 @@ type Cache struct {
 // goroutines that miss on the same ref concurrently may both load and
 // compile — the redundant work is benign because Compiled values for the
 // same Spec are interchangeable, so the second store just overwrites the
-// first with an equivalent result. Errors from load or Compile are never
+// first with an equivalent result. An Invalidate concurrent with an
+// in-flight load bumps the ref's generation, so the straggler's stale
+// result is discarded instead of stored — it can never overwrite an entry
+// cached after the Invalidate. Errors from load or Compile are never
 // cached, so the next Get retries.
 func NewCache(load func(ctx context.Context, ref string) (Spec, error), compileOpts ...Option) *Cache {
 	return &Cache{
 		load:    load,
 		opts:    compileOpts,
 		entries: make(map[string]*Compiled),
+		gens:    make(map[string]uint64),
 	}
 }
 
@@ -49,6 +57,7 @@ func NewCache(load func(ctx context.Context, ref string) (Spec, error), compileO
 func (c *Cache) Get(ctx context.Context, ref string) (*Compiled, error) {
 	c.mu.RLock()
 	compiled, ok := c.entries[ref]
+	gen := c.gens[ref]
 	c.mu.RUnlock()
 	if ok {
 		return compiled, nil
@@ -64,7 +73,12 @@ func (c *Cache) Get(ctx context.Context, ref string) (*Compiled, error) {
 	}
 
 	c.mu.Lock()
-	c.entries[ref] = compiled
+	if c.gens[ref] == gen {
+		c.entries[ref] = compiled
+	}
+	// Otherwise an Invalidate landed while this load was in flight: discard
+	// the stale result from the cache but still return it — it was correct
+	// when this call began, and the next Get reloads fresh.
 	c.mu.Unlock()
 	return compiled, nil
 }
@@ -74,6 +88,7 @@ func (c *Cache) Get(ctx context.Context, ref string) (*Compiled, error) {
 func (c *Cache) Invalidate(ref string) {
 	c.mu.Lock()
 	delete(c.entries, ref)
+	c.gens[ref]++
 	c.mu.Unlock()
 }
 

--- a/web/smartlink/cache.go
+++ b/web/smartlink/cache.go
@@ -7,8 +7,8 @@ import (
 )
 
 // Resolver resolves a Ref-backed Link to a Decider ready for a click decision.
-// [Cache.Resolver] returns a ready-made one; a Manager (a later task) is the
-// seam's consumer. Resolver does not special-case ErrNoTarget: when the
+// [Cache.Resolver] returns a ready-made one; [WithResolver] wires it into a
+// Manager. Resolver does not special-case ErrNoTarget: when the
 // consumer's load func returns it for a paused or deleted offer, Resolver
 // propagates the wrapped error and leaves the mapping to dead-link handling
 // to the caller.

--- a/web/smartlink/cache.go
+++ b/web/smartlink/cache.go
@@ -24,6 +24,9 @@ type Cache struct {
 	// gens counts Invalidate calls per ref. Get stores a loaded result only
 	// when the generation it observed on the miss is still current, so a
 	// stale in-flight load can never overwrite a post-Invalidate entry.
+	// Growth is bounded by distinct-ref cardinality (~16 bytes/entry) and
+	// deliberately never pruned — dropping a counter would let a stale
+	// in-flight load re-admit a straggler after Invalidate.
 	gens map[string]uint64
 	opts []Option
 
@@ -31,7 +34,10 @@ type Cache struct {
 }
 
 // NewCache returns a Cache that loads a Spec via load and compiles it with
-// compileOpts on a cache miss.
+// compileOpts on a cache miss. ref must be globally unique and load must be
+// a pure function of ref — the cache is keyed by the bare ref string with no
+// tenant dimension, so a multi-tenant consumer whose resolution differs per
+// tenant must embed the tenant in ref itself.
 //
 // Get takes an RLock fast path; on a miss it calls load and Compile outside
 // the write lock, then stores the result under a short write lock. Two

--- a/web/smartlink/cache_test.go
+++ b/web/smartlink/cache_test.go
@@ -3,6 +3,7 @@ package smartlink_test
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/dmitrymomot/forge/web/smartlink"
@@ -87,6 +88,64 @@ func TestCacheCompileErrorPropagates(t *testing.T) {
 	_, err := cache.Get(ctx, "ref-1")
 	if !errors.Is(err, smartlink.ErrNoDefault) {
 		t.Fatalf("Get() error = %v, want wrapping %v", err, smartlink.ErrNoDefault)
+	}
+}
+
+// TestCacheInvalidateDuringLoad asserts that an Invalidate issued while a
+// load is in flight cannot be defeated by the stale result: the straggler's
+// Compiled must not overwrite a fresher entry stored after the Invalidate.
+func TestCacheInvalidateDuringLoad(t *testing.T) {
+	t.Parallel()
+	const (
+		oldURL = "https://old.example.com/"
+		newURL = "https://new.example.com/"
+	)
+	var calls atomic.Int32
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	cache := smartlink.NewCache(func(context.Context, string) (smartlink.Spec, error) {
+		if calls.Add(1) == 1 {
+			close(entered)
+			<-release
+			return smartlink.Spec{Default: []smartlink.Target{{URL: oldURL}}}, nil
+		}
+		return smartlink.Spec{Default: []smartlink.Target{{URL: newURL}}}, nil
+	})
+	ctx := context.Background()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// The straggler still gets a correct-at-call-time result; only the
+		// store must be suppressed.
+		if _, err := cache.Get(ctx, "ref-1"); err != nil {
+			t.Errorf("straggler Get() error = %v", err)
+		}
+	}()
+
+	<-entered // straggler is inside load, nothing cached yet
+	cache.Invalidate("ref-1")
+
+	compiled, err := cache.Get(ctx, "ref-1") // loads and stores the new Spec
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got := compiled.Decide(smartlink.Visit{}).URL; got != newURL {
+		t.Fatalf("post-invalidate Decide().URL = %q, want %q", got, newURL)
+	}
+
+	close(release) // straggler finishes; its stale result must be discarded
+	<-done
+
+	final, err := cache.Get(ctx, "ref-1")
+	if err != nil {
+		t.Fatalf("final Get() error = %v", err)
+	}
+	if got := final.Decide(smartlink.Visit{}).URL; got != newURL {
+		t.Fatalf("final Decide().URL = %q, want %q (stale store overwrote fresh entry)", got, newURL)
+	}
+	if n := calls.Load(); n != 2 {
+		t.Fatalf("load calls = %d, want 2 (final Get must hit the cache)", n)
 	}
 }
 

--- a/web/smartlink/cache_test.go
+++ b/web/smartlink/cache_test.go
@@ -1,0 +1,108 @@
+package smartlink_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+// countingLoad returns a load func that returns spec (or err, if non-nil) and
+// counts its calls in n.
+func countingLoad(n *int, spec smartlink.Spec, err error) func(context.Context, string) (smartlink.Spec, error) {
+	return func(context.Context, string) (smartlink.Spec, error) {
+		*n++
+		if err != nil {
+			return smartlink.Spec{}, err
+		}
+		return spec, nil
+	}
+}
+
+func TestCacheGetCompilesOnce(t *testing.T) {
+	t.Parallel()
+	var calls int
+	cache := smartlink.NewCache(countingLoad(&calls, smartlink.Spec{Default: defTargets()}, nil))
+	ctx := context.Background()
+
+	if _, err := cache.Get(ctx, "ref-1"); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if _, err := cache.Get(ctx, "ref-1"); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("load calls = %d, want 1", calls)
+	}
+}
+
+func TestCacheInvalidate(t *testing.T) {
+	t.Parallel()
+	var calls int
+	cache := smartlink.NewCache(countingLoad(&calls, smartlink.Spec{Default: defTargets()}, nil))
+	ctx := context.Background()
+
+	if _, err := cache.Get(ctx, "ref-1"); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	cache.Invalidate("ref-1")
+	if _, err := cache.Get(ctx, "ref-1"); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("load calls = %d, want 2", calls)
+	}
+}
+
+func TestCacheLoadErrorNotCached(t *testing.T) {
+	t.Parallel()
+	loadErr := errors.New("boundary: db unavailable")
+	first := true
+	cache := smartlink.NewCache(func(context.Context, string) (smartlink.Spec, error) {
+		if first {
+			first = false
+			return smartlink.Spec{}, loadErr
+		}
+		return smartlink.Spec{Default: defTargets()}, nil
+	})
+	ctx := context.Background()
+
+	if _, err := cache.Get(ctx, "ref-1"); !errors.Is(err, loadErr) {
+		t.Fatalf("Get() error = %v, want wrapping %v", err, loadErr)
+	}
+	if _, err := cache.Get(ctx, "ref-1"); err != nil {
+		t.Fatalf("Get() error = %v, want nil on retry", err)
+	}
+}
+
+func TestCacheCompileErrorPropagates(t *testing.T) {
+	t.Parallel()
+	// Spec{} has no default target, a Compile-time validation error.
+	cache := smartlink.NewCache(func(context.Context, string) (smartlink.Spec, error) {
+		return smartlink.Spec{}, nil
+	})
+	ctx := context.Background()
+
+	_, err := cache.Get(ctx, "ref-1")
+	if !errors.Is(err, smartlink.ErrNoDefault) {
+		t.Fatalf("Get() error = %v, want wrapping %v", err, smartlink.ErrNoDefault)
+	}
+}
+
+func TestCacheResolver(t *testing.T) {
+	t.Parallel()
+	cache := smartlink.NewCache(func(context.Context, string) (smartlink.Spec, error) {
+		return smartlink.Spec{Default: defTargets()}, nil
+	})
+	resolver := cache.Resolver(tagDecorator("R"))
+
+	d, err := resolver(context.Background(), smartlink.Link{Ref: "ref-1"})
+	if err != nil {
+		t.Fatalf("Resolver() error = %v", err)
+	}
+	got := d.Decide(smartlink.Visit{}).Rule
+	if got != "R" {
+		t.Fatalf("Decide().Rule = %q, want %q", got, "R")
+	}
+}

--- a/web/smartlink/codes.go
+++ b/web/smartlink/codes.go
@@ -1,0 +1,99 @@
+package smartlink
+
+import (
+	"strings"
+
+	"github.com/dmitrymomot/forge/core/random"
+)
+
+// base58Alphabet is the Bitcoin-style base58 charset: no 0/O/I/l, which are
+// easy to transpose in a printed or read-aloud short code.
+const base58Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+// RandomCode returns a code generator producing n-character strings drawn
+// from the base58 alphabet via [random.String]. Pass it to [WithCodeFunc] in
+// place of the default (a lowercase Crockford [github.com/dmitrymomot/forge/core/id.Short])
+// for shorter or differently-shaped generated codes.
+func RandomCode(n int) func() string {
+	return func() string { return random.String(n, base58Alphabet) }
+}
+
+// defaultReservedCodes are vanity codes that would shadow common app routes
+// or well-known paths. [WithReservedCodes] extends this set.
+var defaultReservedCodes = []string{
+	"api", "admin", "app", "assets", "static", "health", "healthz", "metrics",
+	"favicon.ico", "robots.txt", "login", "logout", "signup", "docs", "status",
+	"www", ".well-known",
+}
+
+// newReservedSet returns a fresh map seeded with defaultReservedCodes, so
+// each Manager owns an independent, separately extensible blocklist.
+func newReservedSet() map[string]struct{} {
+	set := make(map[string]struct{}, len(defaultReservedCodes))
+	for _, c := range defaultReservedCodes {
+		set[c] = struct{}{}
+	}
+	return set
+}
+
+// validCodeChars reports whether code is 1-64 characters, each one of
+// [A-Za-z0-9_-] — the vanity code charset.
+func validCodeChars(code string) bool {
+	if code == "" || len(code) > 64 {
+		return false
+	}
+	for i := range len(code) {
+		c := code[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '_', c == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// macroElide strips {macro} placeholders from a target template, leaving
+// only the literal text. Compile has already validated brace balance by the
+// time this runs, so it is a plain scan, not a re-validation.
+func macroElide(raw string) string {
+	var b strings.Builder
+	rest := raw
+	for {
+		open := strings.IndexByte(rest, '{')
+		if open < 0 {
+			b.WriteString(rest)
+			break
+		}
+		close := strings.IndexByte(rest[open:], '}')
+		if close < 0 {
+			b.WriteString(rest)
+			break
+		}
+		close += open
+		b.WriteString(rest[:open])
+		rest = rest[close+1:]
+	}
+	return b.String()
+}
+
+// authorityHasMacro reports whether raw's authority (host[:port]) segment —
+// between "//" (or "scheme://") and the first '/', '?', or '#' — contains a
+// macro placeholder, so a fully or partially dynamic host is recognized as
+// intentional rather than a missing-host error.
+func authorityHasMacro(raw string) bool {
+	start := -1
+	if i := strings.Index(raw, "://"); i >= 0 {
+		start = i + 3
+	} else if strings.HasPrefix(raw, "//") {
+		start = 2
+	}
+	if start < 0 {
+		return false
+	}
+	end := len(raw)
+	if i := strings.IndexAny(raw[start:], "/?#"); i >= 0 {
+		end = start + i
+	}
+	return strings.ContainsRune(raw[start:end], '{')
+}

--- a/web/smartlink/compile.go
+++ b/web/smartlink/compile.go
@@ -7,9 +7,9 @@ import (
 	"github.com/dmitrymomot/forge/core/clock"
 )
 
-// Link is a compiled Spec ready for per-click decisions. Compile once per
+// Compiled is a compiled Spec ready for per-click decisions. Compile once per
 // rule-set version and reuse; Decide is safe for concurrent use.
-type Link struct {
+type Compiled struct {
 	clock    clock.Clock
 	rules    []compiledRule
 	def      split
@@ -43,9 +43,9 @@ type compiledTarget struct {
 // Compile validates a consumer-hydrated Spec fail-fast — missing default,
 // bad rule or matcher values, malformed or unknown-macro templates are all
 // construction errors — and returns the immutable decision engine for it.
-func Compile(spec Spec, opts ...Option) (*Link, error) {
+func Compile(spec Spec, opts ...Option) (*Compiled, error) {
 	cfg := newConfig(opts...)
-	l := &Link{clock: cfg.clock, params: spec.Params}
+	l := &Compiled{clock: cfg.clock, params: spec.Params}
 	switch spec.Params {
 	case ParamsDrop, ParamsFill, ParamsOverride:
 	default:

--- a/web/smartlink/compile.go
+++ b/web/smartlink/compile.go
@@ -1,0 +1,136 @@
+package smartlink
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// Link is a compiled Spec ready for per-click decisions. Compile once per
+// rule-set version and reuse; Decide is safe for concurrent use.
+type Link struct {
+	clock    clock.Clock
+	rules    []compiledRule
+	def      split
+	params   ParamPolicy
+	needsNow bool
+}
+
+// compiledRule is one validated rule with normalized matchers and a
+// precomputed split.
+type compiledRule struct {
+	name    string
+	when    []matcher
+	targets split
+}
+
+// split is a target list with cumulative weights for deterministic
+// sticky-key bucketing.
+type split struct {
+	targets []compiledTarget
+	cum     []int // cumulative weights, len == len(targets); nil for a single target
+	seed    uint64
+	total   uint64
+}
+
+// compiledTarget pairs the caller's raw target with its parsed URL template.
+type compiledTarget struct {
+	raw  Target
+	tmpl template
+}
+
+// Compile validates a consumer-hydrated Spec fail-fast — missing default,
+// bad rule or matcher values, malformed or unknown-macro templates are all
+// construction errors — and returns the immutable decision engine for it.
+func Compile(spec Spec, opts ...Option) (*Link, error) {
+	cfg := newConfig(opts...)
+	l := &Link{clock: cfg.clock, params: spec.Params}
+	switch spec.Params {
+	case ParamsDrop, ParamsFill, ParamsOverride:
+	default:
+		return nil, fmt.Errorf("%w: unknown ParamPolicy %d", ErrInvalidRule, spec.Params)
+	}
+
+	def, err := compileSplit(spec.Default, "")
+	if err != nil {
+		return nil, err
+	}
+	l.def = def
+
+	seen := make(map[string]struct{}, len(spec.Rules))
+	l.rules = make([]compiledRule, 0, len(spec.Rules))
+	for _, r := range spec.Rules {
+		if r.Name == "" {
+			return nil, fmt.Errorf("%w: empty rule name", ErrInvalidRule)
+		}
+		if _, dup := seen[r.Name]; dup {
+			return nil, fmt.Errorf("%w: duplicate rule name %q", ErrInvalidRule, r.Name)
+		}
+		seen[r.Name] = struct{}{}
+
+		cr := compiledRule{name: r.Name, when: make([]matcher, 0, len(r.When))}
+		for _, m := range r.When {
+			if m == nil {
+				return nil, fmt.Errorf("%w: rule %q: nil matcher", ErrInvalidMatcher, r.Name)
+			}
+			cm, err := m.compile(r.Name)
+			if err != nil {
+				return nil, err
+			}
+			if cm.kind == matchTime {
+				l.needsNow = true
+			}
+			cr.when = append(cr.when, cm)
+		}
+		cr.targets, err = compileSplit(r.Targets, r.Name)
+		if err != nil {
+			return nil, err
+		}
+		l.rules = append(l.rules, cr)
+	}
+	return l, nil
+}
+
+// compileSplit validates a target list (rule targets or the default list,
+// ruleName == "") and precomputes its templates and cumulative weights.
+func compileSplit(targets []Target, ruleName string) (split, error) {
+	where := "default targets"
+	if ruleName != "" {
+		where = fmt.Sprintf("rule %q", ruleName)
+	}
+	if len(targets) == 0 {
+		if ruleName == "" {
+			return split{}, ErrNoDefault
+		}
+		return split{}, fmt.Errorf("%w: %s: no targets", ErrInvalidRule, where)
+	}
+	s := split{targets: make([]compiledTarget, len(targets))}
+	for i, t := range targets {
+		if t.URL == "" {
+			return split{}, fmt.Errorf("%w: %s: empty URL", ErrInvalidTarget, where)
+		}
+		if t.Weight < 0 || (len(targets) > 1 && t.Weight < 1) {
+			return split{}, fmt.Errorf("%w: %s: target %q weight %d", ErrInvalidTarget, where, t.URL, t.Weight)
+		}
+		tmpl, err := parseTemplate(t.URL, where)
+		if err != nil {
+			return split{}, err
+		}
+		s.targets[i] = compiledTarget{raw: t, tmpl: tmpl}
+	}
+	if len(targets) > 1 {
+		s.seed = hashString(fnvOffset, "s\x00"+ruleName)
+		s.cum = make([]int, len(targets))
+		var total int64
+		for i, t := range targets {
+			total += int64(t.Weight)
+			if total > math.MaxInt32 {
+				return split{}, fmt.Errorf("%w: %s: split weights sum past %d", ErrInvalidTarget, where, math.MaxInt32)
+			}
+			s.cum[i] = int(total)
+		}
+		s.total = uint64(total)
+	}
+	return s, nil
+}

--- a/web/smartlink/compile_test.go
+++ b/web/smartlink/compile_test.go
@@ -1,0 +1,98 @@
+package smartlink_test
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+func defTargets() []smartlink.Target {
+	return []smartlink.Target{{URL: "https://example.com/"}}
+}
+
+func TestCompileValidation(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		spec smartlink.Spec
+		want error
+	}{
+		{"empty spec", smartlink.Spec{}, smartlink.ErrNoDefault},
+		{"no default with rules", smartlink.Spec{Rules: []smartlink.Rule{{Name: "r", Targets: defTargets()}}}, smartlink.ErrNoDefault},
+		{"default empty URL", smartlink.Spec{Default: []smartlink.Target{{}}}, smartlink.ErrInvalidTarget},
+		{"default split zero weight", smartlink.Spec{Default: []smartlink.Target{{URL: "https://a.com", Weight: 1}, {URL: "https://b.com"}}}, smartlink.ErrInvalidTarget},
+		{"negative weight single target", smartlink.Spec{Default: []smartlink.Target{{URL: "https://a.com", Weight: -1}}}, smartlink.ErrInvalidTarget},
+		{"split weight overflow", smartlink.Spec{Default: []smartlink.Target{
+			{URL: "https://a.com", Weight: math.MaxInt32}, {URL: "https://b.com", Weight: 1},
+		}}, smartlink.ErrInvalidTarget},
+		{"bad param policy", smartlink.Spec{Default: defTargets(), Params: smartlink.ParamPolicy(99)}, smartlink.ErrInvalidRule},
+		{"empty rule name", smartlink.Spec{Default: defTargets(), Rules: []smartlink.Rule{{Targets: defTargets()}}}, smartlink.ErrInvalidRule},
+		{"duplicate rule name", smartlink.Spec{Default: defTargets(), Rules: []smartlink.Rule{
+			{Name: "r", Targets: defTargets()}, {Name: "r", Targets: defTargets()},
+		}}, smartlink.ErrInvalidRule},
+		{"rule without targets", smartlink.Spec{Default: defTargets(), Rules: []smartlink.Rule{{Name: "r"}}}, smartlink.ErrInvalidRule},
+		{"nil matcher", smartlink.Spec{Default: defTargets(), Rules: []smartlink.Rule{
+			{Name: "r", When: []smartlink.Matcher{nil}, Targets: defTargets()},
+		}}, smartlink.ErrInvalidMatcher},
+		{"geo empty", ruleSpec(smartlink.Geo{}), smartlink.ErrInvalidMatcher},
+		{"geo three letters", ruleSpec(smartlink.Geo{Countries: []string{"USA"}}), smartlink.ErrInvalidMatcher},
+		{"geo digit", ruleSpec(smartlink.Geo{Countries: []string{"D1"}}), smartlink.ErrInvalidMatcher},
+		{"device empty list", ruleSpec(smartlink.Device{}), smartlink.ErrInvalidMatcher},
+		{"device empty value", ruleSpec(smartlink.Device{Devices: []string{""}}), smartlink.ErrInvalidMatcher},
+		{"locale empty list", ruleSpec(smartlink.Locale{}), smartlink.ErrInvalidMatcher},
+		{"param equals no key", ruleSpec(smartlink.ParamEquals{Values: []string{"x"}}), smartlink.ErrInvalidMatcher},
+		{"param equals no values", ruleSpec(smartlink.ParamEquals{Key: "k"}), smartlink.ErrInvalidMatcher},
+		{"time window unbounded", ruleSpec(smartlink.TimeWindow{}), smartlink.ErrInvalidMatcher},
+		{"time window inverted", ruleSpec(smartlink.TimeWindow{From: at, Until: at.Add(-time.Hour)}), smartlink.ErrInvalidMatcher},
+		{"time window empty", ruleSpec(smartlink.TimeWindow{From: at, Until: at}), smartlink.ErrInvalidMatcher},
+		{"percent zero", ruleSpec(smartlink.Percent{}), smartlink.ErrInvalidMatcher},
+		{"percent hundred", ruleSpec(smartlink.Percent{Share: 100}), smartlink.ErrInvalidMatcher},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := smartlink.Compile(tc.spec); !errors.Is(err, tc.want) {
+				t.Fatalf("Compile() error = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompileTemplateValidation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		url  string
+		want error
+	}{
+		{"unclosed brace", "https://a.com/{country", smartlink.ErrInvalidTemplate},
+		{"unmatched close", "https://a.com/}x", smartlink.ErrInvalidTemplate},
+		{"close before open", "https://a.com/}{country}", smartlink.ErrInvalidTemplate},
+		{"trailing close after macro", "https://a.com/{country}}", smartlink.ErrInvalidTemplate},
+		{"bad url escape", "https://a.com/%zz", smartlink.ErrInvalidTemplate},
+		{"unknown macro", "https://a.com/{ip}", smartlink.ErrUnknownMacro},
+		{"empty param macro", "https://a.com/{param.}", smartlink.ErrUnknownMacro},
+		{"empty macro", "https://a.com/{}", smartlink.ErrUnknownMacro},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			spec := smartlink.Spec{Default: []smartlink.Target{{URL: tc.url}}}
+			if _, err := smartlink.Compile(spec); !errors.Is(err, tc.want) {
+				t.Fatalf("Compile() error = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// ruleSpec wraps a single matcher into an otherwise-valid Spec.
+func ruleSpec(m smartlink.Matcher) smartlink.Spec {
+	return smartlink.Spec{
+		Default: defTargets(),
+		Rules:   []smartlink.Rule{{Name: "r", When: []smartlink.Matcher{m}, Targets: defTargets()}},
+	}
+}

--- a/web/smartlink/decide.go
+++ b/web/smartlink/decide.go
@@ -21,7 +21,7 @@ type Decision struct {
 // whose matchers all match wins, falling back to the default target — picks a
 // split target by sticky-key bucket, and renders the final URL. It never
 // fails: every failure mode is a Compile error.
-func (l *Link) Decide(v Visit) Decision {
+func (l *Compiled) Decide(v Visit) Decision {
 	var now time.Time
 	if l.needsNow {
 		now = v.At
@@ -69,7 +69,7 @@ func (s *split) pick(stickyKey string) *compiledTarget {
 
 // finalURL renders the target's macros and merges visit params per the link
 // policy.
-func (l *Link) finalURL(t *compiledTarget, v *Visit) string {
+func (l *Compiled) finalURL(t *compiledTarget, v *Visit) string {
 	rendered := t.tmpl.render(v)
 	if l.params == ParamsDrop || len(v.Params) == 0 {
 		return rendered

--- a/web/smartlink/decide.go
+++ b/web/smartlink/decide.go
@@ -1,0 +1,94 @@
+package smartlink
+
+import (
+	"net/url"
+	"time"
+)
+
+// Decision is the outcome of one Decide call — what the caller redirects to
+// and emits as the click event.
+type Decision struct {
+	// Rule is the matched rule's name; empty when the default target was used.
+	Rule string
+	// URL is the final destination: macros rendered, visit params merged per
+	// the link's ParamPolicy.
+	URL string
+	// Target is the chosen raw (template-form) target, before rendering.
+	Target Target
+}
+
+// Decide evaluates the visit against the link's rules in order — first rule
+// whose matchers all match wins, falling back to the default target — picks a
+// split target by sticky-key bucket, and renders the final URL. It never
+// fails: every failure mode is a Compile error.
+func (l *Link) Decide(v Visit) Decision {
+	var now time.Time
+	if l.needsNow {
+		now = v.At
+		if now.IsZero() {
+			now = l.clock.Now()
+		}
+	}
+	for i := range l.rules {
+		r := &l.rules[i]
+		if matchAll(r.when, &v, now) {
+			t := r.targets.pick(v.StickyKey)
+			return Decision{Rule: r.name, Target: t.raw, URL: l.finalURL(t, &v)}
+		}
+	}
+	t := l.def.pick(v.StickyKey)
+	return Decision{Target: t.raw, URL: l.finalURL(t, &v)}
+}
+
+// matchAll reports whether every matcher in the conjunction matches; an empty
+// conjunction always matches.
+func matchAll(when []matcher, v *Visit, now time.Time) bool {
+	for i := range when {
+		if !when[i].match(v, now) {
+			return false
+		}
+	}
+	return true
+}
+
+// pick buckets the sticky key into the split's cumulative weights. A single
+// target returns directly; an empty key deterministically takes the first
+// target.
+func (s *split) pick(stickyKey string) *compiledTarget {
+	if s.cum == nil || stickyKey == "" {
+		return &s.targets[0]
+	}
+	n := int(hashString(s.seed, stickyKey) % s.total)
+	for i, c := range s.cum {
+		if n < c {
+			return &s.targets[i]
+		}
+	}
+	return &s.targets[len(s.targets)-1] // unreachable: n < total == cum[last]
+}
+
+// finalURL renders the target's macros and merges visit params per the link
+// policy.
+func (l *Link) finalURL(t *compiledTarget, v *Visit) string {
+	rendered := t.tmpl.render(v)
+	if l.params == ParamsDrop || len(v.Params) == 0 {
+		return rendered
+	}
+	u, err := url.Parse(rendered)
+	if err != nil {
+		// Unreachable: the template parsed at compile and macro values are
+		// escaped, so the rendered URL preserves the validated structure.
+		return rendered
+	}
+	q := u.Query()
+	for k, val := range v.Params {
+		if k == "" {
+			continue
+		}
+		if l.params == ParamsOverride || !q.Has(k) {
+			q.Set(k, val)
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}

--- a/web/smartlink/decide_test.go
+++ b/web/smartlink/decide_test.go
@@ -1,0 +1,422 @@
+package smartlink_test
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+func mustCompile(t *testing.T, spec smartlink.Spec, opts ...smartlink.Option) *smartlink.Link {
+	t.Helper()
+	link, err := smartlink.Compile(spec, opts...)
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+	return link
+}
+
+func rule(name, url string, when ...smartlink.Matcher) smartlink.Rule {
+	return smartlink.Rule{Name: name, When: when, Targets: []smartlink.Target{{URL: url}}}
+}
+
+func TestDecideFirstMatchWins(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Rules: []smartlink.Rule{
+			rule("first", "https://first.com", smartlink.Geo{Countries: []string{"DE"}}),
+			rule("second", "https://second.com", smartlink.Geo{Countries: []string{"DE"}}),
+		},
+		Default: defTargets(),
+	})
+	d := link.Decide(smartlink.Visit{Country: "DE"})
+	if d.Rule != "first" || d.URL != "https://first.com" {
+		t.Fatalf("got (%q, %q), want first rule", d.Rule, d.URL)
+	}
+}
+
+func TestDecideDefaultFallback(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Rules:   []smartlink.Rule{rule("de", "https://de.com", smartlink.Geo{Countries: []string{"DE"}})},
+		Default: defTargets(),
+	})
+	d := link.Decide(smartlink.Visit{Country: "US"})
+	if d.Rule != "" || d.URL != "https://example.com/" {
+		t.Fatalf("got (%q, %q), want default", d.Rule, d.URL)
+	}
+	if d.Target.URL != "https://example.com/" {
+		t.Fatalf("Target = %+v, want raw default target", d.Target)
+	}
+}
+
+func TestDecideUnconditionalRule(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Rules:   []smartlink.Rule{rule("maintenance", "https://sorry.com")},
+		Default: defTargets(),
+	})
+	if d := link.Decide(smartlink.Visit{}); d.Rule != "maintenance" {
+		t.Fatalf("Rule = %q, want maintenance", d.Rule)
+	}
+}
+
+func TestDecideConjunction(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Rules: []smartlink.Rule{rule("de-mobile", "https://hit.com",
+			smartlink.Geo{Countries: []string{"DE"}},
+			smartlink.Device{Devices: []string{"mobile"}},
+		)},
+		Default: defTargets(),
+	})
+	if d := link.Decide(smartlink.Visit{Country: "DE", Device: "mobile"}); d.Rule != "de-mobile" {
+		t.Fatalf("both matchers true: Rule = %q, want de-mobile", d.Rule)
+	}
+	if d := link.Decide(smartlink.Visit{Country: "DE", Device: "desktop"}); d.Rule != "" {
+		t.Fatalf("one matcher false: Rule = %q, want default", d.Rule)
+	}
+}
+
+func TestGeoCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Rules:   []smartlink.Rule{rule("geo", "https://hit.com", smartlink.Geo{Countries: []string{"de"}})},
+		Default: defTargets(),
+	})
+	for _, country := range []string{"DE", "de", "De"} {
+		if d := link.Decide(smartlink.Visit{Country: country}); d.Rule != "geo" {
+			t.Fatalf("country %q: Rule = %q, want geo", country, d.Rule)
+		}
+	}
+	if d := link.Decide(smartlink.Visit{}); d.Rule != "" {
+		t.Fatalf("empty country matched geo rule")
+	}
+}
+
+func TestLocaleMatching(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		rule  string
+		visit string
+		want  bool
+	}{
+		{"en", "en", true},
+		{"en", "en-US", true},
+		{"en", "EN-GB", true},
+		{"en-US", "en-US", true},
+		{"en-us", "EN-US", true},
+		{"en-US", "en", false},
+		{"en-US", "en-GB", false},
+		{"en", "de", false},
+		{"en", "", false},
+	}
+	for _, tc := range cases {
+		link := mustCompile(t, smartlink.Spec{
+			Rules:   []smartlink.Rule{rule("loc", "https://hit.com", smartlink.Locale{Locales: []string{tc.rule}})},
+			Default: defTargets(),
+		})
+		got := link.Decide(smartlink.Visit{Locale: tc.visit}).Rule == "loc"
+		if got != tc.want {
+			t.Errorf("rule %q vs visit %q: matched = %v, want %v", tc.rule, tc.visit, got, tc.want)
+		}
+	}
+}
+
+func TestParamEqualsExact(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Rules: []smartlink.Rule{rule("src", "https://hit.com",
+			smartlink.ParamEquals{Key: "source", Values: []string{"fb", "ig"}},
+		)},
+		Default: defTargets(),
+	})
+	if d := link.Decide(smartlink.Visit{Params: map[string]string{"source": "ig"}}); d.Rule != "src" {
+		t.Fatalf("listed value: Rule = %q, want src", d.Rule)
+	}
+	if d := link.Decide(smartlink.Visit{Params: map[string]string{"source": "FB"}}); d.Rule != "" {
+		t.Fatalf("param match must be case-sensitive")
+	}
+	if d := link.Decide(smartlink.Visit{}); d.Rule != "" {
+		t.Fatalf("missing param matched")
+	}
+}
+
+func TestTimeWindow(t *testing.T) {
+	t.Parallel()
+	from := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+	until := from.Add(24 * time.Hour)
+	mock := clock.NewMock(from.Add(time.Hour))
+	link := mustCompile(t, smartlink.Spec{
+		Rules:   []smartlink.Rule{rule("window", "https://hit.com", smartlink.TimeWindow{From: from, Until: until})},
+		Default: defTargets(),
+	}, smartlink.WithClock(mock))
+
+	if d := link.Decide(smartlink.Visit{}); d.Rule != "window" {
+		t.Fatalf("inside window: Rule = %q, want window", d.Rule)
+	}
+	mock.Set(until) // Until is exclusive
+	if d := link.Decide(smartlink.Visit{}); d.Rule != "" {
+		t.Fatalf("at Until: Rule = %q, want default", d.Rule)
+	}
+	mock.Set(from.Add(-time.Second))
+	if d := link.Decide(smartlink.Visit{}); d.Rule != "" {
+		t.Fatalf("before From: Rule = %q, want default", d.Rule)
+	}
+	// Visit.At overrides the clock (click-log replay).
+	if d := link.Decide(smartlink.Visit{At: from.Add(time.Minute)}); d.Rule != "window" {
+		t.Fatalf("Visit.At inside window: Rule = %q, want window", d.Rule)
+	}
+}
+
+func TestTimeWindowOpenEnded(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	link := mustCompile(t, smartlink.Spec{
+		Rules: []smartlink.Rule{
+			rule("until-only", "https://until.com", smartlink.TimeWindow{Until: at}),
+			rule("from-only", "https://from.com", smartlink.TimeWindow{From: at}),
+		},
+		Default: defTargets(),
+	})
+	if d := link.Decide(smartlink.Visit{At: at.Add(-time.Hour)}); d.Rule != "until-only" {
+		t.Fatalf("before at: Rule = %q, want until-only", d.Rule)
+	}
+	if d := link.Decide(smartlink.Visit{At: at.Add(time.Hour)}); d.Rule != "from-only" {
+		t.Fatalf("after at: Rule = %q, want from-only", d.Rule)
+	}
+}
+
+func TestPercentDeterministicAndDistributed(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Rules:   []smartlink.Rule{rule("pct", "https://hit.com", smartlink.Percent{Share: 30})},
+		Default: defTargets(),
+	})
+	// Deterministic: the same sticky key always lands on the same side.
+	first := link.Decide(smartlink.Visit{StickyKey: "visitor-1"}).Rule
+	for range 10 {
+		if got := link.Decide(smartlink.Visit{StickyKey: "visitor-1"}).Rule; got != first {
+			t.Fatalf("same sticky key flipped: %q then %q", first, got)
+		}
+	}
+	// Empty sticky key fails closed.
+	if d := link.Decide(smartlink.Visit{}); d.Rule != "" {
+		t.Fatalf("empty sticky key matched Percent")
+	}
+	// Distribution over many keys approximates the share.
+	matched := 0
+	const n = 5000
+	for i := range n {
+		if link.Decide(smartlink.Visit{StickyKey: "k" + strconv.Itoa(i)}).Rule == "pct" {
+			matched++
+		}
+	}
+	if pct := float64(matched) * 100 / n; pct < 26 || pct > 34 {
+		t.Fatalf("share 30 matched %.1f%% of keys", pct)
+	}
+}
+
+func TestWeightedSplit(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Default: []smartlink.Target{
+			{URL: "https://a.com", Weight: 70},
+			{URL: "https://b.com", Weight: 30},
+		},
+	})
+	// Deterministic per key.
+	first := link.Decide(smartlink.Visit{StickyKey: "visitor-1"}).URL
+	for range 10 {
+		if got := link.Decide(smartlink.Visit{StickyKey: "visitor-1"}).URL; got != first {
+			t.Fatalf("same sticky key flipped targets: %q then %q", first, got)
+		}
+	}
+	// Empty sticky key deterministically takes the first target.
+	if d := link.Decide(smartlink.Visit{}); d.URL != "https://a.com" {
+		t.Fatalf("empty sticky key got %q, want first target", d.URL)
+	}
+	// Distribution approximates the weights.
+	a := 0
+	const n = 5000
+	for i := range n {
+		if link.Decide(smartlink.Visit{StickyKey: "k" + strconv.Itoa(i)}).URL == "https://a.com" {
+			a++
+		}
+	}
+	if pct := float64(a) * 100 / n; pct < 66 || pct > 74 {
+		t.Fatalf("weight 70 target got %.1f%% of keys", pct)
+	}
+}
+
+func TestMacroRendering(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Default: []smartlink.Target{{URL: "https://a.com/{country}/land?d={device}&l={locale}&s={param.sub1}"}},
+	})
+	d := link.Decide(smartlink.Visit{
+		Country: "DE",
+		Device:  "mobile",
+		Locale:  "de-DE",
+		Params:  map[string]string{"sub1": "camp 1&x"},
+	})
+	want := "https://a.com/DE/land?d=mobile&l=de-DE&s=camp+1%26x"
+	if d.URL != want {
+		t.Fatalf("URL = %q, want %q", d.URL, want)
+	}
+	// Empty visit values render as empty substitutions.
+	if got := link.Decide(smartlink.Visit{}).URL; got != "https://a.com//land?d=&l=&s=" {
+		t.Fatalf("sparse visit URL = %q", got)
+	}
+}
+
+func TestMacroPathEscaping(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Default: []smartlink.Target{{URL: "https://a.com/{param.slug}/x"}},
+	})
+	d := link.Decide(smartlink.Visit{Params: map[string]string{"slug": "a b/c?d"}})
+	if want := "https://a.com/a%20b%2Fc%3Fd/x"; d.URL != want {
+		t.Fatalf("URL = %q, want %q", d.URL, want)
+	}
+}
+
+func TestMacroAuthorityEscaping(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Default: []smartlink.Target{{URL: "https://cdn-{param.region}.example.com/lp"}},
+	})
+	// Legitimate per-region subdomains render untouched.
+	if got := link.Decide(smartlink.Visit{Params: map[string]string{"region": "eu-1"}}).URL; got != "https://cdn-eu-1.example.com/lp" {
+		t.Fatalf("URL = %q", got)
+	}
+	// Hostile values cannot introduce userinfo, a port, or end the authority:
+	// the rendered URL still parses with a host under example.com.
+	for _, hostile := range []string{"evil.com@real.com", "a:9999", "evil.com/x", "e?y", "e#z"} {
+		got := link.Decide(smartlink.Visit{Params: map[string]string{"region": hostile}}).URL
+		u, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("region %q rendered unparseable URL %q: %v", hostile, got, err)
+		}
+		if u.User != nil || u.Port() != "" || !strings.HasSuffix(u.Hostname(), ".example.com") || u.Path != "/lp" {
+			t.Fatalf("region %q altered URL structure: %q", hostile, got)
+		}
+	}
+}
+
+func TestMacroSchemeInjection(t *testing.T) {
+	t.Parallel()
+	// A ':' in the first segment of a relative template must not reparse as a
+	// scheme delimiter.
+	link := mustCompile(t, smartlink.Spec{
+		Default: []smartlink.Target{{URL: "{param.p}/lp"}},
+	})
+	got := link.Decide(smartlink.Visit{Params: map[string]string{"p": "https://evil.com"}}).URL
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("rendered unparseable URL %q: %v", got, err)
+	}
+	if u.IsAbs() || u.Host != "" {
+		t.Fatalf("relative template became absolute: %q", got)
+	}
+}
+
+func TestParamPolicies(t *testing.T) {
+	t.Parallel()
+	target := []smartlink.Target{{URL: "https://a.com/lp?keep=orig"}}
+	visit := smartlink.Visit{Params: map[string]string{"keep": "new", "extra": "1", "": "skipme"}}
+
+	drop := mustCompile(t, smartlink.Spec{Default: target})
+	if got := drop.Decide(visit).URL; got != "https://a.com/lp?keep=orig" {
+		t.Fatalf("ParamsDrop URL = %q", got)
+	}
+
+	fill := mustCompile(t, smartlink.Spec{Default: target, Params: smartlink.ParamsFill})
+	if got := fill.Decide(visit).URL; got != "https://a.com/lp?extra=1&keep=orig" {
+		t.Fatalf("ParamsFill URL = %q", got)
+	}
+
+	override := mustCompile(t, smartlink.Spec{Default: target, Params: smartlink.ParamsOverride})
+	if got := override.Decide(visit).URL; got != "https://a.com/lp?extra=1&keep=new" {
+		t.Fatalf("ParamsOverride URL = %q", got)
+	}
+
+	// No visit params: merge policies leave the URL untouched.
+	if got := fill.Decide(smartlink.Visit{}).URL; got != "https://a.com/lp?keep=orig" {
+		t.Fatalf("ParamsFill without params URL = %q", got)
+	}
+}
+
+func TestPercentAndSplitDecorrelated(t *testing.T) {
+	t.Parallel()
+	// A rule gating 50% of traffic into a 50/50 split: if the percent gate
+	// and the split shared a hash, one split side would starve.
+	link := mustCompile(t, smartlink.Spec{
+		Rules: []smartlink.Rule{{
+			Name: "gate",
+			When: []smartlink.Matcher{smartlink.Percent{Share: 50}},
+			Targets: []smartlink.Target{
+				{URL: "https://a.com", Weight: 50},
+				{URL: "https://b.com", Weight: 50},
+			},
+		}},
+		Default: defTargets(),
+	})
+	a, b := 0, 0
+	for i := range 5000 {
+		d := link.Decide(smartlink.Visit{StickyKey: "k" + strconv.Itoa(i)})
+		switch d.URL {
+		case "https://a.com":
+			a++
+		case "https://b.com":
+			b++
+		}
+	}
+	if a == 0 || b == 0 {
+		t.Fatalf("split starved: a=%d b=%d", a, b)
+	}
+	if ratio := float64(a) / float64(a+b); ratio < 0.42 || ratio > 0.58 {
+		t.Fatalf("gated split ratio %.2f, want ~0.5", ratio)
+	}
+}
+
+func TestDecideConcurrent(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Rules: []smartlink.Rule{rule("de", "https://de.com/{country}",
+			smartlink.Geo{Countries: []string{"DE"}}, smartlink.Percent{Share: 50})},
+		Default: []smartlink.Target{
+			{URL: "https://a.com", Weight: 1},
+			{URL: "https://b.com", Weight: 1},
+		},
+	})
+	var wg sync.WaitGroup
+	for g := range 8 {
+		wg.Go(func() {
+			for i := range 200 {
+				link.Decide(smartlink.Visit{Country: "DE", StickyKey: strconv.Itoa(g*1000 + i)})
+			}
+		})
+	}
+	wg.Wait()
+}
+
+func TestDecisionReportsRawTarget(t *testing.T) {
+	t.Parallel()
+	tpl := "https://a.com/{country}"
+	link := mustCompile(t, smartlink.Spec{
+		Default: []smartlink.Target{{URL: tpl}},
+	})
+	d := link.Decide(smartlink.Visit{Country: "DE"})
+	if d.Target.URL != tpl {
+		t.Fatalf("Target.URL = %q, want raw template", d.Target.URL)
+	}
+	if !strings.Contains(d.URL, "/DE") {
+		t.Fatalf("URL = %q, want rendered", d.URL)
+	}
+}

--- a/web/smartlink/decide_test.go
+++ b/web/smartlink/decide_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/dmitrymomot/forge/web/smartlink"
 )
 
-func mustCompile(t *testing.T, spec smartlink.Spec, opts ...smartlink.Option) *smartlink.Link {
+func mustCompile(t *testing.T, spec smartlink.Spec, opts ...smartlink.Option) *smartlink.Compiled {
 	t.Helper()
 	link, err := smartlink.Compile(spec, opts...)
 	if err != nil {

--- a/web/smartlink/decider.go
+++ b/web/smartlink/decider.go
@@ -1,0 +1,30 @@
+package smartlink
+
+import "slices"
+
+// Decider makes the per-click decision. *Compiled implements it; decorators
+// (fraud guards, metrics, A/B overrides) wrap a Decider to build another one.
+type Decider interface {
+	Decide(Visit) Decision
+}
+
+// DecideFunc adapts a plain function to a Decider.
+type DecideFunc func(Visit) Decision
+
+// Decide calls f.
+func (f DecideFunc) Decide(v Visit) Decision { return f(v) }
+
+// Decorator wraps a Decider to produce another one, e.g. adding a fraud
+// guard, metrics, or an A/B override around Decide.
+type Decorator func(Decider) Decider
+
+// Chain composes decorators so the first argument runs outermost:
+// Chain(a, b, c)(d) == a(b(c(d))). Chain() returns its Decider unchanged.
+func Chain(ds ...Decorator) Decorator {
+	return func(d Decider) Decider {
+		for i := range slices.Backward(ds) {
+			d = ds[i](d)
+		}
+		return d
+	}
+}

--- a/web/smartlink/decider_test.go
+++ b/web/smartlink/decider_test.go
@@ -1,0 +1,61 @@
+package smartlink_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+// TestCompiledIsDecider asserts *Compiled satisfies Decider and that a
+// compiled link decides through the interface, not just the concrete type.
+func TestCompiledIsDecider(t *testing.T) {
+	t.Parallel()
+	var _ smartlink.Decider = (*smartlink.Compiled)(nil)
+
+	link := mustCompile(t, smartlink.Spec{Default: defTargets()})
+	var d smartlink.Decider = link
+	if got := d.Decide(smartlink.Visit{}).URL; got != "https://example.com/" {
+		t.Fatalf("Decide via interface = %q, want default target", got)
+	}
+}
+
+// tagDecorator returns a Decorator that appends tag to Decision.Rule before
+// delegating to the wrapped Decider, so composition order is observable.
+func tagDecorator(tag string) smartlink.Decorator {
+	return func(next smartlink.Decider) smartlink.Decider {
+		return smartlink.DecideFunc(func(v smartlink.Visit) smartlink.Decision {
+			d := next.Decide(v)
+			d.Rule += tag
+			return d
+		})
+	}
+}
+
+// TestChainOrder asserts Chain(A, B, C)(d) == A(B(C(d))): C runs closest to
+// d, and A's tag is applied last, ending up outermost in the result.
+func TestChainOrder(t *testing.T) {
+	t.Parallel()
+	base := smartlink.DecideFunc(func(smartlink.Visit) smartlink.Decision {
+		return smartlink.Decision{Rule: "base"}
+	})
+	chained := smartlink.Chain(tagDecorator("A"), tagDecorator("B"), tagDecorator("C"))(base)
+	got := chained.Decide(smartlink.Visit{}).Rule
+	want := "baseCBA"
+	if got != want {
+		t.Fatalf("Chain(A, B, C)(base).Decide().Rule = %q, want %q", got, want)
+	}
+}
+
+// TestChainEmpty asserts Chain() with no decorators returns the wrapped
+// Decider's decisions unchanged.
+func TestChainEmpty(t *testing.T) {
+	t.Parallel()
+	base := smartlink.DecideFunc(func(smartlink.Visit) smartlink.Decision {
+		return smartlink.Decision{Rule: "base", URL: "https://example.com/"}
+	})
+	got := smartlink.Chain()(base).Decide(smartlink.Visit{})
+	want := smartlink.Decision{Rule: "base", URL: "https://example.com/"}
+	if got != want {
+		t.Fatalf("Chain()(base).Decide() = %+v, want %+v", got, want)
+	}
+}

--- a/web/smartlink/doc.go
+++ b/web/smartlink/doc.go
@@ -1,0 +1,64 @@
+// Package smartlink is the destination-decision engine of a TDS/smartlink:
+// ordered rules of typed matchers ([Geo], [Device], [Locale], [ParamEquals],
+// [TimeWindow], [Percent]) evaluated over a caller-built [Visit], first match
+// wins, with a mandatory default target. It selects outbound destinations —
+// it is not web/hostrouter (inbound hosts) and not ops/featureflag ("is X on
+// for subject").
+//
+// [Compile] validates a consumer-hydrated [Spec] fail-fast and returns an
+// immutable [Link]; [Link.Decide] is the infallible per-click hot path. Rule
+// values are consumer data hydrated into the typed vocabulary — there is no
+// DSL, and rule storage/admin, target health checks, and bot filtering stay
+// consumer-side. The package never imports net/http: the caller builds the
+// Visit from its own request facts (web/clientip + web/geoip for country,
+// web/useragent for device) and emits the returned [Decision] as the click
+// event.
+//
+// Weighted splits and [Percent] shares bucket deterministically by FNV-1a
+// hash of the rule name and Visit.StickyKey — never RNG — so a visitor
+// always lands on the same side. Target URLs are templates over a fixed
+// macro vocabulary ({country}, {device}, {locale}, {param.NAME}) parsed at
+// compile time: an unknown macro is a construction error, never an empty
+// substitution at decide time. Macro values escape positionally (authority
+// vs path vs query), so they can never alter the URL structure, and
+// [ParamPolicy] controls merging Visit.Params into the final URL.
+//
+// Multi-tenant apps hydrate per-tenant rule sets and compile per-tenant
+// Links — tenancy is a passed value; there is no stored state to scope.
+package smartlink
+
+import "fmt"
+
+// Example compiles a link that sends German mobile traffic into a weighted
+// split and everyone else to the default, then decides one visit.
+func Example() {
+	link, err := Compile(Spec{
+		Rules: []Rule{{
+			Name: "de-mobile",
+			When: []Matcher{
+				Geo{Countries: []string{"DE", "AT", "CH"}},
+				Device{Devices: []string{"mobile", "tablet"}},
+			},
+			Targets: []Target{
+				{URL: "https://a.example.com/lp?geo={country}&click={param.click_id}", Weight: 70},
+				{URL: "https://b.example.com/lp?geo={country}&click={param.click_id}", Weight: 30},
+			},
+		}},
+		Default: []Target{{URL: "https://example.com/"}},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	d := link.Decide(Visit{
+		Country:   "de",
+		Device:    "mobile",
+		StickyKey: "visitor-42",
+		Params:    map[string]string{"click_id": "abc123"},
+	})
+	fmt.Println(d.Rule)
+	fmt.Println(d.URL)
+	// Output:
+	// de-mobile
+	// https://a.example.com/lp?geo=de&click=abc123
+}

--- a/web/smartlink/doc.go
+++ b/web/smartlink/doc.go
@@ -1,15 +1,21 @@
-// Package smartlink is the destination-decision engine of a TDS/smartlink:
-// ordered rules of typed matchers ([Geo], [Device], [Locale], [ParamEquals],
-// [TimeWindow], [Percent]) evaluated over a caller-built [Visit], first match
-// wins, with a mandatory default target. It selects outbound destinations —
-// it is not web/hostrouter (inbound hosts) and not ops/featureflag ("is X on
-// for subject").
+// Package smartlink is the link package: a destination-decision engine plus
+// a storage-backed manager and redirect handler built on top of it. A
+// stored [Link] is a short code bound to either an inline URL template
+// ([Link.Target]) or a consumer-side offer reference ([Link.Ref]) that
+// resolves to a compiled engine value; a fixed-destination short link is
+// simply the degenerate case — a single default target, no rules — with
+// every ability intact: macros, param forwarding, metadata stamping, hooks.
 //
-// [Compile] validates a consumer-hydrated [Spec] fail-fast and returns an
-// immutable [Compiled]; [Compiled.Decide] is the infallible per-click hot path. Rule
+// # Engine
+//
+// [Compile] validates a consumer-hydrated [Spec] fail-fast — ordered rules
+// of typed matchers ([Geo], [Device], [Locale], [ParamEquals],
+// [TimeWindow], [Percent]) evaluated over a caller-built [Visit], first
+// match wins, with a mandatory default target — and returns an immutable
+// [Compiled]; [Compiled.Decide] is the infallible per-click hot path. Rule
 // values are consumer data hydrated into the typed vocabulary — there is no
 // DSL, and rule storage/admin, target health checks, and bot filtering stay
-// consumer-side. The package never imports net/http: the caller builds the
+// consumer-side. The engine never imports net/http: the caller builds the
 // Visit from its own request facts (web/clientip + web/geoip for country,
 // web/useragent for device) and emits the returned [Decision] as the click
 // event.
@@ -23,42 +29,65 @@
 // vs path vs query), so they can never alter the URL structure, and
 // [ParamPolicy] controls merging Visit.Params into the final URL.
 //
-// Multi-tenant apps hydrate per-tenant rule sets and compile per-tenant
-// [Compiled] values — tenancy is a passed value; there is no stored state to scope.
+// [Decider], [DecideFunc], and [Decorator] let a consumer wrap a [*Compiled]
+// (or a [Cache]-backed [Resolver]) with concerns that must affect the
+// current click, composed left-to-right with [Chain]. [NewCache] is a lazy
+// compile-with-invalidation cache for Ref-backed links: it loads and
+// compiles a consumer's [Spec] on demand, keyed by ref string, and the
+// consumer calls [Cache.Invalidate] from its own offer-save path.
+//
+// # Manager and Handler
+//
+// [NewManager] builds a management surface over a [Store] ([NewMemoryStore]
+// for tests/dev; the pgstore subpackage for production): [Manager.Create]
+// mints a Link (vanity or generated code via [WithCodeFunc], Target
+// (scheme-allowlisted via [WithSchemes]) xor Ref (optionally prechecked via
+// [WithResolver])), and [Manager.Deactivate], [Manager.Activate], and
+// [Manager.Delete] drive its lifecycle. [Manager.Handler] serves the
+// uniform per-click pipeline for both Target and Ref links: resolve the
+// code (cache read-through via [WithCache], liveness checks) — a dead or
+// unknown code redirects to [WithFallbackURL] or answers 404 — build
+// [Visit] from the query string and [WithVisitFunc], merge the link's
+// Metadata into Visit.Params (metadata wins — it identifies the link, not
+// the click), decide (a per-hit degenerate compile for Target links under
+// [WithLinkParamPolicy], the configured [WithResolver] for Ref links),
+// redirect (302 or 307 via [WithRedirectStatus] — 301 is rejected, since a
+// cached permanent redirect would kill hit observation forever, and every
+// response carries Cache-Control: no-store), and call [WithOnHit]
+// synchronously after the response is written. A store, cache, or resolver
+// outage answers 500 — an outage must read as an outage, not as every link
+// being gone.
+//
+// # Hooks
+//
+// Decorators (composed with [Chain]) are the synchronous seam: they run
+// inside Decide and can change the outcome of the current click — a fraud
+// guard diverting a suspicious visit, an A/B override, an inline metrics
+// tap. [WithOnHit] is the asynchronous observer: it runs after the redirect
+// is already written and cannot change it. It must hand the [Hit] to a
+// bounded sink — a queue push, a buffered channel — and never do work
+// inline or spawn a goroutine per hit; a slow or unbounded [WithOnHit]
+// blocks or leaks on every click.
+//
+// # Tenancy
+//
+// [WithScope] scopes management operations only ([Manager.Create],
+// [Manager.Get], [Manager.List], [Manager.Deactivate], [Manager.Activate],
+// [Manager.Delete]), failing closed with [ErrScope] on a hook error or an
+// empty result. [Manager.Resolve] and [Manager.Handler] never consult it: a
+// short code is a public URL, and codes are globally unique regardless of
+// tenant. Without [WithScope], tenant strings pass through verbatim — zero
+// ceremony for single-tenant apps.
+//
+// # Anti-scope
+//
+// This package is not fraud/bot/dup detection (a consumer decorator or
+// [WithOnHit] consumer owns that); not postback delivery, click counting, or
+// analytics storage ([Hit] hands the consumer everything it needs;
+// comms/postback owns tracker postbacks); not offer/spec persistence (rule
+// storage/admin stays consumer-side — [NewCache] only caches compiles); and
+// not QR codes, link-in-bio, or preview pages. It is also not web/hostrouter
+// (inbound hosts), not ops/featureflag ("is X on for subject"), and not
+// auth/magiclink (a self-contained signed token, not a redirect) — this
+// package selects and serves outbound destinations from a stored code.
 package smartlink
-
-import "fmt"
-
-// Example compiles a link that sends German mobile traffic into a weighted
-// split and everyone else to the default, then decides one visit.
-func Example() {
-	link, err := Compile(Spec{
-		Rules: []Rule{{
-			Name: "de-mobile",
-			When: []Matcher{
-				Geo{Countries: []string{"DE", "AT", "CH"}},
-				Device{Devices: []string{"mobile", "tablet"}},
-			},
-			Targets: []Target{
-				{URL: "https://a.example.com/lp?geo={country}&click={param.click_id}", Weight: 70},
-				{URL: "https://b.example.com/lp?geo={country}&click={param.click_id}", Weight: 30},
-			},
-		}},
-		Default: []Target{{URL: "https://example.com/"}},
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	d := link.Decide(Visit{
-		Country:   "de",
-		Device:    "mobile",
-		StickyKey: "visitor-42",
-		Params:    map[string]string{"click_id": "abc123"},
-	})
-	fmt.Println(d.Rule)
-	fmt.Println(d.URL)
-	// Output:
-	// de-mobile
-	// https://a.example.com/lp?geo=de&click=abc123
-}

--- a/web/smartlink/doc.go
+++ b/web/smartlink/doc.go
@@ -27,7 +27,13 @@
 // compile time: an unknown macro is a construction error, never an empty
 // substitution at decide time. Macro values escape positionally (authority
 // vs path vs query), so they can never alter the URL structure, and
-// [ParamPolicy] controls merging Visit.Params into the final URL.
+// [ParamPolicy] controls merging Visit.Params into the final URL. A Target
+// whose authority (host) contains a {param.NAME} macro fed by a
+// visitor-controlled query parameter is a creator opt-in open-redirect
+// surface — the visitor chooses the destination host outright. A creator
+// who must keep the host out of visitor control should instead pin the
+// host-feeding param via the Link's Metadata, since Metadata wins the merge
+// into Visit.Params and so overrides whatever the query string supplies.
 //
 // [Decider], [DecideFunc], and [Decorator] let a consumer wrap a [*Compiled]
 // (or a [Cache]-backed [Resolver]) with concerns that must affect the

--- a/web/smartlink/doc.go
+++ b/web/smartlink/doc.go
@@ -6,7 +6,7 @@
 // for subject").
 //
 // [Compile] validates a consumer-hydrated [Spec] fail-fast and returns an
-// immutable [Link]; [Link.Decide] is the infallible per-click hot path. Rule
+// immutable [Compiled]; [Compiled.Decide] is the infallible per-click hot path. Rule
 // values are consumer data hydrated into the typed vocabulary — there is no
 // DSL, and rule storage/admin, target health checks, and bot filtering stay
 // consumer-side. The package never imports net/http: the caller builds the
@@ -24,7 +24,7 @@
 // [ParamPolicy] controls merging Visit.Params into the final URL.
 //
 // Multi-tenant apps hydrate per-tenant rule sets and compile per-tenant
-// Links — tenancy is a passed value; there is no stored state to scope.
+// [Compiled] values — tenancy is a passed value; there is no stored state to scope.
 package smartlink
 
 import "fmt"

--- a/web/smartlink/doc.go
+++ b/web/smartlink/doc.go
@@ -54,9 +54,11 @@
 // redirect (302 or 307 via [WithRedirectStatus] — 301 is rejected, since a
 // cached permanent redirect would kill hit observation forever, and every
 // response carries Cache-Control: no-store), and call [WithOnHit]
-// synchronously after the response is written. A store, cache, or resolver
-// outage answers 500 — an outage must read as an outage, not as every link
-// being gone.
+// synchronously after the response is written. A store or resolver outage
+// answers 500 — an outage must read as an outage, not as every link being
+// gone. A cache outage never surfaces: any cache error or decode failure is
+// treated as a miss and falls through to the Store (logged at debug), so a
+// bad cache backend degrades to "always hit the Store", not to failures.
 //
 // # Hooks
 //

--- a/web/smartlink/errors.go
+++ b/web/smartlink/errors.go
@@ -19,8 +19,8 @@ var (
 	ErrUnknownMacro = errors.New("smartlink: unknown macro")
 )
 
-// Store and Manager errors. A Manager (a later task) layers codegen, scope,
-// and redirect-time checks on top of a Store.
+// Store and Manager errors. A [Manager] layers codegen, scope, and
+// redirect-time checks on top of a [Store].
 var (
 	// ErrNotFound is returned when a code has no Link record, or by a
 	// tenant-scoped Store mutator when the code belongs to a different tenant.

--- a/web/smartlink/errors.go
+++ b/web/smartlink/errors.go
@@ -1,0 +1,20 @@
+package smartlink
+
+import "errors"
+
+// Compile-time validation errors. Match with errors.Is; Compile wraps each with
+// the offending rule, target, or matcher context. Decide never returns an error.
+var (
+	// ErrNoDefault is returned when a Spec has no default target.
+	ErrNoDefault = errors.New("smartlink: no default target")
+	// ErrInvalidRule is returned for a rule with an empty or duplicate name, or no targets.
+	ErrInvalidRule = errors.New("smartlink: invalid rule")
+	// ErrInvalidTarget is returned for a target with an empty URL or a bad weight.
+	ErrInvalidTarget = errors.New("smartlink: invalid target")
+	// ErrInvalidMatcher is returned for a matcher with empty or out-of-range values.
+	ErrInvalidMatcher = errors.New("smartlink: invalid matcher")
+	// ErrInvalidTemplate is returned for a malformed target URL template.
+	ErrInvalidTemplate = errors.New("smartlink: invalid template")
+	// ErrUnknownMacro is returned for a template macro outside the vocabulary.
+	ErrUnknownMacro = errors.New("smartlink: unknown macro")
+)

--- a/web/smartlink/errors.go
+++ b/web/smartlink/errors.go
@@ -18,3 +18,27 @@ var (
 	// ErrUnknownMacro is returned for a template macro outside the vocabulary.
 	ErrUnknownMacro = errors.New("smartlink: unknown macro")
 )
+
+// Store and Manager errors. A Manager (a later task) layers codegen, scope,
+// and redirect-time checks on top of a Store.
+var (
+	// ErrNotFound is returned when a code has no Link record, or by a
+	// tenant-scoped Store mutator when the code belongs to a different tenant.
+	ErrNotFound = errors.New("smartlink: not found")
+	// ErrDuplicate is returned by Store.Create when the code already exists.
+	ErrDuplicate = errors.New("smartlink: duplicate code")
+	// ErrLinkExpired is returned when a Link's ExpiresAt has passed.
+	ErrLinkExpired = errors.New("smartlink: link expired")
+	// ErrLinkDeactivated is returned when a Link has been deactivated.
+	ErrLinkDeactivated = errors.New("smartlink: link deactivated")
+	// ErrNoTarget is returned when a Link has neither a Target URL nor a Ref
+	// to a compiled Spec.
+	ErrNoTarget = errors.New("smartlink: no target")
+	// ErrInvalidLink is returned for a malformed Link or CreateParams.
+	ErrInvalidLink = errors.New("smartlink: invalid link")
+	// ErrCodeReserved is returned when a caller-supplied code collides with a
+	// reserved value.
+	ErrCodeReserved = errors.New("smartlink: code reserved")
+	// ErrScope is returned when a required tenant scope is missing.
+	ErrScope = errors.New("smartlink: scope required")
+)

--- a/web/smartlink/example_test.go
+++ b/web/smartlink/example_test.go
@@ -1,0 +1,78 @@
+package smartlink_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+// Example compiles a link that sends German mobile traffic into a weighted
+// split and everyone else to the default, then decides one visit.
+func Example() {
+	link, err := smartlink.Compile(smartlink.Spec{
+		Rules: []smartlink.Rule{{
+			Name: "de-mobile",
+			When: []smartlink.Matcher{
+				smartlink.Geo{Countries: []string{"DE", "AT", "CH"}},
+				smartlink.Device{Devices: []string{"mobile", "tablet"}},
+			},
+			Targets: []smartlink.Target{
+				{URL: "https://a.example.com/lp?geo={country}&click={param.click_id}", Weight: 70},
+				{URL: "https://b.example.com/lp?geo={country}&click={param.click_id}", Weight: 30},
+			},
+		}},
+		Default: []smartlink.Target{{URL: "https://example.com/"}},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	d := link.Decide(smartlink.Visit{
+		Country:   "de",
+		Device:    "mobile",
+		StickyKey: "visitor-42",
+		Params:    map[string]string{"click_id": "abc123"},
+	})
+	fmt.Println(d.Rule)
+	fmt.Println(d.URL)
+	// Output:
+	// de-mobile
+	// https://a.example.com/lp?geo=de&click=abc123
+}
+
+// Example_manager creates a fixed-destination link with a vanity code and
+// serves one hit through the redirect handler: the incoming click_id query
+// param forwards into the destination under the default ParamsFill policy,
+// while the target's own src param is left untouched.
+func Example_manager() {
+	mgr, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithBaseURL("https://s.example.com/"))
+	if err != nil {
+		panic(err)
+	}
+
+	link, err := mgr.Create(context.Background(), smartlink.CreateParams{
+		Code:   "promo",
+		Target: "https://dest.example.com/landing?src=affiliate42",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(link.ShortURL)
+
+	mux := http.NewServeMux()
+	mux.Handle("/{code}", mgr.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/promo?click_id=abc123", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	fmt.Println(rec.Code)
+	fmt.Println(rec.Header().Get("Location"))
+	// Output:
+	// https://s.example.com/promo
+	// 302
+	// https://dest.example.com/landing?click_id=abc123&src=affiliate42
+}

--- a/web/smartlink/handler.go
+++ b/web/smartlink/handler.go
@@ -22,6 +22,12 @@ import (
 // "Cache-Control: no-store": a redirect decision can change on the next
 // rule evaluation or offer update, so nothing here is safe for a client or
 // intermediary to cache.
+//
+// The Handler redirects for every HTTP method, including HEAD, and
+// [WithOnHit] fires for all of them alike — it does not special-case
+// method. A consumer that needs method awareness (e.g. to skip counting
+// HEAD as a click) stamps the method into the Visit itself via
+// [WithVisitFunc], e.g. into Visit.Params, and reads it back from the Hit.
 func (m *Manager) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		code := r.PathValue("code")

--- a/web/smartlink/handler.go
+++ b/web/smartlink/handler.go
@@ -1,0 +1,151 @@
+package smartlink
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Handler returns an http.Handler implementing the uniform redirect
+// pipeline for both Target- and Ref-backed Links: resolve the code (cache
+// read-through + liveness), build the Visit, decide, redirect, and fire
+// OnHit synchronously after the redirect is written.
+//
+// The code comes from r.PathValue("code") when the Handler is mounted on a
+// pattern with a {code} wildcard (e.g. mux.Handle("/{code}", m.Handler()));
+// otherwise it falls back to the trimmed request path, so the Handler also
+// works mounted bare at "/".
+//
+// Every response — success, dead link, or error — carries
+// "Cache-Control: no-store": a redirect decision can change on the next
+// rule evaluation or offer update, so nothing here is safe for a client or
+// intermediary to cache.
+func (m *Manager) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		code := r.PathValue("code")
+		if code == "" {
+			code = strings.Trim(r.URL.Path, "/")
+		}
+		w.Header().Set("Cache-Control", "no-store")
+
+		ctx := r.Context()
+		l, err := m.Resolve(ctx, code)
+		if err != nil {
+			m.resolveFailed(ctx, w, r, code, err)
+			return
+		}
+
+		v := Visit{Params: firstQueryValues(r.URL.Query())}
+		if m.cfg.visitFunc != nil {
+			v = m.cfg.visitFunc(r, v)
+		}
+		for k, val := range l.Metadata {
+			if v.Params == nil {
+				v.Params = make(map[string]string, len(l.Metadata))
+			}
+			v.Params[k] = val
+		}
+
+		d, ok := m.decider(ctx, w, r, code, l)
+		if !ok {
+			return
+		}
+
+		dec := d.Decide(v)
+		http.Redirect(w, r, dec.URL, m.cfg.redirectStatus)
+		if m.cfg.onHit != nil {
+			m.cfg.onHit(ctx, Hit{Link: l, Visit: v, Decision: dec})
+		}
+	})
+}
+
+// decider resolves l to a Decider — a per-hit degenerate compile for a
+// Target link, or the configured Resolver for a Ref link — writing an error
+// response and reporting ok == false when it cannot produce one.
+func (m *Manager) decider(ctx context.Context, w http.ResponseWriter, r *http.Request, code string, l Link) (Decider, bool) {
+	switch {
+	case l.Target != "":
+		compiled, err := m.compileTarget(l)
+		if err != nil {
+			// Unreachable in practice: Create validates Target with the same
+			// compile call. Still handled as an internal error, not a 404 —
+			// it reflects a configuration/data problem, not a dead link.
+			m.cfg.logger.ErrorContext(ctx, "smartlink: compile target", "code", code, "error", err)
+			internalServerError(w)
+			return nil, false
+		}
+		return compiled, true
+
+	case m.cfg.resolver == nil:
+		m.cfg.logger.ErrorContext(ctx, "smartlink: ref link with no resolver configured", "code", code)
+		internalServerError(w)
+		return nil, false
+
+	default:
+		resolved, err := m.cfg.resolver(ctx, l)
+		if err != nil {
+			if errors.Is(err, ErrNoTarget) {
+				m.deadLink(w, r)
+				return nil, false
+			}
+			m.cfg.logger.ErrorContext(ctx, "smartlink: resolver error", "code", code, "error", err)
+			internalServerError(w)
+			return nil, false
+		}
+		return resolved, true
+	}
+}
+
+// compileTarget compiles the degenerate single-target Spec for a
+// Target-backed Link, using the configured link param policy. No caching in
+// v1: a single-template compile is a few µs (see bench_test.go), and an
+// unbounded per-code compiled cache is a memory liability at affiliate-code
+// cardinality.
+func (m *Manager) compileTarget(l Link) (Decider, error) {
+	return Compile(Spec{Default: []Target{{URL: l.Target}}, Params: m.cfg.linkParamPolicy})
+}
+
+// resolveFailed maps a Resolve error to the dead-link path (fallback
+// redirect or 404) for the expected sentinels, or a logged 500 for anything
+// else — an outage must read as an outage, not as every link being gone.
+func (m *Manager) resolveFailed(ctx context.Context, w http.ResponseWriter, r *http.Request, code string, err error) {
+	if errors.Is(err, ErrNotFound) || errors.Is(err, ErrLinkExpired) || errors.Is(err, ErrLinkDeactivated) {
+		m.deadLink(w, r)
+		return
+	}
+	m.cfg.logger.ErrorContext(ctx, "smartlink: resolve error", "code", code, "error", err)
+	internalServerError(w)
+}
+
+// deadLink redirects to the configured fallback URL, or answers 404 without one.
+func (m *Manager) deadLink(w http.ResponseWriter, r *http.Request) {
+	if m.cfg.fallbackURL != "" {
+		http.Redirect(w, r, m.cfg.fallbackURL, m.cfg.redirectStatus)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+// internalServerError writes a plain 500 response.
+func internalServerError(w http.ResponseWriter) {
+	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+}
+
+// firstQueryValues flattens q to its first value per key — the shape Visit
+// wants for ParamEquals, {param.NAME} macros, and the link's param-merge
+// policy. A request with no query params yields a nil map, matching Visit's
+// zero value.
+func firstQueryValues(q url.Values) map[string]string {
+	if len(q) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(q))
+	for k, vals := range q {
+		if len(vals) > 0 {
+			out[k] = vals[0]
+		}
+	}
+	return out
+}

--- a/web/smartlink/handler.go
+++ b/web/smartlink/handler.go
@@ -75,9 +75,11 @@ func (m *Manager) decider(ctx context.Context, w http.ResponseWriter, r *http.Re
 	case l.Target != "":
 		compiled, err := m.compileTarget(l)
 		if err != nil {
-			// Unreachable in practice: Create validates Target with the same
-			// compile call. Still handled as an internal error, not a 404 —
-			// it reflects a configuration/data problem, not a dead link.
+			// Rows created through this Manager cannot fail here — Create
+			// validates Target with the same compile call. Rows written to the
+			// Store directly (migrations, another Manager with different
+			// options, admin tooling) can, so it stays an internal error, not
+			// a 404 — a configuration/data problem, not a dead link.
 			m.cfg.logger.ErrorContext(ctx, "smartlink: compile target", "code", code, "error", err)
 			internalServerError(w)
 			return nil, false

--- a/web/smartlink/handler_test.go
+++ b/web/smartlink/handler_test.go
@@ -1,0 +1,485 @@
+package smartlink_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+// newMuxHandler mounts h on a pattern with a {code} wildcard, so
+// r.PathValue("code") is populated the way a real router would.
+func newMuxHandler(h http.Handler) http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle("/r/{code}", h)
+	return mux
+}
+
+// TestHandlerTargetRedirect asserts a Target-backed Link redirects with the
+// configured status, the resolved Location, and a no-store cache header.
+func TestHandlerTargetRedirect(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t)
+	l, err := m.Create(context.Background(), smartlink.CreateParams{Target: "https://dest.example.com/"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+	if got, want := rec.Header().Get("Location"), "https://dest.example.com/"; got != want {
+		t.Fatalf("Location = %q, want %q", got, want)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want %q", got, "no-store")
+	}
+}
+
+// TestHandlerParamForwarding asserts an incoming query param forwards under
+// the default ParamsFill policy, but the target's own param wins on collision.
+func TestHandlerParamForwarding(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t)
+	l, err := m.Create(context.Background(), smartlink.CreateParams{Target: "https://dest.example.com/lp?click_id=own"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code+"?click_id=incoming&extra=1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	loc := rec.Header().Get("Location")
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("Location %q unparseable: %v", loc, err)
+	}
+	q := u.Query()
+	if got, want := q.Get("click_id"), "own"; got != want {
+		t.Fatalf("click_id = %q, want %q (target's own param must win on collision)", got, want)
+	}
+	if got, want := q.Get("extra"), "1"; got != want {
+		t.Fatalf("extra = %q, want %q (incoming param must forward)", got, want)
+	}
+}
+
+// TestHandlerMetadataWins asserts the link's Metadata overrides a same-key
+// query param when both reach the {param.NAME} macro.
+func TestHandlerMetadataWins(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t)
+	l, err := m.Create(context.Background(), smartlink.CreateParams{
+		Target:   "https://dest.example.com/lp?aff={param.affiliate_id}",
+		Metadata: map[string]string{"affiliate_id": "meta-value"},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code+"?affiliate_id=query-value", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	loc := rec.Header().Get("Location")
+	if !strings.Contains(loc, "aff=meta-value") {
+		t.Fatalf("Location = %q, want metadata value (meta-value) to win over the query param", loc)
+	}
+	if strings.Contains(loc, "query-value") {
+		t.Fatalf("Location = %q, must not carry the shadowed query value", loc)
+	}
+}
+
+// geoResolver returns a Resolver whose Spec redirects DE visitors to a
+// distinct target, falling back to a default target otherwise.
+func geoResolver() smartlink.Resolver {
+	return func(context.Context, smartlink.Link) (smartlink.Decider, error) {
+		return smartlink.Compile(smartlink.Spec{
+			Rules: []smartlink.Rule{{
+				Name:    "de",
+				When:    []smartlink.Matcher{smartlink.Geo{Countries: []string{"DE"}}},
+				Targets: []smartlink.Target{{URL: "https://de.example.com/"}},
+			}},
+			Default: []smartlink.Target{{URL: "https://default.example.com/"}},
+		})
+	}
+}
+
+// TestHandlerVisitFuncEnriches asserts a geo rule matches only when a
+// configured VisitFunc sets Visit.Country from the request; without one, the
+// same request falls through to the default target.
+func TestHandlerVisitFuncEnriches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with VisitFunc", func(t *testing.T) {
+		t.Parallel()
+		visitFunc := func(r *http.Request, v smartlink.Visit) smartlink.Visit {
+			v.Country = r.Header.Get("X-Country")
+			return v
+		}
+		m := newTestManager(t, smartlink.WithResolver(geoResolver()), smartlink.WithVisitFunc(visitFunc))
+		l, err := m.Create(context.Background(), smartlink.CreateParams{Ref: "geo-1"})
+		if err != nil {
+			t.Fatalf("Create() error = %v, want nil", err)
+		}
+		h := newMuxHandler(m.Handler())
+
+		req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code, nil)
+		req.Header.Set("X-Country", "DE")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if got, want := rec.Header().Get("Location"), "https://de.example.com/"; got != want {
+			t.Fatalf("Location = %q, want %q (geo rule target)", got, want)
+		}
+	})
+
+	t.Run("without VisitFunc falls to default", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t, smartlink.WithResolver(geoResolver()))
+		l, err := m.Create(context.Background(), smartlink.CreateParams{Ref: "geo-1"})
+		if err != nil {
+			t.Fatalf("Create() error = %v, want nil", err)
+		}
+		h := newMuxHandler(m.Handler())
+
+		req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code, nil)
+		req.Header.Set("X-Country", "DE") // ignored: no VisitFunc reads it
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if got, want := rec.Header().Get("Location"), "https://default.example.com/"; got != want {
+			t.Fatalf("Location = %q, want %q (default target)", got, want)
+		}
+	})
+}
+
+// TestHandlerRefResolves is an end-to-end test of a Ref-backed Link through
+// a real Cache-backed Resolver (Task 4's Cache.Resolver).
+func TestHandlerRefResolves(t *testing.T) {
+	t.Parallel()
+	c := smartlink.NewCache(func(_ context.Context, ref string) (smartlink.Spec, error) {
+		return smartlink.Spec{Default: []smartlink.Target{{URL: "https://offer.example.com/" + ref}}}, nil
+	})
+	m := newTestManager(t, smartlink.WithResolver(c.Resolver()))
+	l, err := m.Create(context.Background(), smartlink.CreateParams{Ref: "offer-42"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+	if got, want := rec.Header().Get("Location"), "https://offer.example.com/offer-42"; got != want {
+		t.Fatalf("Location = %q, want %q", got, want)
+	}
+}
+
+// TestHandlerRefNoTarget asserts a Resolver error wrapping ErrNoTarget is
+// dead-link handling: fallback redirect when configured, else 404.
+func TestHandlerRefNoTarget(t *testing.T) {
+	t.Parallel()
+	resolver := func(context.Context, smartlink.Link) (smartlink.Decider, error) {
+		return nil, fmt.Errorf("offer paused: %w", smartlink.ErrNoTarget)
+	}
+
+	t.Run("with fallback", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t, smartlink.WithResolver(resolver), smartlink.WithFallbackURL("https://fallback.example.com/"))
+		l, err := m.Create(context.Background(), smartlink.CreateParams{Ref: "paused-1", SkipRefCheck: true})
+		if err != nil {
+			t.Fatalf("Create() error = %v, want nil", err)
+		}
+		h := newMuxHandler(m.Handler())
+
+		req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code, nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusFound {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+		}
+		if got, want := rec.Header().Get("Location"), "https://fallback.example.com/"; got != want {
+			t.Fatalf("Location = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without fallback 404", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t, smartlink.WithResolver(resolver))
+		l, err := m.Create(context.Background(), smartlink.CreateParams{Ref: "paused-2", SkipRefCheck: true})
+		if err != nil {
+			t.Fatalf("Create() error = %v, want nil", err)
+		}
+		h := newMuxHandler(m.Handler())
+
+		req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code, nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+		}
+	})
+}
+
+// TestHandlerRefNoResolver asserts a Ref-backed Link with no configured
+// Resolver is a configuration error: 500, not a dead link.
+func TestHandlerRefNoResolver(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t)
+	l, err := m.Create(context.Background(), smartlink.CreateParams{Ref: "any-ref"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+// TestHandlerDeadLink covers the three dead-link sentinels (unknown,
+// expired, deactivated) both with and without a configured fallback URL.
+func TestHandlerDeadLink(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		codeFor func(t *testing.T, m *smartlink.Manager) string
+	}{
+		{
+			name:    "unknown",
+			codeFor: func(*testing.T, *smartlink.Manager) string { return "does-not-exist" },
+		},
+		{
+			name: "expired",
+			codeFor: func(t *testing.T, m *smartlink.Manager) string {
+				l, err := m.Create(context.Background(), smartlink.CreateParams{
+					Target:    "https://dest.example.com/",
+					ExpiresAt: time.Now().Add(-time.Hour),
+				})
+				if err != nil {
+					t.Fatalf("Create() error = %v, want nil", err)
+				}
+				return l.Code
+			},
+		},
+		{
+			name: "deactivated",
+			codeFor: func(t *testing.T, m *smartlink.Manager) string {
+				l, err := m.Create(context.Background(), smartlink.CreateParams{Target: "https://dest.example.com/"})
+				if err != nil {
+					t.Fatalf("Create() error = %v, want nil", err)
+				}
+				if err := m.Deactivate(context.Background(), l.Code); err != nil {
+					t.Fatalf("Deactivate() error = %v, want nil", err)
+				}
+				return l.Code
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"/fallback", func(t *testing.T) {
+			t.Parallel()
+			m := newTestManager(t, smartlink.WithFallbackURL("https://fallback.example.com/"))
+			code := tc.codeFor(t, m)
+			h := newMuxHandler(m.Handler())
+
+			req := httptest.NewRequest(http.MethodGet, "/r/"+code, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusFound {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+			}
+			if got, want := rec.Header().Get("Location"), "https://fallback.example.com/"; got != want {
+				t.Fatalf("Location = %q, want %q", got, want)
+			}
+		})
+
+		t.Run(tc.name+"/404", func(t *testing.T) {
+			t.Parallel()
+			m := newTestManager(t)
+			code := tc.codeFor(t, m)
+			h := newMuxHandler(m.Handler())
+
+			req := httptest.NewRequest(http.MethodGet, "/r/"+code, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+			}
+		})
+	}
+}
+
+var errStoreBoom = errors.New("store boundary: unavailable")
+
+// erroringStore is a Store whose every method errors, to simulate a backing
+// database outage.
+type erroringStore struct{}
+
+func (erroringStore) Create(context.Context, smartlink.Link) error { return errStoreBoom }
+func (erroringStore) Get(context.Context, string) (smartlink.Link, error) {
+	return smartlink.Link{}, errStoreBoom
+}
+func (erroringStore) List(context.Context, smartlink.Filter) ([]smartlink.Link, error) {
+	return nil, errStoreBoom
+}
+func (erroringStore) Deactivate(context.Context, string, string, time.Time) error {
+	return errStoreBoom
+}
+func (erroringStore) Activate(context.Context, string, string) error { return errStoreBoom }
+func (erroringStore) Delete(context.Context, string, string) error   { return errStoreBoom }
+
+// TestHandlerStoreOutage asserts a Store error other than the dead-link
+// sentinels is a 500 — an outage must read as an outage, not as every link
+// being gone — and that no-store still applies.
+func TestHandlerStoreOutage(t *testing.T) {
+	t.Parallel()
+	m, err := smartlink.NewManager(erroringStore{})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/r/any-code", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want %q even on outage", got, "no-store")
+	}
+}
+
+// TestHandlerOnHit asserts OnHit fires synchronously, exactly once, only on
+// a successful redirect, carrying the resolved Link (ShortURL populated),
+// the merged Visit, and the final Decision.
+func TestHandlerOnHit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fires on successful redirect", func(t *testing.T) {
+		t.Parallel()
+		var got smartlink.Hit
+		hits := 0
+		onHit := func(_ context.Context, h smartlink.Hit) {
+			hits++
+			got = h
+		}
+		m := newTestManager(t, smartlink.WithOnHit(onHit), smartlink.WithBaseURL("https://s.example.com"))
+		l, err := m.Create(context.Background(), smartlink.CreateParams{
+			Target:   "https://dest.example.com/",
+			Metadata: map[string]string{"m1": "v1"},
+		})
+		if err != nil {
+			t.Fatalf("Create() error = %v, want nil", err)
+		}
+		h := newMuxHandler(m.Handler())
+
+		req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code+"?q=1", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if hits != 1 {
+			t.Fatalf("onHit calls = %d, want 1", hits)
+		}
+		if got.Link.Code != l.Code || got.Link.ShortURL == "" {
+			t.Fatalf("Hit.Link = %+v, want Code %q and ShortURL populated", got.Link, l.Code)
+		}
+		if got.Visit.Params["q"] != "1" || got.Visit.Params["m1"] != "v1" {
+			t.Fatalf("Hit.Visit.Params = %+v, want merged query %q and metadata %q", got.Visit.Params, "q=1", "m1=v1")
+		}
+		if got.Decision.URL != rec.Header().Get("Location") {
+			t.Fatalf("Hit.Decision.URL = %q, want match redirect Location %q", got.Decision.URL, rec.Header().Get("Location"))
+		}
+	})
+
+	t.Run("not called on dead link", func(t *testing.T) {
+		t.Parallel()
+		hits := 0
+		m := newTestManager(t, smartlink.WithOnHit(func(context.Context, smartlink.Hit) { hits++ }))
+		h := newMuxHandler(m.Handler())
+
+		req := httptest.NewRequest(http.MethodGet, "/r/unknown-code", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+		}
+		if hits != 0 {
+			t.Fatalf("onHit calls = %d, want 0 on dead link", hits)
+		}
+	})
+}
+
+// TestHandler307 asserts WithRedirectStatus(307) is honored by the redirect.
+func TestHandler307(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t, smartlink.WithRedirectStatus(http.StatusTemporaryRedirect))
+	l, err := m.Create(context.Background(), smartlink.CreateParams{Target: "https://dest.example.com/"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusTemporaryRedirect)
+	}
+}
+
+// TestHandlerPathFallback asserts a Handler mounted without a {code}
+// pattern (so r.PathValue("code") is empty) falls back to extracting the
+// code from the trimmed URL path.
+func TestHandlerPathFallback(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t)
+	l, err := m.Create(context.Background(), smartlink.CreateParams{Target: "https://dest.example.com/", Code: "fallback-code"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/"+l.Code, nil)
+	rec := httptest.NewRecorder()
+	m.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+	if got, want := rec.Header().Get("Location"), "https://dest.example.com/"; got != want {
+		t.Fatalf("Location = %q, want %q", got, want)
+	}
+}

--- a/web/smartlink/link.go
+++ b/web/smartlink/link.go
@@ -3,10 +3,10 @@ package smartlink
 import "time"
 
 // Link is a stored short-code record: a code bound to a redirect target —
-// either a literal Target URL or, via Ref, a compiled [Spec] resolved by a
-// Manager (a later task) — plus tenant scope and caller metadata. ShortURL is
-// derived from Code and the app's base URL for API responses; it is never
-// persisted.
+// either a literal Target URL template or, via Ref, a consumer [Spec]
+// resolved through [WithResolver] — plus tenant scope and caller metadata.
+// ShortURL is derived from Code and the app's base URL for API responses;
+// it is never persisted.
 type Link struct {
 	CreatedAt     time.Time         `json:"created_at"`
 	ExpiresAt     time.Time         `json:"expires_at,omitzero"`
@@ -19,11 +19,12 @@ type Link struct {
 	ShortURL      string            `json:"short_url,omitempty"`
 }
 
-// CreateParams are the caller-supplied fields for creating a Link. A Manager
-// (a later task) validates Target/Ref, generates Code when empty, and stamps
-// CreatedAt before handing the resulting Link to Store.Create. SkipRefCheck
-// bypasses the Manager's check that Ref names a known compiled Spec, for
-// callers that register the Spec after the Link.
+// CreateParams are the caller-supplied fields for creating a Link.
+// [Manager.Create] validates Target/Ref, generates Code when empty, and
+// stamps CreatedAt before handing the resulting Link to Store.Create.
+// SkipRefCheck bypasses the create-time check that Ref resolves via the
+// configured [WithResolver], for callers that register the Spec after the
+// Link.
 type CreateParams struct {
 	ExpiresAt    time.Time
 	Target       string

--- a/web/smartlink/link.go
+++ b/web/smartlink/link.go
@@ -1,0 +1,41 @@
+package smartlink
+
+import "time"
+
+// Link is a stored short-code record: a code bound to a redirect target —
+// either a literal Target URL or, via Ref, a compiled [Spec] resolved by a
+// Manager (a later task) — plus tenant scope and caller metadata. ShortURL is
+// derived from Code and the app's base URL for API responses; it is never
+// persisted.
+type Link struct {
+	CreatedAt     time.Time         `json:"created_at"`
+	ExpiresAt     time.Time         `json:"expires_at,omitzero"`
+	DeactivatedAt time.Time         `json:"deactivated_at,omitzero"`
+	Code          string            `json:"code"`
+	Target        string            `json:"target,omitempty"`
+	Ref           string            `json:"ref,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	Tenant        string            `json:"tenant,omitempty"`
+	ShortURL      string            `json:"short_url,omitempty"`
+}
+
+// CreateParams are the caller-supplied fields for creating a Link. A Manager
+// (a later task) validates Target/Ref, generates Code when empty, and stamps
+// CreatedAt before handing the resulting Link to Store.Create. SkipRefCheck
+// bypasses the Manager's check that Ref names a known compiled Spec, for
+// callers that register the Spec after the Link.
+type CreateParams struct {
+	ExpiresAt    time.Time
+	Target       string
+	Ref          string
+	Code         string
+	Metadata     map[string]string
+	Tenant       string
+	SkipRefCheck bool
+}
+
+// Filter narrows Store.List. Zero fields match everything; Limit 0 means no cap.
+type Filter struct {
+	Tenant string
+	Limit  int
+}

--- a/web/smartlink/manager.go
+++ b/web/smartlink/manager.go
@@ -17,8 +17,9 @@ const maxCodeAttempts = 5
 // Manager is the management surface over a [Store]: it validates and
 // creates Links (vanity or generated code, Target or Ref, tenant scope) and
 // drives their lifecycle (Get, List, Deactivate, Activate, Delete).
-// Resolving a code to a redirect decision is a Handler's job (a later
-// task). Safe for concurrent use — all state lives in the Store.
+// Resolving a code to a live Link is [Manager.Resolve]; serving it as a
+// redirect is [Manager.Handler]. Safe for concurrent use — all state lives
+// in the Store.
 type Manager struct {
 	store Store
 	cfg   managerConfig

--- a/web/smartlink/manager.go
+++ b/web/smartlink/manager.go
@@ -1,0 +1,260 @@
+package smartlink
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"net/url"
+	"slices"
+	"time"
+)
+
+// maxCodeAttempts caps how many times Create retries a colliding generated
+// code before giving up.
+const maxCodeAttempts = 5
+
+// Manager is the management surface over a [Store]: it validates and
+// creates Links (vanity or generated code, Target or Ref, tenant scope) and
+// drives their lifecycle (Get, List, Deactivate, Activate, Delete).
+// Resolving a code to a redirect decision is a Handler's job (a later
+// task). Safe for concurrent use — all state lives in the Store.
+type Manager struct {
+	store Store
+	cfg   managerConfig
+}
+
+// NewManager builds a Manager over store. It returns an error if any
+// ManagerOption failed validation (e.g. an invalid WithBaseURL or an
+// unsupported WithRedirectStatus code).
+func NewManager(store Store, opts ...ManagerOption) (*Manager, error) {
+	if store == nil {
+		return nil, errors.New("smartlink: nil store")
+	}
+	cfg := newManagerConfig()
+	for _, o := range opts {
+		o(cfg)
+	}
+	if len(cfg.errs) > 0 {
+		return nil, errors.Join(cfg.errs...)
+	}
+	return &Manager{store: store, cfg: *cfg}, nil
+}
+
+// Create validates p and inserts a new Link. Exactly one of Target or Ref
+// must be set, else [ErrInvalidLink]. A caller-supplied Code (vanity) must
+// be 1-64 characters of [A-Za-z0-9_-] and not in the reserved blocklist
+// (else [ErrInvalidLink]/[ErrCodeReserved]); a collision surfaces
+// [ErrDuplicate] from the Store. An empty Code is generated via the
+// configured code function, retried up to 5 times on a collision before
+// giving up with a wrapped error. Metadata is cloned. The returned Link has
+// ShortURL populated (see [Manager.ShortURL]); the record handed to the
+// Store never carries one, since it is derived, not persisted.
+func (m *Manager) Create(ctx context.Context, p CreateParams) (Link, error) {
+	if (p.Target == "") == (p.Ref == "") {
+		return Link{}, fmt.Errorf("%w: exactly one of Target or Ref is required", ErrInvalidLink)
+	}
+
+	tenant, err := m.tenantScope(ctx)
+	if err != nil {
+		return Link{}, err
+	}
+	if m.cfg.scope != nil {
+		switch {
+		case p.Tenant == "":
+			p.Tenant = tenant
+		case p.Tenant != tenant:
+			return Link{}, ErrScope
+		}
+	}
+
+	if p.Code != "" {
+		if err := m.validateVanityCode(p.Code); err != nil {
+			return Link{}, err
+		}
+	}
+	if p.Target != "" {
+		if err := m.validateTarget(p.Target); err != nil {
+			return Link{}, err
+		}
+	}
+	if p.Ref != "" && !p.SkipRefCheck && m.cfg.resolver != nil {
+		if _, err := m.cfg.resolver(ctx, Link{Ref: p.Ref, Tenant: p.Tenant}); err != nil {
+			return Link{}, fmt.Errorf("%w: ref %q: %w", ErrInvalidLink, p.Ref, err)
+		}
+	}
+
+	l := Link{
+		ExpiresAt: p.ExpiresAt,
+		Target:    p.Target,
+		Ref:       p.Ref,
+		Code:      p.Code,
+		Metadata:  maps.Clone(p.Metadata),
+		Tenant:    p.Tenant,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	if l.Code != "" {
+		if err := m.store.Create(ctx, l); err != nil {
+			return Link{}, err
+		}
+	} else if err := m.createGenerated(ctx, &l); err != nil {
+		return Link{}, err
+	}
+
+	l.ShortURL = m.ShortURL(l.Code)
+	return l, nil
+}
+
+// createGenerated assigns l.Code from the configured code function and
+// creates it, retrying on ErrDuplicate up to maxCodeAttempts times.
+func (m *Manager) createGenerated(ctx context.Context, l *Link) error {
+	var lastErr error
+	for range maxCodeAttempts {
+		l.Code = m.cfg.codeFunc()
+		err := m.store.Create(ctx, *l)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, ErrDuplicate) {
+			return err
+		}
+		lastErr = err
+	}
+	m.cfg.logger.WarnContext(ctx, "smartlink: exhausted code generation attempts", "attempts", maxCodeAttempts)
+	return fmt.Errorf("smartlink: generate unique code after %d attempts: %w", maxCodeAttempts, lastErr)
+}
+
+// validateVanityCode checks a caller-supplied Code against the charset,
+// length, and reserved-word rules. The charset check runs first, so a
+// reserved word containing a dot ("favicon.ico", "robots.txt",
+// ".well-known") is rejected as ErrInvalidLink rather than
+// ErrCodeReserved — it can never be a valid vanity code regardless of the
+// blocklist.
+func (m *Manager) validateVanityCode(code string) error {
+	if !validCodeChars(code) {
+		return fmt.Errorf("%w: code %q must be 1-64 characters of [A-Za-z0-9_-]", ErrInvalidLink, code)
+	}
+	if _, reserved := m.cfg.reserved[code]; reserved {
+		return fmt.Errorf("%w: code %q", ErrCodeReserved, code)
+	}
+	return nil
+}
+
+// validateTarget compiles raw as the sole default target of a degenerate
+// Spec — surfacing template errors (bad macro, malformed template) as
+// ErrInvalidLink — then checks its macro-elided scheme is on the allowlist
+// and non-empty, and that its host is non-empty unless the authority is
+// itself (at least partly) a macro, in which case a dynamic-host template
+// stays legal.
+func (m *Manager) validateTarget(raw string) error {
+	if _, err := Compile(Spec{Default: []Target{{URL: raw}}, Params: m.cfg.linkParamPolicy}); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidLink, err)
+	}
+	u, err := url.Parse(macroElide(raw))
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidLink, err)
+	}
+	if u.Scheme == "" || !slices.Contains(m.cfg.schemes, u.Scheme) {
+		return fmt.Errorf("%w: scheme %q not allowed", ErrInvalidLink, u.Scheme)
+	}
+	if u.Host == "" && !authorityHasMacro(raw) {
+		return fmt.Errorf("%w: target %q has no host", ErrInvalidLink, raw)
+	}
+	return nil
+}
+
+// Get returns the Link stored under code, with ShortURL populated. With
+// WithScope configured, a record belonging to a different tenant reads as
+// [ErrNotFound] so existence cannot be probed across tenants.
+func (m *Manager) Get(ctx context.Context, code string) (Link, error) {
+	tenant, err := m.tenantScope(ctx)
+	if err != nil {
+		return Link{}, err
+	}
+	l, err := m.store.Get(ctx, code)
+	if err != nil {
+		return Link{}, err
+	}
+	if m.cfg.scope != nil && l.Tenant != tenant {
+		return Link{}, ErrNotFound
+	}
+	l.ShortURL = m.ShortURL(l.Code)
+	return l, nil
+}
+
+// List returns Links matching f, with ShortURL populated on each. With
+// WithScope configured, f.Tenant is forced to the scoped tenant regardless
+// of the caller-supplied value.
+func (m *Manager) List(ctx context.Context, f Filter) ([]Link, error) {
+	tenant, err := m.tenantScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if m.cfg.scope != nil {
+		f.Tenant = tenant
+	}
+	links, err := m.store.List(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+	for i := range links {
+		links[i].ShortURL = m.ShortURL(links[i].Code)
+	}
+	return links, nil
+}
+
+// Deactivate marks code inactive. With WithScope configured, the scoped
+// tenant is passed as the Store predicate, so a foreign-tenant code is
+// untouched and reads back as [ErrNotFound].
+func (m *Manager) Deactivate(ctx context.Context, code string) error {
+	tenant, err := m.tenantScope(ctx)
+	if err != nil {
+		return err
+	}
+	return m.store.Deactivate(ctx, code, tenant, time.Now().UTC())
+}
+
+// Activate clears a prior Deactivate. See [Manager.Deactivate] for scope handling.
+func (m *Manager) Activate(ctx context.Context, code string) error {
+	tenant, err := m.tenantScope(ctx)
+	if err != nil {
+		return err
+	}
+	return m.store.Activate(ctx, code, tenant)
+}
+
+// Delete removes code. See [Manager.Deactivate] for scope handling.
+func (m *Manager) Delete(ctx context.Context, code string) error {
+	tenant, err := m.tenantScope(ctx)
+	if err != nil {
+		return err
+	}
+	return m.store.Delete(ctx, code, tenant)
+}
+
+// ShortURL renders code onto the base URL from [WithBaseURL]. Without that
+// option it returns "".
+func (m *Manager) ShortURL(code string) string {
+	if m.cfg.baseURL == "" {
+		return ""
+	}
+	return m.cfg.baseURL + code
+}
+
+// tenantScope resolves the management-op tenant from the configured scope
+// hook, failing closed with ErrScope on a hook error or an empty result.
+// Without WithScope it returns "" (unscoped, verbatim passthrough).
+func (m *Manager) tenantScope(ctx context.Context) (string, error) {
+	if m.cfg.scope == nil {
+		return "", nil
+	}
+	t, err := m.cfg.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrScope, err)
+	}
+	if t == "" {
+		return "", ErrScope
+	}
+	return t, nil
+}

--- a/web/smartlink/manager.go
+++ b/web/smartlink/manager.go
@@ -108,11 +108,18 @@ func (m *Manager) Create(ctx context.Context, p CreateParams) (Link, error) {
 }
 
 // createGenerated assigns l.Code from the configured code function and
-// creates it, retrying on ErrDuplicate up to maxCodeAttempts times.
+// creates it, retrying on ErrDuplicate up to maxCodeAttempts times. An empty
+// string from a broken [WithCodeFunc] is treated as a failed attempt (not
+// stored) and retried the same way — a misbehaving generator exhausts the
+// loop and surfaces the same error as an unlucky collision streak, rather
+// than silently persisting a Link with an empty code.
 func (m *Manager) createGenerated(ctx context.Context, l *Link) error {
-	var lastErr error
+	lastErr := errors.New("generated code was empty")
 	for range maxCodeAttempts {
 		l.Code = m.cfg.codeFunc()
+		if l.Code == "" {
+			continue
+		}
 		err := m.store.Create(ctx, *l)
 		if err == nil {
 			return nil

--- a/web/smartlink/manager.go
+++ b/web/smartlink/manager.go
@@ -206,31 +206,46 @@ func (m *Manager) List(ctx context.Context, f Filter) ([]Link, error) {
 
 // Deactivate marks code inactive. With WithScope configured, the scoped
 // tenant is passed as the Store predicate, so a foreign-tenant code is
-// untouched and reads back as [ErrNotFound].
+// untouched and reads back as [ErrNotFound]. On success it best-effort
+// evicts any cached entry for code (see [Manager.invalidateCache]).
 func (m *Manager) Deactivate(ctx context.Context, code string) error {
 	tenant, err := m.tenantScope(ctx)
 	if err != nil {
 		return err
 	}
-	return m.store.Deactivate(ctx, code, tenant, time.Now().UTC())
+	if err := m.store.Deactivate(ctx, code, tenant, time.Now().UTC()); err != nil {
+		return err
+	}
+	m.invalidateCache(ctx, code)
+	return nil
 }
 
-// Activate clears a prior Deactivate. See [Manager.Deactivate] for scope handling.
+// Activate clears a prior Deactivate. See [Manager.Deactivate] for scope
+// handling and cache invalidation.
 func (m *Manager) Activate(ctx context.Context, code string) error {
 	tenant, err := m.tenantScope(ctx)
 	if err != nil {
 		return err
 	}
-	return m.store.Activate(ctx, code, tenant)
+	if err := m.store.Activate(ctx, code, tenant); err != nil {
+		return err
+	}
+	m.invalidateCache(ctx, code)
+	return nil
 }
 
-// Delete removes code. See [Manager.Deactivate] for scope handling.
+// Delete removes code. See [Manager.Deactivate] for scope handling and
+// cache invalidation.
 func (m *Manager) Delete(ctx context.Context, code string) error {
 	tenant, err := m.tenantScope(ctx)
 	if err != nil {
 		return err
 	}
-	return m.store.Delete(ctx, code, tenant)
+	if err := m.store.Delete(ctx, code, tenant); err != nil {
+		return err
+	}
+	m.invalidateCache(ctx, code)
+	return nil
 }
 
 // ShortURL renders code onto the base URL from [WithBaseURL]. Without that

--- a/web/smartlink/manager_options.go
+++ b/web/smartlink/manager_options.go
@@ -79,21 +79,34 @@ func WithCodeFunc(f func() string) ManagerOption {
 }
 
 // WithBaseURL sets the base [Manager.ShortURL] renders a code onto. It must
-// be an absolute http(s) URL (scheme and host); a trailing slash is added if
-// missing. Without this option, ShortURL always returns "".
+// be an absolute http(s) URL (scheme and host); any trailing slashes are
+// trimmed and exactly one is added back, so "https://s.example.com//" can't
+// produce a double slash in a rendered ShortURL. Without this option,
+// ShortURL always returns "".
 func WithBaseURL(u string) ManagerOption {
 	return func(c *managerConfig) {
-		parsed, err := url.Parse(u)
-		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-			c.errs = append(c.errs, fmt.Errorf("smartlink: base URL must be absolute (scheme and host): %q", u))
+		if err := validateAbsoluteHTTPURL(u); err != nil {
+			c.errs = append(c.errs, fmt.Errorf("smartlink: base URL: %w", err))
 			return
 		}
-		if parsed.Scheme != "http" && parsed.Scheme != "https" {
-			c.errs = append(c.errs, fmt.Errorf("smartlink: base URL scheme must be http or https: %q", u))
-			return
-		}
-		c.baseURL = strings.TrimSuffix(u, "/") + "/"
+		c.baseURL = strings.TrimRight(u, "/") + "/"
 	}
+}
+
+// validateAbsoluteHTTPURL requires u to be an absolute URL with a non-empty
+// host and an http or https scheme. Shared by [WithBaseURL] and
+// [WithFallbackURL], whose values are both rendered as redirect Location
+// headers and so must not be relative — a typo'd relative fallback would
+// silently redirect relative to the handler's own path.
+func validateAbsoluteHTTPURL(u string) error {
+	parsed, err := url.Parse(u)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("must be absolute (scheme and host): %q", u)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("scheme must be http or https: %q", u)
+	}
+	return nil
 }
 
 // WithSchemes replaces the allowed Target URL schemes (default "http",
@@ -160,9 +173,17 @@ func WithOnHit(f func(context.Context, Hit)) ManagerOption {
 // so [Manager.Handler]) consults before the Store: cs is the backing
 // [cache.Store] and ttl bounds how long a cached record is reused. Cache
 // errors degrade to Store reads; lifecycle mutations best-effort evict, so
-// a warmed entry is stale for at most ttl.
+// a warmed entry is stale for at most ttl. ttl must be positive: [cache.WithTTL]
+// treats a non-positive ttl as "never expire", which would let a cached
+// entry that survives a failed eviction (see [Manager.invalidateCache])
+// serve forever instead of bounding its staleness — a non-positive ttl is a
+// NewManager error.
 func WithCache(cs cache.Store, ttl time.Duration) ManagerOption {
 	return func(c *managerConfig) {
+		if ttl <= 0 {
+			c.errs = append(c.errs, fmt.Errorf("smartlink: cache ttl must be positive, got %s", ttl))
+			return
+		}
 		c.cacheStore = cs
 		c.cacheTTL = ttl
 	}
@@ -170,9 +191,18 @@ func WithCache(cs cache.Store, ttl time.Duration) ManagerOption {
 
 // WithFallbackURL sets the destination [Manager.Handler] redirects to for a
 // dead link (unknown, expired, or deactivated code, or a Ref the resolver
-// reports as [ErrNoTarget]). Without it, dead links answer 404.
+// reports as [ErrNoTarget]). Without it, dead links answer 404. Like
+// [WithBaseURL], it must be an absolute http(s) URL (scheme and host): a
+// typo'd relative value would silently redirect relative to the handler's
+// own path instead of failing construction.
 func WithFallbackURL(u string) ManagerOption {
-	return func(c *managerConfig) { c.fallbackURL = u }
+	return func(c *managerConfig) {
+		if err := validateAbsoluteHTTPURL(u); err != nil {
+			c.errs = append(c.errs, fmt.Errorf("smartlink: fallback URL: %w", err))
+			return
+		}
+		c.fallbackURL = u
+	}
 }
 
 // WithRedirectStatus sets the HTTP status [Manager.Handler] uses for a

--- a/web/smartlink/manager_options.go
+++ b/web/smartlink/manager_options.go
@@ -1,0 +1,196 @@
+package smartlink
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/logger"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+// VisitFunc builds or decorates a [Visit] from the inbound request. A
+// Handler (a later task) calls it before Decide; the Visit passed in is the
+// zero value on the first call in a chain.
+type VisitFunc func(*http.Request, Visit) Visit
+
+// Hit is delivered to a [WithOnHit] callback (a later task) after a redirect
+// decision has been made: the resolved Link, the Visit built for the
+// request, and the Decision Decide returned.
+type Hit struct {
+	Link     Link
+	Visit    Visit
+	Decision Decision
+}
+
+// managerConfig holds NewManager's resolved options. A ManagerOption that
+// fails validation appends to errs instead of returning an error directly —
+// options compose as plain function calls — and NewManager joins and
+// surfaces errs once every option has run.
+type managerConfig struct {
+	codeFunc        func() string
+	scope           func(context.Context) (string, error)
+	resolver        Resolver
+	visitFunc       VisitFunc
+	onHit           func(context.Context, Hit)
+	cacheStore      cache.Store
+	logger          *slog.Logger
+	reserved        map[string]struct{}
+	baseURL         string
+	fallbackURL     string
+	schemes         []string
+	errs            []error
+	cacheTTL        time.Duration
+	linkParamPolicy ParamPolicy
+	redirectStatus  int
+}
+
+// ManagerOption configures [NewManager].
+type ManagerOption func(*managerConfig)
+
+// newManagerConfig returns a managerConfig seeded with every documented
+// default, ready for ManagerOption values to override.
+func newManagerConfig() *managerConfig {
+	return &managerConfig{
+		codeFunc:        func() string { return id.NewShort().StringLower() },
+		schemes:         []string{"http", "https"},
+		reserved:        newReservedSet(),
+		linkParamPolicy: ParamsFill,
+		redirectStatus:  http.StatusFound,
+		logger:          logger.NewNope(),
+	}
+}
+
+// WithCodeFunc overrides the generated-code generator. Default: a lowercase
+// Crockford [github.com/dmitrymomot/forge/core/id.Short] via
+// id.NewShort().StringLower(). A nil f is ignored.
+func WithCodeFunc(f func() string) ManagerOption {
+	return func(c *managerConfig) {
+		if f != nil {
+			c.codeFunc = f
+		}
+	}
+}
+
+// WithBaseURL sets the base [Manager.ShortURL] renders a code onto. It must
+// be an absolute http(s) URL (scheme and host); a trailing slash is added if
+// missing. Without this option, ShortURL always returns "".
+func WithBaseURL(u string) ManagerOption {
+	return func(c *managerConfig) {
+		parsed, err := url.Parse(u)
+		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+			c.errs = append(c.errs, fmt.Errorf("smartlink: base URL must be absolute (scheme and host): %q", u))
+			return
+		}
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			c.errs = append(c.errs, fmt.Errorf("smartlink: base URL scheme must be http or https: %q", u))
+			return
+		}
+		c.baseURL = strings.TrimSuffix(u, "/") + "/"
+	}
+}
+
+// WithSchemes replaces the allowed Target URL schemes (default "http",
+// "https"). Create rejects a Target whose macro-elided scheme is not in
+// this set; scheme comparison is case-insensitive, since [url.Parse] always
+// lowercases the parsed scheme.
+func WithSchemes(s ...string) ManagerOption {
+	return func(c *managerConfig) {
+		schemes := slices.Clone(s)
+		for i, sch := range schemes {
+			schemes[i] = strings.ToLower(sch)
+		}
+		c.schemes = schemes
+	}
+}
+
+// WithReservedCodes extends the default vanity-code blocklist.
+func WithReservedCodes(codes ...string) ManagerOption {
+	return func(c *managerConfig) {
+		for _, code := range codes {
+			c.reserved[code] = struct{}{}
+		}
+	}
+}
+
+// WithScope derives a tenant scope from the request context on every
+// management call, failing closed with [ErrScope] when the hook errors or
+// returns an empty string. Without this option, tenant strings pass through
+// verbatim — single-tenant zero ceremony.
+func WithScope(f func(ctx context.Context) (string, error)) ManagerOption {
+	return func(c *managerConfig) { c.scope = f }
+}
+
+// WithLinkParamPolicy sets the [ParamPolicy] Create uses only to validate a
+// Target template against a degenerate [Spec]. Default [ParamsFill] — the
+// zero value [ParamsDrop] would validate a Target that silently drops
+// forwarded params at decide time.
+func WithLinkParamPolicy(p ParamPolicy) ManagerOption {
+	return func(c *managerConfig) { c.linkParamPolicy = p }
+}
+
+// WithResolver sets the [Resolver] Create uses to confirm a Ref-backed
+// Link's Ref names a resolvable [Spec] before it is stored. Skipped when
+// [CreateParams.SkipRefCheck] is set, or when no Resolver is configured.
+func WithResolver(r Resolver) ManagerOption {
+	return func(c *managerConfig) { c.resolver = r }
+}
+
+// WithVisitFunc sets the [VisitFunc] a Handler (a later task) uses to build
+// the [Visit] for each request.
+func WithVisitFunc(f VisitFunc) ManagerOption {
+	return func(c *managerConfig) { c.visitFunc = f }
+}
+
+// WithOnHit registers a callback a Handler (a later task) invokes after each
+// redirect decision, for click logging or analytics.
+func WithOnHit(f func(context.Context, Hit)) ManagerOption {
+	return func(c *managerConfig) { c.onHit = f }
+}
+
+// WithCache configures the read-through compile cache a Handler (a later
+// task) uses when resolving Ref-backed Links: cs is the backing
+// [cache.Store] and ttl bounds how long a resolved entry is reused.
+func WithCache(cs cache.Store, ttl time.Duration) ManagerOption {
+	return func(c *managerConfig) {
+		c.cacheStore = cs
+		c.cacheTTL = ttl
+	}
+}
+
+// WithFallbackURL sets the destination a Handler (a later task) redirects to
+// when a code cannot be resolved to a live decision.
+func WithFallbackURL(u string) ManagerOption {
+	return func(c *managerConfig) { c.fallbackURL = u }
+}
+
+// WithRedirectStatus sets the HTTP status a Handler (a later task) uses for
+// a successful redirect. Only 302 (Found, the default) and 307 (Temporary
+// Redirect) are accepted: a 301 (permanent) would let browsers cache a
+// destination that can change on the next rule evaluation. Any other value
+// is a NewManager error.
+func WithRedirectStatus(code int) ManagerOption {
+	return func(c *managerConfig) {
+		if code != http.StatusFound && code != http.StatusTemporaryRedirect {
+			c.errs = append(c.errs, fmt.Errorf("smartlink: redirect status %d must be 302 or 307", code))
+			return
+		}
+		c.redirectStatus = code
+	}
+}
+
+// WithLogger sets the diagnostic logger. Default [logger.NewNope] (silent).
+// A nil l is ignored.
+func WithLogger(l *slog.Logger) ManagerOption {
+	return func(c *managerConfig) {
+		if l != nil {
+			c.logger = l
+		}
+	}
+}

--- a/web/smartlink/manager_options.go
+++ b/web/smartlink/manager_options.go
@@ -15,14 +15,14 @@ import (
 	"github.com/dmitrymomot/forge/resilience/cache"
 )
 
-// VisitFunc builds or decorates a [Visit] from the inbound request. A
-// Handler (a later task) calls it before Decide; the Visit passed in is the
-// zero value on the first call in a chain.
+// VisitFunc builds or decorates a [Visit] from the inbound request.
+// [Manager.Handler] calls it before Decide, passing a Visit whose Params
+// are already pre-filled from the query string (first value per key).
 type VisitFunc func(*http.Request, Visit) Visit
 
-// Hit is delivered to a [WithOnHit] callback (a later task) after a redirect
-// decision has been made: the resolved Link, the Visit built for the
-// request, and the Decision Decide returned.
+// Hit is delivered to a [WithOnHit] callback after [Manager.Handler] writes
+// a redirect: the resolved Link, the Visit built for the request, and the
+// Decision Decide returned.
 type Hit struct {
 	Link     Link
 	Visit    Visit
@@ -142,21 +142,25 @@ func WithResolver(r Resolver) ManagerOption {
 	return func(c *managerConfig) { c.resolver = r }
 }
 
-// WithVisitFunc sets the [VisitFunc] a Handler (a later task) uses to build
-// the [Visit] for each request.
+// WithVisitFunc sets the [VisitFunc] [Manager.Handler] uses to enrich the
+// [Visit] for each request.
 func WithVisitFunc(f VisitFunc) ManagerOption {
 	return func(c *managerConfig) { c.visitFunc = f }
 }
 
-// WithOnHit registers a callback a Handler (a later task) invokes after each
-// redirect decision, for click logging or analytics.
+// WithOnHit registers a callback [Manager.Handler] invokes synchronously
+// after each redirect is written. Hand the [Hit] to a bounded sink (queue
+// push, buffered channel) — never do work inline or spawn per-hit
+// goroutines, since a slow callback blocks every click.
 func WithOnHit(f func(context.Context, Hit)) ManagerOption {
 	return func(c *managerConfig) { c.onHit = f }
 }
 
-// WithCache configures the read-through compile cache a Handler (a later
-// task) uses when resolving Ref-backed Links: cs is the backing
-// [cache.Store] and ttl bounds how long a resolved entry is reused.
+// WithCache configures the read-through Link cache [Manager.Resolve] (and
+// so [Manager.Handler]) consults before the Store: cs is the backing
+// [cache.Store] and ttl bounds how long a cached record is reused. Cache
+// errors degrade to Store reads; lifecycle mutations best-effort evict, so
+// a warmed entry is stale for at most ttl.
 func WithCache(cs cache.Store, ttl time.Duration) ManagerOption {
 	return func(c *managerConfig) {
 		c.cacheStore = cs
@@ -164,14 +168,15 @@ func WithCache(cs cache.Store, ttl time.Duration) ManagerOption {
 	}
 }
 
-// WithFallbackURL sets the destination a Handler (a later task) redirects to
-// when a code cannot be resolved to a live decision.
+// WithFallbackURL sets the destination [Manager.Handler] redirects to for a
+// dead link (unknown, expired, or deactivated code, or a Ref the resolver
+// reports as [ErrNoTarget]). Without it, dead links answer 404.
 func WithFallbackURL(u string) ManagerOption {
 	return func(c *managerConfig) { c.fallbackURL = u }
 }
 
-// WithRedirectStatus sets the HTTP status a Handler (a later task) uses for
-// a successful redirect. Only 302 (Found, the default) and 307 (Temporary
+// WithRedirectStatus sets the HTTP status [Manager.Handler] uses for a
+// successful redirect. Only 302 (Found, the default) and 307 (Temporary
 // Redirect) are accepted: a 301 (permanent) would let browsers cache a
 // destination that can change on the next rule evaluation. Any other value
 // is a NewManager error.

--- a/web/smartlink/manager_test.go
+++ b/web/smartlink/manager_test.go
@@ -1,0 +1,423 @@
+package smartlink_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+func newTestManager(t *testing.T, opts ...smartlink.ManagerOption) *smartlink.Manager {
+	t.Helper()
+	m, err := smartlink.NewManager(smartlink.NewMemoryStore(), opts...)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v, want nil", err)
+	}
+	return m
+}
+
+// TestNewManagerRejects301 asserts WithRedirectStatus only accepts 302 and
+// 307 — a 301 (or any other status) is a NewManager error.
+func TestNewManagerRejects301(t *testing.T) {
+	t.Parallel()
+	cases := []int{301, 200, 404, 0}
+	for _, code := range cases {
+		if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithRedirectStatus(code)); err == nil {
+			t.Fatalf("NewManager(WithRedirectStatus(%d)) error = nil, want error", code)
+		}
+	}
+	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithRedirectStatus(302)); err != nil {
+		t.Fatalf("NewManager(WithRedirectStatus(302)) error = %v, want nil", err)
+	}
+	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithRedirectStatus(307)); err != nil {
+		t.Fatalf("NewManager(WithRedirectStatus(307)) error = %v, want nil", err)
+	}
+}
+
+// TestNewManagerBadBaseURL asserts WithBaseURL requires an absolute http(s) URL.
+func TestNewManagerBadBaseURL(t *testing.T) {
+	t.Parallel()
+	cases := []string{"", "app.example.com/verify", "ftp://example.com/"}
+	for _, u := range cases {
+		if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithBaseURL(u)); err == nil {
+			t.Fatalf("NewManager(WithBaseURL(%q)) error = nil, want error", u)
+		}
+	}
+	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithBaseURL("https://s.example.com")); err != nil {
+		t.Fatalf("NewManager(WithBaseURL(valid)) error = %v, want nil", err)
+	}
+}
+
+// TestCreateTargetXorRef asserts Create requires exactly one of Target/Ref.
+func TestCreateTargetXorRef(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	if _, err := m.Create(ctx, smartlink.CreateParams{}); !errors.Is(err, smartlink.ErrInvalidLink) {
+		t.Fatalf("Create(neither) = %v, want ErrInvalidLink", err)
+	}
+	if _, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Ref: "offer-1"}); !errors.Is(err, smartlink.ErrInvalidLink) {
+		t.Fatalf("Create(both) = %v, want ErrInvalidLink", err)
+	}
+}
+
+// TestCreateGeneratedCodeDefault asserts the default code function produces a
+// 16-character lowercase Crockford base32 code parseable via id.ParseShort.
+func TestCreateGeneratedCodeDefault(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t)
+	l, err := m.Create(context.Background(), smartlink.CreateParams{Target: "https://example.com/"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	if len(l.Code) != 16 {
+		t.Fatalf("len(Code) = %d, want 16 (Code = %q)", len(l.Code), l.Code)
+	}
+	const crockfordLower = "0123456789abcdefghjkmnpqrstvwxyz"
+	for _, c := range l.Code {
+		if !strings.ContainsRune(crockfordLower, c) {
+			t.Fatalf("Code %q has char %q outside lowercase Crockford base32", l.Code, c)
+		}
+	}
+	if _, err := id.ParseShort(l.Code); err != nil {
+		t.Fatalf("id.ParseShort(%q) error = %v, want nil", l.Code, err)
+	}
+}
+
+// TestCreateCollisionRetry asserts Create retries a colliding generated code
+// up to 5 times, and gives up with an error when every attempt collides.
+func TestCreateCollisionRetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("succeeds after two collisions", func(t *testing.T) {
+		t.Parallel()
+		store := smartlink.NewMemoryStore()
+		ctx := context.Background()
+		for _, taken := range []string{"taken1", "taken2"} {
+			if err := store.Create(ctx, smartlink.Link{Code: taken, Target: "https://x.example.com/"}); err != nil {
+				t.Fatalf("seed Create(%q) = %v, want nil", taken, err)
+			}
+		}
+		codes := []string{"taken1", "taken2", "fresh"}
+		i := 0
+		codeFunc := func() string {
+			c := codes[i]
+			i++
+			return c
+		}
+		m, err := smartlink.NewManager(store, smartlink.WithCodeFunc(codeFunc))
+		if err != nil {
+			t.Fatalf("NewManager() error = %v, want nil", err)
+		}
+		got, cerr := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/"})
+		if cerr != nil {
+			t.Fatalf("Create() error = %v, want nil", cerr)
+		}
+		if got.Code != "fresh" {
+			t.Fatalf("Code = %q, want %q", got.Code, "fresh")
+		}
+	})
+
+	t.Run("always colliding gives up", func(t *testing.T) {
+		t.Parallel()
+		store := smartlink.NewMemoryStore()
+		ctx := context.Background()
+		if err := store.Create(ctx, smartlink.Link{Code: "dup", Target: "https://x.example.com/"}); err != nil {
+			t.Fatalf("seed Create() = %v, want nil", err)
+		}
+		m, err := smartlink.NewManager(store, smartlink.WithCodeFunc(func() string { return "dup" }))
+		if err != nil {
+			t.Fatalf("NewManager() error = %v, want nil", err)
+		}
+		if _, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/"}); err == nil {
+			t.Fatal("Create() error = nil, want error after exhausting retries")
+		}
+	})
+}
+
+// TestCreateVanity covers caller-supplied Code validation: charset, length,
+// reserved blocklist, and duplicate surfacing.
+func TestCreateVanity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t)
+		l, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Code: "my-code_1"})
+		if err != nil {
+			t.Fatalf("Create() error = %v, want nil", err)
+		}
+		if l.Code != "my-code_1" {
+			t.Fatalf("Code = %q, want %q", l.Code, "my-code_1")
+		}
+	})
+
+	t.Run("invalid chars", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t)
+		if _, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Code: "bad code!"}); !errors.Is(err, smartlink.ErrInvalidLink) {
+			t.Fatalf("Create() = %v, want ErrInvalidLink", err)
+		}
+	})
+
+	t.Run("too long", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t)
+		long := strings.Repeat("a", 65)
+		if _, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Code: long}); !errors.Is(err, smartlink.ErrInvalidLink) {
+			t.Fatalf("Create() = %v, want ErrInvalidLink", err)
+		}
+	})
+
+	t.Run("reserved", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t)
+		if _, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Code: "api"}); !errors.Is(err, smartlink.ErrCodeReserved) {
+			t.Fatalf("Create() = %v, want ErrCodeReserved", err)
+		}
+	})
+
+	t.Run("duplicate", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t)
+		if _, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Code: "dup"}); err != nil {
+			t.Fatalf("Create() error = %v, want nil", err)
+		}
+		if _, err := m.Create(ctx, smartlink.CreateParams{Target: "https://b.example.com/", Code: "dup"}); !errors.Is(err, smartlink.ErrDuplicate) {
+			t.Fatalf("Create() = %v, want ErrDuplicate", err)
+		}
+	})
+}
+
+// TestCreateTargetValidation covers Target compile/scheme/host validation.
+func TestCreateTargetValidation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cases := []struct {
+		name    string
+		target  string
+		wantErr bool
+	}{
+		{"bad template", "https://example.com/{unknown}", true},
+		{"disallowed scheme", "ftp://example.com/file", true},
+		{"scheme-relative", "//example.com/path", true},
+		{"macro host allowed", "https://{param.host}/path", false},
+		{"plain host required", "https:///path", true},
+		{"valid absolute", "https://example.com/path", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := newTestManager(t)
+			_, err := m.Create(ctx, smartlink.CreateParams{Target: tc.target})
+			if tc.wantErr && !errors.Is(err, smartlink.ErrInvalidLink) {
+				t.Fatalf("Create(%q) = %v, want ErrInvalidLink", tc.target, err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("Create(%q) = %v, want nil", tc.target, err)
+			}
+		})
+	}
+}
+
+// TestCreateRefValidation covers Ref validation via the configured Resolver.
+func TestCreateRefValidation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("resolver error wraps ErrInvalidLink", func(t *testing.T) {
+		t.Parallel()
+		resolverErr := errors.New("ref not found")
+		resolver := func(context.Context, smartlink.Link) (smartlink.Decider, error) {
+			return nil, resolverErr
+		}
+		m := newTestManager(t, smartlink.WithResolver(resolver))
+		_, err := m.Create(ctx, smartlink.CreateParams{Ref: "missing-offer"})
+		if !errors.Is(err, smartlink.ErrInvalidLink) {
+			t.Fatalf("Create() = %v, want ErrInvalidLink", err)
+		}
+		if !errors.Is(err, resolverErr) {
+			t.Fatalf("Create() = %v, want wrapped resolver error", err)
+		}
+	})
+
+	t.Run("SkipRefCheck bypasses resolver", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		resolver := func(context.Context, smartlink.Link) (smartlink.Decider, error) {
+			called = true
+			return nil, errors.New("should not be called")
+		}
+		m := newTestManager(t, smartlink.WithResolver(resolver))
+		if _, err := m.Create(ctx, smartlink.CreateParams{Ref: "future-offer", SkipRefCheck: true}); err != nil {
+			t.Fatalf("Create() error = %v, want nil", err)
+		}
+		if called {
+			t.Fatal("resolver was called despite SkipRefCheck")
+		}
+	})
+
+	t.Run("no resolver configured skips check", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t)
+		if _, err := m.Create(ctx, smartlink.CreateParams{Ref: "any-ref"}); err != nil {
+			t.Fatalf("Create() error = %v, want nil", err)
+		}
+	})
+}
+
+// TestCreateMetadataCloned asserts CreateParams.Metadata is cloned: mutating
+// the caller's map after Create must not affect the returned or stored Link.
+func TestCreateMetadataCloned(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t)
+	ctx := context.Background()
+	meta := map[string]string{"k": "v1"}
+	l, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Code: "meta1", Metadata: meta})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	meta["k"] = "mutated"
+	if l.Metadata["k"] != "v1" {
+		t.Fatalf("Metadata[k] = %q, want %q (caller mutation leaked into returned Link)", l.Metadata["k"], "v1")
+	}
+	got, err := m.Get(ctx, "meta1")
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if got.Metadata["k"] != "v1" {
+		t.Fatalf("stored Metadata[k] = %q, want %q", got.Metadata["k"], "v1")
+	}
+}
+
+// TestShortURL covers ShortURL with/without WithBaseURL and slash normalization.
+func TestShortURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without base returns empty", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t)
+		if got := m.ShortURL("abc"); got != "" {
+			t.Fatalf("ShortURL() = %q, want empty", got)
+		}
+	})
+
+	t.Run("with base, no trailing slash", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t, smartlink.WithBaseURL("https://s.example.com"))
+		if got, want := m.ShortURL("abc"), "https://s.example.com/abc"; got != want {
+			t.Fatalf("ShortURL() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("with base, trailing slash", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t, smartlink.WithBaseURL("https://s.example.com/"))
+		if got, want := m.ShortURL("abc"), "https://s.example.com/abc"; got != want {
+			t.Fatalf("ShortURL() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("populated on Create result", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t, smartlink.WithBaseURL("https://s.example.com"))
+		l, err := m.Create(context.Background(), smartlink.CreateParams{Target: "https://example.com/", Code: "shorty"})
+		if err != nil {
+			t.Fatalf("Create() error = %v, want nil", err)
+		}
+		if want := "https://s.example.com/shorty"; l.ShortURL != want {
+			t.Fatalf("ShortURL = %q, want %q", l.ShortURL, want)
+		}
+	})
+}
+
+// TestCreateShortURLNotPersisted asserts ShortURL is derived, never
+// persisted: the stored record (read directly from the Store) must have an
+// empty ShortURL while the Create-returned copy has it populated.
+func TestCreateShortURLNotPersisted(t *testing.T) {
+	t.Parallel()
+	store := smartlink.NewMemoryStore()
+	m, err := smartlink.NewManager(store, smartlink.WithBaseURL("https://s.example.com"))
+	if err != nil {
+		t.Fatalf("NewManager() error = %v, want nil", err)
+	}
+	ctx := context.Background()
+	l, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Code: "persist1"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	if l.ShortURL == "" {
+		t.Fatal("returned Link.ShortURL is empty, want populated")
+	}
+	stored, err := store.Get(ctx, "persist1")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v, want nil", err)
+	}
+	if stored.ShortURL != "" {
+		t.Fatalf("stored Link.ShortURL = %q, want empty (must not be persisted)", stored.ShortURL)
+	}
+}
+
+// TestLifecycle asserts Deactivate/Activate/Delete reach the Store.
+func TestLifecycle(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t)
+	ctx := context.Background()
+	l, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Code: "life1"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+
+	if err := m.Deactivate(ctx, l.Code); err != nil {
+		t.Fatalf("Deactivate() error = %v, want nil", err)
+	}
+	got, err := m.Get(ctx, l.Code)
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if got.DeactivatedAt.IsZero() {
+		t.Fatal("DeactivatedAt is zero after Deactivate, want set")
+	}
+
+	if err := m.Activate(ctx, l.Code); err != nil {
+		t.Fatalf("Activate() error = %v, want nil", err)
+	}
+	got, err = m.Get(ctx, l.Code)
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if !got.DeactivatedAt.IsZero() {
+		t.Fatal("DeactivatedAt is non-zero after Activate, want zero")
+	}
+
+	if err := m.Delete(ctx, l.Code); err != nil {
+		t.Fatalf("Delete() error = %v, want nil", err)
+	}
+	if _, err := m.Get(ctx, l.Code); !errors.Is(err, smartlink.ErrNotFound) {
+		t.Fatalf("Get() after Delete = %v, want ErrNotFound", err)
+	}
+}
+
+// TestRandomCode asserts RandomCode(n) generates n-character codes drawn from
+// the base58 alphabet.
+func TestRandomCode(t *testing.T) {
+	t.Parallel()
+	const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+	gen := smartlink.RandomCode(12)
+	for range 20 {
+		code := gen()
+		if len(code) != 12 {
+			t.Fatalf("len(code) = %d, want 12 (code = %q)", len(code), code)
+		}
+		for _, c := range code {
+			if !strings.ContainsRune(alphabet, c) {
+				t.Fatalf("code %q contains char %q outside base58 alphabet", code, c)
+			}
+		}
+	}
+}

--- a/web/smartlink/manager_test.go
+++ b/web/smartlink/manager_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/resilience/cache"
 	"github.com/dmitrymomot/forge/web/smartlink"
 )
 
@@ -48,6 +50,37 @@ func TestNewManagerBadBaseURL(t *testing.T) {
 	}
 	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithBaseURL("https://s.example.com")); err != nil {
 		t.Fatalf("NewManager(WithBaseURL(valid)) error = %v, want nil", err)
+	}
+}
+
+// TestNewManagerBadFallbackURL asserts WithFallbackURL requires an absolute
+// http(s) URL, same as WithBaseURL: a relative value would silently redirect
+// relative to the handler's own path instead of failing construction.
+func TestNewManagerBadFallbackURL(t *testing.T) {
+	t.Parallel()
+	cases := []string{"", "/relative/path", "app.example.com/verify", "ftp://example.com/"}
+	for _, u := range cases {
+		if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithFallbackURL(u)); err == nil {
+			t.Fatalf("NewManager(WithFallbackURL(%q)) error = nil, want error", u)
+		}
+	}
+	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithFallbackURL("https://fallback.example.com/")); err != nil {
+		t.Fatalf("NewManager(WithFallbackURL(valid)) error = %v, want nil", err)
+	}
+}
+
+// TestNewManagerRejectsNonPositiveCacheTTL asserts WithCache rejects a
+// zero or negative ttl: [cache.WithTTL] treats it as "never expire", which
+// would defeat the bounded-staleness guarantee on a failed cache eviction.
+func TestNewManagerRejectsNonPositiveCacheTTL(t *testing.T) {
+	t.Parallel()
+	for _, ttl := range []time.Duration{0, -time.Second} {
+		if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithCache(cache.NewMemoryStore(), ttl)); err == nil {
+			t.Fatalf("NewManager(WithCache(ttl=%s)) error = nil, want error", ttl)
+		}
+	}
+	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithCache(cache.NewMemoryStore(), time.Minute)); err != nil {
+		t.Fatalf("NewManager(WithCache(ttl=1m)) error = %v, want nil", err)
 	}
 }
 
@@ -137,6 +170,17 @@ func TestCreateCollisionRetry(t *testing.T) {
 			t.Fatal("Create() error = nil, want error after exhausting retries")
 		}
 	})
+}
+
+// TestCreateGeneratedCodeEmptyFails asserts a [WithCodeFunc] that returns ""
+// never persists a Link with an empty code: each empty result is treated as
+// a failed attempt, and Create errors once the retry budget is exhausted.
+func TestCreateGeneratedCodeEmptyFails(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t, smartlink.WithCodeFunc(func() string { return "" }))
+	if _, err := m.Create(context.Background(), smartlink.CreateParams{Target: "https://example.com/"}); err == nil {
+		t.Fatal("Create() error = nil, want error (empty generated code must not be stored)")
+	}
 }
 
 // TestCreateVanity covers caller-supplied Code validation: charset, length,
@@ -320,6 +364,14 @@ func TestShortURL(t *testing.T) {
 		m := newTestManager(t, smartlink.WithBaseURL("https://s.example.com/"))
 		if got, want := m.ShortURL("abc"), "https://s.example.com/abc"; got != want {
 			t.Fatalf("ShortURL() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("with base, multiple trailing slashes", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t, smartlink.WithBaseURL("https://s.example.com//"))
+		if got, want := m.ShortURL("abc"), "https://s.example.com/abc"; got != want {
+			t.Fatalf("ShortURL() = %q, want %q (must not double up the slash)", got, want)
 		}
 	})
 

--- a/web/smartlink/matcher.go
+++ b/web/smartlink/matcher.go
@@ -1,0 +1,244 @@
+package smartlink
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+// Matcher is one typed condition in a rule's conjunction. The set is closed —
+// exactly [Geo], [Device], [Locale], [ParamEquals], [TimeWindow], and
+// [Percent] — rule values are consumer data hydrated into these types, never a
+// DSL.
+type Matcher interface {
+	// compile validates and normalizes the matcher into its evaluated form,
+	// sealing the interface to this package.
+	compile(ruleName string) (matcher, error)
+}
+
+// matcherKind discriminates the compiled matcher union.
+type matcherKind uint8
+
+const (
+	matchGeo matcherKind = iota
+	matchDevice
+	matchLocale
+	matchParam
+	matchTime
+	matchPercent
+)
+
+// matcher is the compiled, normalized form evaluated on every Decide — a
+// tagged union rather than an interface so the hot path stays devirtualized
+// and the Visit never escapes (measured: 2 allocs → 0 on the literal decide;
+// see bench_test.go).
+type matcher struct {
+	from   time.Time
+	until  time.Time
+	key    string   // matchParam: the visit param key
+	values []string // matchGeo/matchDevice/matchLocale/matchParam: normalized any-of values
+	seed   uint64   // matchPercent: precomputed FNV state over the rule-name salt
+	share  uint64   // matchPercent: 1..99
+	kind   matcherKind
+}
+
+// match reports whether the visit satisfies this condition. now is only
+// meaningful for matchTime (resolved once per Decide when a link has any
+// TimeWindow).
+func (m *matcher) match(v *Visit, now time.Time) bool {
+	switch m.kind {
+	case matchGeo:
+		return containsFold(m.values, v.Country)
+	case matchDevice:
+		return containsFold(m.values, v.Device)
+	case matchLocale:
+		return localeMatches(m.values, v.Locale)
+	case matchParam:
+		pv, ok := v.Params[m.key]
+		return ok && slices.Contains(m.values, pv)
+	case matchTime:
+		if !m.from.IsZero() && now.Before(m.from) {
+			return false
+		}
+		return m.until.IsZero() || now.Before(m.until)
+	case matchPercent:
+		if v.StickyKey == "" {
+			return false
+		}
+		return hashString(m.seed, v.StickyKey)%100 < m.share
+	}
+	return false // unreachable: compile only emits the kinds above
+}
+
+// Geo matches when the visit country equals any listed ISO 3166-1 alpha-2
+// code (any case).
+type Geo struct {
+	Countries []string
+}
+
+func (m Geo) compile(ruleName string) (matcher, error) {
+	if len(m.Countries) == 0 {
+		return matcher{}, fmt.Errorf("%w: rule %q: Geo needs at least one country", ErrInvalidMatcher, ruleName)
+	}
+	countries := make([]string, len(m.Countries))
+	for i, c := range m.Countries {
+		if len(c) != 2 || !isAlpha(c) {
+			return matcher{}, fmt.Errorf("%w: rule %q: Geo country %q is not an alpha-2 code", ErrInvalidMatcher, ruleName, c)
+		}
+		countries[i] = strings.ToUpper(c)
+	}
+	return matcher{kind: matchGeo, values: countries}, nil
+}
+
+// Device matches when the visit device class equals any listed value
+// (case-insensitive; web/useragent DeviceType vocabulary by convention).
+type Device struct {
+	Devices []string
+}
+
+func (m Device) compile(ruleName string) (matcher, error) {
+	devices, err := nonEmptyLower(m.Devices, ruleName, "Device")
+	if err != nil {
+		return matcher{}, err
+	}
+	return matcher{kind: matchDevice, values: devices}, nil
+}
+
+// Locale matches the visit locale against any listed BCP-47-style tag,
+// case-insensitively. A bare-language value ("en") also matches any
+// region-qualified visit locale with that primary subtag ("en-US"); a
+// region-qualified value requires a full match.
+type Locale struct {
+	Locales []string
+}
+
+func (m Locale) compile(ruleName string) (matcher, error) {
+	locales, err := nonEmptyLower(m.Locales, ruleName, "Locale")
+	if err != nil {
+		return matcher{}, err
+	}
+	return matcher{kind: matchLocale, values: locales}, nil
+}
+
+// localeMatches implements Locale semantics against pre-lowercased rule values.
+func localeMatches(locales []string, visit string) bool {
+	primary, _, _ := strings.Cut(visit, "-")
+	for _, l := range locales {
+		if strings.EqualFold(visit, l) {
+			return true
+		}
+		if !strings.Contains(l, "-") && strings.EqualFold(primary, l) {
+			return true
+		}
+	}
+	return false
+}
+
+// ParamEquals matches when the visit param Key equals any listed value
+// (exact, case-sensitive — sub-IDs are case-sensitive).
+type ParamEquals struct {
+	Key    string
+	Values []string
+}
+
+func (m ParamEquals) compile(ruleName string) (matcher, error) {
+	if m.Key == "" {
+		return matcher{}, fmt.Errorf("%w: rule %q: ParamEquals needs a key", ErrInvalidMatcher, ruleName)
+	}
+	if len(m.Values) == 0 {
+		return matcher{}, fmt.Errorf("%w: rule %q: ParamEquals %q needs at least one value", ErrInvalidMatcher, ruleName, m.Key)
+	}
+	return matcher{kind: matchParam, key: m.Key, values: slices.Clone(m.Values)}, nil
+}
+
+// TimeWindow matches when the decision time t satisfies From <= t < Until as
+// absolute instants. Either bound may be zero (open-ended); both zero, or
+// Until not after From, is a compile error. t is Visit.At when set, otherwise
+// the link's clock.
+type TimeWindow struct {
+	From  time.Time
+	Until time.Time
+}
+
+func (m TimeWindow) compile(ruleName string) (matcher, error) {
+	if m.From.IsZero() && m.Until.IsZero() {
+		return matcher{}, fmt.Errorf("%w: rule %q: TimeWindow needs at least one bound", ErrInvalidMatcher, ruleName)
+	}
+	if !m.From.IsZero() && !m.Until.IsZero() && !m.Until.After(m.From) {
+		return matcher{}, fmt.Errorf("%w: rule %q: TimeWindow Until must be after From", ErrInvalidMatcher, ruleName)
+	}
+	return matcher{kind: matchTime, from: m.From, until: m.Until}, nil
+}
+
+// Percent matches a deterministic Share percent of traffic, bucketed by hash
+// of the rule name and Visit.StickyKey — the same visitor always lands on the
+// same side. Share must be 1..99 (0 is a dead rule, 100 is no gate — both
+// compile errors). An empty StickyKey never matches (fails closed past this
+// rule).
+type Percent struct {
+	Share int
+}
+
+func (m Percent) compile(ruleName string) (matcher, error) {
+	if m.Share < 1 || m.Share > 99 {
+		return matcher{}, fmt.Errorf("%w: rule %q: Percent share %d outside 1..99", ErrInvalidMatcher, ruleName, m.Share)
+	}
+	return matcher{kind: matchPercent, seed: hashString(fnvOffset, "p\x00"+ruleName), share: uint64(m.Share)}, nil
+}
+
+// isAlpha reports whether s is ASCII letters only.
+func isAlpha(s string) bool {
+	for i := range len(s) {
+		c := s[i]
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') {
+			return false
+		}
+	}
+	return true
+}
+
+// nonEmptyLower validates a non-empty list of non-empty values and returns a
+// lowercased copy.
+func nonEmptyLower(values []string, ruleName, kind string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, fmt.Errorf("%w: rule %q: %s needs at least one value", ErrInvalidMatcher, ruleName, kind)
+	}
+	out := make([]string, len(values))
+	for i, v := range values {
+		if v == "" {
+			return nil, fmt.Errorf("%w: rule %q: %s has an empty value", ErrInvalidMatcher, ruleName, kind)
+		}
+		out[i] = strings.ToLower(v)
+	}
+	return out, nil
+}
+
+// containsFold reports whether list (pre-normalized at compile) contains s
+// case-insensitively. No allocations.
+func containsFold(list []string, s string) bool {
+	for _, v := range list {
+		if strings.EqualFold(v, s) {
+			return true
+		}
+	}
+	return false
+}
+
+const (
+	fnvOffset = 14695981039346656037
+	fnvPrime  = 1099511628211
+)
+
+// hashString continues an FNV-1a 64 hash over s from state h, with a trailing
+// separator multiply so concatenated segments can't collide with shifted
+// boundaries. Inlined to stay allocation-free on the hot path (featureflag
+// precedent).
+func hashString(h uint64, s string) uint64 {
+	for i := range len(s) {
+		h ^= uint64(s[i])
+		h *= fnvPrime
+	}
+	h *= fnvPrime // NUL separator: h ^= 0 is a no-op, the multiply still mixes
+	return h
+}

--- a/web/smartlink/memory.go
+++ b/web/smartlink/memory.go
@@ -1,0 +1,116 @@
+package smartlink
+
+import (
+	"cmp"
+	"context"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+)
+
+// MemoryStore is an in-memory [Store] for tests and development. Its
+// behavior is the reference contract other Store implementations must match.
+type MemoryStore struct {
+	links map[string]Link
+	mu    sync.RWMutex
+}
+
+// NewMemoryStore returns an empty MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{links: make(map[string]Link)}
+}
+
+// cloneLink copies l's Metadata so callers cannot mutate stored state
+// through a shared map (and vice versa).
+func cloneLink(l Link) Link {
+	l.Metadata = maps.Clone(l.Metadata)
+	return l
+}
+
+// Create implements Store.
+func (s *MemoryStore) Create(_ context.Context, l Link) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.links[l.Code]; ok {
+		return ErrDuplicate
+	}
+	s.links[l.Code] = cloneLink(l)
+	return nil
+}
+
+// Get implements Store.
+func (s *MemoryStore) Get(_ context.Context, code string) (Link, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	l, ok := s.links[code]
+	if !ok {
+		return Link{}, ErrNotFound
+	}
+	return cloneLink(l), nil
+}
+
+// List implements Store.
+func (s *MemoryStore) List(_ context.Context, f Filter) ([]Link, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Link, 0, len(s.links))
+	for _, l := range s.links {
+		if f.Tenant != "" && l.Tenant != f.Tenant {
+			continue
+		}
+		out = append(out, cloneLink(l))
+	}
+	slices.SortFunc(out, func(a, b Link) int {
+		if c := b.CreatedAt.Compare(a.CreatedAt); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Code, b.Code)
+	})
+	if f.Limit > 0 && len(out) > f.Limit {
+		out = out[:f.Limit]
+	}
+	return out, nil
+}
+
+// Deactivate implements Store. A zero at is a no-op on DeactivatedAt (it
+// never reactivates an already-deactivated link), but the existence and
+// tenant predicate are still enforced.
+func (s *MemoryStore) Deactivate(_ context.Context, code, tenant string, at time.Time) error {
+	return s.mutate(code, tenant, func(l *Link) {
+		if !at.IsZero() {
+			l.DeactivatedAt = at
+		}
+	})
+}
+
+// Activate implements Store.
+func (s *MemoryStore) Activate(_ context.Context, code, tenant string) error {
+	return s.mutate(code, tenant, func(l *Link) { l.DeactivatedAt = time.Time{} })
+}
+
+// Delete implements Store.
+func (s *MemoryStore) Delete(_ context.Context, code, tenant string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	l, ok := s.links[code]
+	if !ok || (tenant != "" && l.Tenant != tenant) {
+		return ErrNotFound
+	}
+	delete(s.links, code)
+	return nil
+}
+
+// mutate applies fn to the record at code under the write lock, after
+// checking existence and the tenant predicate atomically with the mutation.
+func (s *MemoryStore) mutate(code, tenant string, fn func(*Link)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	l, ok := s.links[code]
+	if !ok || (tenant != "" && l.Tenant != tenant) {
+		return ErrNotFound
+	}
+	fn(&l)
+	s.links[code] = l
+	return nil
+}

--- a/web/smartlink/memory_test.go
+++ b/web/smartlink/memory_test.go
@@ -1,0 +1,290 @@
+package smartlink_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+// TestMemoryStoreCreateGet asserts a created Link round-trips through Get
+// unchanged, and that creating a second Link with the same code fails with
+// ErrDuplicate.
+func TestMemoryStoreCreateGet(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := smartlink.NewMemoryStore()
+	created := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	l := smartlink.Link{Code: "abc123", Target: "https://example.com/", CreatedAt: created}
+
+	if err := s.Create(ctx, l); err != nil {
+		t.Fatalf("Create() = %v, want nil", err)
+	}
+	got, err := s.Get(ctx, "abc123")
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if got.Code != l.Code || got.Target != l.Target || !got.CreatedAt.Equal(l.CreatedAt) {
+		t.Fatalf("Get() = %+v, want %+v", got, l)
+	}
+
+	if err := s.Create(ctx, l); !errors.Is(err, smartlink.ErrDuplicate) {
+		t.Fatalf("Create() duplicate = %v, want ErrDuplicate", err)
+	}
+}
+
+// TestMemoryStoreGetUnknown asserts Get on an absent code returns ErrNotFound.
+func TestMemoryStoreGetUnknown(t *testing.T) {
+	t.Parallel()
+	s := smartlink.NewMemoryStore()
+	if _, err := s.Get(context.Background(), "missing"); !errors.Is(err, smartlink.ErrNotFound) {
+		t.Fatalf("Get() = %v, want ErrNotFound", err)
+	}
+}
+
+// TestMemoryStoreListOrder asserts List returns Links ordered by CreatedAt
+// descending, code ascending on ties, honors the tenant filter, and caps
+// results at Limit (0 meaning no cap).
+func TestMemoryStoreListOrder(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := smartlink.NewMemoryStore()
+	base := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+
+	links := []smartlink.Link{
+		{Code: "b", Tenant: "t1", CreatedAt: base},
+		{Code: "a", Tenant: "t1", CreatedAt: base}, // same CreatedAt as "b", tie broken by code
+		{Code: "c", Tenant: "t2", CreatedAt: base.Add(time.Hour)},
+		{Code: "d", Tenant: "t1", CreatedAt: base.Add(2 * time.Hour)},
+	}
+	for _, l := range links {
+		if err := s.Create(ctx, l); err != nil {
+			t.Fatalf("Create(%q) = %v, want nil", l.Code, err)
+		}
+	}
+
+	all, err := s.List(ctx, smartlink.Filter{})
+	if err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+	wantOrder := []string{"d", "c", "a", "b"}
+	if got := codesOf(all); !equalStrings(got, wantOrder) {
+		t.Fatalf("List() codes = %v, want %v", got, wantOrder)
+	}
+
+	t1, err := s.List(ctx, smartlink.Filter{Tenant: "t1"})
+	if err != nil {
+		t.Fatalf("List(tenant) error = %v, want nil", err)
+	}
+	wantT1 := []string{"d", "a", "b"}
+	if got := codesOf(t1); !equalStrings(got, wantT1) {
+		t.Fatalf("List(tenant=t1) codes = %v, want %v", got, wantT1)
+	}
+
+	limited, err := s.List(ctx, smartlink.Filter{Limit: 2})
+	if err != nil {
+		t.Fatalf("List(limit) error = %v, want nil", err)
+	}
+	wantLimited := []string{"d", "c"}
+	if got := codesOf(limited); !equalStrings(got, wantLimited) {
+		t.Fatalf("List(limit=2) codes = %v, want %v", got, wantLimited)
+	}
+}
+
+// TestMemoryStoreTenantPredicate asserts Deactivate/Activate/Delete with a
+// non-empty tenant apply only when the record belongs to that tenant (else
+// ErrNotFound, record untouched), and that an empty tenant is unconstrained.
+func TestMemoryStoreTenantPredicate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	at := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+
+	newStore := func(t *testing.T) smartlink.Store {
+		t.Helper()
+		s := smartlink.NewMemoryStore()
+		if err := s.Create(ctx, smartlink.Link{Code: "code1", Tenant: "owner"}); err != nil {
+			t.Fatalf("Create() = %v, want nil", err)
+		}
+		return s
+	}
+
+	t.Run("deactivate wrong tenant", func(t *testing.T) {
+		t.Parallel()
+		s := newStore(t)
+		if err := s.Deactivate(ctx, "code1", "intruder", at); !errors.Is(err, smartlink.ErrNotFound) {
+			t.Fatalf("Deactivate(wrong tenant) = %v, want ErrNotFound", err)
+		}
+		got, _ := s.Get(ctx, "code1")
+		if !got.DeactivatedAt.IsZero() {
+			t.Fatalf("record was deactivated despite wrong tenant: %+v", got)
+		}
+	})
+
+	t.Run("deactivate correct tenant", func(t *testing.T) {
+		t.Parallel()
+		s := newStore(t)
+		if err := s.Deactivate(ctx, "code1", "owner", at); err != nil {
+			t.Fatalf("Deactivate(correct tenant) = %v, want nil", err)
+		}
+		got, _ := s.Get(ctx, "code1")
+		if !got.DeactivatedAt.Equal(at) {
+			t.Fatalf("DeactivatedAt = %v, want %v", got.DeactivatedAt, at)
+		}
+	})
+
+	t.Run("deactivate zero at leaves active", func(t *testing.T) {
+		t.Parallel()
+		s := newStore(t)
+		if err := s.Deactivate(ctx, "code1", "owner", time.Time{}); err != nil {
+			t.Fatalf("Deactivate(zero at) = %v, want nil", err)
+		}
+		got, _ := s.Get(ctx, "code1")
+		if !got.DeactivatedAt.IsZero() {
+			t.Fatalf("DeactivatedAt = %v, want zero (still active)", got.DeactivatedAt)
+		}
+	})
+
+	t.Run("deactivate zero at does not reactivate", func(t *testing.T) {
+		t.Parallel()
+		s := newStore(t)
+		if err := s.Deactivate(ctx, "code1", "owner", at); err != nil {
+			t.Fatalf("Deactivate() = %v, want nil", err)
+		}
+		if err := s.Deactivate(ctx, "code1", "owner", time.Time{}); err != nil {
+			t.Fatalf("Deactivate(zero at) = %v, want nil", err)
+		}
+		got, _ := s.Get(ctx, "code1")
+		if !got.DeactivatedAt.Equal(at) {
+			t.Fatalf("DeactivatedAt = %v, want unchanged %v (zero at must not reactivate)", got.DeactivatedAt, at)
+		}
+	})
+
+	t.Run("activate wrong tenant", func(t *testing.T) {
+		t.Parallel()
+		s := newStore(t)
+		if err := s.Deactivate(ctx, "code1", "owner", at); err != nil {
+			t.Fatalf("Deactivate() = %v, want nil", err)
+		}
+		if err := s.Activate(ctx, "code1", "intruder"); !errors.Is(err, smartlink.ErrNotFound) {
+			t.Fatalf("Activate(wrong tenant) = %v, want ErrNotFound", err)
+		}
+		got, _ := s.Get(ctx, "code1")
+		if got.DeactivatedAt.IsZero() {
+			t.Fatalf("record was activated despite wrong tenant: %+v", got)
+		}
+	})
+
+	t.Run("activate empty tenant unconstrained", func(t *testing.T) {
+		t.Parallel()
+		s := newStore(t)
+		if err := s.Deactivate(ctx, "code1", "owner", at); err != nil {
+			t.Fatalf("Deactivate() = %v, want nil", err)
+		}
+		if err := s.Activate(ctx, "code1", ""); err != nil {
+			t.Fatalf("Activate(empty tenant) = %v, want nil", err)
+		}
+		got, _ := s.Get(ctx, "code1")
+		if !got.DeactivatedAt.IsZero() {
+			t.Fatalf("DeactivatedAt = %v, want zero after Activate", got.DeactivatedAt)
+		}
+	})
+
+	t.Run("delete wrong tenant", func(t *testing.T) {
+		t.Parallel()
+		s := newStore(t)
+		if err := s.Delete(ctx, "code1", "intruder"); !errors.Is(err, smartlink.ErrNotFound) {
+			t.Fatalf("Delete(wrong tenant) = %v, want ErrNotFound", err)
+		}
+		if _, err := s.Get(ctx, "code1"); err != nil {
+			t.Fatalf("record was deleted despite wrong tenant: Get() = %v", err)
+		}
+	})
+
+	t.Run("delete correct tenant", func(t *testing.T) {
+		t.Parallel()
+		s := newStore(t)
+		if err := s.Delete(ctx, "code1", "owner"); err != nil {
+			t.Fatalf("Delete(correct tenant) = %v, want nil", err)
+		}
+		if _, err := s.Get(ctx, "code1"); !errors.Is(err, smartlink.ErrNotFound) {
+			t.Fatalf("Get() after delete = %v, want ErrNotFound", err)
+		}
+	})
+}
+
+// TestMemoryStoreMetadataAliasing asserts Metadata maps are cloned on both
+// write and read: mutating the caller's map after Create, and mutating a map
+// returned by Get, must not affect stored state.
+func TestMemoryStoreMetadataAliasing(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := smartlink.NewMemoryStore()
+	meta := map[string]string{"k": "v1"}
+	if err := s.Create(ctx, smartlink.Link{Code: "code1", Metadata: meta}); err != nil {
+		t.Fatalf("Create() = %v, want nil", err)
+	}
+
+	meta["k"] = "mutated-by-caller"
+	got, err := s.Get(ctx, "code1")
+	if err != nil {
+		t.Fatalf("Get() = %v, want nil", err)
+	}
+	if got.Metadata["k"] != "v1" {
+		t.Fatalf("Metadata[k] = %q, want %q (caller mutation leaked into store)", got.Metadata["k"], "v1")
+	}
+
+	got.Metadata["k"] = "mutated-by-reader"
+	got2, err := s.Get(ctx, "code1")
+	if err != nil {
+		t.Fatalf("Get() = %v, want nil", err)
+	}
+	if got2.Metadata["k"] != "v1" {
+		t.Fatalf("Metadata[k] = %q, want %q (reader mutation leaked into store)", got2.Metadata["k"], "v1")
+	}
+}
+
+// TestMemoryStoreDeleteRecreate asserts a code freed by Delete can be
+// immediately reused by Create.
+func TestMemoryStoreDeleteRecreate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := smartlink.NewMemoryStore()
+	if err := s.Create(ctx, smartlink.Link{Code: "code1", Target: "https://a.example.com/"}); err != nil {
+		t.Fatalf("Create() = %v, want nil", err)
+	}
+	if err := s.Delete(ctx, "code1", ""); err != nil {
+		t.Fatalf("Delete() = %v, want nil", err)
+	}
+	if err := s.Create(ctx, smartlink.Link{Code: "code1", Target: "https://b.example.com/"}); err != nil {
+		t.Fatalf("Create() after delete = %v, want nil", err)
+	}
+	got, err := s.Get(ctx, "code1")
+	if err != nil {
+		t.Fatalf("Get() = %v, want nil", err)
+	}
+	if got.Target != "https://b.example.com/" {
+		t.Fatalf("Target = %q, want new target after recreate", got.Target)
+	}
+}
+
+func codesOf(links []smartlink.Link) []string {
+	out := make([]string, len(links))
+	for i, l := range links {
+		out[i] = l.Code
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/web/smartlink/options.go
+++ b/web/smartlink/options.go
@@ -1,0 +1,28 @@
+package smartlink
+
+import "github.com/dmitrymomot/forge/core/clock"
+
+type config struct {
+	clock clock.Clock
+}
+
+// Option configures Compile.
+type Option func(*config)
+
+func newConfig(opts ...Option) config {
+	c := config{clock: clock.System()}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// WithClock sets the clock TimeWindow matchers evaluate against when Visit.At
+// is zero. Defaults to clock.System(). A nil clock is ignored.
+func WithClock(c clock.Clock) Option {
+	return func(cfg *config) {
+		if c != nil {
+			cfg.clock = c
+		}
+	}
+}

--- a/web/smartlink/pgstore/doc.go
+++ b/web/smartlink/pgstore/doc.go
@@ -1,0 +1,10 @@
+// Package pgstore is the Postgres smartlink.Store driver over pgx. The DDL
+// (forge_smart_links) ships as an embedded goose migration in Migrations;
+// apply it via data/migration under its own version table before first use:
+//
+//	_ = migration.New(pgstore.Migrations, migration.WithTable("forge_smartlink_schema")).Up(ctx, db)
+//
+// Every mutator is a single statement with the tenant predicate inline, so
+// the existence check and the tenant check are atomic with the write. Zero
+// time.Time fields map to SQL NULL and back.
+package pgstore

--- a/web/smartlink/pgstore/migrations/00001_create_forge_smart_links.sql
+++ b/web/smartlink/pgstore/migrations/00001_create_forge_smart_links.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+CREATE TABLE forge_smart_links (
+    code           text PRIMARY KEY,
+    target         text NOT NULL DEFAULT '',
+    ref            text NOT NULL DEFAULT '',
+    metadata       jsonb NOT NULL DEFAULT '{}',
+    tenant         text NOT NULL DEFAULT '',
+    created_at     timestamptz NOT NULL,
+    expires_at     timestamptz,
+    deactivated_at timestamptz
+);
+CREATE INDEX forge_smart_links_tenant_created_idx ON forge_smart_links (tenant, created_at DESC, code);
+-- +goose Down
+DROP TABLE forge_smart_links;

--- a/web/smartlink/pgstore/pgstore.go
+++ b/web/smartlink/pgstore/pgstore.go
@@ -1,0 +1,181 @@
+package pgstore
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"io/fs"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_smart_links, rooted so
+// its .sql files sit at fsys root (data/migration.New globs fsys's root, not
+// subdirectories). Apply via data/migration under its own version table
+// ("forge_smartlink_schema").
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// Store is the Postgres implementation of smartlink.Store. The pool's
+// lifecycle is the caller's.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+var _ smartlink.Store = (*Store)(nil)
+
+// New builds a Postgres smartlink Store. Apply Migrations first.
+func New(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const cols = `code, target, ref, metadata, tenant, created_at, expires_at, deactivated_at`
+
+const createSQL = `
+INSERT INTO forge_smart_links (` + cols + `)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+
+// Create inserts l keyed by l.Code. A colliding code yields smartlink.ErrDuplicate.
+func (s *Store) Create(ctx context.Context, l smartlink.Link) error {
+	meta := l.Metadata
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	_, err := s.pool.Exec(ctx, createSQL,
+		l.Code, l.Target, l.Ref, meta, l.Tenant,
+		l.CreatedAt, nullTime(l.ExpiresAt), nullTime(l.DeactivatedAt))
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
+		return smartlink.ErrDuplicate
+	}
+	return err
+}
+
+// Get returns the Link stored under code, or smartlink.ErrNotFound.
+func (s *Store) Get(ctx context.Context, code string) (smartlink.Link, error) {
+	return scanLink(s.pool.QueryRow(ctx, `SELECT `+cols+` FROM forge_smart_links WHERE code = $1`, code))
+}
+
+// List returns Links matching f, newest first (created_at descending, code
+// ascending on ties). An empty Filter.Tenant matches every tenant; a zero
+// Filter.Limit applies no cap.
+func (s *Store) List(ctx context.Context, f smartlink.Filter) ([]smartlink.Link, error) {
+	sql := `SELECT ` + cols + ` FROM forge_smart_links
+	        WHERE ($1 = '' OR tenant = $1)
+	        ORDER BY created_at DESC, code ASC`
+	args := []any{f.Tenant}
+	if f.Limit > 0 {
+		sql += ` LIMIT $2`
+		args = append(args, f.Limit)
+	}
+	rows, err := s.pool.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	// Non-nil empty (not nil) on zero rows, matching the memory store so
+	// callers see identical List results whichever Store backs the Manager.
+	out := []smartlink.Link{}
+	for rows.Next() {
+		l, err := scanLink(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
+// deactivateSQL leaves deactivated_at untouched when $3 is NULL (a zero at),
+// so Deactivate never reactivates an already-deactivated link, while still
+// enforcing the tenant predicate atomically with the write.
+const deactivateSQL = `
+UPDATE forge_smart_links
+SET deactivated_at = CASE WHEN $3::timestamptz IS NULL THEN deactivated_at ELSE $3 END
+WHERE code = $1 AND ($2 = '' OR tenant = $2)`
+
+// Deactivate sets DeactivatedAt to at on code, scoped to tenant. A zero at
+// leaves the link active but still enforces the code/tenant predicate.
+func (s *Store) Deactivate(ctx context.Context, code, tenant string, at time.Time) error {
+	return s.exec(ctx, deactivateSQL, code, tenant, nullTime(at))
+}
+
+const activateSQL = `
+UPDATE forge_smart_links SET deactivated_at = NULL
+WHERE code = $1 AND ($2 = '' OR tenant = $2)`
+
+// Activate clears DeactivatedAt on code, scoped to tenant.
+func (s *Store) Activate(ctx context.Context, code, tenant string) error {
+	return s.exec(ctx, activateSQL, code, tenant)
+}
+
+const deleteSQL = `DELETE FROM forge_smart_links WHERE code = $1 AND ($2 = '' OR tenant = $2)`
+
+// Delete removes code, scoped to tenant.
+func (s *Store) Delete(ctx context.Context, code, tenant string) error {
+	return s.exec(ctx, deleteSQL, code, tenant)
+}
+
+// exec runs sql and maps a zero-row result to smartlink.ErrNotFound: the
+// tenant predicate is inline in sql, so a mismatch and a missing code are
+// indistinguishable and both surface the same error.
+func (s *Store) exec(ctx context.Context, sql string, args ...any) error {
+	tag, err := s.pool.Exec(ctx, sql, args...)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return smartlink.ErrNotFound
+	}
+	return nil
+}
+
+// row is satisfied by both pgx.Row and pgx.Rows.
+type row interface{ Scan(dest ...any) error }
+
+func scanLink(r row) (smartlink.Link, error) {
+	var l smartlink.Link
+	var exp, deact *time.Time
+	err := r.Scan(&l.Code, &l.Target, &l.Ref, &l.Metadata, &l.Tenant,
+		&l.CreatedAt, &exp, &deact)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return smartlink.Link{}, smartlink.ErrNotFound
+	}
+	if err != nil {
+		return smartlink.Link{}, err
+	}
+	l.ExpiresAt = deref(exp)
+	l.DeactivatedAt = deref(deact)
+	return l, nil
+}
+
+// deref maps SQL NULL back to the zero time.
+func deref(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
+// nullTime maps the zero time to SQL NULL.
+func nullTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}

--- a/web/smartlink/pgstore/pgstore_test.go
+++ b/web/smartlink/pgstore/pgstore_test.go
@@ -1,0 +1,272 @@
+//go:build integration
+
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/random"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+	"github.com/dmitrymomot/forge/web/smartlink"
+	"github.com/dmitrymomot/forge/web/smartlink/pgstore"
+)
+
+var _ smartlink.Store = (*pgstore.Store)(nil)
+
+func newStore(t *testing.T) *pgstore.Store {
+	t.Helper()
+	cfg := postgres.DefaultConfig()
+	cfg.URL = pgtest.DSN(t)
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgstore.Migrations, migration.WithTable("forge_smartlink_schema")).Up(context.Background(), db))
+	return pgstore.New(pool)
+}
+
+// code returns a code unique per call: the table persists across test runs,
+// so a fixed literal would collide on the code primary key.
+func code() string { return "code-" + random.String(12) }
+
+func TestPg_CreateGetRoundTrip(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	c := code()
+	created := time.Now().UTC().Truncate(time.Millisecond)
+	l := smartlink.Link{
+		Code:      c,
+		Target:    "https://example.com/",
+		Ref:       "ref1",
+		Tenant:    "tenant-" + random.String(8),
+		Metadata:  map[string]string{"k": "v"},
+		CreatedAt: created,
+	}
+	require.NoError(t, s.Create(ctx, l))
+
+	got, err := s.Get(ctx, c)
+	require.NoError(t, err)
+	assert.Equal(t, l.Code, got.Code)
+	assert.Equal(t, l.Target, got.Target)
+	assert.Equal(t, l.Ref, got.Ref)
+	assert.Equal(t, l.Tenant, got.Tenant)
+	assert.Equal(t, l.Metadata, got.Metadata)
+	assert.True(t, got.CreatedAt.Equal(created))
+	// zero ExpiresAt/DeactivatedAt round-trip through NULL back to zero.
+	assert.True(t, got.ExpiresAt.IsZero())
+	assert.True(t, got.DeactivatedAt.IsZero())
+}
+
+func TestPg_CreateDuplicate(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	c := code()
+	require.NoError(t, s.Create(ctx, smartlink.Link{Code: c, CreatedAt: time.Now().UTC()}))
+	err := s.Create(ctx, smartlink.Link{Code: c, CreatedAt: time.Now().UTC()})
+	assert.ErrorIs(t, err, smartlink.ErrDuplicate)
+}
+
+func TestPg_GetNotFound(t *testing.T) {
+	s := newStore(t)
+	_, err := s.Get(context.Background(), code())
+	assert.ErrorIs(t, err, smartlink.ErrNotFound)
+}
+
+func TestPg_ListOrderFilterLimit(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	tenant := "tenant-" + random.String(8)
+	other := "tenant-" + random.String(8)
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	cb, ca, cc, cd := code(), code(), code(), code()
+	// cb and ca share CreatedAt: tie is broken by code ascending.
+	links := []smartlink.Link{
+		{Code: cb, Tenant: tenant, CreatedAt: base},
+		{Code: ca, Tenant: tenant, CreatedAt: base},
+		{Code: cc, Tenant: other, CreatedAt: base.Add(time.Hour)},
+		{Code: cd, Tenant: tenant, CreatedAt: base.Add(2 * time.Hour)},
+	}
+	for _, l := range links {
+		require.NoError(t, s.Create(ctx, l))
+	}
+	wantOrder := []string{cd, cc, ca, cb}
+	if ca > cb {
+		wantOrder = []string{cd, cc, cb, ca}
+	}
+
+	all, err := s.List(ctx, smartlink.Filter{})
+	require.NoError(t, err)
+	all = filterCodes(all, cb, ca, cc, cd)
+	require.Len(t, all, 4)
+	assert.Equal(t, wantOrder, codesOf(all))
+
+	scoped, err := s.List(ctx, smartlink.Filter{Tenant: tenant})
+	require.NoError(t, err)
+	require.Len(t, scoped, 3)
+	for _, l := range scoped {
+		assert.Equal(t, tenant, l.Tenant)
+	}
+
+	limited, err := s.List(ctx, smartlink.Filter{Tenant: tenant, Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+	assert.Equal(t, cd, limited[0].Code)
+}
+
+func TestPg_ListEmptyNonNil(t *testing.T) {
+	s := newStore(t)
+	none, err := s.List(context.Background(), smartlink.Filter{Tenant: "tenant-" + random.String(12)})
+	require.NoError(t, err)
+	assert.NotNil(t, none)
+	assert.Empty(t, none)
+}
+
+func TestPg_TenantPredicateMutators(t *testing.T) {
+	ctx := context.Background()
+	at := time.Now().UTC().Truncate(time.Millisecond)
+
+	setup := func(t *testing.T) (*pgstore.Store, string, string) {
+		t.Helper()
+		s := newStore(t)
+		c, owner := code(), "owner-"+random.String(8)
+		require.NoError(t, s.Create(ctx, smartlink.Link{Code: c, Tenant: owner, CreatedAt: time.Now().UTC()}))
+		return s, c, owner
+	}
+
+	t.Run("deactivate wrong tenant", func(t *testing.T) {
+		s, c, _ := setup(t)
+		err := s.Deactivate(ctx, c, "intruder", at)
+		assert.ErrorIs(t, err, smartlink.ErrNotFound)
+		got, _ := s.Get(ctx, c)
+		assert.True(t, got.DeactivatedAt.IsZero())
+	})
+
+	t.Run("deactivate correct tenant", func(t *testing.T) {
+		s, c, owner := setup(t)
+		require.NoError(t, s.Deactivate(ctx, c, owner, at))
+		got, err := s.Get(ctx, c)
+		require.NoError(t, err)
+		assert.True(t, got.DeactivatedAt.Equal(at))
+	})
+
+	t.Run("deactivate zero at leaves active", func(t *testing.T) {
+		s, c, owner := setup(t)
+		require.NoError(t, s.Deactivate(ctx, c, owner, time.Time{}))
+		got, err := s.Get(ctx, c)
+		require.NoError(t, err)
+		assert.True(t, got.DeactivatedAt.IsZero())
+	})
+
+	t.Run("deactivate zero at does not reactivate", func(t *testing.T) {
+		s, c, owner := setup(t)
+		require.NoError(t, s.Deactivate(ctx, c, owner, at))
+		require.NoError(t, s.Deactivate(ctx, c, owner, time.Time{}))
+		got, err := s.Get(ctx, c)
+		require.NoError(t, err)
+		assert.True(t, got.DeactivatedAt.Equal(at))
+	})
+
+	t.Run("deactivate zero at still enforces predicate", func(t *testing.T) {
+		s, c, _ := setup(t)
+		err := s.Deactivate(ctx, c, "intruder", time.Time{})
+		assert.ErrorIs(t, err, smartlink.ErrNotFound)
+	})
+
+	t.Run("activate wrong tenant", func(t *testing.T) {
+		s, c, owner := setup(t)
+		require.NoError(t, s.Deactivate(ctx, c, owner, at))
+		err := s.Activate(ctx, c, "intruder")
+		assert.ErrorIs(t, err, smartlink.ErrNotFound)
+		got, _ := s.Get(ctx, c)
+		assert.False(t, got.DeactivatedAt.IsZero())
+	})
+
+	t.Run("activate empty tenant unconstrained", func(t *testing.T) {
+		s, c, owner := setup(t)
+		require.NoError(t, s.Deactivate(ctx, c, owner, at))
+		require.NoError(t, s.Activate(ctx, c, ""))
+		got, err := s.Get(ctx, c)
+		require.NoError(t, err)
+		assert.True(t, got.DeactivatedAt.IsZero())
+	})
+
+	t.Run("delete wrong tenant", func(t *testing.T) {
+		s, c, _ := setup(t)
+		err := s.Delete(ctx, c, "intruder")
+		assert.ErrorIs(t, err, smartlink.ErrNotFound)
+		_, err = s.Get(ctx, c)
+		assert.NoError(t, err)
+	})
+
+	t.Run("delete correct tenant", func(t *testing.T) {
+		s, c, owner := setup(t)
+		require.NoError(t, s.Delete(ctx, c, owner))
+		_, err := s.Get(ctx, c)
+		assert.ErrorIs(t, err, smartlink.ErrNotFound)
+	})
+}
+
+func TestPg_DeleteRecreate(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	c := code()
+	require.NoError(t, s.Create(ctx, smartlink.Link{Code: c, Target: "https://a.example.com/", CreatedAt: time.Now().UTC()}))
+	require.NoError(t, s.Delete(ctx, c, ""))
+	require.NoError(t, s.Create(ctx, smartlink.Link{Code: c, Target: "https://b.example.com/", CreatedAt: time.Now().UTC()}))
+
+	got, err := s.Get(ctx, c)
+	require.NoError(t, err)
+	assert.Equal(t, "https://b.example.com/", got.Target)
+}
+
+func TestPg_MetadataNilVsEmpty(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	cNil := code()
+	require.NoError(t, s.Create(ctx, smartlink.Link{Code: cNil, CreatedAt: time.Now().UTC(), Metadata: nil}))
+	gotNil, err := s.Get(ctx, cNil)
+	require.NoError(t, err)
+	assert.Empty(t, gotNil.Metadata)
+
+	cEmpty := code()
+	require.NoError(t, s.Create(ctx, smartlink.Link{Code: cEmpty, CreatedAt: time.Now().UTC(), Metadata: map[string]string{}}))
+	gotEmpty, err := s.Get(ctx, cEmpty)
+	require.NoError(t, err)
+	assert.Empty(t, gotEmpty.Metadata)
+}
+
+func codesOf(links []smartlink.Link) []string {
+	out := make([]string, len(links))
+	for i, l := range links {
+		out[i] = l.Code
+	}
+	return out
+}
+
+// filterCodes narrows links to only those whose code is in want, preserving
+// order; the table persists across test runs, so unrelated rows from other
+// tests may otherwise pollute an unscoped List.
+func filterCodes(links []smartlink.Link, want ...string) []smartlink.Link {
+	set := make(map[string]bool, len(want))
+	for _, c := range want {
+		set[c] = true
+	}
+	out := make([]smartlink.Link, 0, len(want))
+	for _, l := range links {
+		if set[l.Code] {
+			out = append(out, l)
+		}
+	}
+	return out
+}

--- a/web/smartlink/resolve.go
+++ b/web/smartlink/resolve.go
@@ -1,0 +1,112 @@
+package smartlink
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+// cachePrefix namespaces Manager's cache keys under a code, so a shared
+// cache.Store can hold entries from other consumers without collision.
+const cachePrefix = "smartlink:code:"
+
+// Resolve returns the live Link stored under code: a cache read-through
+// lookup (see [WithCache]) followed by liveness checks. A deactivated Link
+// surfaces [ErrLinkDeactivated]; one whose ExpiresAt has passed surfaces
+// [ErrLinkExpired]; an unknown code surfaces [ErrNotFound] from the Store.
+//
+// Resolve is the public, unscoped read path: a code is a public URL, so
+// unlike the management ops it never consults [WithScope]. The returned
+// Link has ShortURL populated (see [Manager.ShortURL]).
+func (m *Manager) Resolve(ctx context.Context, code string) (Link, error) {
+	l, err := m.lookup(ctx, code)
+	if err != nil {
+		return Link{}, err
+	}
+	if !l.DeactivatedAt.IsZero() {
+		return Link{}, ErrLinkDeactivated
+	}
+	if !l.ExpiresAt.IsZero() && !l.ExpiresAt.After(time.Now()) {
+		return Link{}, ErrLinkExpired
+	}
+	l.ShortURL = m.ShortURL(l.Code)
+	return l, nil
+}
+
+// lookup reads code via cache read-through when [WithCache] is configured,
+// else directly from the Store. A cache miss or any cache error falls
+// through to the Store and best-effort repopulates the cache; cache errors
+// are logged at debug and never fail the resolve — the Store stays the
+// source of truth, so a bad cache backend degrades to "always hit the
+// Store", not "links stop resolving".
+func (m *Manager) lookup(ctx context.Context, code string) (Link, error) {
+	if m.cfg.cacheStore == nil {
+		return m.store.Get(ctx, code)
+	}
+
+	key := cachePrefix + code
+	if l, ok := m.cacheGet(ctx, code, key); ok {
+		return l, nil
+	}
+
+	l, err := m.store.Get(ctx, code)
+	if err != nil {
+		return Link{}, err
+	}
+	m.cacheSet(ctx, code, key, l)
+	return l, nil
+}
+
+// cacheGet attempts the cache read-through hit path, reporting ok == false
+// on a miss, a cache error, or a decode failure — any of which the caller
+// treats identically: fall through to the Store.
+func (m *Manager) cacheGet(ctx context.Context, code, key string) (Link, bool) {
+	raw, err := m.cfg.cacheStore.Get(ctx, key)
+	if err != nil {
+		if !errors.Is(err, cache.ErrNotFound) {
+			m.cfg.logger.DebugContext(ctx, "smartlink: cache get failed", "code", code, "error", err)
+		}
+		return Link{}, false
+	}
+	var l Link
+	if err := json.Unmarshal(raw, &l); err != nil {
+		m.cfg.logger.DebugContext(ctx, "smartlink: cache decode failed", "code", code, "error", err)
+		return Link{}, false
+	}
+	return l, true
+}
+
+// cacheSet best-effort writes l under key with the configured TTL. ShortURL
+// is stripped before caching — it is derived from the base URL, never
+// persisted, and must not leak through the cache either. Failures are
+// logged at debug and otherwise ignored.
+func (m *Manager) cacheSet(ctx context.Context, code, key string, l Link) {
+	l.ShortURL = ""
+	raw, err := json.Marshal(l)
+	if err != nil {
+		m.cfg.logger.DebugContext(ctx, "smartlink: cache encode failed", "code", code, "error", err)
+		return
+	}
+	if err := m.cfg.cacheStore.Set(ctx, key, raw, cache.WithTTL(m.cfg.cacheTTL)); err != nil {
+		m.cfg.logger.DebugContext(ctx, "smartlink: cache set failed", "code", code, "error", err)
+	}
+}
+
+// invalidateCache best-effort evicts code's cache entry after a lifecycle
+// mutation (Deactivate, Activate, Delete), bounding staleness of a warmed
+// entry to at most the configured TTL (when a positive [WithCache] ttl is
+// set — a non-positive ttl means "never expire" per [cache.WithTTL], and an
+// entry that survives a failed eviction here has no bound). A no-op without
+// [WithCache]; a failure is logged at debug, never surfaced — the mutation
+// already succeeded against the Store.
+func (m *Manager) invalidateCache(ctx context.Context, code string) {
+	if m.cfg.cacheStore == nil {
+		return
+	}
+	if err := m.cfg.cacheStore.Delete(ctx, cachePrefix+code); err != nil {
+		m.cfg.logger.DebugContext(ctx, "smartlink: cache invalidate failed", "code", code, "error", err)
+	}
+}

--- a/web/smartlink/resolve.go
+++ b/web/smartlink/resolve.go
@@ -97,11 +97,10 @@ func (m *Manager) cacheSet(ctx context.Context, code, key string, l Link) {
 
 // invalidateCache best-effort evicts code's cache entry after a lifecycle
 // mutation (Deactivate, Activate, Delete), bounding staleness of a warmed
-// entry to at most the configured TTL (when a positive [WithCache] ttl is
-// set — a non-positive ttl means "never expire" per [cache.WithTTL], and an
-// entry that survives a failed eviction here has no bound). A no-op without
-// [WithCache]; a failure is logged at debug, never surfaced — the mutation
-// already succeeded against the Store.
+// entry to at most the configured [WithCache] ttl (ttl is validated positive
+// at construction, so an entry that survives a failed eviction here is
+// always bounded). A no-op without [WithCache]; a failure is logged at
+// debug, never surfaced — the mutation already succeeded against the Store.
 func (m *Manager) invalidateCache(ctx context.Context, code string) {
 	if m.cfg.cacheStore == nil {
 		return

--- a/web/smartlink/resolve_test.go
+++ b/web/smartlink/resolve_test.go
@@ -1,0 +1,215 @@
+package smartlink_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/resilience/cache"
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+// TestResolveLiveness asserts Resolve enforces liveness after retrieval: an
+// active Link resolves cleanly, an expired one surfaces ErrLinkExpired, a
+// deactivated one surfaces ErrLinkDeactivated, and an unknown code surfaces
+// ErrNotFound from the Store.
+func TestResolveLiveness(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	active, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Code: "active1"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	if got, err := m.Resolve(ctx, active.Code); err != nil {
+		t.Fatalf("Resolve(active) error = %v, want nil", err)
+	} else if got.Code != active.Code {
+		t.Fatalf("Resolve(active).Code = %q, want %q", got.Code, active.Code)
+	}
+
+	expired, err := m.Create(ctx, smartlink.CreateParams{
+		Target:    "https://example.com/",
+		Code:      "expired1",
+		ExpiresAt: time.Now().Add(-time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	if _, err := m.Resolve(ctx, expired.Code); !errors.Is(err, smartlink.ErrLinkExpired) {
+		t.Fatalf("Resolve(expired) = %v, want ErrLinkExpired", err)
+	}
+
+	deactivated, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Code: "deact1"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	if err := m.Deactivate(ctx, deactivated.Code); err != nil {
+		t.Fatalf("Deactivate() error = %v, want nil", err)
+	}
+	if _, err := m.Resolve(ctx, deactivated.Code); !errors.Is(err, smartlink.ErrLinkDeactivated) {
+		t.Fatalf("Resolve(deactivated) = %v, want ErrLinkDeactivated", err)
+	}
+
+	if _, err := m.Resolve(ctx, "unknown-code"); !errors.Is(err, smartlink.ErrNotFound) {
+		t.Fatalf("Resolve(unknown) = %v, want ErrNotFound", err)
+	}
+}
+
+// countingStore wraps a Store and counts Get calls, to prove cache
+// read-through skips the backing Store on a hit.
+type countingStore struct {
+	smartlink.Store
+	gets atomic.Int32
+}
+
+func (s *countingStore) Get(ctx context.Context, code string) (smartlink.Link, error) {
+	s.gets.Add(1)
+	return s.Store.Get(ctx, code)
+}
+
+// TestResolveCacheReadThrough asserts a second Resolve for the same code is
+// served entirely from the cache: the backing Store's Get is called only
+// once, and the cached data matches the store-backed first read.
+func TestResolveCacheReadThrough(t *testing.T) {
+	t.Parallel()
+	store := &countingStore{Store: smartlink.NewMemoryStore()}
+	m, err := smartlink.NewManager(store, smartlink.WithCache(cache.NewMemoryStore(), time.Minute))
+	if err != nil {
+		t.Fatalf("NewManager() error = %v, want nil", err)
+	}
+	ctx := context.Background()
+
+	created, err := m.Create(ctx, smartlink.CreateParams{
+		Target:   "https://example.com/",
+		Code:     "cache1",
+		Metadata: map[string]string{"k": "v"},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+
+	first, err := m.Resolve(ctx, created.Code)
+	if err != nil {
+		t.Fatalf("Resolve() #1 error = %v, want nil", err)
+	}
+	if got := store.gets.Load(); got != 1 {
+		t.Fatalf("store Gets after first Resolve = %d, want 1", got)
+	}
+
+	second, err := m.Resolve(ctx, created.Code)
+	if err != nil {
+		t.Fatalf("Resolve() #2 error = %v, want nil", err)
+	}
+	if got := store.gets.Load(); got != 1 {
+		t.Fatalf("store Gets after second Resolve = %d, want 1 (must be served from cache)", got)
+	}
+	if second.Code != first.Code || second.Target != first.Target || second.Metadata["k"] != "v" {
+		t.Fatalf("second Resolve = %+v, want same data as first %+v", second, first)
+	}
+}
+
+var errCacheBoom = errors.New("cache boundary: unavailable")
+
+// failingCache is a cache.Store whose every method errors, to prove cache
+// errors never fail Resolve — the Store stays the source of truth.
+type failingCache struct{}
+
+func (failingCache) Get(context.Context, string) ([]byte, error) { return nil, errCacheBoom }
+func (failingCache) Set(context.Context, string, []byte, ...cache.SetOption) error {
+	return errCacheBoom
+}
+func (failingCache) Delete(context.Context, string) error       { return errCacheBoom }
+func (failingCache) Has(context.Context, string) (bool, error)  { return false, errCacheBoom }
+func (failingCache) DeletePrefix(context.Context, string) error { return errCacheBoom }
+func (failingCache) Close() error                               { return nil }
+
+// TestResolveCacheErrorFallsThrough asserts a failing cache (Get and Set
+// both erroring) never fails Resolve: the Store still serves the Link.
+func TestResolveCacheErrorFallsThrough(t *testing.T) {
+	t.Parallel()
+	m, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithCache(failingCache{}, time.Minute))
+	if err != nil {
+		t.Fatalf("NewManager() error = %v, want nil", err)
+	}
+	ctx := context.Background()
+
+	created, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Code: "cerr1"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	got, err := m.Resolve(ctx, created.Code)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil (store must still serve on cache error)", err)
+	}
+	if got.Code != created.Code {
+		t.Fatalf("Resolve().Code = %q, want %q", got.Code, created.Code)
+	}
+}
+
+// TestLifecycleInvalidatesCache asserts Deactivate, Activate, and Delete
+// each best-effort evict the cache key after a successful Store mutation,
+// bounding staleness of a warmed cache entry to at most the configured TTL.
+func TestLifecycleInvalidatesCache(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T) (*smartlink.Manager, cache.Store, string, string) {
+		t.Helper()
+		cs := cache.NewMemoryStore()
+		m, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithCache(cs, time.Minute))
+		if err != nil {
+			t.Fatalf("NewManager() error = %v, want nil", err)
+		}
+		ctx := context.Background()
+		l, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/"})
+		if err != nil {
+			t.Fatalf("Create() error = %v, want nil", err)
+		}
+		if _, err := m.Resolve(ctx, l.Code); err != nil {
+			t.Fatalf("Resolve() (warm cache) error = %v, want nil", err)
+		}
+		key := "smartlink:code:" + l.Code
+		if _, err := cs.Get(ctx, key); err != nil {
+			t.Fatalf("cache Get() after warm-up = %v, want nil (cached)", err)
+		}
+		return m, cs, l.Code, key
+	}
+
+	t.Run("Deactivate", func(t *testing.T) {
+		t.Parallel()
+		m, cs, code, key := setup(t)
+		ctx := context.Background()
+		if err := m.Deactivate(ctx, code); err != nil {
+			t.Fatalf("Deactivate() error = %v, want nil", err)
+		}
+		if _, err := cs.Get(ctx, key); !errors.Is(err, cache.ErrNotFound) {
+			t.Fatalf("cache Get() after Deactivate = %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("Activate", func(t *testing.T) {
+		t.Parallel()
+		m, cs, code, key := setup(t)
+		ctx := context.Background()
+		if err := m.Activate(ctx, code); err != nil {
+			t.Fatalf("Activate() error = %v, want nil", err)
+		}
+		if _, err := cs.Get(ctx, key); !errors.Is(err, cache.ErrNotFound) {
+			t.Fatalf("cache Get() after Activate = %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		t.Parallel()
+		m, cs, code, key := setup(t)
+		ctx := context.Background()
+		if err := m.Delete(ctx, code); err != nil {
+			t.Fatalf("Delete() error = %v, want nil", err)
+		}
+		if _, err := cs.Get(ctx, key); !errors.Is(err, cache.ErrNotFound) {
+			t.Fatalf("cache Get() after Delete = %v, want ErrNotFound", err)
+		}
+	})
+}

--- a/web/smartlink/resolve_test.go
+++ b/web/smartlink/resolve_test.go
@@ -111,6 +111,36 @@ func TestResolveCacheReadThrough(t *testing.T) {
 	}
 }
 
+// TestResolveCorruptCacheFallsThrough asserts a cache entry that fails to
+// decode (garbage bytes, not the Link JSON envelope) degrades identically to
+// a miss: Resolve still returns the Link from the backing Store instead of
+// surfacing a decode error.
+func TestResolveCorruptCacheFallsThrough(t *testing.T) {
+	t.Parallel()
+	cs := cache.NewMemoryStore()
+	m, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithCache(cs, time.Minute))
+	if err != nil {
+		t.Fatalf("NewManager() error = %v, want nil", err)
+	}
+	ctx := context.Background()
+
+	created, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Code: "corrupt1"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	if err := cs.Set(ctx, "smartlink:code:"+created.Code, []byte("not json"), cache.WithTTL(time.Minute)); err != nil {
+		t.Fatalf("cache Set() error = %v, want nil", err)
+	}
+
+	got, err := m.Resolve(ctx, created.Code)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil (corrupt cache entry must degrade to Store)", err)
+	}
+	if got.Code != created.Code {
+		t.Fatalf("Resolve().Code = %q, want %q", got.Code, created.Code)
+	}
+}
+
 var errCacheBoom = errors.New("cache boundary: unavailable")
 
 // failingCache is a cache.Store whose every method errors, to prove cache

--- a/web/smartlink/rule.go
+++ b/web/smartlink/rule.go
@@ -1,0 +1,58 @@
+package smartlink
+
+// ParamPolicy controls how Visit.Params merge into the final URL after macro
+// rendering. ParamsFill and ParamsOverride re-encode the query, which sorts
+// its keys — don't point merged links at order-sensitive (e.g. signed) URLs.
+type ParamPolicy int
+
+const (
+	// ParamsDrop never merges visit params into the URL (default).
+	ParamsDrop ParamPolicy = iota
+	// ParamsFill adds visit params only for keys the target URL doesn't set.
+	ParamsFill
+	// ParamsOverride replaces the target URL's same-key params with visit values.
+	ParamsOverride
+)
+
+// Spec is the consumer-hydrated definition of one smartlink: ordered rules
+// evaluated first-match-wins, with a mandatory default target. Rule values are
+// consumer data (however stored) hydrated into this typed vocabulary.
+type Spec struct {
+	// Rules are evaluated in order; the first rule whose matchers all match
+	// wins. May be empty for a default-only link.
+	Rules []Rule
+	// Default is the mandatory fallback target list; a weighted split when it
+	// has more than one entry.
+	Default []Target
+	// Params is the merge policy for Visit.Params into the final URL.
+	Params ParamPolicy
+}
+
+// Rule is one ordered decision row: a conjunction of matchers selecting a
+// target list.
+type Rule struct {
+	// Name identifies the rule in Decision.Rule and salts its Percent and
+	// split bucketing. Required and unique within a Spec.
+	Name string
+	// When is the matcher conjunction (AND). An empty list matches every
+	// visit — an unconditional override that shadows everything after it.
+	When []Matcher
+	// Targets holds one or more destinations; more than one forms a weighted
+	// split bucketed by Visit.StickyKey.
+	Targets []Target
+}
+
+// Target is one destination URL template with its split weight.
+type Target struct {
+	// URL is the destination template; it may contain {country}, {device},
+	// {locale}, and {param.NAME} macros in the host, path, or query. Macro
+	// values escape by position, so they can never alter the URL structure:
+	// path and query values percent-encode, and a host-position value renders
+	// only when it is entirely hostname-safe bytes ([A-Za-z0-9._~-]) — any
+	// other value renders empty, yielding a dead but well-formed URL, never a
+	// different destination shape.
+	URL string
+	// Weight is the target's relative share of a split; must be >= 1 when the
+	// target list has more than one entry, ignored otherwise.
+	Weight int
+}

--- a/web/smartlink/scope_test.go
+++ b/web/smartlink/scope_test.go
@@ -1,0 +1,215 @@
+package smartlink_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/ctxkey"
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+var tenantKey = ctxkey.New[string]("tenant")
+
+// scopeFromCtx reads the tenant from ctx, if any; absent context yields an
+// empty scope (fails closed downstream, per Manager's WithScope contract).
+func scopeFromCtx(ctx context.Context) (string, error) {
+	t, _ := tenantKey.From(ctx)
+	return t, nil
+}
+
+func newScopedManager(t *testing.T, opts ...smartlink.ManagerOption) (*smartlink.Manager, smartlink.Store) {
+	t.Helper()
+	store := smartlink.NewMemoryStore()
+	all := append([]smartlink.ManagerOption{smartlink.WithScope(scopeFromCtx)}, opts...)
+	m, err := smartlink.NewManager(store, all...)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v, want nil", err)
+	}
+	return m, store
+}
+
+// TestScopeFailClosed asserts every management op fails with ErrScope when
+// the scope hook returns an empty tenant or an error.
+func TestScopeFailClosed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty scope", func(t *testing.T) {
+		t.Parallel()
+		m, _ := newScopedManager(t)
+		ctx := context.Background() // no tenant in context -> empty scope
+
+		if _, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/"}); !errors.Is(err, smartlink.ErrScope) {
+			t.Fatalf("Create() = %v, want ErrScope", err)
+		}
+		if _, err := m.Get(ctx, "any"); !errors.Is(err, smartlink.ErrScope) {
+			t.Fatalf("Get() = %v, want ErrScope", err)
+		}
+		if _, err := m.List(ctx, smartlink.Filter{}); !errors.Is(err, smartlink.ErrScope) {
+			t.Fatalf("List() = %v, want ErrScope", err)
+		}
+		if err := m.Deactivate(ctx, "any"); !errors.Is(err, smartlink.ErrScope) {
+			t.Fatalf("Deactivate() = %v, want ErrScope", err)
+		}
+		if err := m.Activate(ctx, "any"); !errors.Is(err, smartlink.ErrScope) {
+			t.Fatalf("Activate() = %v, want ErrScope", err)
+		}
+		if err := m.Delete(ctx, "any"); !errors.Is(err, smartlink.ErrScope) {
+			t.Fatalf("Delete() = %v, want ErrScope", err)
+		}
+	})
+
+	t.Run("hook error", func(t *testing.T) {
+		t.Parallel()
+		hookErr := errors.New("no tenant resolvable")
+		m, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithScope(func(context.Context) (string, error) {
+			return "", hookErr
+		}))
+		if err != nil {
+			t.Fatalf("NewManager() error = %v, want nil", err)
+		}
+		ctx := context.Background()
+		_, cerr := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/"})
+		if !errors.Is(cerr, smartlink.ErrScope) {
+			t.Fatalf("Create() = %v, want wrapped ErrScope", cerr)
+		}
+		if !errors.Is(cerr, hookErr) {
+			t.Fatalf("Create() = %v, want wrapped hook error", cerr)
+		}
+	})
+}
+
+// TestScopeCreateTenantMismatch asserts Create defaults an empty
+// CreateParams.Tenant to the scope tenant, accepts a matching one, and
+// rejects a mismatched one with ErrScope.
+func TestScopeCreateTenantMismatch(t *testing.T) {
+	t.Parallel()
+	m, _ := newScopedManager(t)
+	ctx := tenantKey.With(context.Background(), "tenant-a")
+
+	l, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/"})
+	if err != nil {
+		t.Fatalf("Create(empty tenant) error = %v, want nil", err)
+	}
+	if l.Tenant != "tenant-a" {
+		t.Fatalf("Tenant = %q, want %q", l.Tenant, "tenant-a")
+	}
+
+	if _, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Tenant: "tenant-a"}); err != nil {
+		t.Fatalf("Create(matching tenant) error = %v, want nil", err)
+	}
+
+	if _, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Tenant: "tenant-b"}); !errors.Is(err, smartlink.ErrScope) {
+		t.Fatalf("Create(mismatched tenant) = %v, want ErrScope", err)
+	}
+}
+
+// TestScopeGetForeignTenant asserts Get on a record owned by a different
+// tenant reads as ErrNotFound.
+func TestScopeGetForeignTenant(t *testing.T) {
+	t.Parallel()
+	m, _ := newScopedManager(t)
+	ctxA := tenantKey.With(context.Background(), "tenant-a")
+	ctxB := tenantKey.With(context.Background(), "tenant-b")
+
+	l, err := m.Create(ctxA, smartlink.CreateParams{Target: "https://example.com/", Code: "foreign1"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+
+	if _, err := m.Get(ctxB, l.Code); !errors.Is(err, smartlink.ErrNotFound) {
+		t.Fatalf("Get(foreign tenant) = %v, want ErrNotFound", err)
+	}
+	if _, err := m.Get(ctxA, l.Code); err != nil {
+		t.Fatalf("Get(owning tenant) error = %v, want nil", err)
+	}
+}
+
+// TestScopeListForced asserts List overrides Filter.Tenant with the scope
+// tenant, ignoring whatever the caller supplied.
+func TestScopeListForced(t *testing.T) {
+	t.Parallel()
+	m, _ := newScopedManager(t)
+	ctxA := tenantKey.With(context.Background(), "tenant-a")
+	ctxB := tenantKey.With(context.Background(), "tenant-b")
+
+	if _, err := m.Create(ctxA, smartlink.CreateParams{Target: "https://example.com/", Code: "la"}); err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	if _, err := m.Create(ctxB, smartlink.CreateParams{Target: "https://example.com/", Code: "lb"}); err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+
+	links, err := m.List(ctxA, smartlink.Filter{Tenant: "tenant-b"})
+	if err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+	if len(links) != 1 || links[0].Code != "la" {
+		t.Fatalf("List() = %+v, want only tenant-a's link", links)
+	}
+}
+
+// TestScopeMutatorsUsePredicate asserts Deactivate/Delete pass the scope
+// tenant as the Store predicate, so a foreign-tenant code is untouched.
+func TestScopeMutatorsUsePredicate(t *testing.T) {
+	t.Parallel()
+	m, store := newScopedManager(t)
+	ctxA := tenantKey.With(context.Background(), "tenant-a")
+	ctxB := tenantKey.With(context.Background(), "tenant-b")
+
+	if _, err := m.Create(ctxA, smartlink.CreateParams{Target: "https://example.com/", Code: "predicate1"}); err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+
+	if err := m.Deactivate(ctxB, "predicate1"); !errors.Is(err, smartlink.ErrNotFound) {
+		t.Fatalf("Deactivate(foreign tenant) = %v, want ErrNotFound", err)
+	}
+	got, err := store.Get(context.Background(), "predicate1")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v, want nil", err)
+	}
+	if !got.DeactivatedAt.IsZero() {
+		t.Fatal("record was deactivated by foreign tenant")
+	}
+
+	if err := m.Delete(ctxB, "predicate1"); !errors.Is(err, smartlink.ErrNotFound) {
+		t.Fatalf("Delete(foreign tenant) = %v, want ErrNotFound", err)
+	}
+	if _, err := store.Get(context.Background(), "predicate1"); err != nil {
+		t.Fatalf("record was deleted by foreign tenant: store.Get() = %v", err)
+	}
+
+	if err := m.Deactivate(ctxA, "predicate1"); err != nil {
+		t.Fatalf("Deactivate(owning tenant) error = %v, want nil", err)
+	}
+	got, err = store.Get(context.Background(), "predicate1")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v, want nil", err)
+	}
+	if got.DeactivatedAt.IsZero() {
+		t.Fatal("record was not deactivated by owning tenant")
+	}
+}
+
+// TestUnscopedPassthrough asserts that without WithScope, tenant strings
+// pass through verbatim and management ops work with a plain context.
+func TestUnscopedPassthrough(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t) // no WithScope
+	ctx := context.Background()
+
+	l, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/", Tenant: "any-tenant", Code: "unscoped1"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	if l.Tenant != "any-tenant" {
+		t.Fatalf("Tenant = %q, want passthrough %q", l.Tenant, "any-tenant")
+	}
+
+	if _, err := m.Get(ctx, "unscoped1"); err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if err := m.Deactivate(ctx, "unscoped1"); err != nil {
+		t.Fatalf("Deactivate() error = %v, want nil", err)
+	}
+}

--- a/web/smartlink/store.go
+++ b/web/smartlink/store.go
@@ -1,0 +1,39 @@
+package smartlink
+
+import (
+	"context"
+	"time"
+)
+
+// Store persists Link records by code. [MemoryStore] is the in-memory
+// reference implementation; a Postgres driver (a later task) implements the
+// same contract.
+//
+// Deactivate, Activate, and Delete take a tenant: when non-empty, the
+// mutation applies only to a record owned by that tenant, and the tenant
+// check must be atomic with the mutation (no separate read-then-write, since
+// codes are reusable after Delete and a race could target the wrong
+// record); a mismatched or missing code returns ErrNotFound either way. An
+// empty tenant is unconstrained. Codes are case-sensitive.
+type Store interface {
+	// Create inserts l keyed by l.Code. Returns ErrDuplicate if the code
+	// already exists.
+	Create(ctx context.Context, l Link) error
+
+	// Get returns the Link stored under code. Returns ErrNotFound if none exists.
+	Get(ctx context.Context, code string) (Link, error)
+
+	// List returns Links matching f, ordered by CreatedAt descending, then
+	// Code ascending to break ties.
+	List(ctx context.Context, f Filter) ([]Link, error)
+
+	// Deactivate sets DeactivatedAt to at on code, scoped to tenant. A zero
+	// at leaves the link active.
+	Deactivate(ctx context.Context, code, tenant string, at time.Time) error
+
+	// Activate clears DeactivatedAt on code, scoped to tenant.
+	Activate(ctx context.Context, code, tenant string) error
+
+	// Delete removes code, scoped to tenant.
+	Delete(ctx context.Context, code, tenant string) error
+}

--- a/web/smartlink/store.go
+++ b/web/smartlink/store.go
@@ -6,8 +6,8 @@ import (
 )
 
 // Store persists Link records by code. [MemoryStore] is the in-memory
-// reference implementation; a Postgres driver (a later task) implements the
-// same contract.
+// reference implementation; the pgstore subpackage is the Postgres driver
+// implementing the same contract.
 //
 // Deactivate, Activate, and Delete take a tenant: when non-empty, the
 // mutation applies only to a record owned by that tenant, and the tenant

--- a/web/smartlink/template.go
+++ b/web/smartlink/template.go
@@ -1,0 +1,209 @@
+package smartlink
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// macroKind identifies which visit fact a template macro renders.
+type macroKind uint8
+
+const (
+	macroNone macroKind = iota // literal segment, no macro
+	macroCountry
+	macroDevice
+	macroLocale
+	macroParam
+)
+
+// escMode selects the positional escaping for a macro, decided at compile
+// from the literal text preceding it: authority (between "//" and the first
+// '/', '?', or '#') renders hostname-safe values verbatim and anything else
+// as empty — net/url forbids percent-escapes like %40 in a host, so encoding
+// isn't an option and a hostile value fails closed to a dead but well-formed
+// URL; path escapes with url.PathEscape plus ':' (so a value can't smuggle a
+// scheme into the first segment of a relative template); query escapes with
+// url.QueryEscape. Together these keep macro values from ever altering the
+// URL structure validated at compile time.
+type escMode uint8
+
+const (
+	escPath escMode = iota
+	escQuery
+	escAuthority
+)
+
+// segment is one compiled piece of a URL template: a literal followed by an
+// optional macro.
+type segment struct {
+	literal string
+	param   string // param name for macroParam
+	macro   macroKind
+	esc     escMode
+}
+
+// template is a compiled URL template. A nil segs means the URL is a plain
+// literal and renders with zero work.
+type template struct {
+	raw  string
+	segs []segment
+}
+
+// parseTemplate compiles a target URL template: splits out {macro}
+// placeholders, resolves the vocabulary, assigns positional escaping, and
+// validates the macro-elided template parses as a URL.
+func parseTemplate(raw, where string) (template, error) {
+	if !strings.ContainsRune(raw, '{') && !strings.ContainsRune(raw, '}') {
+		if _, err := url.Parse(raw); err != nil {
+			return template{}, fmt.Errorf("%w: %s: %v", ErrInvalidTemplate, where, err)
+		}
+		return template{raw: raw}, nil
+	}
+
+	var segs []segment
+	var elided strings.Builder
+	rest := raw
+	for {
+		open := strings.IndexByte(rest, '{')
+		if open < 0 {
+			break
+		}
+		close := strings.IndexByte(rest[open:], '}')
+		if close < 0 {
+			return template{}, fmt.Errorf("%w: %s: unclosed '{' in %q", ErrInvalidTemplate, where, raw)
+		}
+		close += open
+		literal := rest[:open]
+		if strings.ContainsRune(literal, '}') {
+			return template{}, fmt.Errorf("%w: %s: unmatched '}' in %q", ErrInvalidTemplate, where, raw)
+		}
+		name := rest[open+1 : close]
+		kind, param, err := resolveMacro(name, where)
+		if err != nil {
+			return template{}, err
+		}
+		elided.WriteString(literal)
+		segs = append(segs, segment{literal: literal, macro: kind, param: param, esc: escapeModeFor(elided.String())})
+		rest = rest[close+1:]
+	}
+	if strings.ContainsRune(rest, '}') {
+		return template{}, fmt.Errorf("%w: %s: unmatched '}' in %q", ErrInvalidTemplate, where, raw)
+	}
+	if rest != "" {
+		segs = append(segs, segment{literal: rest})
+		elided.WriteString(rest)
+	}
+	if _, err := url.Parse(elided.String()); err != nil {
+		return template{}, fmt.Errorf("%w: %s: %v", ErrInvalidTemplate, where, err)
+	}
+	return template{raw: raw, segs: segs}, nil
+}
+
+// escapeModeFor derives a macro's escaping from the macro-elided literal
+// prefix before it (macro values never create structure, so the prefix alone
+// fixes the position).
+func escapeModeFor(prefix string) escMode {
+	if strings.ContainsRune(prefix, '?') {
+		return escQuery
+	}
+	auth := -1
+	if i := strings.Index(prefix, "://"); i >= 0 {
+		auth = i + 3
+	} else if strings.HasPrefix(prefix, "//") {
+		auth = 2
+	}
+	if auth >= 0 && !strings.ContainsAny(prefix[auth:], "/?#") {
+		return escAuthority
+	}
+	return escPath
+}
+
+// resolveMacro maps a macro name to its kind; unknown names are compile
+// errors, never empty substitutions at decide time.
+func resolveMacro(name, where string) (macroKind, string, error) {
+	switch name {
+	case "country":
+		return macroCountry, "", nil
+	case "device":
+		return macroDevice, "", nil
+	case "locale":
+		return macroLocale, "", nil
+	}
+	if param, ok := strings.CutPrefix(name, "param."); ok && param != "" {
+		return macroParam, param, nil
+	}
+	return macroNone, "", fmt.Errorf("%w: %s: {%s}", ErrUnknownMacro, where, name)
+}
+
+// render substitutes visit values into the template. A known macro whose
+// visit value is empty renders as an empty string — the visit context is
+// genuinely sparse.
+func (t template) render(v *Visit) string {
+	if t.segs == nil {
+		return t.raw
+	}
+	var b strings.Builder
+	b.Grow(len(t.raw) + 16)
+	for _, s := range t.segs {
+		b.WriteString(s.literal)
+		var val string
+		switch s.macro {
+		case macroNone:
+			continue
+		case macroCountry:
+			val = v.Country
+		case macroDevice:
+			val = v.Device
+		case macroLocale:
+			val = v.Locale
+		case macroParam:
+			val = v.Params[s.param]
+		}
+		if val == "" {
+			continue
+		}
+		switch s.esc {
+		case escAuthority:
+			if isHostSafe(val) {
+				b.WriteString(val)
+			}
+		case escPath:
+			writePathEscaped(&b, val)
+		case escQuery:
+			b.WriteString(url.QueryEscape(val))
+		}
+	}
+	return b.String()
+}
+
+// isHostSafe reports whether every byte of s belongs to the unreserved
+// hostname set, so an authority-position value can't introduce userinfo
+// ('@'), a port (':'), or end the authority ('/', '?', '#').
+func isHostSafe(s string) bool {
+	for i := range len(s) {
+		c := s[i]
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '.' || c == '-' || c == '_' || c == '~' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// writePathEscaped writes url.PathEscape output with ':' additionally
+// encoded: a ':' in the first segment of a relative template would otherwise
+// reparse as a scheme delimiter.
+func writePathEscaped(b *strings.Builder, s string) {
+	escaped := url.PathEscape(s)
+	for {
+		i := strings.IndexByte(escaped, ':')
+		if i < 0 {
+			b.WriteString(escaped)
+			return
+		}
+		b.WriteString(escaped[:i])
+		b.WriteString("%3A")
+		escaped = escaped[i+1:]
+	}
+}

--- a/web/smartlink/visit.go
+++ b/web/smartlink/visit.go
@@ -24,5 +24,7 @@ type Visit struct {
 	// StickyKey is the bucketing identity (click ID, visitor ID) that keeps
 	// Percent matchers and weighted splits deterministic per visitor. With an
 	// empty key, Percent never matches and splits pick their first target.
+	// Consumers typically set it to their fingerprint digest, so weighted-split
+	// stickiness and fraud identity agree by construction.
 	StickyKey string
 }

--- a/web/smartlink/visit.go
+++ b/web/smartlink/visit.go
@@ -1,0 +1,28 @@
+package smartlink
+
+import "time"
+
+// Visit is the caller-built context of one click. The caller assembles it from
+// whatever request facts it has (web/clientip + web/geoip for Country,
+// web/useragent for Device, parsed query params) — this package never touches
+// net/http.
+type Visit struct {
+	// At overrides the decision time for TimeWindow matchers — useful when
+	// replaying click logs. Zero means "now" per the link's clock.
+	At time.Time
+	// Params carries inbound query params / sub-IDs. ParamEquals matches
+	// against it, {param.NAME} macros render from it, and the link's
+	// ParamPolicy merges it into the final URL.
+	Params map[string]string
+	// Country is the visitor's ISO 3166-1 alpha-2 country code, any case.
+	Country string
+	// Device is the device class in web/useragent DeviceType vocabulary
+	// ("desktop", "mobile", "tablet", ...); pass string(ua.Device.Type).
+	Device string
+	// Locale is a BCP-47-style tag ("en" or "en-US"), any case.
+	Locale string
+	// StickyKey is the bucketing identity (click ID, visitor ID) that keeps
+	// Percent matchers and weighted splits deterministic per visitor. With an
+	// empty key, Percent never matches and splits pick their first target.
+	StickyKey string
+}


### PR DESCRIPTION
## Summary

`web/smartlink` becomes the single link package: the TDS decision engine plus a storage-backed short-code Manager and a redirect Handler with one uniform per-click pipeline. A stored link is a code pointing at either an inline URL template (`Target`) or a consumer offer reference (`Ref`); both resolve through the same flow — Visit build → `VisitFunc` enrich → metadata-wins merge → decorated `Decide` → 302/307 no-store redirect → sync `OnHit` — so a plain short link is just the degenerate case (single default target) with full abilities: macros, param forwarding (`ParamsFill` default), per-link `Metadata`, hooks.

This supersedes and closes #64 (engine merged here verbatim as the seed commits, compiled artifact renamed `Link`→`Compiled`) and #65 (shortlink; behaviors ported per spec — tenant-predicate atomic mutators, fallback/no-store/never-301, vanity codes + blocklist, bounded-staleness cache read-through — code written fresh). Design spec: `docs/superpowers/specs/2026-07-17-smartlink-unified-design.md`.

## What's inside

- **Engine (seeded from #64, unchanged semantics):** `Spec`/`Compile`/`*Compiled.Decide`, typed matchers, positional macro escaping, deterministic weighted splits.
- **Decorator seam:** `Decider`/`DecideFunc`/`Decorator`/`Chain` — sync guards (fraud divert, A/B, metrics) wrap `Decide`; `*Compiled` satisfies `Decider` directly.
- **Compile cache:** `NewCache(load)` with lazy compile, `Invalidate`, ready-made `Resolver(decorators...)`; per-ref generation guard so an `Invalidate` can never be overwritten by an in-flight stale load.
- **Record + Store seam:** `Link` (Target XOR Ref, Metadata, lifecycle), reference `MemoryStore`, `pgstore` driver (goose migration `forge_smart_links`, version table `forge_smartlink_schema`).
- **Manager:** `id.Short` lowercase codes by default (`WithCodeFunc` seam, base58 `RandomCode` helper), vanity codes + reserved blocklist, create-time validation (template compile, scheme allowlist, Ref check via resolver), `WithScope` fail-closed tenancy on management ops (resolve/Handler public), `WithBaseURL`/`ShortURL`, `WithCache` read-through (non-positive TTL rejected at construction).
- **Handler:** uniform pipeline for both record kinds; dead links → fallback/404; store or resolver outage → 500; cache outage degrades to store reads; `OnHit{Link, Visit, Decision}` fires synchronously post-redirect (bounded-sink contract documented).

## Benchmarks

Required bench + measured optimization pass (`docs/superpowers/plans/2026-07-18-smartlink-bench-{baseline,after}.txt`, committed). Product-side Target path (`Resolve` + per-hit degenerate compile + `Decide`), isolated from httptest scaffolding:

| Bench (after) | ns/op | B/op | allocs/op |
|---|---|---|---|
| ResolveDecideTarget (product path) | 1044 | 1560 | 19 |
| HandlerTarget (full ServeHTTP incl. httptest) | 3284 | 9124 | 51 |
| DecideMerge (engine, ParamsFill) | 564.3 | 760 | 11 |
| MemoryStoreGet | 112.9 | 336 | 2 |
| Chain3 (3 decorators) | 37.86 | 0 | 0 |
| DecideBare | 8.679 | 0 | 0 |

Optimization decision: the per-hit degenerate compile is ≤35% of the product path (Decide's URL merge dominates at ≥54%), so the spec's gate for adding a compiled-link LRU is not met — no optimization applied, decision recorded with derivations from the committed files.

## Testing

- Unit tier (Docker-free): full black-box suite incl. handler pipeline, scope fail-closed, cache races (channel-sequenced, no sleeps), corrupt-cache-bytes degrade-to-store; `-race` clean; 93.8% coverage.
- Integration tier (`just test-integration`, testcontainers pg16): pgstore conformance mirroring the memory-store reference contract (tenant-predicate atomicity, zero-`at` Deactivate no-op, delete-recreate, ties ordering); 90.9% coverage.
- `just lint` clean (golangci-lint, nilaway, betteralign, modernize, incl. integration tag).

## Notes for reviewers

- Metadata normalization: `MemoryStore` returns `nil` for empty metadata where `pgstore` returns an empty map — both `len == 0`, normalized by `omitempty` through the cache; deliberate, covered by each store's tests.
- `WithFallbackURL` validates absolute http(s) at construction (an empty or relative fallback is a config error, not a silent no-op). New package, so no external callers affected.
- Dynamic-host target templates (authority macros) are a creator-opt-in surface; doc.go advises pinning host-feeding params via link Metadata (metadata wins the merge).

## Catalog

`docs/packages.md`: `web/shortlink` entry removed (absorbed); `web/smartlink` entry rewritten for the unified package. Deps: `core/clock`, `core/id`, `core/random`, `resilience/cache`, `ops/logger` (+ pgx in the pgstore driver).
