### PR TITLE
test(rbac,geoip): move doc.go Examples into example_test.go so go test actually runs them

### DIFF
--- a/auth/rbac/doc.go
+++ b/auth/rbac/doc.go
@@ -12,35 +12,3 @@
 // access.Subject.Roles → rbac.Decider(rs, rbac.FromSubject()). Gate routes with
 // access.RequirePermission and toggle views with access.Can.
 package rbac
-
-import (
-	"context"
-	"fmt"
-
-	"github.com/dmitrymomot/forge/auth/access"
-)
-
-func Example() {
-	rs, err := NewRoleSet(
-		WithRoles(
-			Role("viewer", "documents:read"),
-			Role("editor", "documents:*"),
-			Role("admin", "*"),
-		),
-		WithRoleInheritance(
-			RoleInherits("editor", "viewer"),
-		),
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	d := Decider(rs, FromSubject())
-	dec, _ := access.Authorize(
-		context.Background(), d,
-		access.Subject{ID: "u1", Roles: []string{"editor"}},
-		"documents:write", access.Resource{},
-	)
-	fmt.Println(dec.Effect)
-	// Output: allow
-}

--- a/auth/rbac/example_test.go
+++ b/auth/rbac/example_test.go
@@ -1,0 +1,34 @@
+package rbac_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/auth/rbac"
+)
+
+func Example() {
+	rs, err := rbac.NewRoleSet(
+		rbac.WithRoles(
+			rbac.Role("viewer", "documents:read"),
+			rbac.Role("editor", "documents:*"),
+			rbac.Role("admin", "*"),
+		),
+		rbac.WithRoleInheritance(
+			rbac.RoleInherits("editor", "viewer"),
+		),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	d := rbac.Decider(rs, rbac.FromSubject())
+	dec, _ := access.Authorize(
+		context.Background(), d,
+		access.Subject{ID: "u1", Roles: []string{"editor"}},
+		"documents:write", access.Resource{},
+	)
+	fmt.Println(dec.Effect)
+	// Output: allow
+}

--- a/web/geoip/doc.go
+++ b/web/geoip/doc.go
@@ -18,22 +18,3 @@
 //
 //	logger.New(logger.WithContextExtractors(geoip.LogExtractor))
 package geoip
-
-import (
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-)
-
-// Example wires a header-only source (no database file needed) and reads the
-// cached Location in a handler.
-func Example() {
-	src := Cloudflare()
-	h := Middleware(src)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		fmt.Println(Get(r).CountryCode)
-	}))
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	r.Header.Set("CF-IPCountry", "US")
-	h.ServeHTTP(httptest.NewRecorder(), r)
-	// Output: US
-}

--- a/web/geoip/example_test.go
+++ b/web/geoip/example_test.go
@@ -1,0 +1,22 @@
+package geoip_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/dmitrymomot/forge/web/geoip"
+)
+
+// Example wires a header-only source (no database file needed) and reads the
+// cached Location in a handler.
+func Example() {
+	src := geoip.Cloudflare()
+	h := geoip.Middleware(src)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		fmt.Println(geoip.Get(r).CountryCode)
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("CF-IPCountry", "US")
+	h.ServeHTTP(httptest.NewRecorder(), r)
+	// Output: US
+}


### PR DESCRIPTION
## Summary

`func Example` defined in a non-`_test.go` file is never compiled or executed by `go test` — the test runner only scans `_test.go` files for examples — so the runnable-looking examples in `auth/rbac/doc.go` and `web/geoip/doc.go` were never verified and could silently rot or stop compiling.

Swept the whole repo (`grep -rln '^func Example' --include='*.go' | grep -v _test.go`): these two files were the only offenders. (`web/smartlink` had the same issue and was already fixed inside #68.)

## Changes

- Moved each `Example` verbatim into a new black-box `example_test.go` (`package rbac_test` / `package geoip_test`, calls prefixed with the package qualifier — both examples used only exported APIs, so no behavior change).
- Removed the funcs and their now-unused imports from the two `doc.go` files; package prose untouched.
- Both examples now appear as `RUN/PASS` under `go test -run Example -v` with their deterministic `// Output:` blocks enforced.

## Verification

- `go test ./auth/rbac/... ./web/geoip/... -count=1` green, examples executing.
- `just fmt` clean, `just lint` 0 issues (all tiers incl. integration tag).