### PR TITLE
fix(smartlink): apply full-package review fixes — cache races, bucketing independence, param-merge fidelity, validation gaps

### DIFF
--- a/web/smartlink/bench_test.go
+++ b/web/smartlink/bench_test.go
@@ -223,7 +223,7 @@ func BenchmarkResolveDecideTarget(b *testing.B) {
 // resolved through a warm [smartlink.Cache] Resolver — the compile cache's
 // hit path, not the load-and-compile miss path.
 func BenchmarkHandlerRef(b *testing.B) {
-	c := smartlink.NewCache(func(_ context.Context, ref string) (smartlink.Spec, error) {
+	c := mustNewCache(b, func(_ context.Context, ref string) (smartlink.Spec, error) {
 		return smartlink.Spec{Default: []smartlink.Target{{URL: "https://offer.example.com/" + ref}}}, nil
 	})
 	m, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithResolver(c.Resolver()))

--- a/web/smartlink/cache.go
+++ b/web/smartlink/cache.go
@@ -2,6 +2,7 @@ package smartlink
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 )
@@ -11,7 +12,9 @@ import (
 // Manager. Resolver does not special-case ErrNoTarget: when the
 // consumer's load func returns it for a paused or deleted offer, Resolver
 // propagates the wrapped error and leaves the mapping to dead-link handling
-// to the caller.
+// to the caller. A load func should return an error wrapping [ErrRefNotFound]
+// for a ref that names no known Spec, so [Manager.Create]'s ref precheck can
+// tell caller error from infrastructure failure.
 type Resolver func(ctx context.Context, l Link) (Decider, error)
 
 // Cache is a lazy compile cache for Ref-backed Links. Offers live in the
@@ -20,81 +23,134 @@ type Resolver func(ctx context.Context, l Link) (Decider, error)
 // offer-save path. Safe for concurrent use.
 type Cache struct {
 	load    func(ctx context.Context, ref string) (Spec, error)
-	entries map[string]*Compiled
-	// gens counts Invalidate calls per ref. Get stores a loaded result only
-	// when the generation it observed on the miss is still current, so a
-	// stale in-flight load can never overwrite a post-Invalidate entry.
-	// Growth is bounded by distinct-ref cardinality (~16 bytes/entry) and
-	// deliberately never pruned — dropping a counter would let a stale
-	// in-flight load re-admit a straggler after Invalidate.
-	gens map[string]uint64
-	opts []Option
+	entries map[string]*refEntry
+	opts    []Option
+	mu      sync.RWMutex
+}
 
-	mu sync.RWMutex
+// refEntry is one ref's cache slot. The goroutine that inserts it (the
+// leader) loads and compiles while concurrent Gets for the same ref wait on
+// wg — one load per ref per miss window, never a thundering herd against the
+// consumer's database. Invalidate simply removes the entry from the map, so
+// an in-flight leader finishes into a detached entry: its waiters still get
+// the result (correct when their calls began), but the next Get misses and
+// reloads fresh. Entry lifetime doubles as the cache itself, so there is no
+// side bookkeeping to prune.
+type refEntry struct {
+	compiled *Compiled
+	err      error
+	wg       sync.WaitGroup
 }
 
 // NewCache returns a Cache that loads a Spec via load and compiles it with
-// compileOpts on a cache miss. ref must be globally unique and load must be
-// a pure function of ref — the cache is keyed by the bare ref string with no
-// tenant dimension, so a multi-tenant consumer whose resolution differs per
-// tenant must embed the tenant in ref itself.
+// compileOpts on a cache miss; a nil load is a construction error. ref must
+// be globally unique and load must be a pure function of ref — the cache is
+// keyed by the bare ref string with no tenant dimension, so a multi-tenant
+// consumer whose resolution differs per tenant must embed the tenant in ref
+// itself.
 //
-// Get takes an RLock fast path; on a miss it calls load and Compile outside
-// the write lock, then stores the result under a short write lock. Two
-// goroutines that miss on the same ref concurrently may both load and
-// compile — the redundant work is benign because Compiled values for the
-// same Spec are interchangeable, so the second store just overwrites the
-// first with an equivalent result. An Invalidate concurrent with an
-// in-flight load bumps the ref's generation, so the straggler's stale
-// result is discarded instead of stored — it can never overwrite an entry
-// cached after the Invalidate. Errors from load or Compile are never
-// cached, so the next Get retries.
-func NewCache(load func(ctx context.Context, ref string) (Spec, error), compileOpts ...Option) *Cache {
+// A loaded Spec with an empty Salt gets the ref as its Salt, so distinct
+// refs bucket their splits and Percent matchers independently by default
+// (see [Spec.Salt]).
+//
+// Errors from load or Compile are never cached, so the next Get retries.
+func NewCache(load func(ctx context.Context, ref string) (Spec, error), compileOpts ...Option) (*Cache, error) {
+	if load == nil {
+		return nil, errors.New("smartlink: nil load func")
+	}
 	return &Cache{
 		load:    load,
 		opts:    compileOpts,
-		entries: make(map[string]*Compiled),
-		gens:    make(map[string]uint64),
-	}
+		entries: make(map[string]*refEntry),
+	}, nil
 }
 
 // Get returns the Compiled engine for ref, loading and compiling it on a
-// cache miss. Errors from load or Compile are wrapped, not cached.
+// cache miss. Concurrent misses on the same ref share one load. Errors from
+// load or Compile are wrapped, not cached.
 func (c *Cache) Get(ctx context.Context, ref string) (*Compiled, error) {
 	c.mu.RLock()
-	compiled, ok := c.entries[ref]
-	gen := c.gens[ref]
+	e, ok := c.entries[ref]
 	c.mu.RUnlock()
-	if ok {
-		return compiled, nil
+	if !ok {
+		var leader bool
+		c.mu.Lock()
+		if e, ok = c.entries[ref]; !ok {
+			e = &refEntry{}
+			e.wg.Add(1)
+			c.entries[ref] = e
+			leader = true
+		}
+		c.mu.Unlock()
+		if leader {
+			return c.fill(ctx, ref, e)
+		}
 	}
+	e.wg.Wait()
+	return e.compiled, e.err
+}
 
-	spec, err := c.load(ctx, ref)
-	if err != nil {
-		return nil, fmt.Errorf("smartlink: load ref %q: %w", ref, err)
-	}
-	compiled, err = Compile(spec, c.opts...)
-	if err != nil {
-		return nil, fmt.Errorf("smartlink: compile ref %q: %w", ref, err)
-	}
+// fill loads and compiles ref into e, releasing waiters exactly once even if
+// load or Compile panics (the panic then propagates to the leader's caller;
+// waiters observe an error). load runs with cancellation detached so one
+// canceled request cannot fail the waiters sharing the flight
+// (resilience/singleflight precedent). An errored or panicked entry is
+// removed — if still current — so the next Get retries instead of caching
+// the failure.
+func (c *Cache) fill(ctx context.Context, ref string, e *refEntry) (*Compiled, error) {
+	finished := false
+	defer func() {
+		if !finished {
+			e.err = fmt.Errorf("smartlink: load ref %q: panic during load or compile", ref)
+			e.wg.Done()
+			c.removeEntry(ref, e)
+		}
+	}()
 
-	c.mu.Lock()
-	if c.gens[ref] == gen {
-		c.entries[ref] = compiled
+	compiled, err := c.loadCompile(ctx, ref)
+	e.compiled, e.err = compiled, err
+	finished = true
+	e.wg.Done()
+	if err != nil {
+		c.removeEntry(ref, e)
+		return nil, err
 	}
-	// Otherwise an Invalidate landed while this load was in flight: discard
-	// the stale result from the cache but still return it — it was correct
-	// when this call began, and the next Get reloads fresh.
-	c.mu.Unlock()
 	return compiled, nil
 }
 
+// loadCompile loads ref's Spec (cancellation-detached — see fill) and
+// compiles it, defaulting an empty Salt to the ref.
+func (c *Cache) loadCompile(ctx context.Context, ref string) (*Compiled, error) {
+	spec, err := c.load(context.WithoutCancel(ctx), ref)
+	if err != nil {
+		return nil, fmt.Errorf("smartlink: load ref %q: %w", ref, err)
+	}
+	if spec.Salt == "" {
+		spec.Salt = ref
+	}
+	compiled, err := Compile(spec, c.opts...)
+	if err != nil {
+		return nil, fmt.Errorf("smartlink: compile ref %q: %w", ref, err)
+	}
+	return compiled, nil
+}
+
+// removeEntry deletes ref's slot only if it still holds e — an Invalidate
+// (or a successor fill) may already have replaced it.
+func (c *Cache) removeEntry(ref string, e *refEntry) {
+	c.mu.Lock()
+	if c.entries[ref] == e {
+		delete(c.entries, ref)
+	}
+	c.mu.Unlock()
+}
+
 // Invalidate evicts ref's cached entry, if any, so the next Get reloads and
-// recompiles it. Call this from the consumer's offer-save path.
+// recompiles it. Call this from the consumer's offer-save path. An in-flight
+// load for ref finishes into the detached entry and is never re-admitted.
 func (c *Cache) Invalidate(ref string) {
 	c.mu.Lock()
 	delete(c.entries, ref)
-	c.gens[ref]++
 	c.mu.Unlock()
 }
 

--- a/web/smartlink/cache_test.go
+++ b/web/smartlink/cache_test.go
@@ -21,10 +21,27 @@ func countingLoad(n *int, spec smartlink.Spec, err error) func(context.Context, 
 	}
 }
 
+// mustNewCache builds a Cache or fails the test.
+func mustNewCache(tb testing.TB, load func(context.Context, string) (smartlink.Spec, error), opts ...smartlink.Option) *smartlink.Cache {
+	tb.Helper()
+	c, err := smartlink.NewCache(load, opts...)
+	if err != nil {
+		tb.Fatalf("NewCache() error = %v", err)
+	}
+	return c
+}
+
+func TestNewCacheNilLoad(t *testing.T) {
+	t.Parallel()
+	if _, err := smartlink.NewCache(nil); err == nil {
+		t.Fatal("NewCache(nil) error = nil, want construction error")
+	}
+}
+
 func TestCacheGetCompilesOnce(t *testing.T) {
 	t.Parallel()
 	var calls int
-	cache := smartlink.NewCache(countingLoad(&calls, smartlink.Spec{Default: defTargets()}, nil))
+	cache := mustNewCache(t, countingLoad(&calls, smartlink.Spec{Default: defTargets()}, nil))
 	ctx := context.Background()
 
 	if _, err := cache.Get(ctx, "ref-1"); err != nil {
@@ -41,7 +58,7 @@ func TestCacheGetCompilesOnce(t *testing.T) {
 func TestCacheInvalidate(t *testing.T) {
 	t.Parallel()
 	var calls int
-	cache := smartlink.NewCache(countingLoad(&calls, smartlink.Spec{Default: defTargets()}, nil))
+	cache := mustNewCache(t, countingLoad(&calls, smartlink.Spec{Default: defTargets()}, nil))
 	ctx := context.Background()
 
 	if _, err := cache.Get(ctx, "ref-1"); err != nil {
@@ -60,7 +77,7 @@ func TestCacheLoadErrorNotCached(t *testing.T) {
 	t.Parallel()
 	loadErr := errors.New("boundary: db unavailable")
 	first := true
-	cache := smartlink.NewCache(func(context.Context, string) (smartlink.Spec, error) {
+	cache := mustNewCache(t, func(context.Context, string) (smartlink.Spec, error) {
 		if first {
 			first = false
 			return smartlink.Spec{}, loadErr
@@ -80,7 +97,7 @@ func TestCacheLoadErrorNotCached(t *testing.T) {
 func TestCacheCompileErrorPropagates(t *testing.T) {
 	t.Parallel()
 	// Spec{} has no default target, a Compile-time validation error.
-	cache := smartlink.NewCache(func(context.Context, string) (smartlink.Spec, error) {
+	cache := mustNewCache(t, func(context.Context, string) (smartlink.Spec, error) {
 		return smartlink.Spec{}, nil
 	})
 	ctx := context.Background()
@@ -103,7 +120,7 @@ func TestCacheInvalidateDuringLoad(t *testing.T) {
 	var calls atomic.Int32
 	entered := make(chan struct{})
 	release := make(chan struct{})
-	cache := smartlink.NewCache(func(context.Context, string) (smartlink.Spec, error) {
+	cache := mustNewCache(t, func(context.Context, string) (smartlink.Spec, error) {
 		if calls.Add(1) == 1 {
 			close(entered)
 			<-release
@@ -151,7 +168,7 @@ func TestCacheInvalidateDuringLoad(t *testing.T) {
 
 func TestCacheResolver(t *testing.T) {
 	t.Parallel()
-	cache := smartlink.NewCache(func(context.Context, string) (smartlink.Spec, error) {
+	cache := mustNewCache(t, func(context.Context, string) (smartlink.Spec, error) {
 		return smartlink.Spec{Default: defTargets()}, nil
 	})
 	resolver := cache.Resolver(tagDecorator("R"))
@@ -163,5 +180,48 @@ func TestCacheResolver(t *testing.T) {
 	got := d.Decide(smartlink.Visit{}).Rule
 	if got != "R" {
 		t.Fatalf("Decide().Rule = %q, want %q", got, "R")
+	}
+}
+
+// TestCacheGetDedupsConcurrentLoads asserts concurrent Gets for one ref
+// share a single load+compile instead of each hitting the consumer's
+// database: the second Get joins the in-flight leader (or hits the completed
+// entry) — either way exactly one load runs.
+func TestCacheGetDedupsConcurrentLoads(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	cache := mustNewCache(t, func(context.Context, string) (smartlink.Spec, error) {
+		if calls.Add(1) == 1 {
+			close(entered)
+			<-release
+		}
+		return smartlink.Spec{Default: defTargets()}, nil
+	})
+	ctx := context.Background()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, err := cache.Get(ctx, "ref-1"); err != nil {
+			t.Errorf("leader Get() error = %v", err)
+		}
+	}()
+	<-entered // leader is inside load; the entry is already in the map
+
+	joined := make(chan struct{})
+	go func() {
+		defer close(joined)
+		if _, err := cache.Get(ctx, "ref-1"); err != nil {
+			t.Errorf("joining Get() error = %v", err)
+		}
+	}()
+	close(release)
+	<-done
+	<-joined
+
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("load calls = %d, want 1 (concurrent misses must share one load)", n)
 	}
 }

--- a/web/smartlink/codes.go
+++ b/web/smartlink/codes.go
@@ -1,8 +1,6 @@
 package smartlink
 
 import (
-	"strings"
-
 	"github.com/dmitrymomot/forge/core/random"
 )
 
@@ -51,49 +49,4 @@ func validCodeChars(code string) bool {
 		}
 	}
 	return true
-}
-
-// macroElide strips {macro} placeholders from a target template, leaving
-// only the literal text. Compile has already validated brace balance by the
-// time this runs, so it is a plain scan, not a re-validation.
-func macroElide(raw string) string {
-	var b strings.Builder
-	rest := raw
-	for {
-		open := strings.IndexByte(rest, '{')
-		if open < 0 {
-			b.WriteString(rest)
-			break
-		}
-		close := strings.IndexByte(rest[open:], '}')
-		if close < 0 {
-			b.WriteString(rest)
-			break
-		}
-		close += open
-		b.WriteString(rest[:open])
-		rest = rest[close+1:]
-	}
-	return b.String()
-}
-
-// authorityHasMacro reports whether raw's authority (host[:port]) segment —
-// between "//" (or "scheme://") and the first '/', '?', or '#' — contains a
-// macro placeholder, so a fully or partially dynamic host is recognized as
-// intentional rather than a missing-host error.
-func authorityHasMacro(raw string) bool {
-	start := -1
-	if i := strings.Index(raw, "://"); i >= 0 {
-		start = i + 3
-	} else if strings.HasPrefix(raw, "//") {
-		start = 2
-	}
-	if start < 0 {
-		return false
-	}
-	end := len(raw)
-	if i := strings.IndexAny(raw[start:], "/?#"); i >= 0 {
-		end = start + i
-	}
-	return strings.ContainsRune(raw[start:end], '{')
 }

--- a/web/smartlink/compile.go
+++ b/web/smartlink/compile.go
@@ -3,6 +3,7 @@ package smartlink
 import (
 	"fmt"
 	"math"
+	"net/url"
 
 	"github.com/dmitrymomot/forge/core/clock"
 )
@@ -31,13 +32,22 @@ type split struct {
 	targets []compiledTarget
 	cum     []int // cumulative weights, len == len(targets); nil for a single target
 	seed    uint64
-	total   uint64
 }
 
-// compiledTarget pairs the caller's raw target with its parsed URL template.
+// compiledTarget pairs the caller's raw target with its parsed URL template
+// and, for a literal (macro-free) template, the pre-parsed URL decomposition
+// param merges reuse instead of re-parsing an identical string per Decide.
 type compiledTarget struct {
+	lit  *litQuery
 	raw  Target
 	tmpl template
+}
+
+// litQuery is a literal target's URL parsed once at compile: the url.URL to
+// stamp a merged query onto and the pre-split original query pairs.
+type litQuery struct {
+	u     url.URL
+	pairs []qpair
 }
 
 // Compile validates a consumer-hydrated Spec fail-fast — missing default,
@@ -52,7 +62,7 @@ func Compile(spec Spec, opts ...Option) (*Compiled, error) {
 		return nil, fmt.Errorf("%w: unknown ParamPolicy %d", ErrInvalidRule, spec.Params)
 	}
 
-	def, err := compileSplit(spec.Default, "")
+	def, err := compileSplit(spec.Default, spec.Salt, "")
 	if err != nil {
 		return nil, err
 	}
@@ -70,11 +80,11 @@ func Compile(spec Spec, opts ...Option) (*Compiled, error) {
 		seen[r.Name] = struct{}{}
 
 		cr := compiledRule{name: r.Name, when: make([]matcher, 0, len(r.When))}
-		for _, m := range r.When {
+		for idx, m := range r.When {
 			if m == nil {
 				return nil, fmt.Errorf("%w: rule %q: nil matcher", ErrInvalidMatcher, r.Name)
 			}
-			cm, err := m.compile(r.Name)
+			cm, err := m.compile(spec.Salt, r.Name, idx)
 			if err != nil {
 				return nil, err
 			}
@@ -83,7 +93,7 @@ func Compile(spec Spec, opts ...Option) (*Compiled, error) {
 			}
 			cr.when = append(cr.when, cm)
 		}
-		cr.targets, err = compileSplit(r.Targets, r.Name)
+		cr.targets, err = compileSplit(r.Targets, spec.Salt, r.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -93,8 +103,11 @@ func Compile(spec Spec, opts ...Option) (*Compiled, error) {
 }
 
 // compileSplit validates a target list (rule targets or the default list,
-// ruleName == "") and precomputes its templates and cumulative weights.
-func compileSplit(targets []Target, ruleName string) (split, error) {
+// ruleName == "") and precomputes its templates and cumulative weights. salt
+// namespaces the split's bucketing seed per Spec (see [Spec.Salt]) so two
+// links with identical rule names bucket independently. Weight is only
+// consulted for a multi-target list, per its contract.
+func compileSplit(targets []Target, salt, ruleName string) (split, error) {
 	where := "default targets"
 	if ruleName != "" {
 		where = fmt.Sprintf("rule %q", ruleName)
@@ -110,7 +123,7 @@ func compileSplit(targets []Target, ruleName string) (split, error) {
 		if t.URL == "" {
 			return split{}, fmt.Errorf("%w: %s: empty URL", ErrInvalidTarget, where)
 		}
-		if t.Weight < 0 || (len(targets) > 1 && t.Weight < 1) {
+		if len(targets) > 1 && t.Weight < 1 {
 			return split{}, fmt.Errorf("%w: %s: target %q weight %d", ErrInvalidTarget, where, t.URL, t.Weight)
 		}
 		tmpl, err := parseTemplate(t.URL, where)
@@ -118,9 +131,14 @@ func compileSplit(targets []Target, ruleName string) (split, error) {
 			return split{}, err
 		}
 		s.targets[i] = compiledTarget{raw: t, tmpl: tmpl}
+		if tmpl.segs == nil {
+			if u, err := url.Parse(tmpl.raw); err == nil {
+				s.targets[i].lit = &litQuery{u: *u, pairs: splitQuery(u.RawQuery)}
+			}
+		}
 	}
 	if len(targets) > 1 {
-		s.seed = hashString(fnvOffset, "s\x00"+ruleName)
+		s.seed = hashString(fnvOffset, "s\x00"+salt+"\x00"+ruleName)
 		s.cum = make([]int, len(targets))
 		var total int64
 		for i, t := range targets {
@@ -130,7 +148,6 @@ func compileSplit(targets []Target, ruleName string) (split, error) {
 			}
 			s.cum[i] = int(total)
 		}
-		s.total = uint64(total)
 	}
 	return s, nil
 }

--- a/web/smartlink/compile_test.go
+++ b/web/smartlink/compile_test.go
@@ -25,7 +25,6 @@ func TestCompileValidation(t *testing.T) {
 		{"no default with rules", smartlink.Spec{Rules: []smartlink.Rule{{Name: "r", Targets: defTargets()}}}, smartlink.ErrNoDefault},
 		{"default empty URL", smartlink.Spec{Default: []smartlink.Target{{}}}, smartlink.ErrInvalidTarget},
 		{"default split zero weight", smartlink.Spec{Default: []smartlink.Target{{URL: "https://a.com", Weight: 1}, {URL: "https://b.com"}}}, smartlink.ErrInvalidTarget},
-		{"negative weight single target", smartlink.Spec{Default: []smartlink.Target{{URL: "https://a.com", Weight: -1}}}, smartlink.ErrInvalidTarget},
 		{"split weight overflow", smartlink.Spec{Default: []smartlink.Target{
 			{URL: "https://a.com", Weight: math.MaxInt32}, {URL: "https://b.com", Weight: 1},
 		}}, smartlink.ErrInvalidTarget},

--- a/web/smartlink/decide.go
+++ b/web/smartlink/decide.go
@@ -2,6 +2,8 @@ package smartlink
 
 import (
 	"net/url"
+	"slices"
+	"strings"
 	"time"
 )
 
@@ -58,37 +60,113 @@ func (s *split) pick(stickyKey string) *compiledTarget {
 	if s.cum == nil || stickyKey == "" {
 		return &s.targets[0]
 	}
-	n := int(hashString(s.seed, stickyKey) % s.total)
+	n := int(hashString(s.seed, stickyKey) % uint64(s.cum[len(s.cum)-1]))
 	for i, c := range s.cum {
 		if n < c {
 			return &s.targets[i]
 		}
 	}
-	return &s.targets[len(s.targets)-1] // unreachable: n < total == cum[last]
+	return &s.targets[len(s.targets)-1] // unreachable: n < cum[last]
 }
 
 // finalURL renders the target's macros and merges visit params per the link
-// policy.
+// policy. Original query pairs are preserved verbatim (order and encoding
+// intact — a pair url.Values could not round-trip, like an unencoded '%' or a
+// ';', is never silently dropped); merged params append in sorted key order.
+// A literal target reuses its compile-time parse instead of re-parsing the
+// identical string per decide.
 func (l *Compiled) finalURL(t *compiledTarget, v *Visit) string {
-	rendered := t.tmpl.render(v)
 	if l.params == ParamsDrop || len(v.Params) == 0 {
-		return rendered
+		return t.tmpl.render(v)
 	}
+	override := l.params == ParamsOverride
+	if t.lit != nil {
+		u := t.lit.u
+		u.RawQuery = mergeQuery(t.lit.pairs, v.Params, override)
+		return u.String()
+	}
+	rendered := t.tmpl.render(v)
 	u, err := url.Parse(rendered)
 	if err != nil {
 		// Unreachable: the template parsed at compile and macro values are
 		// escaped, so the rendered URL preserves the validated structure.
 		return rendered
 	}
-	q := u.Query()
-	for k, val := range v.Params {
+	u.RawQuery = mergeQuery(splitQuery(u.RawQuery), v.Params, override)
+	return u.String()
+}
+
+// qpair is one raw query pair with its best-effort decoded key.
+type qpair struct {
+	raw string // the pair verbatim as it appeared in the query
+	key string // decoded key; "" when the key does not decode (opaque pair)
+}
+
+// splitQuery splits rawQuery on '&', keeping each non-empty pair verbatim.
+// Keys are decoded best-effort for merge comparisons only; an undecodable key
+// leaves the pair opaque — always preserved, never matched by a param.
+func splitQuery(rawQuery string) []qpair {
+	if rawQuery == "" {
+		return nil
+	}
+	pairs := make([]qpair, 0, strings.Count(rawQuery, "&")+1)
+	for p := range strings.SplitSeq(rawQuery, "&") {
+		if p == "" {
+			continue
+		}
+		rawKey, _, _ := strings.Cut(p, "=")
+		key, err := url.QueryUnescape(rawKey)
+		if err != nil {
+			key = ""
+		}
+		pairs = append(pairs, qpair{raw: p, key: key})
+	}
+	return pairs
+}
+
+// mergeQuery merges params into pairs per policy: fill keeps every original
+// pair and appends only params whose key the target does not already set;
+// override rewrites the first occurrence of a matched key in place (dropping
+// its duplicates, like url.Values.Set) and appends the rest. Appended params
+// are sorted by key for deterministic output.
+func mergeQuery(pairs []qpair, params map[string]string, override bool) string {
+	var b strings.Builder
+	matched := make(map[string]struct{}, len(params))
+	for _, p := range pairs {
+		if v, ok := params[p.key]; ok && p.key != "" {
+			if override {
+				if _, done := matched[p.key]; done {
+					continue
+				}
+				matched[p.key] = struct{}{}
+				writePair(&b, url.QueryEscape(p.key)+"="+url.QueryEscape(v))
+				continue
+			}
+			matched[p.key] = struct{}{}
+		}
+		writePair(&b, p.raw)
+	}
+	keys := make([]string, 0, len(params))
+	for k := range params {
 		if k == "" {
 			continue
 		}
-		if l.params == ParamsOverride || !q.Has(k) {
-			q.Set(k, val)
+		if _, ok := matched[k]; ok {
+			continue
 		}
+		keys = append(keys, k)
 	}
-	u.RawQuery = q.Encode()
-	return u.String()
+	slices.Sort(keys)
+	for _, k := range keys {
+		writePair(&b, url.QueryEscape(k)+"="+url.QueryEscape(params[k]))
+	}
+	return b.String()
+}
+
+// writePair appends pair to b with the '&' separator when b is non-empty.
+func writePair(b *strings.Builder, pair string) {
+	if b.Len() > 0 {
+		b.WriteByte('&')
+	}
+	b.WriteString(pair)
 }

--- a/web/smartlink/decide_test.go
+++ b/web/smartlink/decide_test.go
@@ -1,6 +1,7 @@
 package smartlink_test
 
 import (
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -336,13 +337,14 @@ func TestParamPolicies(t *testing.T) {
 		t.Fatalf("ParamsDrop URL = %q", got)
 	}
 
+	// Original target pairs stay first, verbatim; merged params append sorted.
 	fill := mustCompile(t, smartlink.Spec{Default: target, Params: smartlink.ParamsFill})
-	if got := fill.Decide(visit).URL; got != "https://a.com/lp?extra=1&keep=orig" {
+	if got := fill.Decide(visit).URL; got != "https://a.com/lp?keep=orig&extra=1" {
 		t.Fatalf("ParamsFill URL = %q", got)
 	}
 
 	override := mustCompile(t, smartlink.Spec{Default: target, Params: smartlink.ParamsOverride})
-	if got := override.Decide(visit).URL; got != "https://a.com/lp?extra=1&keep=new" {
+	if got := override.Decide(visit).URL; got != "https://a.com/lp?keep=new&extra=1" {
 		t.Fatalf("ParamsOverride URL = %q", got)
 	}
 
@@ -418,5 +420,96 @@ func TestDecisionReportsRawTarget(t *testing.T) {
 	}
 	if !strings.Contains(d.URL, "/DE") {
 		t.Fatalf("URL = %q, want rendered", d.URL)
+	}
+}
+
+// TestParamMergePreservesRawPairs asserts the merge policies keep original
+// query pairs verbatim — including pairs url.Values cannot round-trip (an
+// unencoded '%', a ';' separator) — instead of silently dropping them.
+func TestParamMergePreservesRawPairs(t *testing.T) {
+	t.Parallel()
+	target := []smartlink.Target{{URL: "https://a.com/lp?promo=50%off&a=1;b=2&keep=orig"}}
+
+	fill := mustCompile(t, smartlink.Spec{Default: target, Params: smartlink.ParamsFill})
+	visit := smartlink.Visit{Params: map[string]string{"sub": "123", "keep": "new"}}
+	if got, want := fill.Decide(visit).URL, "https://a.com/lp?promo=50%off&a=1;b=2&keep=orig&sub=123"; got != want {
+		t.Fatalf("ParamsFill URL = %q, want %q", got, want)
+	}
+
+	override := mustCompile(t, smartlink.Spec{Default: target, Params: smartlink.ParamsOverride})
+	if got, want := override.Decide(smartlink.Visit{Params: map[string]string{"keep": "new"}}).URL, "https://a.com/lp?promo=50%off&a=1;b=2&keep=new"; got != want {
+		t.Fatalf("ParamsOverride URL = %q, want %q", got, want)
+	}
+}
+
+// TestParamOverrideCollapsesDuplicates asserts overriding a key that appears
+// multiple times rewrites the first occurrence and drops the rest, matching
+// url.Values.Set semantics.
+func TestParamOverrideCollapsesDuplicates(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Default: []smartlink.Target{{URL: "https://a.com/lp?k=1&k=2&x=9"}},
+		Params:  smartlink.ParamsOverride,
+	})
+	if got, want := link.Decide(smartlink.Visit{Params: map[string]string{"k": "new"}}).URL, "https://a.com/lp?k=new&x=9"; got != want {
+		t.Fatalf("ParamsOverride URL = %q, want %q", got, want)
+	}
+}
+
+// TestPercentConjunctionComposes asserts two Percent gates in one rule draw
+// independently: 50% AND 50% must pass ~25% of keyed traffic, not collapse
+// into a single 50% gate.
+func TestPercentConjunctionComposes(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Rules: []smartlink.Rule{{
+			Name:    "gate",
+			When:    []smartlink.Matcher{smartlink.Percent{Share: 50}, smartlink.Percent{Share: 50}},
+			Targets: []smartlink.Target{{URL: "https://rule.example.com/"}},
+		}},
+		Default: []smartlink.Target{{URL: "https://def.example.com/"}},
+	})
+	const n = 20000
+	hits := 0
+	for i := range n {
+		if link.Decide(smartlink.Visit{StickyKey: fmt.Sprintf("k%d", i)}).Rule == "gate" {
+			hits++
+		}
+	}
+	share := float64(hits) / n
+	if share < 0.23 || share > 0.27 {
+		t.Fatalf("50%%*50%% conjunction matched %.1f%%, want ~25%% (collapsed gates match 50%%)", share*100)
+	}
+}
+
+// TestSaltDecorrelatesBucketing asserts two identically-shaped splits with
+// different Spec salts assign sticky keys independently, while the same salt
+// stays deterministic.
+func TestSaltDecorrelatesBucketing(t *testing.T) {
+	t.Parallel()
+	spec := func(salt string) smartlink.Spec {
+		return smartlink.Spec{Salt: salt, Default: []smartlink.Target{
+			{URL: "https://one.example.com/", Weight: 1},
+			{URL: "https://two.example.com/", Weight: 1},
+		}}
+	}
+	a := mustCompile(t, spec("link-a"))
+	a2 := mustCompile(t, spec("link-a"))
+	b := mustCompile(t, spec("link-b"))
+
+	const n = 5000
+	differ := 0
+	for i := range n {
+		key := fmt.Sprintf("k%d", i)
+		ua := a.Decide(smartlink.Visit{StickyKey: key}).URL
+		if got := a2.Decide(smartlink.Visit{StickyKey: key}).URL; got != ua {
+			t.Fatalf("same salt diverged for key %q: %q vs %q", key, ua, got)
+		}
+		if b.Decide(smartlink.Visit{StickyKey: key}).URL != ua {
+			differ++
+		}
+	}
+	if frac := float64(differ) / n; frac < 0.25 {
+		t.Fatalf("different salts diverge on %.1f%% of keys, want ~50%% (0%% means salts are ignored)", frac*100)
 	}
 }

--- a/web/smartlink/doc.go
+++ b/web/smartlink/doc.go
@@ -21,8 +21,9 @@
 // event.
 //
 // Weighted splits and [Percent] shares bucket deterministically by FNV-1a
-// hash of the rule name and Visit.StickyKey — never RNG — so a visitor
-// always lands on the same side. Target URLs are templates over a fixed
+// hash of [Spec.Salt], the rule name, and Visit.StickyKey — never RNG — so a
+// visitor always lands on the same side while distinct links bucket
+// independently ([Manager] salts by link code, [Cache] by ref). Target URLs are templates over a fixed
 // macro vocabulary ({country}, {device}, {locale}, {param.NAME}) parsed at
 // compile time: an unknown macro is a construction error, never an empty
 // substitution at decide time. Macro values escape positionally (authority

--- a/web/smartlink/doc.go
+++ b/web/smartlink/doc.go
@@ -23,7 +23,8 @@
 // Weighted splits and [Percent] shares bucket deterministically by FNV-1a
 // hash of [Spec.Salt], the rule name, and Visit.StickyKey — never RNG — so a
 // visitor always lands on the same side while distinct links bucket
-// independently ([Manager] salts by link code, [Cache] by ref). Target URLs are templates over a fixed
+// independently ([Manager] salts by link code, [Cache] by ref). Target
+// URLs are templates over a fixed
 // macro vocabulary ({country}, {device}, {locale}, {param.NAME}) parsed at
 // compile time: an unknown macro is a construction error, never an empty
 // substitution at decide time. Macro values escape positionally (authority

--- a/web/smartlink/errors.go
+++ b/web/smartlink/errors.go
@@ -34,6 +34,12 @@ var (
 	// ErrNoTarget is returned when a Link has neither a Target URL nor a Ref
 	// to a compiled Spec.
 	ErrNoTarget = errors.New("smartlink: no target")
+	// ErrRefNotFound is the sentinel a consumer's [Cache] load func (or a
+	// custom [Resolver]) wraps when a ref names no known Spec. Create's ref
+	// precheck maps it (and ErrNoTarget) to ErrInvalidLink — caller input —
+	// while any other resolver error propagates unwrapped as infrastructure
+	// failure.
+	ErrRefNotFound = errors.New("smartlink: ref not found")
 	// ErrInvalidLink is returned for a malformed Link or CreateParams.
 	ErrInvalidLink = errors.New("smartlink: invalid link")
 	// ErrCodeReserved is returned when a caller-supplied code collides with a

--- a/web/smartlink/example_test.go
+++ b/web/smartlink/example_test.go
@@ -74,5 +74,5 @@ func Example_manager() {
 	// Output:
 	// https://s.example.com/promo
 	// 302
-	// https://dest.example.com/landing?click_id=abc123&src=affiliate42
+	// https://dest.example.com/landing?src=affiliate42&click_id=abc123
 }

--- a/web/smartlink/handler.go
+++ b/web/smartlink/handler.go
@@ -43,7 +43,7 @@ func (m *Manager) Handler() http.Handler {
 			return
 		}
 
-		v := Visit{Params: firstQueryValues(r.URL.Query())}
+		v := Visit{Params: firstQueryValues(r.URL.RawQuery)}
 		if m.cfg.visitFunc != nil {
 			v = m.cfg.visitFunc(r, v)
 		}
@@ -62,7 +62,10 @@ func (m *Manager) Handler() http.Handler {
 		dec := d.Decide(v)
 		http.Redirect(w, r, dec.URL, m.cfg.redirectStatus)
 		if m.cfg.onHit != nil {
-			m.cfg.onHit(ctx, Hit{Link: l, Visit: v, Decision: dec})
+			// Cancellation-detached: a client that disconnects right after
+			// reading the redirect must not cancel hit delivery (a queue push
+			// with the request ctx would silently lose the click).
+			m.cfg.onHit(context.WithoutCancel(ctx), Hit{Link: l, Visit: v, Decision: dec})
 		}
 	})
 }
@@ -107,12 +110,22 @@ func (m *Manager) decider(ctx context.Context, w http.ResponseWriter, r *http.Re
 }
 
 // compileTarget compiles the degenerate single-target Spec for a
-// Target-backed Link, using the configured link param policy. No caching in
-// v1: a single-template compile is a few µs (see bench_test.go), and an
-// unbounded per-code compiled cache is a memory liability at affiliate-code
-// cardinality.
+// Target-backed Link, salted by its code so split/Percent bucketing stays
+// per-link, using the configured link param policy. It re-applies
+// checkTargetURL so a row written to the Store outside this Manager (which
+// never went through Create's validation) cannot serve a disallowed scheme
+// like "javascript:" as a redirect. No caching in v1: a single-template
+// compile is a few µs (see bench_test.go), and an unbounded per-code
+// compiled cache is a memory liability at affiliate-code cardinality.
 func (m *Manager) compileTarget(l Link) (Decider, error) {
-	return Compile(Spec{Default: []Target{{URL: l.Target}}, Params: m.cfg.linkParamPolicy})
+	compiled, err := Compile(Spec{Salt: l.Code, Default: []Target{{URL: l.Target}}, Params: m.cfg.linkParamPolicy})
+	if err != nil {
+		return nil, err
+	}
+	if err := m.checkTargetURL(&compiled.def.targets[0].tmpl); err != nil {
+		return nil, err
+	}
+	return compiled, nil
 }
 
 // resolveFailed maps a Resolve error to the dead-link path (fallback
@@ -141,19 +154,39 @@ func internalServerError(w http.ResponseWriter) {
 	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 }
 
-// firstQueryValues flattens q to its first value per key — the shape Visit
-// wants for ParamEquals, {param.NAME} macros, and the link's param-merge
-// policy. A request with no query params yields a nil map, matching Visit's
-// zero value.
-func firstQueryValues(q url.Values) map[string]string {
-	if len(q) == 0 {
+// firstQueryValues extracts the first value per key from the raw query in a
+// single pass — the shape Visit wants for ParamEquals, {param.NAME} macros,
+// and the link's param-merge policy — without materializing an intermediate
+// url.Values (a map plus a slice per key, discarded immediately, on every
+// redirect). Pairs url.ParseQuery would reject (';' separators, undecodable
+// escapes, empty keys) are skipped, matching r.URL.Query()'s partial-parse
+// behavior. A request with no usable query params yields a nil map, matching
+// Visit's zero value.
+func firstQueryValues(rawQuery string) map[string]string {
+	if rawQuery == "" {
 		return nil
 	}
-	out := make(map[string]string, len(q))
-	for k, vals := range q {
-		if len(vals) > 0 {
-			out[k] = vals[0]
+	var out map[string]string
+	for pair := range strings.SplitSeq(rawQuery, "&") {
+		if pair == "" || strings.ContainsRune(pair, ';') {
+			continue
 		}
+		rawK, rawV, _ := strings.Cut(pair, "=")
+		k, err := url.QueryUnescape(rawK)
+		if err != nil || k == "" {
+			continue
+		}
+		if _, ok := out[k]; ok {
+			continue // first value per key wins, like url.Values ordering
+		}
+		v, err := url.QueryUnescape(rawV)
+		if err != nil {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string, 4)
+		}
+		out[k] = v
 	}
 	return out
 }

--- a/web/smartlink/handler.go
+++ b/web/smartlink/handler.go
@@ -159,9 +159,11 @@ func internalServerError(w http.ResponseWriter) {
 // and the link's param-merge policy — without materializing an intermediate
 // url.Values (a map plus a slice per key, discarded immediately, on every
 // redirect). Pairs url.ParseQuery would reject (';' separators, undecodable
-// escapes, empty keys) are skipped, matching r.URL.Query()'s partial-parse
-// behavior. A request with no usable query params yields a nil map, matching
-// Visit's zero value.
+// escapes) are skipped, matching r.URL.Query()'s partial-parse behavior;
+// empty-key pairs ("?=foo") are additionally dropped on purpose — no
+// consumer (ParamEquals, {param.NAME}, the param merge) can act on an
+// empty key. A request with no usable query params yields a nil map,
+// matching Visit's zero value.
 func firstQueryValues(rawQuery string) map[string]string {
 	if rawQuery == "" {
 		return nil

--- a/web/smartlink/handler_test.go
+++ b/web/smartlink/handler_test.go
@@ -172,7 +172,7 @@ func TestHandlerVisitFuncEnriches(t *testing.T) {
 // a real Cache-backed Resolver (Task 4's Cache.Resolver).
 func TestHandlerRefResolves(t *testing.T) {
 	t.Parallel()
-	c := smartlink.NewCache(func(_ context.Context, ref string) (smartlink.Spec, error) {
+	c := mustNewCache(t, func(_ context.Context, ref string) (smartlink.Spec, error) {
 		return smartlink.Spec{Default: []smartlink.Target{{URL: "https://offer.example.com/" + ref}}}, nil
 	})
 	m := newTestManager(t, smartlink.WithResolver(c.Resolver()))
@@ -481,5 +481,63 @@ func TestHandlerPathFallback(t *testing.T) {
 	}
 	if got, want := rec.Header().Get("Location"), "https://dest.example.com/"; got != want {
 		t.Fatalf("Location = %q, want %q", got, want)
+	}
+}
+
+// TestHandlerOnHitContextDetached asserts the OnHit callback receives a
+// cancellation-detached context: a client disconnecting right after the
+// redirect (canceling the request context) must not cancel hit delivery.
+func TestHandlerOnHitContextDetached(t *testing.T) {
+	t.Parallel()
+	hitCtxErr := make(chan error, 1)
+	m := newTestManager(t, smartlink.WithOnHit(func(ctx context.Context, _ smartlink.Hit) {
+		hitCtxErr <- ctx.Err()
+	}))
+	l, err := m.Create(context.Background(), smartlink.CreateParams{Target: "https://dest.example.com/"})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the client is already gone
+	req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code, nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+	if err := <-hitCtxErr; err != nil {
+		t.Fatalf("OnHit ctx.Err() = %v, want nil (must be cancellation-detached)", err)
+	}
+}
+
+// TestHandlerBlocksDisallowedSchemeFromStore asserts a Target row written to
+// the Store outside the Manager (bypassing Create's validation) cannot serve
+// a disallowed scheme as a redirect: the hit answers 500, not a
+// javascript: Location.
+func TestHandlerBlocksDisallowedSchemeFromStore(t *testing.T) {
+	t.Parallel()
+	store := smartlink.NewMemoryStore()
+	ctx := context.Background()
+	if err := store.Create(ctx, smartlink.Link{Code: "evil", Target: "javascript:alert(1)", CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("store Create() error = %v, want nil", err)
+	}
+	m, err := smartlink.NewManager(store)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/r/evil", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d (disallowed scheme must not redirect)", rec.Code, http.StatusInternalServerError)
+	}
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Fatalf("Location = %q, want empty", loc)
 	}
 }

--- a/web/smartlink/manager.go
+++ b/web/smartlink/manager.go
@@ -7,7 +7,11 @@ import (
 	"maps"
 	"net/url"
 	"slices"
+	"sync/atomic"
 	"time"
+
+	"github.com/dmitrymomot/forge/resilience/cache"
+	"github.com/dmitrymomot/forge/resilience/singleflight"
 )
 
 // maxCodeAttempts caps how many times Create retries a colliding generated
@@ -22,7 +26,13 @@ const maxCodeAttempts = 5
 // in the Store.
 type Manager struct {
 	store Store
-	cfg   managerConfig
+	links *cache.Cache[Link] // typed facade over WithCache's store; nil without WithCache
+	// flight dedups concurrent cache-miss lookups per code, and cacheGen
+	// guards their write-backs against racing lifecycle mutations (see
+	// lookup and invalidateCache).
+	flight   singleflight.Group[Link]
+	cfg      managerConfig
+	cacheGen atomic.Uint64
 }
 
 // NewManager builds a Manager over store. It returns an error if any
@@ -39,7 +49,11 @@ func NewManager(store Store, opts ...ManagerOption) (*Manager, error) {
 	if len(cfg.errs) > 0 {
 		return nil, errors.Join(cfg.errs...)
 	}
-	return &Manager{store: store, cfg: *cfg}, nil
+	m := &Manager{store: store, cfg: *cfg}
+	if cfg.cacheStore != nil {
+		m.links = cache.New[Link](cfg.cacheStore, cache.WithPrefix(cachePrefix), cache.WithDefaultTTL(cfg.cacheTTL))
+	}
+	return m, nil
 }
 
 // Create validates p and inserts a new Link. Exactly one of Target or Ref
@@ -81,7 +95,14 @@ func (m *Manager) Create(ctx context.Context, p CreateParams) (Link, error) {
 	}
 	if p.Ref != "" && !p.SkipRefCheck && m.cfg.resolver != nil {
 		if _, err := m.cfg.resolver(ctx, Link{Ref: p.Ref, Tenant: p.Tenant}); err != nil {
-			return Link{}, fmt.Errorf("%w: ref %q: %w", ErrInvalidLink, p.Ref, err)
+			// Only a ref the resolver positively rejects is caller input error;
+			// anything else (consumer DB down, cache backend failing) is an
+			// infrastructure failure and must not read as ErrInvalidLink to an
+			// API layer mapping it to a 4xx.
+			if errors.Is(err, ErrRefNotFound) || errors.Is(err, ErrNoTarget) {
+				return Link{}, fmt.Errorf("%w: ref %q: %w", ErrInvalidLink, p.Ref, err)
+			}
+			return Link{}, fmt.Errorf("smartlink: check ref %q: %w", p.Ref, err)
 		}
 	}
 
@@ -92,7 +113,10 @@ func (m *Manager) Create(ctx context.Context, p CreateParams) (Link, error) {
 		Code:      p.Code,
 		Metadata:  maps.Clone(p.Metadata),
 		Tenant:    p.Tenant,
-		CreatedAt: time.Now().UTC(),
+		// Truncated to microseconds — Postgres timestamptz precision — so the
+		// returned Link carries the same instant a later Get reads back and
+		// List ordering agrees across Store implementations.
+		CreatedAt: time.Now().UTC().Truncate(time.Microsecond),
 	}
 
 	if l.Code != "" {
@@ -108,16 +132,26 @@ func (m *Manager) Create(ctx context.Context, p CreateParams) (Link, error) {
 }
 
 // createGenerated assigns l.Code from the configured code function and
-// creates it, retrying on ErrDuplicate up to maxCodeAttempts times. An empty
-// string from a broken [WithCodeFunc] is treated as a failed attempt (not
-// stored) and retried the same way — a misbehaving generator exhausts the
-// loop and surfaces the same error as an unlucky collision streak, rather
-// than silently persisting a Link with an empty code.
+// creates it, retrying on ErrDuplicate up to maxCodeAttempts times. Generated
+// codes face the same charset and reserved-word rules as vanity codes — a
+// short random generator can legitimately emit a reserved word like "api"
+// (retried like a collision), while a charset/length violation means the
+// generator itself is broken and fails immediately rather than looping. An
+// empty string is treated as a failed attempt (not stored) and retried, so a
+// misbehaving generator exhausts the loop and surfaces the same error as an
+// unlucky collision streak instead of silently persisting an empty code.
 func (m *Manager) createGenerated(ctx context.Context, l *Link) error {
 	lastErr := errors.New("generated code was empty")
 	for range maxCodeAttempts {
 		l.Code = m.cfg.codeFunc()
 		if l.Code == "" {
+			continue
+		}
+		if !validCodeChars(l.Code) {
+			return fmt.Errorf("%w: generated code %q must be 1-64 characters of [A-Za-z0-9_-]", ErrInvalidLink, l.Code)
+		}
+		if _, reserved := m.cfg.reserved[l.Code]; reserved {
+			lastErr = fmt.Errorf("%w: code %q", ErrCodeReserved, l.Code)
 			continue
 		}
 		err := m.store.Create(ctx, *l)
@@ -151,23 +185,32 @@ func (m *Manager) validateVanityCode(code string) error {
 
 // validateTarget compiles raw as the sole default target of a degenerate
 // Spec — surfacing template errors (bad macro, malformed template) as
-// ErrInvalidLink — then checks its macro-elided scheme is on the allowlist
-// and non-empty, and that its host is non-empty unless the authority is
-// itself (at least partly) a macro, in which case a dynamic-host template
-// stays legal.
+// ErrInvalidLink — then applies the URL policy checks via checkTargetURL.
 func (m *Manager) validateTarget(raw string) error {
-	if _, err := Compile(Spec{Default: []Target{{URL: raw}}, Params: m.cfg.linkParamPolicy}); err != nil {
+	compiled, err := Compile(Spec{Default: []Target{{URL: raw}}, Params: m.cfg.linkParamPolicy})
+	if err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidLink, err)
 	}
-	u, err := url.Parse(macroElide(raw))
+	return m.checkTargetURL(&compiled.def.targets[0].tmpl)
+}
+
+// checkTargetURL enforces the URL policy on a compiled template: its
+// macro-elided scheme must be on the allowlist and non-empty, and its host
+// non-empty unless the authority is itself (at least partly) a macro, in
+// which case a dynamic-host template stays legal. Shared by Create validation
+// and the per-hit compileTarget path, so a row written to the Store outside
+// this Manager faces the same scheme policy at serve time (defense in depth —
+// a directly-inserted "javascript:" target must not become a redirect).
+func (m *Manager) checkTargetURL(t *template) error {
+	u, err := url.Parse(t.elided)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidLink, err)
 	}
 	if u.Scheme == "" || !slices.Contains(m.cfg.schemes, u.Scheme) {
 		return fmt.Errorf("%w: scheme %q not allowed", ErrInvalidLink, u.Scheme)
 	}
-	if u.Host == "" && !authorityHasMacro(raw) {
-		return fmt.Errorf("%w: target %q has no host", ErrInvalidLink, raw)
+	if u.Host == "" && !t.authMacro {
+		return fmt.Errorf("%w: target %q has no host", ErrInvalidLink, t.raw)
 	}
 	return nil
 }
@@ -217,39 +260,37 @@ func (m *Manager) List(ctx context.Context, f Filter) ([]Link, error) {
 // untouched and reads back as [ErrNotFound]. On success it best-effort
 // evicts any cached entry for code (see [Manager.invalidateCache]).
 func (m *Manager) Deactivate(ctx context.Context, code string) error {
-	tenant, err := m.tenantScope(ctx)
-	if err != nil {
-		return err
-	}
-	if err := m.store.Deactivate(ctx, code, tenant, time.Now().UTC()); err != nil {
-		return err
-	}
-	m.invalidateCache(ctx, code)
-	return nil
+	return m.mutateLink(ctx, code, func(ctx context.Context, tenant string) error {
+		return m.store.Deactivate(ctx, code, tenant, time.Now().UTC())
+	})
 }
 
 // Activate clears a prior Deactivate. See [Manager.Deactivate] for scope
 // handling and cache invalidation.
 func (m *Manager) Activate(ctx context.Context, code string) error {
-	tenant, err := m.tenantScope(ctx)
-	if err != nil {
-		return err
-	}
-	if err := m.store.Activate(ctx, code, tenant); err != nil {
-		return err
-	}
-	m.invalidateCache(ctx, code)
-	return nil
+	return m.mutateLink(ctx, code, func(ctx context.Context, tenant string) error {
+		return m.store.Activate(ctx, code, tenant)
+	})
 }
 
 // Delete removes code. See [Manager.Deactivate] for scope handling and
 // cache invalidation.
 func (m *Manager) Delete(ctx context.Context, code string) error {
+	return m.mutateLink(ctx, code, func(ctx context.Context, tenant string) error {
+		return m.store.Delete(ctx, code, tenant)
+	})
+}
+
+// mutateLink is the shared lifecycle-mutation sequence — resolve the tenant
+// scope, run the store op with it, evict the cache entry on success — so the
+// tenant-safety and cache-consistency invariant is stated once, not per
+// method.
+func (m *Manager) mutateLink(ctx context.Context, code string, op func(ctx context.Context, tenant string) error) error {
 	tenant, err := m.tenantScope(ctx)
 	if err != nil {
 		return err
 	}
-	if err := m.store.Delete(ctx, code, tenant); err != nil {
+	if err := op(ctx, tenant); err != nil {
 		return err
 	}
 	m.invalidateCache(ctx, code)

--- a/web/smartlink/manager_options.go
+++ b/web/smartlink/manager_options.go
@@ -111,8 +111,10 @@ func validateAbsoluteHTTPURL(u string) error {
 
 // WithSchemes replaces the allowed Target URL schemes (default "http",
 // "https"). Create rejects a Target whose macro-elided scheme is not in
-// this set; scheme comparison is case-insensitive, since [url.Parse] always
-// lowercases the parsed scheme.
+// this set, and [Manager.Handler] re-checks it before serving a Target-backed
+// redirect, so a row written to the Store directly cannot smuggle a
+// disallowed scheme past the allowlist. Scheme comparison is
+// case-insensitive, since [url.Parse] always lowercases the parsed scheme.
 func WithSchemes(s ...string) ManagerOption {
 	return func(c *managerConfig) {
 		schemes := slices.Clone(s)
@@ -140,12 +142,22 @@ func WithScope(f func(ctx context.Context) (string, error)) ManagerOption {
 	return func(c *managerConfig) { c.scope = f }
 }
 
-// WithLinkParamPolicy sets the [ParamPolicy] Create uses only to validate a
-// Target template against a degenerate [Spec]. Default [ParamsFill] — the
-// zero value [ParamsDrop] would validate a Target that silently drops
-// forwarded params at decide time.
+// WithLinkParamPolicy sets the [ParamPolicy] applied to Target-backed Links:
+// Create validates a Target template against it, and [Manager.Handler]
+// compiles every Target-link redirect with it, so it governs how visit
+// params (sub-IDs, click IDs) merge into the final URL on every hit. Default
+// [ParamsFill] — the zero value [ParamsDrop] would silently strip forwarded
+// params at decide time. An out-of-range value is a NewManager error, like
+// every other validated option, rather than a per-Create/per-hit failure.
 func WithLinkParamPolicy(p ParamPolicy) ManagerOption {
-	return func(c *managerConfig) { c.linkParamPolicy = p }
+	return func(c *managerConfig) {
+		switch p {
+		case ParamsDrop, ParamsFill, ParamsOverride:
+			c.linkParamPolicy = p
+		default:
+			c.errs = append(c.errs, fmt.Errorf("smartlink: unknown ParamPolicy %d", p))
+		}
+	}
 }
 
 // WithResolver sets the [Resolver] Create uses to confirm a Ref-backed
@@ -164,7 +176,9 @@ func WithVisitFunc(f VisitFunc) ManagerOption {
 // WithOnHit registers a callback [Manager.Handler] invokes synchronously
 // after each redirect is written. Hand the [Hit] to a bounded sink (queue
 // push, buffered channel) — never do work inline or spawn per-hit
-// goroutines, since a slow callback blocks every click.
+// goroutines, since a slow callback blocks every click. The callback's
+// context is cancellation-detached from the request: a client disconnecting
+// right after the redirect cannot cancel hit delivery mid-push.
 func WithOnHit(f func(context.Context, Hit)) ManagerOption {
 	return func(c *managerConfig) { c.onHit = f }
 }

--- a/web/smartlink/manager_test.go
+++ b/web/smartlink/manager_test.go
@@ -3,6 +3,7 @@ package smartlink_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -274,9 +275,9 @@ func TestCreateRefValidation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	t.Run("resolver error wraps ErrInvalidLink", func(t *testing.T) {
+	t.Run("unknown ref wraps ErrInvalidLink", func(t *testing.T) {
 		t.Parallel()
-		resolverErr := errors.New("ref not found")
+		resolverErr := fmt.Errorf("offer lookup: %w", smartlink.ErrRefNotFound)
 		resolver := func(context.Context, smartlink.Link) (smartlink.Decider, error) {
 			return nil, resolverErr
 		}
@@ -287,6 +288,22 @@ func TestCreateRefValidation(t *testing.T) {
 		}
 		if !errors.Is(err, resolverErr) {
 			t.Fatalf("Create() = %v, want wrapped resolver error", err)
+		}
+	})
+
+	t.Run("resolver infrastructure error is not ErrInvalidLink", func(t *testing.T) {
+		t.Parallel()
+		infraErr := errors.New("consumer db timeout")
+		resolver := func(context.Context, smartlink.Link) (smartlink.Decider, error) {
+			return nil, infraErr
+		}
+		m := newTestManager(t, smartlink.WithResolver(resolver))
+		_, err := m.Create(ctx, smartlink.CreateParams{Ref: "offer-1"})
+		if errors.Is(err, smartlink.ErrInvalidLink) {
+			t.Fatalf("Create() = %v, must not read as caller input error", err)
+		}
+		if !errors.Is(err, infraErr) {
+			t.Fatalf("Create() = %v, want wrapped infrastructure error", err)
 		}
 	})
 
@@ -472,4 +489,57 @@ func TestRandomCode(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestNewManagerRejectsUnknownParamPolicy asserts an out-of-range
+// WithLinkParamPolicy fails at construction like every other validated
+// option, instead of surfacing per-Create and per-hit.
+func TestNewManagerRejectsUnknownParamPolicy(t *testing.T) {
+	t.Parallel()
+	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithLinkParamPolicy(smartlink.ParamPolicy(7))); err == nil {
+		t.Fatal("NewManager(WithLinkParamPolicy(7)) error = nil, want construction error")
+	}
+}
+
+// TestCreateGeneratedCodeValidation asserts generated codes face the same
+// reserved-word and charset rules as vanity codes.
+func TestCreateGeneratedCodeValidation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("reserved generated code retried", func(t *testing.T) {
+		t.Parallel()
+		seq := []string{"api", "okcode1"}
+		i := 0
+		m := newTestManager(t, smartlink.WithCodeFunc(func() string { i++; return seq[i-1] }))
+		l, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/"})
+		if err != nil {
+			t.Fatalf("Create() error = %v, want nil", err)
+		}
+		if l.Code != "okcode1" {
+			t.Fatalf("Create().Code = %q, want the non-reserved retry %q", l.Code, "okcode1")
+		}
+	})
+
+	t.Run("always-reserved generator exhausts attempts", func(t *testing.T) {
+		t.Parallel()
+		m := newTestManager(t, smartlink.WithCodeFunc(func() string { return "api" }))
+		_, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/"})
+		if !errors.Is(err, smartlink.ErrCodeReserved) {
+			t.Fatalf("Create() = %v, want wrapped ErrCodeReserved", err)
+		}
+	})
+
+	t.Run("invalid charset fails fast", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		m := newTestManager(t, smartlink.WithCodeFunc(func() string { calls++; return "a/b" }))
+		_, err := m.Create(ctx, smartlink.CreateParams{Target: "https://example.com/"})
+		if !errors.Is(err, smartlink.ErrInvalidLink) {
+			t.Fatalf("Create() = %v, want ErrInvalidLink", err)
+		}
+		if calls != 1 {
+			t.Fatalf("code generator calls = %d, want 1 (broken generator must not be retried)", calls)
+		}
+	})
 }

--- a/web/smartlink/matcher.go
+++ b/web/smartlink/matcher.go
@@ -3,6 +3,7 @@ package smartlink
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -13,8 +14,11 @@ import (
 // DSL.
 type Matcher interface {
 	// compile validates and normalizes the matcher into its evaluated form,
-	// sealing the interface to this package.
-	compile(ruleName string) (matcher, error)
+	// sealing the interface to this package. salt is the Spec's bucketing salt
+	// and idx the matcher's position within the rule's conjunction — both feed
+	// Percent's seed so distinct links and distinct Percent gates in one rule
+	// bucket independently.
+	compile(salt, ruleName string, idx int) (matcher, error)
 }
 
 // matcherKind discriminates the compiled matcher union.
@@ -77,7 +81,7 @@ type Geo struct {
 	Countries []string
 }
 
-func (m Geo) compile(ruleName string) (matcher, error) {
+func (m Geo) compile(_, ruleName string, _ int) (matcher, error) {
 	if len(m.Countries) == 0 {
 		return matcher{}, fmt.Errorf("%w: rule %q: Geo needs at least one country", ErrInvalidMatcher, ruleName)
 	}
@@ -97,7 +101,7 @@ type Device struct {
 	Devices []string
 }
 
-func (m Device) compile(ruleName string) (matcher, error) {
+func (m Device) compile(_, ruleName string, _ int) (matcher, error) {
 	devices, err := nonEmptyLower(m.Devices, ruleName, "Device")
 	if err != nil {
 		return matcher{}, err
@@ -113,7 +117,7 @@ type Locale struct {
 	Locales []string
 }
 
-func (m Locale) compile(ruleName string) (matcher, error) {
+func (m Locale) compile(_, ruleName string, _ int) (matcher, error) {
 	locales, err := nonEmptyLower(m.Locales, ruleName, "Locale")
 	if err != nil {
 		return matcher{}, err
@@ -142,7 +146,7 @@ type ParamEquals struct {
 	Values []string
 }
 
-func (m ParamEquals) compile(ruleName string) (matcher, error) {
+func (m ParamEquals) compile(_, ruleName string, _ int) (matcher, error) {
 	if m.Key == "" {
 		return matcher{}, fmt.Errorf("%w: rule %q: ParamEquals needs a key", ErrInvalidMatcher, ruleName)
 	}
@@ -161,7 +165,7 @@ type TimeWindow struct {
 	Until time.Time
 }
 
-func (m TimeWindow) compile(ruleName string) (matcher, error) {
+func (m TimeWindow) compile(_, ruleName string, _ int) (matcher, error) {
 	if m.From.IsZero() && m.Until.IsZero() {
 		return matcher{}, fmt.Errorf("%w: rule %q: TimeWindow needs at least one bound", ErrInvalidMatcher, ruleName)
 	}
@@ -172,19 +176,23 @@ func (m TimeWindow) compile(ruleName string) (matcher, error) {
 }
 
 // Percent matches a deterministic Share percent of traffic, bucketed by hash
-// of the rule name and Visit.StickyKey — the same visitor always lands on the
-// same side. Share must be 1..99 (0 is a dead rule, 100 is no gate — both
-// compile errors). An empty StickyKey never matches (fails closed past this
-// rule).
+// of the Spec salt, rule name, the matcher's position in the rule, and
+// Visit.StickyKey — the same visitor always lands on the same side, distinct
+// links bucket independently (see [Spec.Salt]), and two Percent gates in one
+// rule compose as independent draws instead of collapsing into the wider one.
+// Reordering a rule's matchers therefore reassigns its Percent buckets.
+// Share must be 1..99 (0 is a dead rule, 100 is no gate — both compile
+// errors). An empty StickyKey never matches (fails closed past this rule).
 type Percent struct {
 	Share int
 }
 
-func (m Percent) compile(ruleName string) (matcher, error) {
+func (m Percent) compile(salt, ruleName string, idx int) (matcher, error) {
 	if m.Share < 1 || m.Share > 99 {
 		return matcher{}, fmt.Errorf("%w: rule %q: Percent share %d outside 1..99", ErrInvalidMatcher, ruleName, m.Share)
 	}
-	return matcher{kind: matchPercent, seed: hashString(fnvOffset, "p\x00"+ruleName), share: uint64(m.Share)}, nil
+	seed := hashString(fnvOffset, "p\x00"+salt+"\x00"+ruleName+"\x00"+strconv.Itoa(idx))
+	return matcher{kind: matchPercent, seed: seed, share: uint64(m.Share)}, nil
 }
 
 // isAlpha reports whether s is ASCII letters only.

--- a/web/smartlink/pgstore/pgstore.go
+++ b/web/smartlink/pgstore/pgstore.go
@@ -3,14 +3,15 @@ package pgstore
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"errors"
 	"io/fs"
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/dmitrymomot/forge/data/postgres"
 	"github.com/dmitrymomot/forge/web/smartlink"
 )
 
@@ -51,16 +52,18 @@ INSERT INTO forge_smart_links (` + cols + `)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
 
 // Create inserts l keyed by l.Code. A colliding code yields smartlink.ErrDuplicate.
+// Metadata is stored as its JSON encoding — a nil map as jsonb 'null' — so a
+// nil round-trips back as nil and an empty map as an empty map, matching the
+// MemoryStore reference contract exactly.
 func (s *Store) Create(ctx context.Context, l smartlink.Link) error {
-	meta := l.Metadata
-	if meta == nil {
-		meta = map[string]string{}
+	meta, err := json.Marshal(l.Metadata)
+	if err != nil {
+		return err // unreachable: map[string]string always marshals
 	}
-	_, err := s.pool.Exec(ctx, createSQL,
+	_, err = s.pool.Exec(ctx, createSQL,
 		l.Code, l.Target, l.Ref, meta, l.Tenant,
 		l.CreatedAt, nullTime(l.ExpiresAt), nullTime(l.DeactivatedAt))
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
+	if postgres.IsUniqueViolation(err) {
 		return smartlink.ErrDuplicate
 	}
 	return err
@@ -110,7 +113,8 @@ SET deactivated_at = CASE WHEN $3::timestamptz IS NULL THEN deactivated_at ELSE 
 WHERE code = $1 AND ($2 = '' OR tenant = $2)`
 
 // Deactivate sets DeactivatedAt to at on code, scoped to tenant. A zero at
-// leaves the link active but still enforces the code/tenant predicate.
+// leaves DeactivatedAt unchanged (never reactivates) but still enforces the
+// code/tenant predicate.
 func (s *Store) Deactivate(ctx context.Context, code, tenant string, at time.Time) error {
 	return s.exec(ctx, deactivateSQL, code, tenant, nullTime(at))
 }

--- a/web/smartlink/pgstore/pgstore_test.go
+++ b/web/smartlink/pgstore/pgstore_test.go
@@ -229,6 +229,10 @@ func TestPg_DeleteRecreate(t *testing.T) {
 	assert.Equal(t, "https://b.example.com/", got.Target)
 }
 
+// TestPg_MetadataNilVsEmpty pins the MemoryStore reference contract: nil
+// Metadata round-trips as nil (stored as jsonb 'null'), an explicit empty
+// map as a non-nil empty map — so `l.Metadata == nil` behaves identically
+// whichever Store backs the Manager.
 func TestPg_MetadataNilVsEmpty(t *testing.T) {
 	s := newStore(t)
 	ctx := context.Background()
@@ -237,12 +241,13 @@ func TestPg_MetadataNilVsEmpty(t *testing.T) {
 	require.NoError(t, s.Create(ctx, smartlink.Link{Code: cNil, CreatedAt: time.Now().UTC(), Metadata: nil}))
 	gotNil, err := s.Get(ctx, cNil)
 	require.NoError(t, err)
-	assert.Empty(t, gotNil.Metadata)
+	assert.Nil(t, gotNil.Metadata)
 
 	cEmpty := code()
 	require.NoError(t, s.Create(ctx, smartlink.Link{Code: cEmpty, CreatedAt: time.Now().UTC(), Metadata: map[string]string{}}))
 	gotEmpty, err := s.Get(ctx, cEmpty)
 	require.NoError(t, err)
+	assert.NotNil(t, gotEmpty.Metadata)
 	assert.Empty(t, gotEmpty.Metadata)
 }
 

--- a/web/smartlink/resolve.go
+++ b/web/smartlink/resolve.go
@@ -2,7 +2,6 @@ package smartlink
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"time"
 
@@ -42,55 +41,64 @@ func (m *Manager) Resolve(ctx context.Context, code string) (Link, error) {
 // are logged at debug and never fail the resolve — the Store stays the
 // source of truth, so a bad cache backend degrades to "always hit the
 // Store", not "links stop resolving".
+//
+// Concurrent misses on the same code share one Store read via singleflight,
+// so a hot code whose entry just expired costs one query, not one per
+// waiting request. The write-back is guarded against racing lifecycle
+// mutations: the fill snapshots cacheGen before the Store read, writes the
+// entry, and re-checks — invalidateCache bumps cacheGen before its eviction,
+// so a fill that raced a mutation either sees the bump and evicts its own
+// (possibly stale) write, or wrote early enough that the mutation's eviction
+// removes it. Without this, an in-flight fill could re-cache a deleted
+// link's record after its code was reused by a new Create and serve the
+// previous owner's target for a full TTL.
 func (m *Manager) lookup(ctx context.Context, code string) (Link, error) {
-	if m.cfg.cacheStore == nil {
+	if m.links == nil {
 		return m.store.Get(ctx, code)
 	}
 
-	key := cachePrefix + code
-	if l, ok := m.cacheGet(ctx, code, key); ok {
+	if l, ok := m.cacheGet(ctx, code); ok {
 		return l, nil
 	}
 
-	l, err := m.store.Get(ctx, code)
-	if err != nil {
-		return Link{}, err
-	}
-	m.cacheSet(ctx, code, key, l)
-	return l, nil
+	l, _, err := m.flight.Do(ctx, code, func(ctx context.Context) (Link, error) {
+		gen := m.cacheGen.Load()
+		l, err := m.store.Get(ctx, code)
+		if err != nil {
+			return Link{}, err
+		}
+		m.cacheSet(ctx, code, l)
+		if m.cacheGen.Load() != gen {
+			if err := m.links.Delete(ctx, code); err != nil {
+				m.cfg.logger.DebugContext(ctx, "smartlink: cache evict after raced fill failed", "code", code, "error", err)
+			}
+		}
+		return l, nil
+	})
+	return l, err
 }
 
 // cacheGet attempts the cache read-through hit path, reporting ok == false
 // on a miss, a cache error, or a decode failure — any of which the caller
 // treats identically: fall through to the Store.
-func (m *Manager) cacheGet(ctx context.Context, code, key string) (Link, bool) {
-	raw, err := m.cfg.cacheStore.Get(ctx, key)
+func (m *Manager) cacheGet(ctx context.Context, code string) (Link, bool) {
+	l, err := m.links.Get(ctx, code)
 	if err != nil {
 		if !errors.Is(err, cache.ErrNotFound) {
 			m.cfg.logger.DebugContext(ctx, "smartlink: cache get failed", "code", code, "error", err)
 		}
 		return Link{}, false
 	}
-	var l Link
-	if err := json.Unmarshal(raw, &l); err != nil {
-		m.cfg.logger.DebugContext(ctx, "smartlink: cache decode failed", "code", code, "error", err)
-		return Link{}, false
-	}
 	return l, true
 }
 
-// cacheSet best-effort writes l under key with the configured TTL. ShortURL
+// cacheSet best-effort writes l under code with the configured TTL. ShortURL
 // is stripped before caching — it is derived from the base URL, never
 // persisted, and must not leak through the cache either. Failures are
 // logged at debug and otherwise ignored.
-func (m *Manager) cacheSet(ctx context.Context, code, key string, l Link) {
+func (m *Manager) cacheSet(ctx context.Context, code string, l Link) {
 	l.ShortURL = ""
-	raw, err := json.Marshal(l)
-	if err != nil {
-		m.cfg.logger.DebugContext(ctx, "smartlink: cache encode failed", "code", code, "error", err)
-		return
-	}
-	if err := m.cfg.cacheStore.Set(ctx, key, raw, cache.WithTTL(m.cfg.cacheTTL)); err != nil {
+	if err := m.links.Set(ctx, code, l); err != nil {
 		m.cfg.logger.DebugContext(ctx, "smartlink: cache set failed", "code", code, "error", err)
 	}
 }
@@ -99,13 +107,16 @@ func (m *Manager) cacheSet(ctx context.Context, code, key string, l Link) {
 // mutation (Deactivate, Activate, Delete), bounding staleness of a warmed
 // entry to at most the configured [WithCache] ttl (ttl is validated positive
 // at construction, so an entry that survives a failed eviction here is
-// always bounded). A no-op without [WithCache]; a failure is logged at
-// debug, never surfaced — the mutation already succeeded against the Store.
+// always bounded). The generation counter is bumped BEFORE the eviction so
+// an in-flight lookup fill can detect the race and evict its own write-back
+// (see lookup). A no-op without [WithCache]; a failure is logged at debug,
+// never surfaced — the mutation already succeeded against the Store.
 func (m *Manager) invalidateCache(ctx context.Context, code string) {
-	if m.cfg.cacheStore == nil {
+	if m.links == nil {
 		return
 	}
-	if err := m.cfg.cacheStore.Delete(ctx, cachePrefix+code); err != nil {
+	m.cacheGen.Add(1)
+	if err := m.links.Delete(ctx, code); err != nil {
 		m.cfg.logger.DebugContext(ctx, "smartlink: cache invalidate failed", "code", code, "error", err)
 	}
 }

--- a/web/smartlink/resolve_test.go
+++ b/web/smartlink/resolve_test.go
@@ -3,6 +3,7 @@ package smartlink_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -176,6 +177,136 @@ func TestResolveCacheErrorFallsThrough(t *testing.T) {
 	}
 	if got.Code != created.Code {
 		t.Fatalf("Resolve().Code = %q, want %q", got.Code, created.Code)
+	}
+}
+
+// gateStore counts Gets and, for armCode, stalls the FIRST Get after the
+// underlying read has completed — simulating an in-flight lookup that read
+// the Store but has not yet written the cache.
+type gateStore struct {
+	smartlink.Store
+	entered chan struct{}
+	release chan struct{}
+	armCode string
+	gets    atomic.Int32
+	once    sync.Once
+}
+
+func (s *gateStore) Get(ctx context.Context, code string) (smartlink.Link, error) {
+	l, err := s.Store.Get(ctx, code)
+	s.gets.Add(1)
+	if code == s.armCode {
+		s.once.Do(func() {
+			close(s.entered)
+			<-s.release
+		})
+	}
+	return l, err
+}
+
+// TestResolveStaleWriteBackEvicted reproduces the delete/recreate race: an
+// in-flight Resolve reads the old record, the code is Deleted and re-Created
+// with a new target while that read is stalled, and the straggler's cache
+// write-back must not survive — otherwise the recreated code would serve the
+// previous owner's target for a full TTL.
+func TestResolveStaleWriteBackEvicted(t *testing.T) {
+	t.Parallel()
+	const code = "reuse1"
+	gs := &gateStore{
+		Store:   smartlink.NewMemoryStore(),
+		armCode: code,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	cs := cache.NewMemoryStore()
+	m, err := smartlink.NewManager(gs, smartlink.WithCache(cs, time.Minute))
+	if err != nil {
+		t.Fatalf("NewManager() error = %v, want nil", err)
+	}
+	ctx := context.Background()
+
+	if _, err := m.Create(ctx, smartlink.CreateParams{Code: code, Target: "https://old.example.com/"}); err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// The straggler read the old record; its result is correct for when
+		// the call began — only the cache write-back must be suppressed.
+		if _, err := m.Resolve(ctx, code); err != nil {
+			t.Errorf("straggler Resolve() error = %v", err)
+		}
+	}()
+
+	<-gs.entered // straggler holds the old record, cache still empty
+	if err := m.Delete(ctx, code); err != nil {
+		t.Fatalf("Delete() error = %v, want nil", err)
+	}
+	if _, err := m.Create(ctx, smartlink.CreateParams{Code: code, Target: "https://new.example.com/"}); err != nil {
+		t.Fatalf("Create() (code reuse) error = %v, want nil", err)
+	}
+	close(gs.release)
+	<-done
+
+	if _, err := cs.Get(ctx, "smartlink:code:"+code); !errors.Is(err, cache.ErrNotFound) {
+		t.Fatalf("cache Get() after raced fill = %v, want ErrNotFound (stale write-back must be evicted)", err)
+	}
+	got, err := m.Resolve(ctx, code)
+	if err != nil {
+		t.Fatalf("Resolve() after reuse error = %v, want nil", err)
+	}
+	if got.Target != "https://new.example.com/" {
+		t.Fatalf("Resolve().Target = %q, want the recreated link's target", got.Target)
+	}
+}
+
+// TestResolveMissSingleflight asserts concurrent cache misses for one code
+// share a single Store read instead of stampeding it: a leader Resolve is
+// parked inside Store.Get, the other workers are started while it is parked
+// (so their flight.Do joins the leader's registered call), and the total
+// Store reads must stay 1.
+func TestResolveMissSingleflight(t *testing.T) {
+	t.Parallel()
+	const code, workers = "hot1", 3
+	gs := &gateStore{
+		Store:   smartlink.NewMemoryStore(),
+		armCode: code,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m, err := smartlink.NewManager(gs, smartlink.WithCache(cache.NewMemoryStore(), time.Minute))
+	if err != nil {
+		t.Fatalf("NewManager() error = %v, want nil", err)
+	}
+	ctx := context.Background()
+	if _, err := m.Create(ctx, smartlink.CreateParams{Code: code, Target: "https://example.com/"}); err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Go(func() { // leader: misses cache, parks inside Store.Get
+		if _, err := m.Resolve(ctx, code); err != nil {
+			t.Errorf("leader Resolve() error = %v", err)
+		}
+	})
+	<-gs.entered
+	for range workers {
+		wg.Go(func() {
+			if _, err := m.Resolve(ctx, code); err != nil {
+				t.Errorf("Resolve() error = %v", err)
+			}
+		})
+	}
+	// The workers' path from cache miss to flight join is a handful of
+	// non-blocking statements; this generous scheduling window lets them
+	// reach it while the leader is still parked, keeping the assertion
+	// deterministic in practice.
+	time.Sleep(100 * time.Millisecond)
+	close(gs.release)
+	wg.Wait()
+	if got := gs.gets.Load(); got != 1 {
+		t.Fatalf("store Gets under concurrent miss = %d, want 1 (singleflight)", got)
 	}
 }
 

--- a/web/smartlink/rule.go
+++ b/web/smartlink/rule.go
@@ -1,8 +1,9 @@
 package smartlink
 
 // ParamPolicy controls how Visit.Params merge into the final URL after macro
-// rendering. ParamsFill and ParamsOverride re-encode the query, which sorts
-// its keys — don't point merged links at order-sensitive (e.g. signed) URLs.
+// rendering. ParamsFill and ParamsOverride preserve the target's original
+// query pairs verbatim (order and encoding intact) and append merged params
+// after them in sorted key order; an overridden key is rewritten in place.
 type ParamPolicy int
 
 const (
@@ -18,6 +19,14 @@ const (
 // evaluated first-match-wins, with a mandatory default target. Rule values are
 // consumer data (however stored) hydrated into this typed vocabulary.
 type Spec struct {
+	// Salt namespaces the Spec's sticky bucketing (weighted splits and Percent
+	// matchers): two Specs with different salts bucket the same StickyKey
+	// independently. Set it to a stable link identity — [Manager] uses the
+	// link code for Target links, and [Cache] defaults an empty Salt to the
+	// ref — so unrelated links never share split assignments. An empty Salt
+	// on a hand-compiled Spec is legal but correlates its buckets with every
+	// other unsalted Spec's.
+	Salt string
 	// Rules are evaluated in order; the first rule whose matchers all match
 	// wins. May be empty for a default-only link.
 	Rules []Rule
@@ -31,8 +40,9 @@ type Spec struct {
 // Rule is one ordered decision row: a conjunction of matchers selecting a
 // target list.
 type Rule struct {
-	// Name identifies the rule in Decision.Rule and salts its Percent and
-	// split bucketing. Required and unique within a Spec.
+	// Name identifies the rule in Decision.Rule and, together with
+	// [Spec.Salt], salts its Percent and split bucketing. Required and unique
+	// within a Spec.
 	Name string
 	// When is the matcher conjunction (AND). An empty list matches every
 	// visit — an unconditional override that shadows everything after it.

--- a/web/smartlink/store.go
+++ b/web/smartlink/store.go
@@ -28,7 +28,8 @@ type Store interface {
 	List(ctx context.Context, f Filter) ([]Link, error)
 
 	// Deactivate sets DeactivatedAt to at on code, scoped to tenant. A zero
-	// at leaves the link active.
+	// at leaves DeactivatedAt unchanged — it never activates or deactivates
+	// anything — while still enforcing the code/tenant predicate.
 	Deactivate(ctx context.Context, code, tenant string, at time.Time) error
 
 	// Activate clears DeactivatedAt on code, scoped to tenant.

--- a/web/smartlink/template.go
+++ b/web/smartlink/template.go
@@ -44,10 +44,15 @@ type segment struct {
 }
 
 // template is a compiled URL template. A nil segs means the URL is a plain
-// literal and renders with zero work.
+// literal and renders with zero work. elided is the macro-elided form (equal
+// to raw for a literal) and authMacro reports whether any macro sits in the
+// authority segment — both computed here once so validation layers never
+// re-scan the raw template with a second parser.
 type template struct {
-	raw  string
-	segs []segment
+	raw       string
+	elided    string
+	segs      []segment
+	authMacro bool
 }
 
 // parseTemplate compiles a target URL template: splits out {macro}
@@ -58,11 +63,12 @@ func parseTemplate(raw, where string) (template, error) {
 		if _, err := url.Parse(raw); err != nil {
 			return template{}, fmt.Errorf("%w: %s: %v", ErrInvalidTemplate, where, err)
 		}
-		return template{raw: raw}, nil
+		return template{raw: raw, elided: raw}, nil
 	}
 
 	var segs []segment
 	var elided strings.Builder
+	var authMacro bool
 	rest := raw
 	for {
 		open := strings.IndexByte(rest, '{')
@@ -84,7 +90,11 @@ func parseTemplate(raw, where string) (template, error) {
 			return template{}, err
 		}
 		elided.WriteString(literal)
-		segs = append(segs, segment{literal: literal, macro: kind, param: param, esc: escapeModeFor(elided.String())})
+		esc := escapeModeFor(elided.String())
+		if esc == escAuthority {
+			authMacro = true
+		}
+		segs = append(segs, segment{literal: literal, macro: kind, param: param, esc: esc})
 		rest = rest[close+1:]
 	}
 	if strings.ContainsRune(rest, '}') {
@@ -97,7 +107,7 @@ func parseTemplate(raw, where string) (template, error) {
 	if _, err := url.Parse(elided.String()); err != nil {
 		return template{}, fmt.Errorf("%w: %s: %v", ErrInvalidTemplate, where, err)
 	}
-	return template{raw: raw, segs: segs}, nil
+	return template{raw: raw, elided: elided.String(), segs: segs, authMacro: authMacro}, nil
 }
 
 // escapeModeFor derives a macro's escaping from the macro-elided literal


### PR DESCRIPTION
## Summary

A high-effort multi-agent review of `web/smartlink` (8 finder angles → 23 deduped candidates → per-candidate adversarial verification) surfaced 22 real findings: 14 correctness bugs and 8 reuse/simplification/efficiency cleanups. This PR fixes all of them.

## Correctness fixes

- **Stale cache write-back after code reuse (worst finding).** `lookup` had a TOCTOU between `store.Get` and the cache write: an in-flight resolve could re-cache a deleted link's record after `Delete` + `Create` reused the code, serving the previous owner's (possibly other-tenant's) target for a full TTL. Fixed with a generation counter bumped before every invalidation eviction — a raced fill detects the bump and evicts its own write — plus `resilience/singleflight` on the miss path so a hot code at TTL expiry costs one store read, not one per waiting request. Deterministic regression tests for both (`TestResolveStaleWriteBackEvicted`, `TestResolveMissSingleflight`).
- **Generated codes bypassed all validation.** `createGenerated` stored whatever the code func returned: `RandomCode(3)` can emit `"api"`/`"www"` (both in the reserved blocklist, both expressible in base58), shadowing exactly the routes the blocklist protects; a broken custom generator could persist `"a/b"` or 100-char codes. Generated codes now face the vanity rules: reserved → retried like a collision, charset-invalid → fail fast.
- **Param merges silently dropped undecodable query pairs.** `finalURL` round-tripped through `url.Values`, which drops pairs it can't decode (`promo=50%off`, `a=1;b=2`) — affiliate params vanished from destinations whenever visit params merged. The merge now preserves original pairs verbatim (order and encoding intact), rewrites overridden keys in place, and appends new params in sorted key order.
- **Sticky bucketing was correlated across links and across Percent gates.** Split and Percent seeds were salted only by rule name (empty for default splits), so every link's default split assigned identical buckets, and `Percent{50} AND Percent{50}` collapsed to 50% instead of 25%. New `Spec.Salt` (Manager salts by link code, `Cache` defaults to the ref) plus per-position Percent salting; distribution tests assert 25% conjunction and cross-salt divergence.
- **OnHit lost clicks on client disconnect.** The callback got the request context, which net/http cancels the moment the client closes — a curl-style client disconnecting right after the 302 canceled the queue push. Now `context.WithoutCancel` (same class as the web/idempotency fix).
- **Serve path enforced no scheme allowlist.** A store row written outside the Manager (`javascript:alert(1)`) compiled fine and was served as a redirect Location. `compileTarget` now shares `checkTargetURL` with Create-time validation — defense in depth for directly-written rows.
- **Create misclassified resolver outages as caller error.** Any resolver failure — including a transient consumer-DB timeout — wrapped `ErrInvalidLink`, turning outages into 400s. New `ErrRefNotFound` sentinel: only it (and `ErrNoTarget`) maps to `ErrInvalidLink`; everything else propagates as infrastructure failure.
- **`WithLinkParamPolicy` was unvalidated and its godoc lied.** An out-of-range policy passed construction and failed on every Create and every hit (500s); the doc claimed create-time-validation-only while the policy governs runtime merging on every Target-link redirect. Now validated at `NewManager` like every sibling option, doc corrected.
- **`NewCache(nil)` panicked on the first request** — now a construction error, matching `NewManager`.
- **pgstore diverged from the MemoryStore reference contract on nil Metadata** (nil coerced to `'{}'`, read back non-nil). Metadata is stored as its JSON encoding (`nil` → jsonb `null`), round-tripping exactly; integration test pins nil-vs-empty.
- **Minor contract fixes:** single-target `Weight` is now genuinely ignored per its godoc; `CreatedAt` stamped at µs precision so Manager-returned and store-read timestamps agree and List ordering matches across stores; `Store.Deactivate`'s zero-`at` doc no longer says "leaves the link active" (both implementations leave `DeactivatedAt` unchanged).

## Cleanups

- `Cache` dropped its never-pruned per-ref generation map for per-ref flight entries: concurrent misses share one load+compile (no consumer-DB stampede on cold start/invalidation), `Invalidate` is a plain delete, no unbounded side bookkeeping. Panic-safe (waiters released, entry removed, panic propagates).
- Manager's code cache rides `resilience/cache.Cache[Link]` instead of hand-rolled prefix+JSON+TTL; pgstore uses `data/postgres.IsUniqueViolation` instead of matching SQLSTATE 23505 by hand.
- `macroElide`/`authorityHasMacro` deleted — the compiled template exposes its elided URL and authority-macro fact, so exactly one scanner owns the macro grammar.
- `Deactivate`/`Activate`/`Delete` share one `mutateLink` helper; `split.total` dropped (derivable from `cum`); the handler parses the query in a single pass instead of materializing a throwaway `url.Values`; literal targets pre-parse their URL once at compile.

Deliberately **not** changed: the Store's read-vs-mutate tenancy asymmetry (Get post-filters, mutators take a tenant predicate) — the Store doc justifies it (the predicate must be atomic with the mutation; reads have no TOCTOU), so unifying it would be churn without a bug.

## Benchmarks (darwin/arm64, before → after)

| Benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| DecideMerge | 554.7 → **182.0** | 760 → **112** | 11 → **3** |
| HandlerTarget | 3062 → **2893** | 9124 → **8595** | 51 → **44** |
| ResolveDecideTarget | 945.1 → **802.5** | 1560 → **1320** | 19 → **15** |
| HandlerRef | 1913 → **1845** | 7393 → **6961** | 34 → **30** |
| DecideLiteral / DecideSplit / DecideMacro / DecideBare / Chain3 / MemoryStoreGet | unchanged within noise | | |

## Testing

- `go test -race ./web/smartlink/` — all green, including 12 new regression tests (stale write-back eviction, singleflight dedup, generated-code validation, raw-pair preservation, override duplicate collapse, Percent conjunction independence, salt decorrelation, OnHit context detachment, serve-time scheme block, nil-load construction, cache flight dedup, unknown-ParamPolicy construction error).
- `go test -tags integration ./web/smartlink/pgstore/` — green against Docker Postgres, including the strengthened nil-metadata round-trip.
- `just lint` — clean (golangci-lint, nilaway, betteralign, modernize).