### PR TITLE
feat(data/pagination): keyset cursor + offset page-window pagination

### DIFF
--- a/data/pagination/bench_test.go
+++ b/data/pagination/bench_test.go
@@ -1,0 +1,79 @@
+package pagination_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/dmitrymomot/forge/data/pagination"
+)
+
+var (
+	benchKeyset = pagination.Keyset{
+		{Column: "created_at", Desc: true},
+		{Column: "id", Desc: true},
+	}
+	benchCursor = pagination.Cursor{Keys: []any{"2026-01-01T00:00:00Z", int64(4242)}}
+)
+
+func BenchmarkWhereDollar(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := benchKeyset.Where(benchCursor, pagination.Dollar, 1); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWhereQuestion(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := benchKeyset.Where(benchCursor, pagination.Question, 1); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkOrderBy(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := benchKeyset.OrderBy(false); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncode(b *testing.B) {
+	codec, err := pagination.NewCodec()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := codec.Encode(benchCursor); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	codec, err := pagination.NewCodec()
+	if err != nil {
+		b.Fatal(err)
+	}
+	enc, _ := codec.Encode(benchCursor)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := codec.Decode(enc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkNewWindow(b *testing.B) {
+	q := url.Values{"sort": {"name"}, "status": {"active"}}
+	cfg := pagination.WindowConfig{Page: 10, PerPage: 25, Total: 5000, Span: 2, Query: q}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = pagination.NewWindow(cfg)
+	}
+}

--- a/data/pagination/cursor.go
+++ b/data/pagination/cursor.go
@@ -1,0 +1,133 @@
+package pagination
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/dmitrymomot/forge/crypto/sign"
+)
+
+// Cursor is a decoded keyset position: the boundary row's key values in the
+// keyset's column order, plus the direction the caller is paging. A Cursor is
+// opaque state produced and consumed by a Codec; construct it only via
+// Codec.Decode (or the zero value for the first page).
+type Cursor struct {
+	// Keys holds the boundary row's keyset values, one per keyset column.
+	Keys []any
+	// Backward reports that the caller is paging toward the previous page.
+	// Forward (next-page) cursors carry false.
+	Backward bool
+}
+
+// IsZero reports whether the cursor carries no position — the first page,
+// which needs no comparison.
+func (c Cursor) IsZero() bool { return len(c.Keys) == 0 }
+
+// cursorEnvelope is the JSON-serialized cursor body. Field names are terse to
+// keep encoded cursors short.
+type cursorEnvelope struct {
+	K []any `json:"k"`
+	B bool  `json:"b,omitempty"`
+}
+
+// Codec encodes and decodes opaque page cursors: base64url(JSON), optionally
+// suffixed with an HMAC tag when built WithSigner. The signature makes a
+// cursor tamper-evident; it is not required, because a cursor only names a
+// position the caller could otherwise reach with ordinary query parameters.
+type Codec struct {
+	signer *sign.Signer // nil when unsigned
+}
+
+// NewCodec builds a cursor codec. With no options it produces unsigned
+// cursors; WithSigner adds an HMAC tag.
+func NewCodec(opts ...Option) (*Codec, error) {
+	c, err := newConfig(opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &Codec{signer: c.signer}, nil
+}
+
+// Encode serializes cur into an opaque, URL-safe cursor string. A zero cursor
+// encodes to the empty string, so the first page carries no cursor.
+func (c *Codec) Encode(cur Cursor) (string, error) {
+	if cur.IsZero() {
+		return "", nil
+	}
+	raw, err := json.Marshal(cursorEnvelope{K: cur.Keys, B: cur.Backward})
+	if err != nil {
+		return "", fmt.Errorf("pagination: encode cursor: %w", err)
+	}
+	body := base64.RawURLEncoding.EncodeToString(raw)
+	if c.signer == nil {
+		return body, nil
+	}
+	return body + "." + c.signer.SignString(body), nil
+}
+
+// Decode parses an opaque cursor string back into a Cursor. The empty string
+// decodes to the zero cursor (the first page). A malformed or, for a signed
+// codec, tampered cursor returns ErrBadCursor.
+//
+// Numeric values decode losslessly: integral JSON numbers become int64 (so a
+// bigint key survives beyond 2^53), non-integral ones float64.
+func (c *Codec) Decode(s string) (Cursor, error) {
+	if s == "" {
+		return Cursor{}, nil
+	}
+	body := s
+	if c.signer != nil {
+		b, sig, ok := strings.Cut(s, ".")
+		if !ok || !c.signer.VerifyString(b, sig) {
+			return Cursor{}, ErrBadCursor
+		}
+		body = b
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(body)
+	if err != nil {
+		return Cursor{}, ErrBadCursor
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var env cursorEnvelope
+	if err := dec.Decode(&env); err != nil {
+		return Cursor{}, ErrBadCursor
+	}
+	if len(env.K) == 0 {
+		// A position-less cursor is the zero cursor; a lingering Backward flag
+		// would be a "backward first page" nonsense state. IsZero is the one
+		// source of truth for "no position".
+		return Cursor{}, nil
+	}
+	if err := normalizeNumbers(env.K); err != nil {
+		return Cursor{}, err
+	}
+	return Cursor{Keys: env.K, Backward: env.B}, nil
+}
+
+// normalizeNumbers converts each json.Number in keys to int64 when integral,
+// else float64, so decoded keys bind as ordinary Go scalars rather than the
+// json.Number string type a driver would reject. A value representable as
+// neither (magnitude beyond float64) is a malformed cursor: ErrBadCursor,
+// never a json.Number leaking to the driver.
+func normalizeNumbers(keys []any) error {
+	for i, v := range keys {
+		n, ok := v.(json.Number)
+		if !ok {
+			continue
+		}
+		if iv, err := n.Int64(); err == nil {
+			keys[i] = iv
+			continue
+		}
+		fv, err := n.Float64()
+		if err != nil {
+			return ErrBadCursor
+		}
+		keys[i] = fv
+	}
+	return nil
+}

--- a/data/pagination/cursor_test.go
+++ b/data/pagination/cursor_test.go
@@ -1,0 +1,207 @@
+package pagination_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/crypto/sign"
+	"github.com/dmitrymomot/forge/data/pagination"
+)
+
+func newCodec(t *testing.T, opts ...pagination.Option) *pagination.Codec {
+	t.Helper()
+	c, err := pagination.NewCodec(opts...)
+	if err != nil {
+		t.Fatalf("NewCodec: %v", err)
+	}
+	return c
+}
+
+func newSigner(t *testing.T) *sign.Signer {
+	t.Helper()
+	s, err := sign.New([]byte("cursor-signing-key-0123456789"))
+	if err != nil {
+		t.Fatalf("sign.New: %v", err)
+	}
+	return s
+}
+
+func TestCodecRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cur  pagination.Cursor
+	}{
+		{"forward multi", pagination.Cursor{Keys: []any{"2026-01-01T00:00:00Z", int64(7)}}},
+		{"backward flag", pagination.Cursor{Keys: []any{int64(7)}, Backward: true}},
+		{"mixed scalar types", pagination.Cursor{Keys: []any{int64(3), "x", true, 1.5}}},
+	}
+	for _, sign := range []bool{false, true} {
+		var opts []pagination.Option
+		if sign {
+			opts = append(opts, pagination.WithSigner(newSigner(t)))
+		}
+		codec := newCodec(t, opts...)
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				enc, err := codec.Encode(tt.cur)
+				if err != nil {
+					t.Fatalf("Encode: %v", err)
+				}
+				got, err := codec.Decode(enc)
+				if err != nil {
+					t.Fatalf("Decode: %v", err)
+				}
+				if got.Backward != tt.cur.Backward {
+					t.Errorf("Backward: got %v want %v", got.Backward, tt.cur.Backward)
+				}
+				if len(got.Keys) != len(tt.cur.Keys) {
+					t.Fatalf("Keys len: got %d want %d", len(got.Keys), len(tt.cur.Keys))
+				}
+				for i := range got.Keys {
+					if got.Keys[i] != tt.cur.Keys[i] {
+						t.Errorf("Keys[%d]: got %#v (%T) want %#v (%T)", i, got.Keys[i], got.Keys[i], tt.cur.Keys[i], tt.cur.Keys[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestCodecZeroCursor(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	enc, err := codec.Encode(pagination.Cursor{})
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if enc != "" {
+		t.Errorf("zero cursor should encode to empty string, got %q", enc)
+	}
+	got, err := codec.Decode("")
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !got.IsZero() {
+		t.Errorf("empty string should decode to zero cursor, got %#v", got)
+	}
+}
+
+func TestCodecInt64Precision(t *testing.T) {
+	t.Parallel()
+	// A value beyond 2^53 would corrupt if decoded through float64.
+	const big = int64(9007199254740993) // 2^53 + 1
+	codec := newCodec(t)
+	enc, err := codec.Encode(pagination.Cursor{Keys: []any{big}})
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := codec.Decode(enc)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	iv, ok := got.Keys[0].(int64)
+	if !ok {
+		t.Fatalf("expected int64, got %T", got.Keys[0])
+	}
+	if iv != big {
+		t.Errorf("precision lost: got %d want %d", iv, big)
+	}
+}
+
+func TestCodecNonIntegralFloat(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	enc, _ := codec.Encode(pagination.Cursor{Keys: []any{2.5}})
+	got, err := codec.Decode(enc)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if fv, ok := got.Keys[0].(float64); !ok || fv != 2.5 {
+		t.Errorf("got %#v (%T), want float64 2.5", got.Keys[0], got.Keys[0])
+	}
+}
+
+func TestCodecSignedRejectsTamper(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t, pagination.WithSigner(newSigner(t)))
+	enc, _ := codec.Encode(pagination.Cursor{Keys: []any{int64(7)}})
+
+	// Flip a character in the body (before the "." signature separator).
+	body, _, _ := strings.Cut(enc, ".")
+	tampered := flipFirst(body) + enc[len(body):]
+	if _, err := codec.Decode(tampered); !errors.Is(err, pagination.ErrBadCursor) {
+		t.Errorf("tampered body: got %v want ErrBadCursor", err)
+	}
+
+	// Drop the signature entirely.
+	if _, err := codec.Decode(body); !errors.Is(err, pagination.ErrBadCursor) {
+		t.Errorf("missing signature: got %v want ErrBadCursor", err)
+	}
+}
+
+func TestCodecSignedRejectsForeignKey(t *testing.T) {
+	t.Parallel()
+	issuer := newCodec(t, pagination.WithSigner(newSigner(t)))
+	enc, _ := issuer.Encode(pagination.Cursor{Keys: []any{int64(7)}})
+
+	other, err := sign.New([]byte("a-completely-different-key-value"))
+	if err != nil {
+		t.Fatalf("sign.New: %v", err)
+	}
+	verifier := newCodec(t, pagination.WithSigner(other))
+	if _, err := verifier.Decode(enc); !errors.Is(err, pagination.ErrBadCursor) {
+		t.Errorf("foreign signer: got %v want ErrBadCursor", err)
+	}
+}
+
+func TestCodecDecodeMalformed(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	bad := []string{
+		"!!!not base64!!!",
+		"////",                                  // valid base64 chars but not our alphabet edge
+		base64Raw(`{"k":`),                      // truncated JSON
+		base64Raw(`["not","an","object"]`),      // wrong JSON shape
+		base64Raw(`{"k":[1,2,` + "\x00" + `]}`), // control byte
+		base64Raw(`{"k":[1e400]}`),              // number beyond float64 range
+	}
+	for _, s := range bad {
+		if _, err := codec.Decode(s); !errors.Is(err, pagination.ErrBadCursor) {
+			t.Errorf("Decode(%q): got %v want ErrBadCursor", s, err)
+		}
+	}
+}
+
+func TestUnsignedIgnoresSignature(t *testing.T) {
+	t.Parallel()
+	// An unsigned codec treats the whole string as the body, so a value that
+	// happens to contain "." must not be split.
+	unsigned := newCodec(t)
+	enc, _ := unsigned.Encode(pagination.Cursor{Keys: []any{"has.dot.inside"}})
+	got, err := unsigned.Decode(enc)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Keys[0] != "has.dot.inside" {
+		t.Errorf("got %#v", got.Keys[0])
+	}
+}
+
+func TestCodecEncodeUnmarshalable(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	// A channel cannot be JSON-encoded; Encode must surface the error, not
+	// return a silent empty cursor.
+	if _, err := codec.Encode(pagination.Cursor{Keys: []any{make(chan int)}}); err == nil {
+		t.Fatal("expected an encode error for an unmarshalable key")
+	}
+}
+
+func TestWithSignerNil(t *testing.T) {
+	t.Parallel()
+	if _, err := pagination.NewCodec(pagination.WithSigner(nil)); !errors.Is(err, pagination.ErrNilSigner) {
+		t.Errorf("got %v want ErrNilSigner", err)
+	}
+}

--- a/data/pagination/doc.go
+++ b/data/pagination/doc.go
@@ -1,0 +1,61 @@
+// Package pagination provides the two pagination models a SaaS backend needs,
+// as composable pieces that emit SQL fragments rather than run queries.
+//
+// Keyset (cursor) pagination is the default for APIs, feeds, and infinite
+// scroll: it is stable under inserts and O(1) at any depth. A Keyset names the
+// ordered columns — the last unique, every column NOT NULL — and builds the
+// portable OR-of-ANDs WHERE comparison and the ORDER BY list, with a
+// placeholder-dialect option (Dollar "$n" for pgx, Question "?" for
+// ClickHouse/MySQL/SQLite) and a caller-chosen start index so the fragment
+// composes after a query's existing arguments (a tenant scope clause, say). A
+// Codec turns the boundary row's key values into an opaque base64url(JSON)
+// cursor, optionally HMAC-signed via crypto/sign so it is tamper-evident.
+// NewPage assembles the fetched rows and the next/prev cursors into a Page[T],
+// handling forward and backward paging.
+//
+// Offset (numbered) pagination serves server-rendered admin tables: PageCount
+// and Offset drive the LIMIT/OFFSET query, and NewWindow builds the numbered
+// navigation bar — first/last page always shown, a span of pages around the
+// current one, ellipses for the gaps, and per-link query strings preserving
+// the request's other parameters.
+//
+// The package runs no queries and imports no driver: it emits (sql, args) the
+// caller passes to pgx, database/sql, or any builder. Columns are written
+// verbatim and validated as identifiers; cursor values only ever bind as
+// arguments.
+//
+// # Keyset usage
+//
+//	ks := pagination.Keyset{
+//		{Column: "created_at", Desc: true},
+//		{Column: "id", Desc: true}, // unique tiebreaker
+//	}
+//	codec, _ := pagination.NewCodec() // add pagination.WithSigner(s) to sign
+//
+//	cur, err := codec.Decode(r.URL.Query().Get("cursor")) // zero on first page
+//	if err != nil { /* 400 */ }
+//	where, _ := ks.Where(cur, pagination.Dollar, 1)
+//	order, _ := ks.OrderBy(cur.Backward)
+//
+//	const size = 20
+//	sql := "SELECT id, created_at FROM events"
+//	args := []any{}
+//	if where.SQL != "" {
+//		sql += " WHERE " + where.SQL
+//		args = append(args, where.Args...)
+//	}
+//	sql += " ORDER BY " + order + " LIMIT " + strconv.Itoa(size+1) // +1 sentinel
+//
+//	rows, _ := scanEvents(db.Query(ctx, sql, args...))
+//	page, _ := pagination.NewPage(rows, cur, size, func(e Event) []any {
+//		return []any{e.CreatedAt, e.ID}
+//	}, codec)
+//	// page.Items, page.Next, page.Prev
+//
+// # Offset usage
+//
+//	nav := pagination.NewWindow(pagination.WindowConfig{
+//		Page: p, PerPage: 25, Total: total, Span: 2, Query: r.URL.Query(),
+//	})
+//	limit, offset := nav.PerPage, pagination.Offset(nav.Page, nav.PerPage)
+package pagination

--- a/data/pagination/errors.go
+++ b/data/pagination/errors.go
@@ -34,4 +34,9 @@ var (
 	// ErrNilSigner is returned by NewCodec when WithSigner is given a nil
 	// signer.
 	ErrNilSigner = errors.New("pagination: nil signer")
+
+	// ErrInvalidSize is returned by NewPage when the page size is below 1 —
+	// a page must hold at least one row. Guarding it fails closed instead of
+	// panicking on a slice bound when size comes from an unvalidated request.
+	ErrInvalidSize = errors.New("pagination: invalid page size")
 )

--- a/data/pagination/errors.go
+++ b/data/pagination/errors.go
@@ -1,0 +1,37 @@
+package pagination
+
+import "errors"
+
+var (
+	// ErrBadCursor is returned by Codec.Decode when a cursor cannot be
+	// decoded, or when its signature fails to verify. The two cases are
+	// deliberately indistinguishable so a caller cannot probe the boundary.
+	ErrBadCursor = errors.New("pagination: bad cursor")
+
+	// ErrEmptyKeyset is returned by Keyset.Where and Keyset.OrderBy when the
+	// keyset has no columns: a keyset must name at least one column, the last
+	// of which is unique.
+	ErrEmptyKeyset = errors.New("pagination: empty keyset")
+
+	// ErrInvalidColumn is returned when a keyset column is not a plain,
+	// optionally qualified SQL identifier, so a misuse cannot smuggle SQL
+	// into the emitted fragment.
+	ErrInvalidColumn = errors.New("pagination: invalid column identifier")
+
+	// ErrCursorArity is returned by Keyset.Where when the cursor's value
+	// count does not match the keyset's column count — typically a cursor
+	// minted for a different ordering.
+	ErrCursorArity = errors.New("pagination: cursor arity mismatch")
+
+	// ErrInvalidStart is returned by Keyset.Where when the Dollar dialect is
+	// given a placeholder start index below 1.
+	ErrInvalidStart = errors.New("pagination: invalid placeholder start index")
+
+	// ErrInvalidDialect is returned by Keyset.Where when the dialect is
+	// neither Dollar nor Question.
+	ErrInvalidDialect = errors.New("pagination: invalid dialect")
+
+	// ErrNilSigner is returned by NewCodec when WithSigner is given a nil
+	// signer.
+	ErrNilSigner = errors.New("pagination: nil signer")
+)

--- a/data/pagination/example_test.go
+++ b/data/pagination/example_test.go
@@ -1,0 +1,67 @@
+package pagination_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dmitrymomot/forge/data/pagination"
+)
+
+// Building the WHERE and ORDER BY fragments of a keyset page query. The
+// fragments emit (sql, args); the caller runs the query.
+func ExampleKeyset_Where() {
+	ks := pagination.Keyset{
+		{Column: "created_at", Desc: true},
+		{Column: "id", Desc: true}, // unique tiebreaker
+	}
+	cur := pagination.Cursor{Keys: []any{"2026-01-01T00:00:00Z", int64(42)}}
+
+	where, _ := ks.Where(cur, pagination.Dollar, 1)
+	order, _ := ks.OrderBy(cur.Backward)
+
+	fmt.Println("WHERE " + where.SQL)
+	fmt.Println("ORDER BY " + order)
+	fmt.Println(where.Args)
+	// Output:
+	// WHERE ((created_at < $1) OR (created_at = $1 AND id < $2))
+	// ORDER BY created_at DESC, id DESC
+	// [2026-01-01T00:00:00Z 42]
+}
+
+// A cursor round-trips through an opaque string; large integer keys keep full
+// precision.
+func ExampleCodec() {
+	codec, err := pagination.NewCodec() // add pagination.WithSigner(s) to sign
+	if err != nil {
+		panic(err)
+	}
+
+	enc, _ := codec.Encode(pagination.Cursor{Keys: []any{int64(9007199254740993)}})
+	got, _ := codec.Decode(enc)
+
+	fmt.Printf("%d\n", got.Keys[0])
+	// Output:
+	// 9007199254740993
+}
+
+// A numbered navigation bar with ellipses for a deep offset page.
+func ExampleNewWindow() {
+	w := pagination.NewWindow(pagination.WindowConfig{
+		Page: 10, PerPage: 10, Total: 200, Span: 2,
+	})
+
+	labels := make([]string, len(w.Items))
+	for i, it := range w.Items {
+		switch {
+		case it.Ellipsis:
+			labels[i] = "…"
+		case it.Current:
+			labels[i] = fmt.Sprintf("[%d]", it.Page)
+		default:
+			labels[i] = fmt.Sprintf("%d", it.Page)
+		}
+	}
+	fmt.Println(strings.Join(labels, " "))
+	// Output:
+	// 1 … 8 9 [10] 11 12 … 20
+}

--- a/data/pagination/fuzz_test.go
+++ b/data/pagination/fuzz_test.go
@@ -1,0 +1,43 @@
+package pagination_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/data/pagination"
+)
+
+// FuzzDecode asserts Decode never panics and, on the rare valid input, always
+// round-trips: re-encoding the decoded cursor and decoding again is stable.
+func FuzzDecode(f *testing.F) {
+	codec, err := pagination.NewCodec()
+	if err != nil {
+		f.Fatal(err)
+	}
+	for _, seed := range []string{
+		"",
+		"not-base64!!",
+		base64Raw(`{"k":[1,"a",true]}`),
+		base64Raw(`{"k":[9007199254740993],"b":true}`),
+		base64Raw(`{}`),
+		base64Raw(`[]`),
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		cur, err := codec.Decode(s)
+		if err != nil {
+			return // malformed input is expected to error, not panic
+		}
+		enc, err := codec.Encode(cur)
+		if err != nil {
+			t.Fatalf("re-encode of decoded cursor failed: %v", err)
+		}
+		again, err := codec.Decode(enc)
+		if err != nil {
+			t.Fatalf("re-decode failed: %v", err)
+		}
+		if again.Backward != cur.Backward || len(again.Keys) != len(cur.Keys) {
+			t.Fatalf("round-trip drift: %#v -> %#v", cur, again)
+		}
+	})
+}

--- a/data/pagination/helpers_test.go
+++ b/data/pagination/helpers_test.go
@@ -1,0 +1,23 @@
+package pagination_test
+
+import "encoding/base64"
+
+// base64Raw encodes s the way the codec encodes a cursor body, so tests can
+// hand-craft malformed payloads.
+func base64Raw(s string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(s))
+}
+
+// flipFirst returns s with its first byte changed, to corrupt a signed body.
+func flipFirst(s string) string {
+	if s == "" {
+		return "x"
+	}
+	b := []byte(s)
+	if b[0] == 'A' {
+		b[0] = 'B'
+	} else {
+		b[0] = 'A'
+	}
+	return string(b)
+}

--- a/data/pagination/keyset.go
+++ b/data/pagination/keyset.go
@@ -80,9 +80,13 @@ func (k Keyset) Where(cur Cursor, d Dialect, start int) (Fragment, error) {
 
 	n := len(k)
 	var b strings.Builder
-	// Dollar binds each column once and reuses the placeholder; Question
-	// repeats prefix values, so it needs 1+2+…+n = n(n+1)/2 slots.
-	args := make([]any, 0, n*(n+1)/2)
+	// Dollar binds each column once and reuses the placeholder (n values);
+	// Question repeats prefix values, so it needs 1+2+…+n = n(n+1)/2 slots.
+	capArgs := n
+	if d == Question {
+		capArgs = n * (n + 1) / 2
+	}
+	args := make([]any, 0, capArgs)
 	if d == Dollar {
 		args = append(args, cur.Keys...)
 	}

--- a/data/pagination/keyset.go
+++ b/data/pagination/keyset.go
@@ -1,0 +1,199 @@
+package pagination
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Dialect selects the placeholder style of an emitted SQL fragment.
+type Dialect uint8
+
+const (
+	// Dollar numbers placeholders $1, $2, … (PostgreSQL / pgx). It is the
+	// zero value and the default.
+	Dollar Dialect = iota
+	// Question uses positional ? placeholders (ClickHouse, MySQL, SQLite).
+	Question
+)
+
+// Order names one column of a keyset ordering and its direction.
+type Order struct {
+	// Column is the ordered column: a plain, optionally table-qualified SQL
+	// identifier (e.g. "created_at" or "events.created_at"). It is written
+	// into SQL verbatim, so it must be a trusted identifier, never user input.
+	Column string
+	// Desc orders the column descending when true, ascending when false.
+	Desc bool
+}
+
+// Keyset is the ordered list of columns a keyset (cursor) query sorts and
+// pages by. It must form a strict total order: the final column has to be
+// unique (a primary key or ULID) so no two rows compare equal and a page
+// never splits or repeats a row. Every column must be NOT NULL — a NULL
+// keyset value makes the comparison NULL and silently drops rows.
+type Keyset []Order
+
+// Fragment is a parameterized SQL fragment: SQL text plus the arguments its
+// placeholders bind, in placeholder order. The caller concatenates SQL into
+// the query and appends Args to the query's argument list.
+type Fragment struct {
+	// SQL is the fragment text, already parenthesized so it can be safely
+	// joined with AND/OR. It is empty for the first page (a zero cursor).
+	SQL string
+	// Args are the values the fragment's placeholders bind, in the order the
+	// placeholders appear (Question) or by ascending number (Dollar).
+	Args []any
+}
+
+// Where builds the keyset comparison selecting the rows strictly after cur
+// (before, for a backward cursor) in the keyset's order — the WHERE fragment
+// of a keyset page query. A zero cursor yields an empty Fragment (the first
+// page needs no comparison).
+//
+// The comparison is emitted as the portable lexicographic OR-of-ANDs
+// expansion (row-value comparisons are not honored uniformly across engines),
+// e.g. for ("created_at" DESC, "id" DESC):
+//
+//	((created_at < $1) OR (created_at = $1 AND id < $2))
+//
+// start is the number of the fragment's first placeholder (1-based) for the
+// Dollar dialect, so the fragment composes after a query's existing
+// arguments; it is ignored by Question. Dollar reuses each column's
+// placeholder, so Args holds one value per column; Question cannot reuse
+// positional placeholders, so Args repeats the prefix values.
+func (k Keyset) Where(cur Cursor, d Dialect, start int) (Fragment, error) {
+	if err := k.validate(); err != nil {
+		return Fragment{}, err
+	}
+	if d != Dollar && d != Question {
+		return Fragment{}, ErrInvalidDialect
+	}
+	if d == Dollar && start < 1 {
+		return Fragment{}, ErrInvalidStart
+	}
+	if cur.IsZero() {
+		return Fragment{}, nil
+	}
+	if len(cur.Keys) != len(k) {
+		return Fragment{}, ErrCursorArity
+	}
+
+	n := len(k)
+	var b strings.Builder
+	// Dollar binds each column once and reuses the placeholder; Question
+	// repeats prefix values, so it needs 1+2+…+n = n(n+1)/2 slots.
+	args := make([]any, 0, n*(n+1)/2)
+	if d == Dollar {
+		args = append(args, cur.Keys...)
+	}
+
+	writePlaceholder := func(col int) {
+		if d == Dollar {
+			b.WriteByte('$')
+			b.WriteString(strconv.Itoa(start + col))
+			return
+		}
+		b.WriteByte('?')
+		args = append(args, cur.Keys[col])
+	}
+
+	b.WriteByte('(')
+	for i := range n {
+		if i > 0 {
+			b.WriteString(" OR ")
+		}
+		if n > 1 {
+			b.WriteByte('(')
+		}
+		for j := range i { // equality prefix on the columns before i
+			b.WriteString(k[j].Column)
+			b.WriteString(" = ")
+			writePlaceholder(j)
+			b.WriteString(" AND ")
+		}
+		b.WriteString(k[i].Column)
+		b.WriteByte(' ')
+		b.WriteString(strictOp(k[i].Desc, cur.Backward))
+		b.WriteByte(' ')
+		writePlaceholder(i)
+		if n > 1 {
+			b.WriteByte(')')
+		}
+	}
+	b.WriteByte(')')
+
+	return Fragment{SQL: b.String(), Args: args}, nil
+}
+
+// OrderBy builds the keyset's ORDER BY column list (without the "ORDER BY "
+// keyword), e.g. "created_at DESC, id DESC". A backward cursor reverses every
+// column's direction so the previous page can be fetched in reverse and its
+// rows restored to display order (NewPage does the restoring).
+func (k Keyset) OrderBy(backward bool) (string, error) {
+	if err := k.validate(); err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for i, o := range k {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(o.Column)
+		if o.Desc != backward { // Desc XOR backward
+			b.WriteString(" DESC")
+		} else {
+			b.WriteString(" ASC")
+		}
+	}
+	return b.String(), nil
+}
+
+func (k Keyset) validate() error {
+	if len(k) == 0 {
+		return ErrEmptyKeyset
+	}
+	for _, o := range k {
+		if !validColumn(o.Column) {
+			return ErrInvalidColumn
+		}
+	}
+	return nil
+}
+
+// strictOp returns the strict comparison operator selecting rows after the
+// cursor for a column: ascending forward is ">", descending forward is "<",
+// and a backward cursor flips both.
+func strictOp(desc, backward bool) string {
+	if desc != backward { // Desc XOR backward
+		return "<"
+	}
+	return ">"
+}
+
+// validColumn reports whether s is an SQL identifier of the form part or
+// part.part, where each part is [A-Za-z_][A-Za-z0-9_]*.
+func validColumn(s string) bool {
+	dots := 0
+	atPartStart := true
+	for i := range len(s) {
+		switch c := s[i]; {
+		case c == '.':
+			if atPartStart {
+				return false
+			}
+			if dots++; dots > 1 {
+				return false
+			}
+			atPartStart = true
+		case c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'):
+			atPartStart = false
+		case c >= '0' && c <= '9':
+			if atPartStart {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return !atPartStart // rejects "", trailing dot, and empty parts
+}

--- a/data/pagination/keyset_test.go
+++ b/data/pagination/keyset_test.go
@@ -1,0 +1,219 @@
+package pagination_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/dmitrymomot/forge/data/pagination"
+)
+
+func TestKeysetWhere(t *testing.T) {
+	t.Parallel()
+
+	single := pagination.Keyset{{Column: "id", Desc: false}}
+	multi := pagination.Keyset{
+		{Column: "created_at", Desc: true},
+		{Column: "id", Desc: true},
+	}
+
+	tests := []struct {
+		name    string
+		ks      pagination.Keyset
+		cur     pagination.Cursor
+		dialect pagination.Dialect
+		start   int
+		wantSQL string
+		wantArg []any
+	}{
+		{
+			name:    "single asc dollar forward",
+			ks:      single,
+			cur:     pagination.Cursor{Keys: []any{int64(42)}},
+			dialect: pagination.Dollar,
+			start:   1,
+			wantSQL: "(id > $1)",
+			wantArg: []any{int64(42)},
+		},
+		{
+			name:    "single asc question forward",
+			ks:      single,
+			cur:     pagination.Cursor{Keys: []any{int64(42)}},
+			dialect: pagination.Question,
+			start:   1,
+			wantSQL: "(id > ?)",
+			wantArg: []any{int64(42)},
+		},
+		{
+			name:    "multi desc dollar forward",
+			ks:      multi,
+			cur:     pagination.Cursor{Keys: []any{"2026-01-01", int64(7)}},
+			dialect: pagination.Dollar,
+			start:   1,
+			wantSQL: "((created_at < $1) OR (created_at = $1 AND id < $2))",
+			wantArg: []any{"2026-01-01", int64(7)},
+		},
+		{
+			name:    "multi desc question forward repeats prefix",
+			ks:      multi,
+			cur:     pagination.Cursor{Keys: []any{"2026-01-01", int64(7)}},
+			dialect: pagination.Question,
+			start:   1,
+			wantSQL: "((created_at < ?) OR (created_at = ? AND id < ?))",
+			wantArg: []any{"2026-01-01", "2026-01-01", int64(7)},
+		},
+		{
+			name:    "multi desc dollar backward flips ops",
+			ks:      multi,
+			cur:     pagination.Cursor{Keys: []any{"2026-01-01", int64(7)}, Backward: true},
+			dialect: pagination.Dollar,
+			start:   1,
+			wantSQL: "((created_at > $1) OR (created_at = $1 AND id > $2))",
+			wantArg: []any{"2026-01-01", int64(7)},
+		},
+		{
+			name: "mixed directions dollar forward",
+			ks: pagination.Keyset{
+				{Column: "score", Desc: true},
+				{Column: "name", Desc: false},
+				{Column: "id", Desc: false},
+			},
+			cur:     pagination.Cursor{Keys: []any{int64(9), "bob", int64(3)}},
+			dialect: pagination.Dollar,
+			start:   1,
+			wantSQL: "((score < $1) OR (score = $1 AND name > $2) OR (score = $1 AND name = $2 AND id > $3))",
+			wantArg: []any{int64(9), "bob", int64(3)},
+		},
+		{
+			name:    "dollar start offset composes after existing args",
+			ks:      multi,
+			cur:     pagination.Cursor{Keys: []any{"2026-01-01", int64(7)}},
+			dialect: pagination.Dollar,
+			start:   3,
+			wantSQL: "((created_at < $3) OR (created_at = $3 AND id < $4))",
+			wantArg: []any{"2026-01-01", int64(7)},
+		},
+		{
+			name:    "zero cursor yields empty fragment",
+			ks:      multi,
+			cur:     pagination.Cursor{},
+			dialect: pagination.Dollar,
+			start:   1,
+			wantSQL: "",
+			wantArg: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.ks.Where(tt.cur, tt.dialect, tt.start)
+			if err != nil {
+				t.Fatalf("Where: unexpected error: %v", err)
+			}
+			if got.SQL != tt.wantSQL {
+				t.Errorf("SQL:\n got %q\nwant %q", got.SQL, tt.wantSQL)
+			}
+			if !reflect.DeepEqual(got.Args, tt.wantArg) {
+				t.Errorf("Args: got %#v want %#v", got.Args, tt.wantArg)
+			}
+		})
+	}
+}
+
+func TestKeysetWhereErrors(t *testing.T) {
+	t.Parallel()
+
+	valid := pagination.Keyset{{Column: "id"}}
+	tests := []struct {
+		name    string
+		ks      pagination.Keyset
+		cur     pagination.Cursor
+		dialect pagination.Dialect
+		start   int
+		wantErr error
+	}{
+		{"empty keyset", pagination.Keyset{}, pagination.Cursor{Keys: []any{1}}, pagination.Dollar, 1, pagination.ErrEmptyKeyset},
+		{"invalid column", pagination.Keyset{{Column: "id; DROP TABLE"}}, pagination.Cursor{Keys: []any{1}}, pagination.Dollar, 1, pagination.ErrInvalidColumn},
+		{"arity mismatch", pagination.Keyset{{Column: "a"}, {Column: "b"}}, pagination.Cursor{Keys: []any{1}}, pagination.Dollar, 1, pagination.ErrCursorArity},
+		{"bad dialect", valid, pagination.Cursor{Keys: []any{1}}, pagination.Dialect(9), 1, pagination.ErrInvalidDialect},
+		{"dollar start below 1", valid, pagination.Cursor{Keys: []any{1}}, pagination.Dollar, 0, pagination.ErrInvalidStart},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tt.ks.Where(tt.cur, tt.dialect, tt.start)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("got %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestKeysetWhereQuestionIgnoresStart(t *testing.T) {
+	t.Parallel()
+	ks := pagination.Keyset{{Column: "id"}}
+	got, err := ks.Where(pagination.Cursor{Keys: []any{int64(1)}}, pagination.Question, 0)
+	if err != nil {
+		t.Fatalf("Question with start 0 should be valid: %v", err)
+	}
+	if got.SQL != "(id > ?)" {
+		t.Errorf("got %q", got.SQL)
+	}
+}
+
+func TestKeysetOrderBy(t *testing.T) {
+	t.Parallel()
+	ks := pagination.Keyset{
+		{Column: "created_at", Desc: true},
+		{Column: "id", Desc: false},
+	}
+	tests := []struct {
+		name     string
+		backward bool
+		want     string
+	}{
+		{"forward", false, "created_at DESC, id ASC"},
+		{"backward reverses each", true, "created_at ASC, id DESC"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ks.OrderBy(tt.backward)
+			if err != nil {
+				t.Fatalf("OrderBy: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKeysetOrderByErrors(t *testing.T) {
+	t.Parallel()
+	if _, err := (pagination.Keyset{}).OrderBy(false); !errors.Is(err, pagination.ErrEmptyKeyset) {
+		t.Errorf("empty: got %v", err)
+	}
+	if _, err := (pagination.Keyset{{Column: "1bad"}}).OrderBy(false); !errors.Is(err, pagination.ErrInvalidColumn) {
+		t.Errorf("bad column: got %v", err)
+	}
+}
+
+func TestValidColumn(t *testing.T) {
+	t.Parallel()
+	// Exercised through Where, which rejects invalid identifiers.
+	bad := []string{"", "a.", ".a", "a..b", "a b", "a-b", "1a", "a.b.c", "a;b", "col)"}
+	for _, col := range bad {
+		if _, err := (pagination.Keyset{{Column: col}}).OrderBy(false); !errors.Is(err, pagination.ErrInvalidColumn) {
+			t.Errorf("column %q: expected ErrInvalidColumn, got %v", col, err)
+		}
+	}
+	good := []string{"id", "created_at", "events.created_at", "_x", "a1"}
+	for _, col := range good {
+		if _, err := (pagination.Keyset{{Column: col}}).OrderBy(false); err != nil {
+			t.Errorf("column %q: unexpected error %v", col, err)
+		}
+	}
+}

--- a/data/pagination/options.go
+++ b/data/pagination/options.go
@@ -1,0 +1,41 @@
+package pagination
+
+import (
+	"errors"
+
+	"github.com/dmitrymomot/forge/crypto/sign"
+)
+
+// config holds resolved codec settings before construction.
+type config struct {
+	signer *sign.Signer
+	errs   []error
+}
+
+// Option configures NewCodec. Invalid values accumulate and are returned.
+type Option func(*config)
+
+func newConfig(opts ...Option) (*config, error) {
+	c := &config{}
+	for _, o := range opts {
+		o(c)
+	}
+	if len(c.errs) > 0 {
+		return nil, errors.Join(c.errs...)
+	}
+	return c, nil
+}
+
+// WithSigner signs cursors with the given HMAC signer, making them
+// tamper-evident: Decode returns ErrBadCursor for a forged or altered cursor.
+// A keyset-backed signer (sign.FromKeyset) verifies cursors across key
+// rotation. A nil signer is rejected with ErrNilSigner.
+func WithSigner(s *sign.Signer) Option {
+	return func(c *config) {
+		if s == nil {
+			c.errs = append(c.errs, ErrNilSigner)
+			return
+		}
+		c.signer = s
+	}
+}

--- a/data/pagination/page.go
+++ b/data/pagination/page.go
@@ -1,0 +1,88 @@
+package pagination
+
+// Page is one page of keyset results plus the opaque cursors to fetch the
+// adjacent pages. A cursor is empty when there is no such page: Prev is empty
+// on the first page, Next on the last.
+type Page[T any] struct {
+	// Next fetches the following page (a forward cursor); empty on the last
+	// page.
+	Next string
+	// Prev fetches the preceding page (a backward cursor); empty on the first
+	// page.
+	Prev string
+	// Items are the rows of this page, in display order.
+	Items []T
+}
+
+// KeyFunc extracts a row's keyset values in the keyset's column order — the
+// same columns, in the same order, as the Keyset driving the query.
+type KeyFunc[T any] func(T) []any
+
+// NewPage assembles a Page from the rows a keyset query returned. Fetch one
+// more row than the page size (LIMIT size+1) so NewPage can detect an adjacent
+// page; it trims that sentinel. cur is the request's decoded cursor: its
+// Backward flag and whether it is zero decide which adjacent cursors exist.
+//
+// Pass rows exactly as the query returned them. For a backward request the
+// query's ORDER BY is reversed (Keyset.OrderBy with backward true), so rows
+// arrive in reverse display order; NewPage restores display order. key must
+// extract the same columns the keyset orders by.
+func NewPage[T any](rows []T, cur Cursor, size int, key KeyFunc[T], codec *Codec) (Page[T], error) {
+	hasExtra := len(rows) > size
+	if hasExtra {
+		rows = rows[:size] // drop the sentinel (last row in the query's order)
+	}
+	if cur.Backward {
+		reverse(rows) // reverse-ordered fetch → display order
+	}
+
+	page := Page[T]{Items: rows}
+	if len(rows) == 0 {
+		return page, nil
+	}
+
+	first := Cursor{Keys: key(rows[0]), Backward: true}
+	last := Cursor{Keys: key(rows[len(rows)-1]), Backward: false}
+
+	if cur.Backward {
+		// Came from a later page, so a next page always exists; an earlier
+		// page exists only when a sentinel row was trimmed.
+		next, err := codec.Encode(last)
+		if err != nil {
+			return Page[T]{}, err
+		}
+		page.Next = next
+		if hasExtra {
+			prev, err := codec.Encode(first)
+			if err != nil {
+				return Page[T]{}, err
+			}
+			page.Prev = prev
+		}
+		return page, nil
+	}
+
+	// Forward (or first page): a next page exists only when a sentinel row
+	// was trimmed; a previous page exists only when the request had a cursor.
+	if hasExtra {
+		next, err := codec.Encode(last)
+		if err != nil {
+			return Page[T]{}, err
+		}
+		page.Next = next
+	}
+	if !cur.IsZero() {
+		prev, err := codec.Encode(first)
+		if err != nil {
+			return Page[T]{}, err
+		}
+		page.Prev = prev
+	}
+	return page, nil
+}
+
+func reverse[T any](s []T) {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
+}

--- a/data/pagination/page.go
+++ b/data/pagination/page.go
@@ -27,7 +27,13 @@ type KeyFunc[T any] func(T) []any
 // query's ORDER BY is reversed (Keyset.OrderBy with backward true), so rows
 // arrive in reverse display order; NewPage restores display order. key must
 // extract the same columns the keyset orders by.
+//
+// size must be at least 1 (ErrInvalidSize otherwise), so a size taken from an
+// unvalidated request fails closed rather than panicking on a slice bound.
 func NewPage[T any](rows []T, cur Cursor, size int, key KeyFunc[T], codec *Codec) (Page[T], error) {
+	if size < 1 {
+		return Page[T]{}, ErrInvalidSize
+	}
 	hasExtra := len(rows) > size
 	if hasExtra {
 		rows = rows[:size] // drop the sentinel (last row in the query's order)

--- a/data/pagination/page_test.go
+++ b/data/pagination/page_test.go
@@ -1,6 +1,7 @@
 package pagination_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/dmitrymomot/forge/data/pagination"
@@ -190,6 +191,18 @@ func TestNewPageEncodeErrorPropagates(t *testing.T) {
 	}
 	if _, err := pagination.NewPage(rows(-1, 8), pagination.Cursor{Keys: []any{int64(11)}}, 2, condKey, codec); err == nil {
 		t.Error("forward prev: expected an encode error")
+	}
+}
+
+func TestNewPageInvalidSize(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	// A non-positive size (e.g. an unvalidated ?limit=-1) must fail closed,
+	// never panic on the rows[:size] slice bound.
+	for _, size := range []int{0, -1, -100} {
+		if _, err := pagination.NewPage(rows(3, 2, 1), pagination.Cursor{}, size, rowKey, codec); !errors.Is(err, pagination.ErrInvalidSize) {
+			t.Errorf("size %d: got %v, want ErrInvalidSize", size, err)
+		}
 	}
 }
 

--- a/data/pagination/page_test.go
+++ b/data/pagination/page_test.go
@@ -1,0 +1,206 @@
+package pagination_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/data/pagination"
+)
+
+type row struct{ id int64 }
+
+func rowKey(r row) []any { return []any{r.id} }
+
+// rows builds a slice of rows with the given ids.
+func rows(ids ...int64) []row {
+	out := make([]row, len(ids))
+	for i, id := range ids {
+		out[i] = row{id: id}
+	}
+	return out
+}
+
+func ids(rs []row) []int64 {
+	out := make([]int64, len(rs))
+	for i, r := range rs {
+		out[i] = r.id
+	}
+	return out
+}
+
+// decodeIDs decodes a cursor and returns its single int64 key plus its
+// Backward flag; the cursor must be non-empty.
+func decodeIDs(t *testing.T, codec *pagination.Codec, cur string) (int64, bool) {
+	t.Helper()
+	if cur == "" {
+		t.Fatal("expected a non-empty cursor")
+	}
+	c, err := codec.Decode(cur)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	return c.Keys[0].(int64), c.Backward
+}
+
+func TestNewPageForwardFirstPageHasMore(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	const size = 3
+	// Fetched size+1 rows: a next page exists, no cursor was sent → no prev.
+	fetched := rows(10, 9, 8, 7)
+	page, err := pagination.NewPage(fetched, pagination.Cursor{}, size, rowKey, codec)
+	if err != nil {
+		t.Fatalf("NewPage: %v", err)
+	}
+	if got := ids(page.Items); !equalIDs(got, []int64{10, 9, 8}) {
+		t.Errorf("Items: got %v", got)
+	}
+	if page.Prev != "" {
+		t.Errorf("first page must have no Prev, got %q", page.Prev)
+	}
+	if page.Next == "" {
+		t.Fatal("expected a Next cursor")
+	}
+	if key, backward := decodeIDs(t, codec, page.Next); key != 8 || backward {
+		t.Errorf("Next: got key=%d backward=%v, want 8/false", key, backward)
+	}
+}
+
+func TestNewPageForwardFirstPageNoMore(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	const size = 3
+	page, err := pagination.NewPage(rows(10, 9), pagination.Cursor{}, size, rowKey, codec)
+	if err != nil {
+		t.Fatalf("NewPage: %v", err)
+	}
+	if page.Next != "" || page.Prev != "" {
+		t.Errorf("single short page: Next=%q Prev=%q, want both empty", page.Next, page.Prev)
+	}
+	if got := ids(page.Items); !equalIDs(got, []int64{10, 9}) {
+		t.Errorf("Items: got %v", got)
+	}
+}
+
+func TestNewPageForwardMiddlePage(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	const size = 2
+	// A forward request that arrived with a cursor → prev exists; extra row → next exists.
+	req := pagination.Cursor{Keys: []any{int64(11)}, Backward: false}
+	page, err := pagination.NewPage(rows(9, 8, 7), req, size, rowKey, codec)
+	if err != nil {
+		t.Fatalf("NewPage: %v", err)
+	}
+	if got := ids(page.Items); !equalIDs(got, []int64{9, 8}) {
+		t.Errorf("Items: got %v", got)
+	}
+	if key, backward := decodeIDs(t, codec, page.Next); key != 8 || backward {
+		t.Errorf("Next: got %d/%v want 8/false", key, backward)
+	}
+	if key, backward := decodeIDs(t, codec, page.Prev); key != 9 || !backward {
+		t.Errorf("Prev: got %d/%v want 9/true", key, backward)
+	}
+}
+
+func TestNewPageBackward(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	const size = 2
+	// Backward query returns rows in reversed (ascending) order with a sentinel.
+	// Display order is DESC, so the previous page of {..,8,9} before a later
+	// page is {9,8}; fetched reversed = {8,9,10-sentinel}.
+	req := pagination.Cursor{Keys: []any{int64(7)}, Backward: true}
+	fetched := rows(8, 9, 10) // reversed order, 10 is the sentinel (earliest-back)
+	page, err := pagination.NewPage(fetched, req, size, rowKey, codec)
+	if err != nil {
+		t.Fatalf("NewPage: %v", err)
+	}
+	// Sentinel (10) trimmed, remaining {8,9} reversed to display order {9,8}.
+	if got := ids(page.Items); !equalIDs(got, []int64{9, 8}) {
+		t.Errorf("Items: got %v want [9 8]", got)
+	}
+	// Next always exists coming from a later page; from last display row (8), forward.
+	if key, backward := decodeIDs(t, codec, page.Next); key != 8 || backward {
+		t.Errorf("Next: got %d/%v want 8/false", key, backward)
+	}
+	// Sentinel present → an earlier page exists; Prev from first display row (9), backward.
+	if key, backward := decodeIDs(t, codec, page.Prev); key != 9 || !backward {
+		t.Errorf("Prev: got %d/%v want 9/true", key, backward)
+	}
+}
+
+func TestNewPageBackwardReachesFirstPage(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	const size = 3
+	// Backward with no sentinel → we've reached the first page: no Prev.
+	req := pagination.Cursor{Keys: []any{int64(7)}, Backward: true}
+	fetched := rows(8, 9, 10) // exactly size, reversed
+	page, err := pagination.NewPage(fetched, req, size, rowKey, codec)
+	if err != nil {
+		t.Fatalf("NewPage: %v", err)
+	}
+	if got := ids(page.Items); !equalIDs(got, []int64{10, 9, 8}) {
+		t.Errorf("Items: got %v want [10 9 8]", got)
+	}
+	if page.Prev != "" {
+		t.Errorf("first page reached: Prev should be empty, got %q", page.Prev)
+	}
+	if page.Next == "" {
+		t.Error("expected a Next cursor")
+	}
+}
+
+func TestNewPageEmpty(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	page, err := pagination.NewPage([]row{}, pagination.Cursor{Keys: []any{int64(1)}}, 3, rowKey, codec)
+	if err != nil {
+		t.Fatalf("NewPage: %v", err)
+	}
+	if len(page.Items) != 0 || page.Next != "" || page.Prev != "" {
+		t.Errorf("empty result: got items=%d next=%q prev=%q", len(page.Items), page.Next, page.Prev)
+	}
+}
+
+func TestNewPageEncodeErrorPropagates(t *testing.T) {
+	t.Parallel()
+	codec := newCodec(t)
+	// A key func returning an unmarshalable value makes the cursor Encode
+	// fail; NewPage must return that error rather than a half-built page.
+	badKey := func(row) []any { return []any{make(chan int)} }
+
+	// Forward with a sentinel row → Next is encoded.
+	if _, err := pagination.NewPage(rows(3, 2, 1), pagination.Cursor{}, 2, badKey, codec); err == nil {
+		t.Error("forward: expected an encode error")
+	}
+	// Backward → Next is always encoded.
+	req := pagination.Cursor{Keys: []any{int64(9)}, Backward: true}
+	if _, err := pagination.NewPage(rows(1, 2, 3), req, 2, badKey, codec); err == nil {
+		t.Error("backward: expected an encode error")
+	}
+
+	// Forward Prev branch: no sentinel (so Next is skipped) but a request
+	// cursor is present, so only the Prev cursor (from the first row) encodes.
+	condKey := func(r row) []any {
+		if r.id < 0 {
+			return []any{make(chan int)}
+		}
+		return []any{r.id}
+	}
+	if _, err := pagination.NewPage(rows(-1, 8), pagination.Cursor{Keys: []any{int64(11)}}, 2, condKey, codec); err == nil {
+		t.Error("forward prev: expected an encode error")
+	}
+}
+
+func equalIDs(a, b []int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/data/pagination/window.go
+++ b/data/pagination/window.go
@@ -1,0 +1,178 @@
+package pagination
+
+import (
+	"maps"
+	"net/url"
+	"strconv"
+)
+
+// WindowConfig parameterizes NewWindow.
+type WindowConfig struct {
+	// Query, when non-nil, is the current request's query values. NewWindow
+	// copies it per link and overwrites Param, so each WindowItem and the
+	// Prev/Next links carry a ready query string preserving all other params
+	// (filters, sort). Nil leaves the Query fields empty.
+	Query url.Values
+	// Param is the query parameter naming the page (default "page").
+	Param string
+	// Page is the current page, 1-based. Values outside [1, total pages] clamp.
+	Page int
+	// PerPage is the page size. Values below 1 are treated as 1.
+	PerPage int
+	// Total is the total item count across all pages.
+	Total int
+	// Span is how many page links show on each side of the current page
+	// before an ellipsis (a common value is 2). Negative values are treated
+	// as 0.
+	Span int
+}
+
+// WindowItem is one entry in the page-number bar: a page link, the current
+// page, or an ellipsis standing in for a skipped range.
+type WindowItem struct {
+	// Query is the encoded query string for this page's link (e.g.
+	// "page=3&sort=name"), set when WindowConfig.Query is non-nil; empty for
+	// an ellipsis.
+	Query string
+	// Page is the page number this item links to; 0 for an ellipsis.
+	Page int
+	// Current marks the item for the current page.
+	Current bool
+	// Ellipsis marks a gap standing in for skipped pages.
+	Ellipsis bool
+}
+
+// Window is the view-model for a numbered pagination bar in server-rendered
+// navigation: the elided run of page links plus the resolved previous/next
+// links. It is built by NewWindow from an offset-paginated request.
+type Window struct {
+	// PrevQuery and NextQuery are the encoded query strings for the previous
+	// and next pages, set when WindowConfig.Query is non-nil; empty when that
+	// direction has no page.
+	PrevQuery string
+	NextQuery string
+	// Items is the page-number bar, in display order, with ellipses inserted.
+	Items []WindowItem
+	// Page is the effective (clamped) current page.
+	Page int
+	// PerPage is the effective page size (at least 1).
+	PerPage int
+	// Total is the total item count.
+	Total int
+	// TotalPages is the number of pages (at least 1).
+	TotalPages int
+	// PrevPage and NextPage are the adjacent page numbers; 0 when absent.
+	PrevPage int
+	NextPage int
+	// HasPrev and HasNext report whether an adjacent page exists.
+	HasPrev bool
+	HasNext bool
+}
+
+// NewWindow computes the numbered navigation bar for an offset-paginated
+// request. It always shows the first and last page, a run of Span pages on
+// each side of the current page, and an ellipsis wherever pages are skipped.
+func NewWindow(cfg WindowConfig) Window {
+	perPage := max(cfg.PerPage, 1)
+	span := max(cfg.Span, 0)
+	total := max(cfg.Total, 0)
+
+	totalPages := PageCount(total, perPage)
+	page := min(max(cfg.Page, 1), totalPages)
+
+	param := cfg.Param
+	if param == "" {
+		param = "page"
+	}
+	// Encode the other query params once, then append "&param=N" per link,
+	// instead of cloning and re-encoding the whole map for every page number.
+	var prefix string
+	if cfg.Query != nil {
+		base := maps.Clone(cfg.Query)
+		base.Del(param)
+		if enc := base.Encode(); enc != "" {
+			prefix = enc + "&"
+		}
+	}
+	pair := url.QueryEscape(param) + "="
+	link := func(n int) string {
+		if cfg.Query == nil {
+			return ""
+		}
+		return prefix + pair + strconv.Itoa(n)
+	}
+
+	w := Window{
+		Page:       page,
+		PerPage:    perPage,
+		Total:      total,
+		TotalPages: totalPages,
+		HasPrev:    page > 1,
+		HasNext:    page < totalPages,
+	}
+	if w.HasPrev {
+		w.PrevPage = page - 1
+		w.PrevQuery = link(page - 1)
+	}
+	if w.HasNext {
+		w.NextPage = page + 1
+		w.NextQuery = link(page + 1)
+	}
+
+	item := func(n int) WindowItem {
+		return WindowItem{Page: n, Current: n == page, Query: link(n)}
+	}
+	ellipsis := WindowItem{Ellipsis: true}
+
+	// 1 … [page-span, page+span] … totalPages. An ellipsis stands in only for
+	// a gap of two or more pages; a one-page gap shows that page's digit,
+	// since the ellipsis would cost the same space yet not be clickable.
+	w.Items = append(w.Items, item(1))
+	start := max(2, page-span)
+	end := min(totalPages-1, page+span)
+	switch {
+	case start == 3:
+		w.Items = append(w.Items, item(2))
+	case start > 3:
+		w.Items = append(w.Items, ellipsis)
+	}
+	for n := start; n <= end; n++ {
+		w.Items = append(w.Items, item(n))
+	}
+	switch {
+	case end == totalPages-2:
+		w.Items = append(w.Items, item(totalPages-1))
+	case end < totalPages-2:
+		w.Items = append(w.Items, ellipsis)
+	}
+	if totalPages > 1 {
+		w.Items = append(w.Items, item(totalPages))
+	}
+	return w
+}
+
+// PageCount returns the number of pages holding total items at perPage per
+// page — at least 1, so an empty result still has a first page. perPage below
+// 1 is treated as 1.
+func PageCount(total, perPage int) int {
+	if perPage < 1 {
+		perPage = 1
+	}
+	if total <= 0 {
+		return 1
+	}
+	return (total + perPage - 1) / perPage
+}
+
+// Offset returns the SQL OFFSET for a 1-based page at perPage per page: the
+// count of rows to skip. page below 1 and perPage below 1 clamp to 1, so the
+// result is never negative.
+func Offset(page, perPage int) int {
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 {
+		perPage = 1
+	}
+	return (page - 1) * perPage
+}

--- a/data/pagination/window_test.go
+++ b/data/pagination/window_test.go
@@ -1,0 +1,209 @@
+package pagination_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/dmitrymomot/forge/data/pagination"
+)
+
+// bar renders a Window's items as a compact string: page numbers, "." for the
+// current page's number wrapper, and "…" for an ellipsis.
+func bar(w pagination.Window) string {
+	out := ""
+	for i, it := range w.Items {
+		if i > 0 {
+			out += " "
+		}
+		switch {
+		case it.Ellipsis:
+			out += "…"
+		case it.Current:
+			out += "[" + itoa(it.Page) + "]"
+		default:
+			out += itoa(it.Page)
+		}
+	}
+	return out
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+func TestNewWindowBar(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		page, perPage int
+		total, span   int
+		want          string
+	}{
+		{"single page", 1, 10, 5, 2, "[1]"},
+		{"two pages", 1, 10, 20, 2, "[1] 2"},
+		{"no gaps small", 3, 10, 50, 2, "1 2 [3] 4 5"},
+		{"gap on the right", 2, 10, 200, 2, "1 [2] 3 4 … 20"},
+		{"gaps both sides", 10, 10, 200, 2, "1 … 8 9 [10] 11 12 … 20"},
+		{"gap on the left", 19, 10, 200, 2, "1 … 17 18 [19] 20"},
+		{"span zero", 6, 10, 200, 0, "1 … [6] … 20"},
+		{"adjacent to edges no ellipsis", 3, 10, 200, 2, "1 2 [3] 4 5 … 20"},
+		{"single left gap shows digit not ellipsis", 5, 10, 200, 2, "1 2 3 4 [5] 6 7 … 20"},
+		{"single right gap shows digit not ellipsis", 16, 10, 200, 2, "1 … 14 15 [16] 17 18 19 20"},
+		{"single gaps both sides", 5, 10, 90, 2, "1 2 3 4 [5] 6 7 8 9"},
+		{"clamp page above total", 99, 10, 30, 2, "1 2 [3]"},
+		{"clamp page below one", -5, 10, 30, 2, "[1] 2 3"},
+		{"zero total is one page", 1, 10, 0, 2, "[1]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			w := pagination.NewWindow(pagination.WindowConfig{
+				Page: tt.page, PerPage: tt.perPage, Total: tt.total, Span: tt.span,
+			})
+			if got := bar(w); got != tt.want {
+				t.Errorf("bar:\n got %q\nwant %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewWindowMeta(t *testing.T) {
+	t.Parallel()
+	w := pagination.NewWindow(pagination.WindowConfig{Page: 3, PerPage: 10, Total: 95, Span: 2})
+	if w.TotalPages != 10 {
+		t.Errorf("TotalPages: got %d want 10", w.TotalPages)
+	}
+	if w.Page != 3 || w.PerPage != 10 || w.Total != 95 {
+		t.Errorf("meta: got page=%d perPage=%d total=%d", w.Page, w.PerPage, w.Total)
+	}
+	if !w.HasPrev || w.PrevPage != 2 {
+		t.Errorf("prev: has=%v page=%d", w.HasPrev, w.PrevPage)
+	}
+	if !w.HasNext || w.NextPage != 4 {
+		t.Errorf("next: has=%v page=%d", w.HasNext, w.NextPage)
+	}
+}
+
+func TestNewWindowEdgesNoAdjacent(t *testing.T) {
+	t.Parallel()
+	first := pagination.NewWindow(pagination.WindowConfig{Page: 1, PerPage: 10, Total: 30})
+	if first.HasPrev || first.PrevPage != 0 {
+		t.Errorf("first page must have no prev: has=%v page=%d", first.HasPrev, first.PrevPage)
+	}
+	last := pagination.NewWindow(pagination.WindowConfig{Page: 3, PerPage: 10, Total: 30})
+	if last.HasNext || last.NextPage != 0 {
+		t.Errorf("last page must have no next: has=%v page=%d", last.HasNext, last.NextPage)
+	}
+}
+
+func TestNewWindowLinksPreserveParams(t *testing.T) {
+	t.Parallel()
+	q := url.Values{"sort": {"name"}, "status": {"active"}, "page": {"2"}}
+	w := pagination.NewWindow(pagination.WindowConfig{
+		Page: 2, PerPage: 10, Total: 100, Span: 1, Query: q,
+	})
+	// Each link carries the other params and sets page to its own number.
+	for _, it := range w.Items {
+		if it.Ellipsis {
+			if it.Query != "" {
+				t.Errorf("ellipsis must have empty query, got %q", it.Query)
+			}
+			continue
+		}
+		got, err := url.ParseQuery(it.Query)
+		if err != nil {
+			t.Fatalf("ParseQuery(%q): %v", it.Query, err)
+		}
+		if got.Get("sort") != "name" || got.Get("status") != "active" {
+			t.Errorf("page %d dropped params: %q", it.Page, it.Query)
+		}
+		if got.Get("page") != itoa(it.Page) {
+			t.Errorf("page %d: page param = %q", it.Page, got.Get("page"))
+		}
+	}
+	if w.PrevQuery == "" || w.NextQuery == "" {
+		t.Errorf("prev/next queries should be set: prev=%q next=%q", w.PrevQuery, w.NextQuery)
+	}
+	// The caller's original Query map must not be mutated.
+	if q.Get("page") != "2" {
+		t.Errorf("NewWindow mutated caller's Query: page=%q", q.Get("page"))
+	}
+}
+
+func TestNewWindowNilQueryEmptyLinks(t *testing.T) {
+	t.Parallel()
+	w := pagination.NewWindow(pagination.WindowConfig{Page: 2, PerPage: 10, Total: 100, Span: 2})
+	for _, it := range w.Items {
+		if it.Query != "" {
+			t.Errorf("nil Query should leave item.Query empty, got %q", it.Query)
+		}
+	}
+	if w.PrevQuery != "" || w.NextQuery != "" {
+		t.Errorf("nil Query should leave prev/next empty")
+	}
+}
+
+func TestNewWindowCustomParam(t *testing.T) {
+	t.Parallel()
+	w := pagination.NewWindow(pagination.WindowConfig{
+		Page: 1, PerPage: 10, Total: 100, Query: url.Values{}, Param: "p",
+	})
+	got, _ := url.ParseQuery(w.NextQuery)
+	if got.Get("p") != "2" {
+		t.Errorf("custom param: NextQuery=%q", w.NextQuery)
+	}
+}
+
+func TestPageCount(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		total, perPage, want int
+	}{
+		{0, 10, 1},
+		{1, 10, 1},
+		{10, 10, 1},
+		{11, 10, 2},
+		{100, 10, 10},
+		{5, 0, 5},   // perPage < 1 treated as 1
+		{-3, 10, 1}, // negative total → one page
+	}
+	for _, tt := range cases {
+		if got := pagination.PageCount(tt.total, tt.perPage); got != tt.want {
+			t.Errorf("PageCount(%d,%d) = %d, want %d", tt.total, tt.perPage, got, tt.want)
+		}
+	}
+}
+
+func TestOffset(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		page, perPage, want int
+	}{
+		{1, 10, 0},
+		{2, 10, 10},
+		{3, 25, 50},
+		{0, 10, 0},  // clamps page to 1
+		{-4, 10, 0}, // clamps page to 1
+		{2, 0, 1},   // perPage clamps to 1
+	}
+	for _, tt := range cases {
+		if got := pagination.Offset(tt.page, tt.perPage); got != tt.want {
+			t.Errorf("Offset(%d,%d) = %d, want %d", tt.page, tt.perPage, got, tt.want)
+		}
+	}
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -141,18 +141,6 @@ Deps: none (stdlib only).
 
 ---
 
-**data/pagination**
-
-Opaque cursor codec (base64+JSON, optional HMAC via `sign`), keyset
-WHERE/ORDER fragment builders emitting `(sql, args)` with a
-placeholder-dialect option (`$n` pgx default, `?` for ClickHouse),
-`Page[T]` metadata, and the page-window view-model (ellipses, links
-preserving query params) for server-rendered navigation.
-
-Deps: `crypto/sign`.
-
----
-
 **data/dataloader**
 
 Generic per-request batch-and-cache loader collapsing N+1 lookups; pure
@@ -798,7 +786,7 @@ every B2B SaaS shows in its UI. Optional per-stream hash chaining
 (prev-hash + a verify pass) makes the trail tamper-evident for
 compliance-grade audits.
 
-Deps: `ops/logger`, `data/postgres`; `data/pagination` (planned).
+Deps: `ops/logger`, `data/postgres`, `data/pagination`.
 
 ---
 


### PR DESCRIPTION
Implements the `data/pagination` package from the catalog — two pagination models as composable pieces that emit `(sql, args)` and run no queries themselves (imports no driver).

## Keyset (cursor) pagination — APIs, feeds, infinite scroll
- **`Keyset`** builds the portable **OR-of-ANDs** WHERE comparison and the ORDER BY list, with a placeholder-dialect option:
  - `Dollar` (`$n`, pgx default) reuses each column's placeholder → `args` = one value per column.
  - `Question` (`?`, ClickHouse/MySQL/SQLite) is positional and can't reuse, so `args` repeats the equality-prefix values in exact `?` order.
  - A caller-chosen `start` index lets the fragment compose after a query's existing args (e.g. a `tenant.ScopeClause` at `$1`).
- Mixed ASC/DESC handled; a **backward** cursor flips both the WHERE operators and the ORDER BY directions.
- **Security:** columns are validated identifiers (same rule as `tenant.ScopeClause`); operators are hardcoded; cursor values only ever bind as args — no user input reaches SQL text.
- **`Codec`** encodes the boundary row's key values into an opaque `base64url(JSON)` cursor, optionally HMAC-signed via `crypto/sign` (tamper-evident, rotation-aware via `FromKeyset`). `int64` keys round-trip losslessly (beyond 2^53); a number beyond `float64` range fails closed as `ErrBadCursor`.
- **`NewPage[T]`** assembles fetched rows (`LIMIT size+1`) plus next/prev cursors into `Page[T]`, handling forward and backward paging (sentinel trim + reversal).

## Offset (numbered) pagination — server-rendered admin tables
- `PageCount` / `Offset` drive the `LIMIT`/`OFFSET` query.
- `NewWindow` builds the numbered nav bar: first/last always shown, a `Span` of pages around the current one, **ellipses collapsed to the digit for one-page gaps**, per-link query strings preserving the request's other params — without mutating the caller's `url.Values`.

## Testing & perf
- Black-box tests, **99.5% coverage**, a `Decode` fuzz (15s+ clean), and benchmarks. Exact-string assertions pin the SQL emission for both dialects.
- Benchmarks (Apple M3 Max):
  ```
  WhereDollar     141 ns/op    168 B/op    5 allocs/op
  WhereQuestion   127 ns/op    168 B/op    5 allocs/op
  OrderBy          54 ns/op     48 B/op    2 allocs/op
  Encode          194 ns/op    176 B/op    4 allocs/op
  Decode          699 ns/op   1192 B/op   18 allocs/op
  NewWindow       701 ns/op   1744 B/op   20 allocs/op
  ```
- Post-benchmark optimization pass (measured): `NewWindow` encoded the non-page query params **once** and appends `&page=N` per link instead of cloning + re-encoding the whole map per page number — **2577→701 ns/op, 5680→1744 B/op, 69→20 allocs/op** (~4×).

## Housekeeping
- Deletes the `data/pagination` entry from `docs/packages.md` (shipped-package rule) and untags the `ops/auditlog` dependency.

Deps: `crypto/sign` only.