### PR TITLE
fix(web/smartlink): bound coalesced waits by caller context, close tenancy and resolver safety gaps

### DIFF
--- a/auth/jwt/jwks.go
+++ b/auth/jwt/jwks.go
@@ -123,39 +123,34 @@ type jwksCache struct {
 	fetched bool
 }
 
-// needFetch reports whether resolving kid requires a network fetch given the
-// cache state at now: a cold cache, a set past its refresh TTL, or an unknown
-// kid past the refetch cooldown.
-func (c *jwksCache) needFetch(kid string, now time.Time) bool {
+// snapshot reads kid's resolution state under one lock acquisition: the key
+// (if present), whether the set was ever fetched, and whether resolving kid
+// requires a network fetch given now — a cold cache, a set past its refresh
+// TTL, or an unknown kid past the refetch cooldown.
+func (c *jwksCache) snapshot(kid string, now time.Time) (k Key, ok, fetched, need bool) {
 	c.mu.RLock()
-	_, ok := c.keys[kid]
+	k, ok = c.keys[kid]
 	fetched, fetchedAt := c.fetched, c.fetchedAt
 	c.mu.RUnlock()
 
-	if !fetched || now.Sub(fetchedAt) >= c.refresh {
-		return true
-	}
-	return !ok && now.Sub(fetchedAt) >= c.cooldown
+	need = !fetched || now.Sub(fetchedAt) >= c.refresh ||
+		(!ok && now.Sub(fetchedAt) >= c.cooldown)
+	return k, ok, fetched, need
 }
 
 func (c *jwksCache) get(ctx context.Context, kid string) (Key, error) {
-	c.mu.RLock()
-	k, ok := c.keys[kid]
-	fetched := c.fetched
-	c.mu.RUnlock()
-
-	need := c.needFetch(kid, c.clk.Now())
+	k, ok, fetched, need := c.snapshot(kid, c.clk.Now())
 	if ok && !need {
 		return k, nil
 	}
 	if need {
 		_, _, err := c.group.Do(ctx, "fetch", func(ctx context.Context) (struct{}, error) {
-			// Re-check under the flight: between a caller's staleness check and
-			// its admission here, a just-completed flight may already have
+			// Re-check under the flight: between a caller's staleness snapshot
+			// and its admission here, a just-completed flight may already have
 			// refreshed the set — this caller then becomes a fresh leader and,
 			// without the re-check, would repeat the network fetch it no longer
 			// needs.
-			if !c.needFetch(kid, c.clk.Now()) {
+			if _, _, _, need := c.snapshot(kid, c.clk.Now()); !need {
 				return struct{}{}, nil
 			}
 			keys, err := c.fetchSet(ctx)

--- a/auth/jwt/jwks.go
+++ b/auth/jwt/jwks.go
@@ -123,20 +123,41 @@ type jwksCache struct {
 	fetched bool
 }
 
-func (c *jwksCache) get(ctx context.Context, kid string) (Key, error) {
+// needFetch reports whether resolving kid requires a network fetch given the
+// cache state at now: a cold cache, a set past its refresh TTL, or an unknown
+// kid past the refetch cooldown.
+func (c *jwksCache) needFetch(kid string, now time.Time) bool {
 	c.mu.RLock()
-	k, ok := c.keys[kid]
+	_, ok := c.keys[kid]
 	fetched, fetchedAt := c.fetched, c.fetchedAt
 	c.mu.RUnlock()
 
-	now := c.clk.Now()
-	fresh := fetched && now.Sub(fetchedAt) < c.refresh
-	if ok && fresh {
+	if !fetched || now.Sub(fetchedAt) >= c.refresh {
+		return true
+	}
+	return !ok && now.Sub(fetchedAt) >= c.cooldown
+}
+
+func (c *jwksCache) get(ctx context.Context, kid string) (Key, error) {
+	c.mu.RLock()
+	k, ok := c.keys[kid]
+	fetched := c.fetched
+	c.mu.RUnlock()
+
+	need := c.needFetch(kid, c.clk.Now())
+	if ok && !need {
 		return k, nil
 	}
-	needFetch := !fetched || !fresh || (!ok && now.Sub(fetchedAt) >= c.cooldown)
-	if needFetch {
+	if need {
 		_, _, err := c.group.Do(ctx, "fetch", func(ctx context.Context) (struct{}, error) {
+			// Re-check under the flight: between a caller's staleness check and
+			// its admission here, a just-completed flight may already have
+			// refreshed the set — this caller then becomes a fresh leader and,
+			// without the re-check, would repeat the network fetch it no longer
+			// needs.
+			if !c.needFetch(kid, c.clk.Now()) {
+				return struct{}{}, nil
+			}
 			keys, err := c.fetchSet(ctx)
 			if err != nil {
 				return struct{}{}, err

--- a/web/smartlink/cache.go
+++ b/web/smartlink/cache.go
@@ -5,7 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
 )
+
+// defaultRefTTL bounds how long a compiled ref stays cached without a reload
+// when [WithRefTTL] is not given.
+const defaultRefTTL = 5 * time.Minute
 
 // Resolver resolves a Ref-backed Link to a Decider ready for a click decision.
 // [Cache.Resolver] returns a ready-made one; [WithResolver] wires it into a
@@ -20,108 +27,183 @@ type Resolver func(ctx context.Context, l Link) (Decider, error)
 // Cache is a lazy compile cache for Ref-backed Links. Offers live in the
 // consumer's own database as [Spec] values; Cache loads and compiles them on
 // demand, keyed by ref string, and the consumer invalidates an entry from its
-// offer-save path. Safe for concurrent use.
+// offer-save path. Every entry also expires after the [WithRefTTL] duration,
+// so a missed invalidation (or another node's save in a multi-node
+// deployment) is stale for at most one TTL, and refs that stop being clicked
+// do not stay resident forever. Safe for concurrent use.
 type Cache struct {
-	load    func(ctx context.Context, ref string) (Spec, error)
-	entries map[string]*refEntry
-	opts    []Option
-	mu      sync.RWMutex
+	nextSweep time.Time
+	clock     clock.Clock
+	load      func(ctx context.Context, ref string) (Spec, error)
+	entries   map[string]*refEntry
+	opts      []Option
+	ttl       time.Duration
+	mu        sync.RWMutex
 }
 
-// refEntry is one ref's cache slot. The goroutine that inserts it (the
-// leader) loads and compiles while concurrent Gets for the same ref wait on
-// wg — one load per ref per miss window, never a thundering herd against the
-// consumer's database. Invalidate simply removes the entry from the map, so
-// an in-flight leader finishes into a detached entry: its waiters still get
-// the result (correct when their calls began), but the next Get misses and
-// reloads fresh. Entry lifetime doubles as the cache itself, so there is no
-// side bookkeeping to prune.
+// refEntry is one ref's cache slot. The goroutine that inserts it starts one
+// detached fill; concurrent Gets for the same ref wait on done — one load per
+// ref per miss window, never a thundering herd against the consumer's
+// database — with each caller's wait bounded by its own context. Invalidate
+// simply removes the entry from the map, so an in-flight load finishes into a
+// detached entry: its waiters still get the result (correct when their calls
+// began), but the next Get misses and reloads fresh. Entry lifetime doubles
+// as the cache itself, so there is no side bookkeeping to prune beyond the
+// TTL sweep.
 type refEntry struct {
-	compiled *Compiled
-	err      error
-	wg       sync.WaitGroup
+	done      chan struct{} // closed when the fill completes
+	compiled  *Compiled
+	err       error
+	expiresAt time.Time // set before done closes; zero while in flight
 }
 
-// NewCache returns a Cache that loads a Spec via load and compiles it with
-// compileOpts on a cache miss; a nil load is a construction error. ref must
-// be globally unique and load must be a pure function of ref — the cache is
-// keyed by the bare ref string with no tenant dimension, so a multi-tenant
-// consumer whose resolution differs per tenant must embed the tenant in ref
-// itself.
+// expired reports whether e finished filling and its TTL has passed. An
+// in-flight entry is never expired — joiners share the pending load.
+func (e *refEntry) expired(now time.Time) bool {
+	select {
+	case <-e.done:
+		return now.After(e.expiresAt)
+	default:
+		return false
+	}
+}
+
+// cacheConfig holds NewCache's resolved options, collecting validation
+// failures in errs the same way managerConfig does.
+type cacheConfig struct {
+	compileOpts []Option
+	errs        []error
+	ttl         time.Duration
+}
+
+// CacheOption configures [NewCache].
+type CacheOption func(*cacheConfig)
+
+// WithRefTTL bounds how long a successfully compiled ref is served before the
+// next Get reloads it (default 5m). ttl must be positive: an unbounded entry
+// would survive a missed [Cache.Invalidate] forever, and a multi-node
+// deployment has no way to invalidate another node's process-local cache. A
+// non-positive ttl is a NewCache error.
+func WithRefTTL(ttl time.Duration) CacheOption {
+	return func(c *cacheConfig) {
+		if ttl <= 0 {
+			c.errs = append(c.errs, fmt.Errorf("smartlink: ref ttl must be positive, got %s", ttl))
+			return
+		}
+		c.ttl = ttl
+	}
+}
+
+// WithCompileOptions sets the [Option] values (e.g. [WithClock]) the Cache
+// passes to every [Compile] of a loaded Spec.
+func WithCompileOptions(opts ...Option) CacheOption {
+	return func(c *cacheConfig) { c.compileOpts = append(c.compileOpts, opts...) }
+}
+
+// NewCache returns a Cache that loads a Spec via load and compiles it on a
+// cache miss; a nil load is a construction error. ref must be globally unique
+// and load must be a pure function of ref — the cache is keyed by the bare
+// ref string with no tenant dimension, so a multi-tenant consumer whose
+// resolution differs per tenant must embed the tenant in ref itself.
 //
 // A loaded Spec with an empty Salt gets the ref as its Salt, so distinct
 // refs bucket their splits and Percent matchers independently by default
 // (see [Spec.Salt]).
 //
 // Errors from load or Compile are never cached, so the next Get retries.
-func NewCache(load func(ctx context.Context, ref string) (Spec, error), compileOpts ...Option) (*Cache, error) {
+func NewCache(load func(ctx context.Context, ref string) (Spec, error), opts ...CacheOption) (*Cache, error) {
 	if load == nil {
 		return nil, errors.New("smartlink: nil load func")
 	}
+	cfg := cacheConfig{ttl: defaultRefTTL}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if len(cfg.errs) > 0 {
+		return nil, errors.Join(cfg.errs...)
+	}
 	return &Cache{
-		load:    load,
-		opts:    compileOpts,
+		load: load,
+		opts: cfg.compileOpts,
+		// TTL expiry shares the compile options' clock, so tests (and
+		// TimeWindow matchers) observe one consistent time source.
+		clock:   newConfig(cfg.compileOpts...).clock,
+		ttl:     cfg.ttl,
 		entries: make(map[string]*refEntry),
 	}, nil
 }
 
 // Get returns the Compiled engine for ref, loading and compiling it on a
-// cache miss. Concurrent misses on the same ref share one load. Errors from
-// load or Compile are wrapped, not cached.
+// cache miss (or after TTL expiry). Concurrent misses on the same ref share
+// one load, which runs detached from any single request's cancellation; each
+// caller's wait is still bounded by its own ctx, so a stuck load func cannot
+// pin callers past their deadlines. Errors from load or Compile are wrapped,
+// not cached.
 func (c *Cache) Get(ctx context.Context, ref string) (*Compiled, error) {
+	now := c.clock.Now()
 	c.mu.RLock()
 	e, ok := c.entries[ref]
 	c.mu.RUnlock()
-	if !ok {
-		var leader bool
+	if !ok || e.expired(now) {
 		c.mu.Lock()
-		if e, ok = c.entries[ref]; !ok {
-			e = &refEntry{}
-			e.wg.Add(1)
+		e, ok = c.entries[ref]
+		if !ok || e.expired(now) {
+			e = &refEntry{done: make(chan struct{})}
 			c.entries[ref] = e
-			leader = true
+			c.sweepLocked(now)
+			go c.fill(context.WithoutCancel(ctx), ref, e)
 		}
 		c.mu.Unlock()
-		if leader {
-			return c.fill(ctx, ref, e)
-		}
 	}
-	e.wg.Wait()
-	return e.compiled, e.err
+	select {
+	case <-e.done:
+		return e.compiled, e.err
+	case <-ctx.Done():
+		return nil, fmt.Errorf("smartlink: load ref %q: %w", ref, ctx.Err())
+	}
 }
 
-// fill loads and compiles ref into e, releasing waiters exactly once even if
-// load or Compile panics (the panic then propagates to the leader's caller;
-// waiters observe an error). load runs with cancellation detached so one
-// canceled request cannot fail the waiters sharing the flight
-// (resilience/singleflight precedent). An errored or panicked entry is
-// removed — if still current — so the next Get retries instead of caching
-// the failure.
-func (c *Cache) fill(ctx context.Context, ref string, e *refEntry) (*Compiled, error) {
-	finished := false
+// sweepLocked prunes expired entries, at most once per TTL period so a miss
+// burst never pays repeated full-map scans. Callers hold c.mu. Without this,
+// refs that stop being clicked would stay resident until a Get for that exact
+// ref happened to replace them.
+func (c *Cache) sweepLocked(now time.Time) {
+	if now.Before(c.nextSweep) {
+		return
+	}
+	c.nextSweep = now.Add(c.ttl)
+	for ref, e := range c.entries {
+		if e.expired(now) {
+			delete(c.entries, ref)
+		}
+	}
+}
+
+// fill loads and compiles ref into e and closes e.done exactly once, even if
+// load or Compile panics (the panic is converted to an error every waiter
+// observes — fill runs in its own goroutine, so there is no caller to
+// re-panic into). An errored or panicked entry is removed — if still
+// current — so the next Get retries instead of caching the failure; a
+// successful one gets its TTL stamped before waiters are released.
+func (c *Cache) fill(ctx context.Context, ref string, e *refEntry) {
 	defer func() {
-		if !finished {
-			e.err = fmt.Errorf("smartlink: load ref %q: panic during load or compile", ref)
-			e.wg.Done()
-			c.removeEntry(ref, e)
+		if r := recover(); r != nil {
+			e.compiled, e.err = nil, fmt.Errorf("smartlink: load ref %q: panic during load or compile: %v", ref, r)
 		}
+		if e.err != nil {
+			c.removeEntry(ref, e)
+		} else {
+			e.expiresAt = c.clock.Now().Add(c.ttl)
+		}
+		close(e.done)
 	}()
-
-	compiled, err := c.loadCompile(ctx, ref)
-	e.compiled, e.err = compiled, err
-	finished = true
-	e.wg.Done()
-	if err != nil {
-		c.removeEntry(ref, e)
-		return nil, err
-	}
-	return compiled, nil
+	e.compiled, e.err = c.loadCompile(ctx, ref)
 }
 
-// loadCompile loads ref's Spec (cancellation-detached — see fill) and
-// compiles it, defaulting an empty Salt to the ref.
+// loadCompile loads ref's Spec and compiles it, defaulting an empty Salt to
+// the ref. ctx is already cancellation-detached (see Get).
 func (c *Cache) loadCompile(ctx context.Context, ref string) (*Compiled, error) {
-	spec, err := c.load(context.WithoutCancel(ctx), ref)
+	spec, err := c.load(ctx, ref)
 	if err != nil {
 		return nil, fmt.Errorf("smartlink: load ref %q: %w", ref, err)
 	}

--- a/web/smartlink/cache_test.go
+++ b/web/smartlink/cache_test.go
@@ -3,9 +3,12 @@ package smartlink_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/web/smartlink"
 )
 
@@ -22,7 +25,7 @@ func countingLoad(n *int, spec smartlink.Spec, err error) func(context.Context, 
 }
 
 // mustNewCache builds a Cache or fails the test.
-func mustNewCache(tb testing.TB, load func(context.Context, string) (smartlink.Spec, error), opts ...smartlink.Option) *smartlink.Cache {
+func mustNewCache(tb testing.TB, load func(context.Context, string) (smartlink.Spec, error), opts ...smartlink.CacheOption) *smartlink.Cache {
 	tb.Helper()
 	c, err := smartlink.NewCache(load, opts...)
 	if err != nil {
@@ -163,6 +166,116 @@ func TestCacheInvalidateDuringLoad(t *testing.T) {
 	}
 	if n := calls.Load(); n != 2 {
 		t.Fatalf("load calls = %d, want 2 (final Get must hit the cache)", n)
+	}
+}
+
+// TestCacheRejectsNonPositiveTTL asserts WithRefTTL requires a positive
+// duration: an unbounded entry would defeat the staleness/residency bound.
+func TestCacheRejectsNonPositiveTTL(t *testing.T) {
+	t.Parallel()
+	load := func(context.Context, string) (smartlink.Spec, error) {
+		return smartlink.Spec{Default: defTargets()}, nil
+	}
+	for _, ttl := range []time.Duration{0, -time.Second} {
+		if _, err := smartlink.NewCache(load, smartlink.WithRefTTL(ttl)); err == nil {
+			t.Fatalf("NewCache(WithRefTTL(%s)) error = nil, want error", ttl)
+		}
+	}
+}
+
+// TestCacheRefTTLExpiry asserts a cached entry is served only within its TTL:
+// once the (mocked) clock passes expiry, the next Get reloads instead of
+// serving the resident compile forever.
+func TestCacheRefTTLExpiry(t *testing.T) {
+	t.Parallel()
+	mock := clock.NewMock(time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC))
+	var calls int
+	cache := mustNewCache(t, countingLoad(&calls, smartlink.Spec{Default: defTargets()}, nil),
+		smartlink.WithRefTTL(time.Minute),
+		smartlink.WithCompileOptions(smartlink.WithClock(mock)))
+	ctx := context.Background()
+
+	for range 2 {
+		if _, err := cache.Get(ctx, "ref-1"); err != nil {
+			t.Fatalf("Get() error = %v", err)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("load calls before expiry = %d, want 1", calls)
+	}
+
+	mock.Advance(2 * time.Minute)
+	if _, err := cache.Get(ctx, "ref-1"); err != nil {
+		t.Fatalf("Get() after expiry error = %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("load calls after expiry = %d, want 2 (expired entry must reload)", calls)
+	}
+}
+
+// TestCacheGetContextBoundsWait asserts a Get whose context ends while the
+// shared load is stuck returns the context error instead of waiting
+// indefinitely, while the detached load still completes into the cache for
+// later callers.
+func TestCacheGetContextBoundsWait(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	cache := mustNewCache(t, func(context.Context, string) (smartlink.Spec, error) {
+		if calls.Add(1) == 1 {
+			close(entered)
+			<-release
+		}
+		return smartlink.Spec{Default: defTargets()}, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := cache.Get(ctx, "ref-1")
+		errCh <- err
+	}()
+	<-entered // the load is stuck; the Get is waiting on the fill
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Get() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Get() did not return after its context was canceled")
+	}
+
+	close(release) // the detached load finishes into the cache
+	if _, err := cache.Get(context.Background(), "ref-1"); err != nil {
+		t.Fatalf("Get() after release error = %v, want nil (fill must complete into the cache)", err)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("load calls = %d, want 1 (a canceled waiter must not abort or rerun the shared load)", n)
+	}
+}
+
+// TestCacheLoadPanicBecomesError asserts a panicking load surfaces as an
+// error to every caller — the fill runs in a detached goroutine with no
+// caller to re-panic into — and is not cached, so the next Get retries.
+func TestCacheLoadPanicBecomesError(t *testing.T) {
+	t.Parallel()
+	first := true
+	cache := mustNewCache(t, func(context.Context, string) (smartlink.Spec, error) {
+		if first {
+			first = false
+			panic("load boom")
+		}
+		return smartlink.Spec{Default: defTargets()}, nil
+	})
+	ctx := context.Background()
+
+	if _, err := cache.Get(ctx, "ref-1"); err == nil || !strings.Contains(err.Error(), "panic") {
+		t.Fatalf("Get() error = %v, want the load panic converted to an error", err)
+	}
+	if _, err := cache.Get(ctx, "ref-1"); err != nil {
+		t.Fatalf("Get() error = %v, want nil on retry (a panicked entry must not be cached)", err)
 	}
 }
 

--- a/web/smartlink/doc.go
+++ b/web/smartlink/doc.go
@@ -57,8 +57,10 @@
 // (or a [Cache]-backed [Resolver]) with concerns that must affect the
 // current click, composed left-to-right with [Chain]. [NewCache] is a lazy
 // compile-with-invalidation cache for Ref-backed links: it loads and
-// compiles a consumer's [Spec] on demand, keyed by ref string, and the
-// consumer calls [Cache.Invalidate] from its own offer-save path.
+// compiles a consumer's [Spec] on demand, keyed by ref string; the consumer
+// calls [Cache.Invalidate] from its own offer-save path, and every entry
+// also expires after [WithRefTTL] (default 5m), bounding both a missed
+// invalidation and the resident lifetime of refs that stop being clicked.
 //
 // # Manager and Handler
 //
@@ -89,7 +91,9 @@
 // Decorators (composed with [Chain]) are the synchronous seam: they run
 // inside Decide and can change the outcome of the current click — a fraud
 // guard diverting a suspicious visit, an A/B override, an inline metrics
-// tap. [WithOnHit] is the asynchronous observer: it runs after the redirect
+// tap. [WithDecorators] wraps every link's Decider — Target- and Ref-backed
+// alike — while a [Cache.Resolver] chain decorates Ref links only, inside
+// the manager chain. [WithOnHit] is the asynchronous observer: it runs after the redirect
 // is already written and cannot change it. It must hand the [Hit] to a
 // bounded sink — a queue push, a buffered channel — and never do work
 // inline or spawn a goroutine per hit; a slow or unbounded [WithOnHit]

--- a/web/smartlink/doc.go
+++ b/web/smartlink/doc.go
@@ -93,11 +93,11 @@
 // guard diverting a suspicious visit, an A/B override, an inline metrics
 // tap. [WithDecorators] wraps every link's Decider — Target- and Ref-backed
 // alike — while a [Cache.Resolver] chain decorates Ref links only, inside
-// the manager chain. [WithOnHit] is the asynchronous observer: it runs after the redirect
-// is already written and cannot change it. It must hand the [Hit] to a
-// bounded sink — a queue push, a buffered channel — and never do work
-// inline or spawn a goroutine per hit; a slow or unbounded [WithOnHit]
-// blocks or leaks on every click.
+// the manager chain. [WithOnHit] is the asynchronous observer: it runs
+// after the redirect is already written and cannot change it. It must hand
+// the [Hit] to a bounded sink — a queue push, a buffered channel — and
+// never do work inline or spawn a goroutine per hit; a slow or unbounded
+// [WithOnHit] blocks or leaks on every click.
 //
 // # Tenancy
 //

--- a/web/smartlink/handler.go
+++ b/web/smartlink/handler.go
@@ -71,8 +71,9 @@ func (m *Manager) Handler() http.Handler {
 }
 
 // decider resolves l to a Decider — a per-hit degenerate compile for a
-// Target link, or the configured Resolver for a Ref link — writing an error
-// response and reporting ok == false when it cannot produce one.
+// Target link, or the configured Resolver for a Ref link, either wrapped in
+// the [WithDecorators] chain — writing an error response and reporting
+// ok == false when it cannot produce one.
 func (m *Manager) decider(ctx context.Context, w http.ResponseWriter, r *http.Request, code string, l Link) (Decider, bool) {
 	switch {
 	case l.Target != "":
@@ -87,7 +88,7 @@ func (m *Manager) decider(ctx context.Context, w http.ResponseWriter, r *http.Re
 			internalServerError(w)
 			return nil, false
 		}
-		return compiled, true
+		return m.decorated(compiled), true
 
 	case m.cfg.resolver == nil:
 		m.cfg.logger.ErrorContext(ctx, "smartlink: ref link with no resolver configured", "code", code)
@@ -105,8 +106,23 @@ func (m *Manager) decider(ctx context.Context, w http.ResponseWriter, r *http.Re
 			internalServerError(w)
 			return nil, false
 		}
-		return resolved, true
+		// A (nil, nil) resolver result would panic in Decide; treat it like a
+		// resolver error — a consumer bug is an internal error, not a dead link.
+		if resolved == nil {
+			m.cfg.logger.ErrorContext(ctx, "smartlink: resolver returned nil Decider without error", "code", code)
+			internalServerError(w)
+			return nil, false
+		}
+		return m.decorated(resolved), true
 	}
+}
+
+// decorated wraps d in the WithDecorators chain, if one is configured.
+func (m *Manager) decorated(d Decider) Decider {
+	if m.decorate == nil {
+		return d
+	}
+	return m.decorate(d)
 }
 
 // compileTarget compiles the degenerate single-target Spec for a

--- a/web/smartlink/handler_test.go
+++ b/web/smartlink/handler_test.go
@@ -242,6 +242,64 @@ func TestHandlerRefNoTarget(t *testing.T) {
 	})
 }
 
+// TestHandlerResolverNilDecider asserts a resolver that returns (nil, nil)
+// at serve time (its row admitted via SkipRefCheck) answers 500 instead of
+// panicking on Decide.
+func TestHandlerResolverNilDecider(t *testing.T) {
+	t.Parallel()
+	resolver := func(context.Context, smartlink.Link) (smartlink.Decider, error) { return nil, nil }
+	m := newTestManager(t, smartlink.WithResolver(resolver))
+	l, err := m.Create(context.Background(), smartlink.CreateParams{Ref: "offer-1", SkipRefCheck: true})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d (nil Decider is a consumer bug, not a dead link)", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+// TestHandlerDecoratorsWrapBothKinds asserts the WithDecorators chain runs
+// for Target- and Ref-backed links alike: a diverting decorator rewrites the
+// redirect destination for both.
+func TestHandlerDecoratorsWrapBothKinds(t *testing.T) {
+	t.Parallel()
+	const guardURL = "https://guard.example.com/"
+	divert := func(next smartlink.Decider) smartlink.Decider {
+		return smartlink.DecideFunc(func(v smartlink.Visit) smartlink.Decision {
+			d := next.Decide(v)
+			d.URL = guardURL
+			return d
+		})
+	}
+	m := newTestManager(t, smartlink.WithResolver(geoResolver()), smartlink.WithDecorators(divert))
+	ctx := context.Background()
+
+	target, err := m.Create(ctx, smartlink.CreateParams{Target: "https://dest.example.com/"})
+	if err != nil {
+		t.Fatalf("Create(target) error = %v, want nil", err)
+	}
+	ref, err := m.Create(ctx, smartlink.CreateParams{Ref: "offer-1"})
+	if err != nil {
+		t.Fatalf("Create(ref) error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	for name, code := range map[string]string{"target": target.Code, "ref": ref.Code} {
+		req := httptest.NewRequest(http.MethodGet, "/r/"+code, nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if got := rec.Header().Get("Location"); got != guardURL {
+			t.Fatalf("%s link Location = %q, want %q (decorator must wrap every link's Decider)", name, got, guardURL)
+		}
+	}
+}
+
 // TestHandlerRefNoResolver asserts a Ref-backed Link with no configured
 // Resolver is a configuration error: 500, not a dead link.
 func TestHandlerRefNoResolver(t *testing.T) {

--- a/web/smartlink/manager.go
+++ b/web/smartlink/manager.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/dmitrymomot/forge/resilience/cache"
-	"github.com/dmitrymomot/forge/resilience/singleflight"
 )
 
 // maxCodeAttempts caps how many times Create retries a colliding generated
@@ -27,10 +26,13 @@ const maxCodeAttempts = 5
 type Manager struct {
 	store Store
 	links *cache.Cache[Link] // typed facade over WithCache's store; nil without WithCache
+	// decorate is the precomputed WithDecorators chain the Handler wraps
+	// around every link's Decider; nil when none are configured.
+	decorate Decorator
 	// flight dedups concurrent cache-miss lookups per code, and cacheGen
 	// guards their write-backs against racing lifecycle mutations (see
 	// lookup and invalidateCache).
-	flight   singleflight.Group[Link]
+	flight   lookupFlight
 	cfg      managerConfig
 	cacheGen atomic.Uint64
 }
@@ -50,6 +52,9 @@ func NewManager(store Store, opts ...ManagerOption) (*Manager, error) {
 		return nil, errors.Join(cfg.errs...)
 	}
 	m := &Manager{store: store, cfg: *cfg}
+	if len(cfg.decorators) > 0 {
+		m.decorate = Chain(cfg.decorators...)
+	}
 	if cfg.cacheStore != nil {
 		m.links = cache.New[Link](cfg.cacheStore, cache.WithPrefix(cachePrefix), cache.WithDefaultTTL(cfg.cacheTTL))
 	}
@@ -94,7 +99,8 @@ func (m *Manager) Create(ctx context.Context, p CreateParams) (Link, error) {
 		}
 	}
 	if p.Ref != "" && !p.SkipRefCheck && m.cfg.resolver != nil {
-		if _, err := m.cfg.resolver(ctx, Link{Ref: p.Ref, Tenant: p.Tenant}); err != nil {
+		d, err := m.cfg.resolver(ctx, Link{Ref: p.Ref, Tenant: p.Tenant})
+		if err != nil {
 			// Only a ref the resolver positively rejects is caller input error;
 			// anything else (consumer DB down, cache backend failing) is an
 			// infrastructure failure and must not read as ErrInvalidLink to an
@@ -103,6 +109,12 @@ func (m *Manager) Create(ctx context.Context, p CreateParams) (Link, error) {
 				return Link{}, fmt.Errorf("%w: ref %q: %w", ErrInvalidLink, p.Ref, err)
 			}
 			return Link{}, fmt.Errorf("smartlink: check ref %q: %w", p.Ref, err)
+		}
+		// A (nil, nil) resolver is a consumer bug, not caller input: reject it
+		// here rather than letting the link store successfully and panic (now
+		// 500) on its first hit.
+		if d == nil {
+			return Link{}, fmt.Errorf("smartlink: check ref %q: resolver returned nil Decider without error", p.Ref)
 		}
 	}
 

--- a/web/smartlink/manager_options.go
+++ b/web/smartlink/manager_options.go
@@ -2,6 +2,7 @@ package smartlink
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -45,6 +46,7 @@ type managerConfig struct {
 	baseURL         string
 	fallbackURL     string
 	schemes         []string
+	decorators      []Decorator
 	errs            []error
 	cacheTTL        time.Duration
 	linkParamPolicy ParamPolicy
@@ -79,14 +81,23 @@ func WithCodeFunc(f func() string) ManagerOption {
 }
 
 // WithBaseURL sets the base [Manager.ShortURL] renders a code onto. It must
-// be an absolute http(s) URL (scheme and host); any trailing slashes are
-// trimmed and exactly one is added back, so "https://s.example.com//" can't
-// produce a double slash in a rendered ShortURL. Without this option,
-// ShortURL always returns "".
+// be an absolute http(s) URL (scheme and host) without a query or fragment —
+// ShortURL appends the code as a path segment, so a base like
+// "https://s.example.com/?utm=x" would render unusable URLs such as
+// "...?utm=x/promo". Any trailing slashes are trimmed and exactly one is
+// added back, so "https://s.example.com//" can't produce a double slash in a
+// rendered ShortURL. Without this option, ShortURL always returns "".
 func WithBaseURL(u string) ManagerOption {
 	return func(c *managerConfig) {
 		if err := validateAbsoluteHTTPURL(u); err != nil {
 			c.errs = append(c.errs, fmt.Errorf("smartlink: base URL: %w", err))
+			return
+		}
+		// Checked on the raw string, not the parsed URL: a bare trailing "?"
+		// or "#" parses to empty RawQuery/Fragment yet would still survive
+		// into the rendered ShortURL text.
+		if strings.ContainsAny(u, "?#") {
+			c.errs = append(c.errs, fmt.Errorf("smartlink: base URL: must not carry a query or fragment: %q", u))
 			return
 		}
 		c.baseURL = strings.TrimRight(u, "/") + "/"
@@ -137,9 +148,27 @@ func WithReservedCodes(codes ...string) ManagerOption {
 // WithScope derives a tenant scope from the request context on every
 // management call, failing closed with [ErrScope] when the hook errors or
 // returns an empty string. Without this option, tenant strings pass through
-// verbatim — single-tenant zero ceremony.
+// verbatim — single-tenant zero ceremony. A nil f is a NewManager error, not
+// a silent fall-back to unscoped: a caller who asked for scoping must never
+// run without it.
 func WithScope(f func(ctx context.Context) (string, error)) ManagerOption {
-	return func(c *managerConfig) { c.scope = f }
+	return func(c *managerConfig) {
+		if f == nil {
+			c.errs = append(c.errs, errors.New("smartlink: nil scope func"))
+			return
+		}
+		c.scope = f
+	}
+}
+
+// WithDecorators sets the [Decorator] chain [Manager.Handler] wraps around
+// every link's Decider — Target- and Ref-backed alike — composed with [Chain]
+// (first argument outermost). This is the synchronous seam for Target links,
+// which have no [Resolver] to decorate; Ref-specific decorators can still
+// live in the Resolver (e.g. [Cache.Resolver]) and run inside this chain,
+// since this chain wraps the Decider the Resolver returns.
+func WithDecorators(ds ...Decorator) ManagerOption {
+	return func(c *managerConfig) { c.decorators = slices.Clone(ds) }
 }
 
 // WithLinkParamPolicy sets the [ParamPolicy] applied to Target-backed Links:

--- a/web/smartlink/manager_test.go
+++ b/web/smartlink/manager_test.go
@@ -40,10 +40,15 @@ func TestNewManagerRejects301(t *testing.T) {
 	}
 }
 
-// TestNewManagerBadBaseURL asserts WithBaseURL requires an absolute http(s) URL.
+// TestNewManagerBadBaseURL asserts WithBaseURL requires an absolute http(s)
+// URL without a query or fragment — ShortURL appends the code as raw text, so
+// "https://s.example.com/?utm=x" would render "...?utm=x/promo".
 func TestNewManagerBadBaseURL(t *testing.T) {
 	t.Parallel()
-	cases := []string{"", "app.example.com/verify", "ftp://example.com/"}
+	cases := []string{
+		"", "app.example.com/verify", "ftp://example.com/",
+		"https://s.example.com/?utm=x", "https://s.example.com/#promo", "https://s.example.com/?",
+	}
 	for _, u := range cases {
 		if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithBaseURL(u)); err == nil {
 			t.Fatalf("NewManager(WithBaseURL(%q)) error = nil, want error", u)
@@ -82,6 +87,28 @@ func TestNewManagerRejectsNonPositiveCacheTTL(t *testing.T) {
 	}
 	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithCache(cache.NewMemoryStore(), time.Minute)); err != nil {
 		t.Fatalf("NewManager(WithCache(ttl=1m)) error = %v, want nil", err)
+	}
+}
+
+// TestNewManagerRejectsNilScope asserts WithScope(nil) is a construction
+// error: silently dropping the hook would run management ops unscoped,
+// violating the fail-closed tenancy contract.
+func TestNewManagerRejectsNilScope(t *testing.T) {
+	t.Parallel()
+	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithScope(nil)); err == nil {
+		t.Fatal("NewManager(WithScope(nil)) error = nil, want error")
+	}
+}
+
+// TestCreateRefRejectsNilResolverDecider asserts the ref precheck rejects a
+// resolver that returns (nil, nil): such a link would store successfully and
+// then fail on its first hit.
+func TestCreateRefRejectsNilResolverDecider(t *testing.T) {
+	t.Parallel()
+	resolver := func(context.Context, smartlink.Link) (smartlink.Decider, error) { return nil, nil }
+	m := newTestManager(t, smartlink.WithResolver(resolver))
+	if _, err := m.Create(context.Background(), smartlink.CreateParams{Ref: "offer-1"}); err == nil {
+		t.Fatal("Create(ref) error = nil, want error when the resolver returns a nil Decider")
 	}
 }
 

--- a/web/smartlink/resolve.go
+++ b/web/smartlink/resolve.go
@@ -3,6 +3,8 @@ package smartlink
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/dmitrymomot/forge/resilience/cache"
@@ -42,7 +44,7 @@ func (m *Manager) Resolve(ctx context.Context, code string) (Link, error) {
 // source of truth, so a bad cache backend degrades to "always hit the
 // Store", not "links stop resolving".
 //
-// Concurrent misses on the same code share one Store read via singleflight,
+// Concurrent misses on the same code share one Store read (see lookupFlight),
 // so a hot code whose entry just expired costs one query, not one per
 // waiting request. The write-back is guarded against racing lifecycle
 // mutations: the fill snapshots cacheGen before the Store read, writes the
@@ -61,7 +63,7 @@ func (m *Manager) lookup(ctx context.Context, code string) (Link, error) {
 		return l, nil
 	}
 
-	l, _, err := m.flight.Do(ctx, code, func(ctx context.Context) (Link, error) {
+	return m.flight.do(ctx, code, func(ctx context.Context) (Link, error) {
 		gen := m.cacheGen.Load()
 		l, err := m.store.Get(ctx, code)
 		if err != nil {
@@ -75,7 +77,69 @@ func (m *Manager) lookup(ctx context.Context, code string) (Link, error) {
 		}
 		return l, nil
 	})
-	return l, err
+}
+
+// lookupFlight coalesces concurrent cache-miss lookups per code. It exists
+// instead of resilience/singleflight because that Group's waiters block
+// without regard for their context: a stuck Store read would pin every
+// redirect request for that code indefinitely. Here the shared read runs
+// detached in one goroutine per key and every caller — leader and joiners
+// alike — selects on completion versus its own ctx, so each request's wait is
+// bounded by its own deadline while the read still completes once for the
+// callers that stay.
+type lookupFlight struct {
+	m  map[string]*lookupCall
+	mu sync.Mutex
+}
+
+// lookupCall is one in-flight coalesced lookup; done is closed after link and
+// err are set.
+type lookupCall struct {
+	err  error
+	done chan struct{}
+	link Link
+}
+
+// do returns the result of fn for key, starting one detached execution when
+// none is in flight and otherwise joining the existing one. A caller whose
+// ctx ends first gets its ctx error; the shared execution keeps running for
+// the others and is deregistered when it completes.
+func (f *lookupFlight) do(ctx context.Context, key string, fn func(context.Context) (Link, error)) (Link, error) {
+	f.mu.Lock()
+	if f.m == nil {
+		f.m = make(map[string]*lookupCall)
+	}
+	c, ok := f.m[key]
+	if !ok {
+		c = &lookupCall{done: make(chan struct{})}
+		f.m[key] = c
+		go f.run(context.WithoutCancel(ctx), key, c, fn)
+	}
+	f.mu.Unlock()
+
+	select {
+	case <-c.done:
+		return c.link, c.err
+	case <-ctx.Done():
+		return Link{}, ctx.Err()
+	}
+}
+
+// run executes fn into c and closes c.done exactly once, converting a panic
+// to an error every waiter observes (run has no caller to re-panic into).
+func (f *lookupFlight) run(ctx context.Context, key string, c *lookupCall, fn func(context.Context) (Link, error)) {
+	defer func() {
+		if r := recover(); r != nil {
+			c.link, c.err = Link{}, fmt.Errorf("smartlink: lookup %q: panic during coalesced fill: %v", key, r)
+		}
+		close(c.done)
+		f.mu.Lock()
+		if f.m[key] == c {
+			delete(f.m, key)
+		}
+		f.mu.Unlock()
+	}()
+	c.link, c.err = fn(ctx)
 }
 
 // cacheGet attempts the cache read-through hit path, reporting ok == false

--- a/web/smartlink/resolve_test.go
+++ b/web/smartlink/resolve_test.go
@@ -310,6 +310,48 @@ func TestResolveMissSingleflight(t *testing.T) {
 	}
 }
 
+// TestResolveMissWaitBoundedByContext asserts a coalesced cache-miss Resolve
+// whose context ends while the shared Store read is stuck returns the context
+// error instead of waiting indefinitely — a wedged Store must not pin
+// redirect requests past their deadlines.
+func TestResolveMissWaitBoundedByContext(t *testing.T) {
+	t.Parallel()
+	const code = "stuck1"
+	gs := &gateStore{
+		Store:   smartlink.NewMemoryStore(),
+		armCode: code,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m, err := smartlink.NewManager(gs, smartlink.WithCache(cache.NewMemoryStore(), time.Minute))
+	if err != nil {
+		t.Fatalf("NewManager() error = %v, want nil", err)
+	}
+	if _, err := m.Create(context.Background(), smartlink.CreateParams{Code: code, Target: "https://example.com/"}); err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Go(func() { // leader: misses the cache, parks inside Store.Get
+		if _, err := m.Resolve(context.Background(), code); err != nil {
+			t.Errorf("leader Resolve() error = %v", err)
+		}
+	})
+	<-gs.entered // the coalesced Store read is registered and stuck
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := m.Resolve(ctx, code); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Resolve() with canceled ctx = %v, want context.Canceled", err)
+	}
+
+	close(gs.release)
+	wg.Wait()
+	if _, err := m.Resolve(context.Background(), code); err != nil {
+		t.Fatalf("Resolve() after release error = %v, want nil", err)
+	}
+}
+
 // TestLifecycleInvalidatesCache asserts Deactivate, Activate, and Delete
 // each best-effort evict the cache key after a successful Store mutation,
 // bounding staleness of a warmed cache entry to at most the configured TTL.


### PR DESCRIPTION
## Description

Fixes the six actionable issues from the post-merge review of web/smartlink (PR #68), covering cache resilience and API safety.

**P1 — cache-miss coalescing dropped request deadlines.** Both coalescing points (`Cache.Get` for ref compiles, `Manager.lookup` for the Link read-through cache) blocked waiters unconditionally, so a stuck Store/Ref loader pinned every redirect request for that key indefinitely. The shared load now runs in one detached goroutine per key and every caller — leader and joiners alike — selects on completion vs its own context: each request's wait is bounded by its own deadline while the load still completes once into the cache for the callers that stay. `Manager.lookup` replaces `resilience/singleflight` (whose waiters ignore ctx by design) with a local `lookupFlight`; the cacheGen write-back race guard is unchanged. Panics in detached fills are converted to errors every waiter observes, since there is no caller left to re-panic into.

**P1 — `WithScope(nil)` silently ran unscoped.** Now a `NewManager` construction error: a caller who asked for scoping must never run without it (fail-closed tenancy contract).

**P1 — a resolver returning `(nil, nil)` passed creation, then panicked on the first hit.** Rejected at `Create`'s ref precheck, and `Manager.Handler` answers a logged 500 if one still reaches serve time (e.g. a row admitted via `SkipRefCheck`) — a consumer bug reads as an internal error, not a dead link or a crash.

**P2 — fixed-target links had no synchronous decorator seam.** New `WithDecorators(ds ...Decorator)` wraps every link's Decider, Target- and Ref-backed alike, composed with `Chain`. Ref-specific chains in `Cache.Resolver` still work and run inside the manager chain.

**P2 — `WithBaseURL` accepted query/fragment URLs that `ShortURL` rendered into unusable text** (`...?utm=x/promo`). Rejected at construction; the check runs on the raw string so a bare trailing `?` or `#` (which parses to empty `RawQuery`/`Fragment`) can't slip through.

**P2 — the ref compile cache had unbounded lifetime and cardinality.** Entries now expire after a TTL (default 5m; must be positive, mirroring `WithCache`'s bounded-staleness rule) and an amortized once-per-TTL sweep prunes refs that stop being clicked — bounding both the staleness of a missed `Invalidate` (or another node's save) and the resident set. **API change:** `NewCache(load, ...CacheOption)` with `WithRefTTL` and `WithCompileOptions` replaces the old variadic `Option` list. TTL expiry shares the compile options' clock, so it is testable via `WithClock`.

Reviewed and deliberately not changed: the global `cacheGen` counter (false-positive self-evictions cost one extra miss, never correctness; per-code generations would add a second keyed map), per-hit Target recompiles (documented decision backed by the ~µs compile benchmark), and the unscoped Postgres `List` sort (needs its own index; store-level trade-off).

### Benchmarks (Apple M3 Max, before → after)

| benchmark | before | after |
|---|---|---|
| HandlerTarget | 3000 ns/op, 44 allocs | 3064 ns/op, 44 allocs |
| ResolveDecideTarget | 830 ns/op, 15 allocs | 860 ns/op, 15 allocs |
| HandlerRef | 1849 ns/op, 30 allocs | 1984 ns/op, 30 allocs |

Allocations unchanged; the HandlerRef delta is the TTL-expiry check on the ref cache hit path — the cost of bounded entry lifetime.

## Checklist

- [x] `just lint` passes
- [x] `just test` passes
- [x] New code has tests
- [x] Commit messages follow conventional commits
