### PR TITLE
docs(core): fix comments and refresh doc.go across core packages

### DIFF
--- a/core/bytesize/bytesize.go
+++ b/core/bytesize/bytesize.go
@@ -37,7 +37,9 @@ var parseUnits = []struct {
 }
 
 // Parse converts a human byte-size string ("10MB", "1.5GiB", "512", "10 MB")
-// into a ByteSize. Suffixes are case-insensitive; a bare number is bytes.
+// into a ByteSize. Suffixes are case-insensitive; a bare number is bytes. It
+// returns an error wrapping ErrInvalidSize if s is empty, has an unrecognized
+// suffix or malformed number, or the resulting value overflows int64.
 func Parse(s string) (ByteSize, error) {
 	trimmed := strings.TrimSpace(s)
 	if trimmed == "" {
@@ -133,12 +135,13 @@ func format(n int64, base int64, units []string) string {
 	return sign + s + units[i]
 }
 
-// MarshalText renders b as its String form.
+// MarshalText renders b as its String form. It never returns an error.
 func (b ByteSize) MarshalText() ([]byte, error) {
 	return []byte(b.String()), nil
 }
 
-// UnmarshalText parses p into b.
+// UnmarshalText parses p as a byte size and stores the result in b. On
+// error, b is left unchanged.
 func (b *ByteSize) UnmarshalText(p []byte) error {
 	v, err := Parse(string(p))
 	if err != nil {

--- a/core/bytesize/doc.go
+++ b/core/bytesize/doc.go
@@ -1,5 +1,5 @@
 // Package bytesize parses and formats human byte sizes and provides a ByteSize
-// type that drops into env-tagged config and JSON via TextMarshaler. SI
+// type that drops into JSON via TextMarshaler/TextUnmarshaler. SI
 // suffixes (KB/MB/GB...) are powers of 1000; IEC suffixes (KiB/MiB/GiB...) are
 // powers of 1024. Formatting defaults to IEC and always round-trips through
 // Parse (values not exact in any unit fall back to a byte count). No bit units.
@@ -10,6 +10,6 @@
 //	if err != nil {
 //		// handle invalid size
 //	}
-//	n.String()           // "10000000B" (not exact in IEC units, falls back to bytes)
-//	bytesize.FormatSI(n) // "10MB"
+//	iec := n.String()          // "10000000B" (not exact in IEC units, falls back to bytes)
+//	si := bytesize.FormatSI(n) // "10MB"
 package bytesize

--- a/core/ctxkey/doc.go
+++ b/core/ctxkey/doc.go
@@ -10,7 +10,8 @@
 //
 // # Usage
 //
-//	var userIDKey = ctxkey.New[string]("userID")
+//	ctx := context.Background()
+//	userIDKey := ctxkey.New[string]("userID")
 //
 //	ctx = userIDKey.With(ctx, "u_123")
 //	id, ok := userIDKey.From(ctx) // (string, bool) — no assertion at the call site

--- a/core/decimal/arith_test.go
+++ b/core/decimal/arith_test.go
@@ -65,7 +65,8 @@ func TestSub_MinInt64OverflowPromotes(t *testing.T) {
 	got := decimal.Zero.Sub(decimal.New(math.MinInt64, 0))
 	assert.Equal(t, "9223372036854775808", got.String())
 
-	// Boundary: MinInt64 - (-1) also overflows and must promote.
+	// Boundary: MinInt64 - (-1) = MinInt64 + 1 fits back in int64, so this
+	// adjacent case stays on the fast path without promoting.
 	got2 := decimal.New(math.MinInt64, 0).Sub(decimal.FromInt(-1))
 	assert.Equal(t, "-9223372036854775807", got2.String())
 

--- a/core/decimal/div_test.go
+++ b/core/decimal/div_test.go
@@ -100,7 +100,6 @@ func ratRoundToScale(r *big.Rat, scale int32, mode decimal.RoundingMode) *big.Ra
 	if neg {
 		q.Neg(q)
 	}
-	// result = q / 10^scale
 	return new(big.Rat).SetFrac(q, pow)
 }
 
@@ -146,14 +145,16 @@ func TestDiv_NegativeScaleClamped(t *testing.T) {
 	assert.Equal(t, int32(0), got.Scale())
 }
 
-// TestDiv_BigRoundingHighScale drives Div's big.Int path with a non-terminating
-// quotient rounded at a high scale (exercises divRound on large values).
+// TestDiv_BigRoundingHighScale drives Div's big.Int path with a large-magnitude
+// dividend rounded at a high scale (exercises divRound on big.Int operands).
 func TestDiv_BigRoundingHighScale(t *testing.T) {
 	x := decimal.MustParse(bigVal)
 	y := decimal.MustParse("7")
 	got, err := x.Div(y, 20, decimal.HalfEven)
 	require.NoError(t, err)
-	// Verify against exact recomputation: got*7 rounded back should be near x.
+	// Smoke-checks the big.Int path only: the requested scale is honored and the
+	// output isn't the degenerate "0"; exact correctness is covered by
+	// TestDiv_RatOracle.
 	assert.Equal(t, int32(20), got.Scale())
 	assert.NotEqual(t, "0", got.String())
 }
@@ -220,13 +221,14 @@ func TestDiv_DirectedModesCeilUp(t *testing.T) {
 	}
 }
 
-// TestDiv_LargeNegativeExponent drives the exp<0 branch of Div (denominator
-// scaled by 10^-exp) with a divisor whose scale is large, producing a
-// big-magnitude quotient. TestDiv_NegativeExponentScalesDenominator only takes
-// this branch with a small result; these push it to int64-boundary magnitudes
-// and force a HalfEven round on the resulting large remainder.
+// TestDiv_LargeNegativeExponent divides by values with a large negative
+// exponent in scientific notation (1e-14, 3e-19). Because the divisor's scale
+// dwarfs the target scale, Div takes its exp>=0 branch — the numerator, not
+// the denominator, is scaled by 10^exp — producing a large intermediate
+// numerator; the second case also forces a HalfEven round on a
+// non-terminating remainder.
 func TestDiv_LargeNegativeExponent(t *testing.T) {
-	// 1 / 1e-14 = 1e14 exact; denominator multiplied by 10^14.
+	// 1 / 1e-14 = 1e14 exact; numerator multiplied by 10^14.
 	got, err := decimal.MustParse("1").Div(decimal.MustParse("0.00000000000001"), 0, decimal.HalfEven)
 	require.NoError(t, err)
 	assert.Equal(t, "100000000000000", got.String())

--- a/core/decimal/errors.go
+++ b/core/decimal/errors.go
@@ -5,7 +5,7 @@ import "errors"
 // ErrSyntax is returned by Parse for input that is not a valid decimal literal.
 var ErrSyntax = errors.New("decimal: invalid syntax")
 
-// ErrDivByZero is returned by Div when the divisor is zero.
+// ErrDivByZero is returned by Div, QuoRem, and Mod when the divisor is zero.
 var ErrDivByZero = errors.New("decimal: division by zero")
 
 // ErrScan is returned by Scan when the SQL source value cannot be converted to a

--- a/core/decimal/parse.go
+++ b/core/decimal/parse.go
@@ -68,8 +68,8 @@ func allDigits(s string) bool {
 	return true
 }
 
-// MustParse is like Parse but panics on error. For package-level test/config
-// literals known to be valid.
+// MustParse is like Parse but panics on error. It is intended for
+// package-level test/config literals known to be valid.
 func MustParse(s string) Decimal {
 	d, err := Parse(s)
 	if err != nil {
@@ -80,7 +80,7 @@ func MustParse(s string) Decimal {
 
 // String renders d preserving its stored scale: 2.50 → "2.50", 0.001 → "0.001".
 func (d Decimal) String() string {
-	// Absolute-value coefficient digits, sign handled separately.
+	// digits holds the coefficient's absolute-value digits; neg tracks the sign separately.
 	var digits string
 	var neg bool
 	if d.big != nil {
@@ -117,8 +117,8 @@ func (d Decimal) String() string {
 	return out
 }
 
-// formatUint renders u in base 10 without importing strconv into this hot path
-// via a fixed buffer.
+// formatUint renders u in base 10 using a fixed buffer, avoiding a strconv
+// import in this hot path.
 func formatUint(u uint64) string {
 	if u == 0 {
 		return "0"

--- a/core/enum/doc.go
+++ b/core/enum/doc.go
@@ -5,21 +5,19 @@
 //
 // # Usage
 //
-//	type Status string
+//	type Priority string
 //
 //	const (
-//		StatusActive Status = "active"
-//		StatusPaused Status = "paused"
+//		PriorityLow  Priority = "low"
+//		PriorityHigh Priority = "high"
 //	)
 //
-//	var Statuses = enum.New(StatusActive, StatusPaused)
+//	var Priorities = enum.New(PriorityLow, PriorityHigh)
 //
-//	func Example() {
-//		Statuses.Valid(StatusActive) // true
+//	Priorities.Valid(PriorityLow) // true
 //
-//		v, err := Statuses.Parse("paused")
-//		// v == StatusPaused, err == nil
+//	v, err := Priorities.Parse("high")
+//	// v == PriorityHigh, err == nil
 //
-//		Statuses.Values() // []Status{StatusActive, StatusPaused}
-//	}
+//	Priorities.Values() // []Priority{PriorityLow, PriorityHigh}
 package enum

--- a/core/errorsx/coded.go
+++ b/core/errorsx/coded.go
@@ -7,7 +7,7 @@ import "fmt"
 type codedError struct {
 	err  error // wrapped error (nil for a leaf)
 	code string
-	msg  string // used when err == nil (leaf, from New/Errorf)
+	msg  string // used when err == nil (leaf, from New only)
 }
 
 func (e *codedError) Error() string {
@@ -24,8 +24,9 @@ func (e *codedError) Error() string {
 // Code reports this error's code. Satisfied by errors.As in the package Code func.
 func (e *codedError) Code() string { return e.code }
 
-// Unwrap exposes the wrapped error. It returns nil for a leaf (New/Errorf without
-// a %w arg), which stops the errors.Is/As walk at this error.
+// Unwrap exposes the wrapped error. It returns nil only for a leaf created via
+// New, which stops the errors.Is/As walk at this error; Errorf always sets it
+// (fmt.Errorf never returns nil), even without a %w verb.
 func (e *codedError) Unwrap() error { return e.err }
 
 // coder is the interface a coded error satisfies. Kept unexported: Code(err)

--- a/core/filetype/doc.go
+++ b/core/filetype/doc.go
@@ -16,11 +16,12 @@
 //
 // # Usage
 //
+//	head := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
 //	t, ok := filetype.Detect(head) // ok=false means genuinely unknown
 //	if ok && t.MIME == "image/png" {
-//		// ...
+//		// accept the upload
 //	}
 //
-//	// For an io.Reader whose bytes must stay intact for a later stage:
+//	src := bytes.NewReader(head)
 //	typ, stream, err := filetype.DetectReader(src) // stream replays src in full
 package filetype

--- a/core/fsm/doc.go
+++ b/core/fsm/doc.go
@@ -16,71 +16,50 @@
 // edge-guards, enter-guards(to), then exit-hooks(from), edge-hooks,
 // enter-hooks(to); first error aborts.
 //
-// # Compile-time flows
+// # Usage
 //
 // Declare a typed lifecycle once at package init. The Define anchor binds
-// both type parameters so every part infers them:
+// both type parameters so every part infers them, then Fire validates and
+// applies a transition for the caller to persist:
 //
-//	type Status string
+//	type invoiceStatus string
 //
 //	const (
-//		StatusDraft  Status = "draft"
-//		StatusIssued Status = "issued"
-//		StatusPaid   Status = "paid"
-//		StatusVoid   Status = "void"
+//		invoiceDraft  invoiceStatus = "draft"
+//		invoiceIssued invoiceStatus = "issued"
 //	)
 //
-//	var d fsm.Define[Status, *Invoice]
+//	type invoice struct{ Status invoiceStatus }
 //
-//	var InvoiceFSM = fsm.MustNew(StatusDraft,
-//		d.Edge(StatusDraft, StatusIssued, d.Hook(assignNumber)),
-//		d.Edge(StatusIssued, StatusPaid),
-//		d.EdgeFromAny(StatusVoid, d.Guard(notPaid)),
-//		d.OnEnter(StatusIssued, d.Hook(stampIssuedAt)),
-//	)
+//	var d fsm.Define[invoiceStatus, *invoice]
+//	var invoiceFSM = fsm.MustNew(invoiceDraft, d.Edge(invoiceDraft, invoiceIssued))
 //
-//	func Transition(ctx context.Context, inv *Invoice, to Status) error {
-//		if err := InvoiceFSM.Fire(ctx, inv, inv.Status, to); err != nil {
-//			return err
-//		}
-//		inv.Status = to
-//		return saveInvoice(ctx, inv) // conditional write, see below
+//	inv := &invoice{Status: invoiceDraft}
+//	if err := invoiceFSM.Fire(context.Background(), inv, inv.Status, invoiceIssued); err == nil {
+//		inv.Status = invoiceIssued
 //	}
+//
+// Real flows attach Guard and Hook attachments to Edge, EdgeFromAny,
+// OnEnter, and OnExit, and build the machine with MustNew at package
+// scope (the regexp.MustCompile precedent) so a broken definition panics
+// at init instead of at first use.
 //
 // # Tenant-defined flows
 //
 // Runtime flows load a Definition (JSON) from the consumer's DB and
-// compile it against the app's registered guard/hook vocabulary. Compile
-// fails closed with every issue in one single-line error — validate at
-// flow-save time and a stored definition always fires cleanly. Cache
-// compiled machines by (tenant, flow, version); they are immutable, so a
-// version-keyed cache never needs invalidation:
+// compile it against the app's registered guard/hook vocabulary via a
+// Registry. Compile fails closed with every issue in one single-line
+// error — validate at flow-save time and a stored definition always
+// fires cleanly. Cache compiled machines by (tenant, flow, version); they
+// are immutable, so a version-keyed cache never needs invalidation:
 //
-//	reg := fsm.Registry[*Move]{
-//		Guards: map[string]fsm.Func[string, *Move]{
-//			"admin_only":      adminOnly,
-//			"subtasks_closed": subtasksClosed,
-//		},
-//		Hooks: map[string]fsm.Func[string, *Move]{
-//			"stamp_completed": stampCompleted,
-//		},
-//	}
+//	m, err := fsm.Compile(def, reg)
 //
-//	var def fsm.Definition
-//	if err := json.Unmarshal(row.FlowJSON, &def); err != nil {
-//		return err
-//	}
-//	m, err := fsm.Compile(def, reg) // cache under row.ProjectID + ":" + row.Version
-//
-//	err = m.Fire(ctx, &Move{Task: task, Actor: actor}, task.Status, target)
-//	switch {
-//	case errors.Is(err, fsm.ErrGuardDenied):
-//		// 422: err carries the human reason ("subtasks still open")
-//	case errors.Is(err, fsm.ErrIllegalTransition), errors.Is(err, fsm.ErrUnknownState):
-//		// 409: stale board — flow or task changed under the user
-//	case err != nil:
-//		// 500: a hook broke; nothing was persisted
-//	}
+// Map Fire's error into a response: ErrGuardDenied is a domain denial
+// (422 — the wrapped guard error carries the human reason);
+// ErrIllegalTransition or ErrUnknownState means the flow or task changed
+// under the caller (409 — stale board); any other error means a hook
+// failed and nothing was persisted (500).
 //
 // Allowed returns the targets the current entity may actually move to
 // (guards evaluated, hooks never run) — it renders per-user status

--- a/core/i18n/cldr/doc.go
+++ b/core/i18n/cldr/doc.go
@@ -3,12 +3,13 @@
 //
 // It is data, not policy. core/i18n imports nothing from this package and
 // applies none of it automatically — the dependency arrow runs one way, and
-// the compiler enforces it. Wire what you want, explicitly:
+// the compiler enforces it. Wire what you want, explicitly.
+//
+// # Usage
 //
 //	bundle, err := i18n.New(
-//	    i18n.WithMessages(catalogFS),
+//	    i18n.WithTranslations("uk-UA", "app", map[string]any{"greeting": "Привіт"}),
 //	    i18n.WithPlural("uk", cldr.Uk),
-//	    i18n.WithPlural("pl", cldr.Pl),
 //	    i18n.WithFormat("uk-UA", cldr.FormatUkUA),
 //	)
 //

--- a/core/i18n/cldr/plural.go
+++ b/core/i18n/cldr/plural.go
@@ -16,8 +16,6 @@ func magnitude(n int) uint64 {
 	return uint64(n)
 }
 
-// --- shared rule bodies -----------------------------------------------------
-
 // oneOther: one for exactly 1 (or -1), other otherwise. The simple two-form
 // shape shared by Germanic, Uralic, and several unrelated languages whose
 // CLDR cardinal rule draws no further distinction.
@@ -235,7 +233,6 @@ func hebrew(n int) i18n.PluralCategory {
 	}
 }
 
-// --- per-language rules -----------------------------------------------------
 // One exported var per language. Never a family bucket: sharing a body is
 // fine, sharing an identifier is how uk/ru 21 and pt/it 0 got broken before.
 

--- a/core/i18n/currency.go
+++ b/core/i18n/currency.go
@@ -8,9 +8,9 @@ import (
 // uint64's safe decimal range (10^19 < 2^64 <= 10^20). No real ISO-4217
 // currency has more than 4 minor units (CLF); this is a defensive backstop
 // against a pathological Currency value, not a realistic path. Without it, a
-// MinorUnits at or beyond 20 would overflow the repeated-multiply divisor —
-// which can silently wrap to exactly zero — turning the following division
-// into a panic.
+// MinorUnits of 20 or more would overflow the repeated-multiply divisor,
+// corrupting the rendered digits, and a MinorUnits of 64 or more would wrap
+// it to exactly zero, turning the following division into a panic.
 const maxCurrencyDigits = 19
 
 // Currency formats m for the locale. The amount and symbol come from money —
@@ -27,8 +27,8 @@ func (b *Bundle) AppendCurrency(dst []byte, loc Locale, m money.Money) []byte {
 	return appendCurrencySpec(dst, m, b.specFor(b.locIdx(loc)))
 }
 
-// appendCurrencySpec renders m under s. Shared by Bundle and Localizer
-// (Task 10), which must not re-implement this.
+// appendCurrencySpec renders m under s. Shared by Bundle and Localizer,
+// which must not re-implement this.
 func appendCurrencySpec(dst []byte, m money.Money, s *FormatSpec) []byte {
 	cur := m.Currency()
 	minor, ok := m.MinorOK()
@@ -43,7 +43,7 @@ func appendCurrencySpec(dst []byte, m money.Money, s *FormatSpec) []byte {
 	if minor < 0 {
 		dst = append(dst, '-')
 	}
-	mag := absU64(minor) // shared with Number/Percent; see format.go
+	mag := absU64(minor) // shared with NumberInt; see format.go
 
 	if s.CurrencyBefore {
 		dst = append(dst, cur.Symbol...)

--- a/core/i18n/doc.go
+++ b/core/i18n/doc.go
@@ -10,6 +10,18 @@
 // Invariant (ISO-8601, "." decimal). Neither is an error, and neither
 // pretends to know your language's grammar.
 //
+// # Usage
+//
+//	catalog := fstest.MapFS{"en/app.json": &fstest.MapFile{Data: []byte(`{"greeting": "Hello, {{name}}!"}`)}}
+//	bundle, err := i18n.New(i18n.WithMessages(catalog))
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	fmt.Println(bundle.T(bundle.Default(), "app.greeting", "name", "Ann"))
+//	// Output: Hello, Ann!
+//
+// # CLDR data
+//
 // Correct CLDR data lives in the sibling package core/i18n/cldr and is
 // never applied automatically:
 //

--- a/core/i18n/format_test.go
+++ b/core/i18n/format_test.go
@@ -23,8 +23,9 @@ var deSpec = i18n.FormatSpec{
 	PercentSpace:   true,
 }
 
-// frSpec uses U+00A0 NO-BREAK SPACE as its group separator, written as an
-// escape so the distinction from a plain space stays visible in source.
+// frSpec uses U+00A0 NO-BREAK SPACE as its group separator: the raw NBSP
+// byte embedded directly below, not a plain space — the two are visually
+// indistinguishable in most editors and diffs.
 var frSpec = i18n.FormatSpec{
 	DecimalSep:     ",",
 	GroupSep:       " ",

--- a/core/id/doc.go
+++ b/core/id/doc.go
@@ -9,24 +9,23 @@
 //   - Short: 80-bit, 16-char Crockford base32, compact and URL-safe (link
 //     shorteners and similar).
 //
-// The zero-argument free functions cover the common case:
-//
-//	u := id.NewUUID()
-//	l := id.NewULID()
-//	s := id.NewShort()
-//
-// For deterministic tests or strictly-increasing same-millisecond ordering, use
-// a Generator:
-//
-//	g := id.NewGenerator(id.WithClock(clk), id.WithMonotonic())
-//	a, b := g.Short(), g.Short() // strictly increasing
-//
-// Under heavy concurrent generation, a single shared Generator created with
-// WithMonotonic can outperform the free functions: the free functions call
-// crypto/rand on every call (which serializes internally), while monotonic mode
-// draws randomness once per millisecond and increments in between.
+// The zero-argument free functions (NewUUID, NewULID, NewShort) cover the
+// common case. For deterministic tests or strictly-increasing same-millisecond
+// ordering, construct a Generator instead: WithClock injects a test clock, and
+// WithMonotonic makes a single shared Generator strictly increasing — and,
+// under heavy concurrent generation, faster than the free functions, since it
+// draws randomness once per millisecond and increments it instead of calling
+// crypto/rand (which serializes internally) on every call.
 //
 // All generation reads crypto/rand and panics only if the OS RNG fails, an
 // unrecoverable condition. Parsing and Scan are case-insensitive; the Parse
 // functions and Scan return ErrMalformed (via errors.Is) on invalid input.
+//
+// # Usage
+//
+//	u := id.NewUUID()
+//	l := id.NewULID()
+//	s := id.NewShort()
+//	g := id.NewGenerator(id.WithMonotonic())
+//	first, second := g.Short(), g.Short() // strictly increasing
 package id

--- a/core/id/generator.go
+++ b/core/id/generator.go
@@ -68,7 +68,7 @@ func setUUIDBits(u *UUID) {
 	u[8] = (u[8] & 0x3f) | 0x80 // variant 0b10
 }
 
-// UUID returns a new version-7 UUID.
+// UUID returns a new version-7 UUID timestamped from g's clock.
 func (g *Generator) UUID() UUID {
 	if !g.monotonic {
 		var u UUID
@@ -94,7 +94,7 @@ func (g *Generator) UUID() UUID {
 	return g.uuidVal
 }
 
-// ULID returns a new ULID.
+// ULID returns a new ULID timestamped from g's clock.
 func (g *Generator) ULID() ULID {
 	if !g.monotonic {
 		var u ULID
@@ -117,7 +117,7 @@ func (g *Generator) ULID() ULID {
 	return g.ulidVal
 }
 
-// Short returns a new Short.
+// Short returns a new Short timestamped from g's clock.
 func (g *Generator) Short() Short {
 	if !g.monotonic {
 		var s Short

--- a/core/iox/doc.go
+++ b/core/iox/doc.go
@@ -6,10 +6,10 @@
 //
 // # Usage
 //
-//	body := iox.LimitReader(r.Body, maxBodySize)
-//	data, err := io.ReadAll(body)
+//	var body io.ReadCloser // from an *http.Request's Body
+//	limited := iox.LimitReader(body, 1<<20)
+//	data, err := io.ReadAll(limited)
 //	if errors.Is(err, iox.ErrLimitExceeded) {
-//		_ = iox.DrainClose(r.Body) // reject but keep the connection alive
-//		return errTooLarge
+//		_ = iox.DrainClose(body) // reject but keep the connection alive
 //	}
 package iox

--- a/core/iox/iox.go
+++ b/core/iox/iox.go
@@ -91,6 +91,8 @@ func NewCountingWriter(w io.Writer) *CountingWriter {
 	return &CountingWriter{w: w}
 }
 
+// Write writes p to the underlying writer and adds the bytes actually
+// written to the running count, even on a short write or error.
 func (c *CountingWriter) Write(p []byte) (int, error) {
 	n, err := c.w.Write(p)
 	c.n += int64(n)

--- a/core/money/allocate.go
+++ b/core/money/allocate.go
@@ -6,7 +6,8 @@ import "sort"
 // at the currency's MinorUnits using the largest-remainder method so that the
 // returned parts always sum back to m exactly. It returns ErrInvalidAllocation
 // when no ratios are given, any ratio is negative, or the ratios sum to zero or
-// less.
+// less. It returns ErrOverflow when the amount's minor-unit count or an
+// intermediate product exceeds int64 range, or the ratio sum overflows int.
 func (m Money) Allocate(ratios ...int) ([]Money, error) {
 	if len(ratios) == 0 {
 		return nil, ErrInvalidAllocation
@@ -90,7 +91,8 @@ func (m Money) Allocate(ratios ...int) ([]Money, error) {
 }
 
 // Split divides the amount into n equal parts, distributing any remainder minor
-// units to the first parts. It returns ErrInvalidAllocation for n <= 0.
+// units to the first parts. It returns ErrInvalidAllocation for n <= 0, or
+// ErrOverflow if the amount's minor-unit count exceeds int64 range.
 func (m Money) Split(n int) ([]Money, error) {
 	if n <= 0 {
 		return nil, ErrInvalidAllocation

--- a/core/money/doc.go
+++ b/core/money/doc.go
@@ -33,5 +33,5 @@
 //	if err != nil {
 //		// price and shipping share a currency here, so this is unreachable
 //	}
-//	total.String() // "24.99 USD"
+//	_ = total.String() // "24.99 USD"
 package money

--- a/core/money/errors.go
+++ b/core/money/errors.go
@@ -10,19 +10,22 @@ var ErrCurrencyMismatch = errors.New("money: currency mismatch")
 // bundled ISO-4217 table.
 var ErrUnknownCurrency = errors.New("money: unknown currency")
 
-// ErrInvalidAllocation is returned by Allocate when the ratios sum to zero or
-// less (nothing to allocate proportionally), and by Split for a non-positive
-// part count.
+// ErrInvalidAllocation is returned by Allocate when no ratios are given, any
+// ratio is negative, or the ratios sum to zero or less (nothing to allocate
+// proportionally), and by Split for a non-positive part count.
 var ErrInvalidAllocation = errors.New("money: invalid allocation ratios")
 
-// ErrScan is returned by Money.Scan when the SQL source value cannot be parsed
-// as the "<amount> <code>" text form, and by Value and MarshalJSON when the
-// Money has no currency code to serialize.
+// ErrScan is returned by Money.Scan when the source is nil, an unsupported
+// type, or a string missing the "<amount> <code>" shape (no separating
+// space). A malformed amount or unrecognized currency code within an
+// otherwise well-shaped string instead surfaces decimal's parse error or
+// ErrUnknownCurrency. ErrScan is also returned by Value and MarshalJSON when
+// the Money has no currency code to serialize.
 var ErrScan = errors.New("money: unsupported Scan source")
 
 // ErrOverflow is returned by Allocate and Split when the amount's minor-unit
-// count, the ratio sum, or a proportional product exceeds int64 range — cases
-// where the int64 largest-remainder split cannot be computed without silent
-// wraparound. (The decimal amount itself is arbitrary-precision; only these
-// integer intermediates are bounded.)
+// count or a proportional product exceeds int64 range, or the ratio sum
+// overflows int — cases where the largest-remainder split cannot be computed
+// without silent wraparound. (The decimal amount itself is arbitrary-precision;
+// only these integer intermediates are bounded.)
 var ErrOverflow = errors.New("money: integer overflow")

--- a/core/money/money.go
+++ b/core/money/money.go
@@ -54,7 +54,8 @@ func Parse(s string, c Currency) (Money, error) {
 // Amount returns the exact decimal amount.
 func (m Money) Amount() decimal.Decimal { return m.amount }
 
-// Currency returns the currency.
+// Currency returns m's currency. It is the zero Currency for the zero Money
+// value or any Money otherwise never assigned a currency.
 func (m Money) Currency() Currency { return m.currency }
 
 // Minor returns the amount rounded to the currency's MinorUnits (banker's

--- a/core/phone/doc.go
+++ b/core/phone/doc.go
@@ -21,8 +21,7 @@
 // is NULL) and JSON (zero Phone is null). What this is NOT: no per-country
 // length/pattern validation, no line-type or carrier lookup, no pretty
 // per-country grouping, and no area-code disambiguation of shared dial codes —
-// the libphonenumber swamp stays out. Cheap E.164 shape validation lives in
-// core/validate.
+// the libphonenumber swamp stays out.
 //
 // # Usage
 //

--- a/core/qrcode/doc.go
+++ b/core/qrcode/doc.go
@@ -11,22 +11,17 @@
 //
 // # Usage
 //
-//	// A 2FA enrollment QR as an <img src> value.
-//	uri, err := qrcode.DataURI("otpauth://totp/App:user?secret=ABC&issuer=App")
+//	var link string // e.g. a short link or otpauth:// URI
+//	var logo image.Image // decoded PNG/JPEG, e.g. via image.Decode
 //
-//	// A branded referral code: high error correction, rounded modules, logo.
+//	// A branded QR: high error correction, rounded modules, centered logo.
 //	png, err := qrcode.PNG(link,
 //		qrcode.WithLevel(qrcode.LevelH),
 //		qrcode.WithModuleShape(qrcode.ShapeRounded),
-//		qrcode.WithLogo(logoImg),
-//		qrcode.WithSize(512),
+//		qrcode.WithLogo(logo),
 //	)
 //
 //	// The raw grid, to render your own way.
 //	m, err := qrcode.Encode(link)
-//	for y := 0; y < m.Size(); y++ {
-//		for x := 0; x < m.Size(); x++ {
-//			_ = m.Module(x, y) // true = dark
-//		}
-//	}
+//	dark := m.Module(0, 0) // true = dark; iterate [0, m.Size()) for the rest
 package qrcode

--- a/core/qrcode/options.go
+++ b/core/qrcode/options.go
@@ -36,7 +36,8 @@ func WithBackground(col color.Color) Option { return func(c *config) { c.bg = co
 func WithLogo(img image.Image) Option { return func(c *config) { c.logo = img } }
 
 // WithLogoSize sets the logo width as a fraction of the code width (default
-// 0.2, capped at 0.3).
+// 0.2). Must be in (0, 0.3]; out-of-range values make the encode/render call
+// return ErrInvalidLogoSize.
 func WithLogoSize(frac float64) Option { return func(c *config) { c.logoSize = frac } }
 
 // WithModuleShape styles the data modules (default ShapeSquare).

--- a/core/qrcode/render_png.go
+++ b/core/qrcode/render_png.go
@@ -144,7 +144,10 @@ func downsample(src *image.RGBA, ss int) *image.RGBA {
 	return dst
 }
 
-// PNG encodes data as a PNG image.
+// PNG encodes data as a PNG image and returns the raw file bytes. Returns
+// ErrTooLarge if data exceeds the QR capacity at the effective level, or one
+// of ErrInvalidScale, ErrInvalidBorder, ErrInvalidLogoSize, ErrInvalidColor if
+// opts are invalid.
 func PNG(data string, opts ...Option) ([]byte, error) {
 	c, err := newConfig(opts...)
 	if err != nil {
@@ -164,6 +167,7 @@ func PNG(data string, opts ...Option) ([]byte, error) {
 }
 
 // DataURI encodes data as a base64 PNG data URI ("data:image/png;base64,…").
+// Errors are the same as PNG's.
 func DataURI(data string, opts ...Option) (string, error) {
 	raw, err := PNG(data, opts...)
 	if err != nil {

--- a/core/qrcode/render_svg.go
+++ b/core/qrcode/render_svg.go
@@ -41,6 +41,10 @@ func svgFill(c color.Color) string {
 // finder ratio. This mirrors the PNG renderer. When both shapes are square
 // (the default) every module is a plain square and the whole matrix is a single
 // combined <path>.
+//
+// Returns ErrTooLarge if data exceeds the QR capacity at the effective level,
+// or one of ErrInvalidScale, ErrInvalidBorder, ErrInvalidLogoSize,
+// ErrInvalidColor if opts are invalid.
 func SVG(data string, opts ...Option) ([]byte, error) {
 	c, err := newConfig(opts...)
 	if err != nil {

--- a/core/qrcode/shape_test.go
+++ b/core/qrcode/shape_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestDotsRaisesLevel(t *testing.T) {
-	// A short input renders fine at M; with ShapeDots the encoder must use >=Q,
-	// so decoding proves nothing here — assert via SVG size/level indirectly:
-	// dots at level L request still produce a valid image without error.
+	// ShapeDots forces effectiveLevel to raise the requested LevelL to >=Q, so
+	// decoding the output wouldn't confirm LevelL took effect. This just checks
+	// the combination still produces a valid image without error.
 	if _, err := qrcode.PNG("dots", qrcode.WithLevel(qrcode.LevelL), qrcode.WithModuleShape(qrcode.ShapeDots), qrcode.WithScale(6)); err != nil {
 		t.Fatalf("PNG dots: %v", err)
 	}
@@ -45,7 +45,7 @@ func countForeground(t *testing.T, raw []byte) int {
 	n := 0
 	for y := b.Min.Y; y < b.Max.Y; y++ {
 		for x := b.Min.X; x < b.Max.X; x++ {
-			// Compare against opaque black in the 8-bit space RGBA() maps to.
+			// RGBA() scales components to 16 bits; opaque black is r=g=b=0, a=0xffff.
 			if r, g, bl, a := img.At(x, y).RGBA(); r == 0 && g == 0 && bl == 0 && a == 0xffff {
 				n++
 			}

--- a/core/random/doc.go
+++ b/core/random/doc.go
@@ -1,17 +1,19 @@
 // Package random provides small, safe helpers over crypto/rand for secure entropy:
 // token nonces, salts, and opaque identifiers.
 //
-// Bytes/Hex/URLSafe/Int panic only on a crypto/rand failure, which means the OS RNG
-// is broken and the program cannot safely continue. Use Read for an error-returning
-// variant. Int is unbiased (rejection sampling via crypto/rand.Int).
+// Bytes, Hex, and URLSafe panic on a crypto/rand failure, which means the OS
+// RNG is broken and the program cannot safely continue; use Read for an
+// error-returning variant. Int is unbiased (rejection sampling via crypto/rand.Int)
+// and additionally panics if max <= 0.
 //
 // String draws n characters from one or more charsets (Lowercase, Uppercase, Digits,
 // Alphabetic, Alphanumeric, Symbols), defaulting to Alphanumeric when none are given.
 // Overlapping charsets are de-duplicated so the result stays uniform over distinct
-// characters. Like Bytes, it is crypto-secure and panics only on a crypto/rand
-// failure; use Read if you need the error-returning escape hatch instead. DigitCode
-// is a thin wrapper over String(n, Digits) for OTP and verification codes, preserving
-// leading zeros.
+// characters. Like Bytes, it panics on a crypto/rand failure, and additionally
+// panics if n < 0 or the combined charset is empty; use Read if you need the
+// error-returning escape hatch instead. DigitCode is a thin wrapper over
+// String(n, Digits) for OTP and verification codes, preserving leading zeros, and
+// panics if n <= 0.
 //
 // # Usage
 //

--- a/core/slicex/slicex.go
+++ b/core/slicex/slicex.go
@@ -14,7 +14,9 @@ func Map[T, U any](s []T, fn func(T) U) []U {
 	return out
 }
 
-// Filter returns a new slice of the elements of s for which pred returns true.
+// Filter returns a new slice of the elements of s for which pred returns
+// true. A nil input yields a nil result; a non-nil input yields a non-nil
+// result even if no elements match.
 func Filter[T any](s []T, pred func(T) bool) []T {
 	if s == nil {
 		return nil
@@ -58,6 +60,7 @@ func KeyBy[T any, K comparable](s []T, key func(T) K) map[K]T {
 
 // Unique returns the elements of s with duplicates removed, preserving
 // first-seen order (unlike slices.Compact, which needs sorted input).
+// A nil input yields a nil result; a non-nil input yields a non-nil result.
 func Unique[T comparable](s []T) []T {
 	if s == nil {
 		return nil
@@ -74,7 +77,9 @@ func Unique[T comparable](s []T) []T {
 	return out
 }
 
-// Flatten concatenates the sub-slices of s into one slice.
+// Flatten concatenates the sub-slices of s into one slice. A nil input
+// yields a nil result; a non-nil input yields a non-nil result even if all
+// sub-slices are empty.
 func Flatten[T any](s [][]T) []T {
 	if s == nil {
 		return nil
@@ -93,7 +98,8 @@ func Flatten[T any](s [][]T) []T {
 // Chunk splits s into consecutive slices of at most n elements. The final
 // chunk may be shorter. Chunk panics if n < 1, matching slices.Chunk. Unlike
 // slices.Chunk it returns a materialized [][]T rather than an iterator; each
-// chunk has capacity clamped so appending to it cannot overwrite s.
+// chunk has capacity clamped so appending to it cannot overwrite s. A nil
+// input yields a nil result.
 func Chunk[T any](s []T, n int) [][]T {
 	if n < 1 {
 		panic("slicex: Chunk called with n < 1")

--- a/core/slug/doc.go
+++ b/core/slug/doc.go
@@ -14,7 +14,10 @@
 //
 // # Usage
 //
-//	slug.Make("Héllo, World!")                          // "hello-world"
-//	slug.Make("admin", slug.WithReservedSlugs("admin")) // "admin-<random>"
-//	slug.Unique("post", exists)                         // "post", "post-2", "post-3", …
+//	s := slug.Make("Héllo, World!")
+//	// s == "hello-world"
+//
+//	exists := func(candidate string) bool { return false } // e.g. a DB lookup
+//	u := slug.Unique("Hello World", exists)
+//	// u == "hello-world"
 package slug

--- a/core/stringsx/doc.go
+++ b/core/stringsx/doc.go
@@ -3,9 +3,9 @@
 // TruncateWords, a last-N-runes Mask, and a naive English Pluralize.
 //
 // stringsx is for TRUSTED, developer-facing strings. Untrusted input belongs to
-// the sanitize package; locale-aware pluralization belongs to the future i18n
-// package (multi-language + custom plural rules) — do not reach for Pluralize
-// when you need real localization.
+// the sanitize package; locale-aware pluralization belongs to the i18n package
+// (multi-language + custom plural rules) — do not reach for Pluralize when you
+// need real localization.
 //
 // # Usage
 //

--- a/core/stringsx/stringsx.go
+++ b/core/stringsx/stringsx.go
@@ -41,7 +41,8 @@ func TruncateWords(s string, n int) string {
 }
 
 // Mask keeps the last keep runes of s and replaces the rest with '*'. When keep
-// >= len(s) or keep <= 0 the whole string is masked (never leaks characters).
+// is greater than or equal to the number of runes in s, or keep <= 0, the whole
+// string is masked (never leaks characters).
 func Mask(s string, keep int) string {
 	r := []rune(s)
 	if keep <= 0 || keep >= len(r) {
@@ -54,7 +55,7 @@ func Mask(s string, keep int) string {
 // best-effort helper for trusted, developer-facing strings only: append "s";
 // "es" after s/x/z/ch/sh; consonant + "y" -> "ies". It is NOT a linguistics
 // engine (no irregular plurals). Locale-aware pluralization belongs to the
-// future i18n package. Returns word unchanged when n == 1.
+// i18n package. Returns word unchanged when n == 1.
 func Pluralize(word string, n int) string {
 	if n == 1 || word == "" {
 		return word

--- a/core/structfields/structfields.go
+++ b/core/structfields/structfields.go
@@ -7,10 +7,10 @@ import (
 
 // Field is one exported struct field surfaced by Walk.
 type Field struct {
-	Set   func(v any) error
-	Value reflect.Value // settable when Walk received a non-nil *struct
-	Name  string        // Go field name
-	Tag   Tag           // parsed tagKey tag
+	Set   func(v any) error // assigns/converts v into the field; ErrNotSettable on a read-only (value-struct) walk
+	Value reflect.Value     // settable when Walk received a non-nil *struct
+	Name  string            // Go field name
+	Tag   Tag               // parsed tagKey tag
 }
 
 // Walk visits each exported field of a struct (or non-nil *struct) exactly

--- a/core/typeconv/doc.go
+++ b/core/typeconv/doc.go
@@ -1,6 +1,6 @@
 // Package typeconv converts strings to Go scalars and back without reflection.
 //
-// It is the scalar substrate that envconfig, form decoding, and featureflag
+// It is the scalar substrate that config, form decoding, and featureflag
 // build field decoders on: Parse[T] and the ParseInt/ParseUint/... helpers turn
 // a string into a typed value; Format is the lossless inverse. Struct-field
 // walking belongs to structfields; locale-aware parsing belongs to i18n.

--- a/core/validate/alloc_test.go
+++ b/core/validate/alloc_test.go
@@ -12,8 +12,8 @@ import (
 //
 // Note: the rules exercised here are pure (ASCII/NotBlank/MinLen). Rules backed by a
 // stdlib parser that allocates internally (e.g. Email via net/mail, or the regexp-
-// backed UUID/Numeric) are intentionally excluded — their non-zero allocs come from
-// the stdlib call, not from validate's Rule/Apply machinery, which this guards.
+// backed UUID) are intentionally excluded — their non-zero allocs come from the
+// stdlib call, not from validate's Rule/Apply machinery, which this guards.
 func TestZeroAllocHappyPath(t *testing.T) {
 	code := "ABC123"
 	name := "abc"

--- a/core/validate/doc.go
+++ b/core/validate/doc.go
@@ -5,13 +5,7 @@
 //
 // Param-less rules are used bare (validate.Email, validate.Required); parameterized
 // rules are constructors that return a Rule[T] (validate.MinLen(2)). Apply runs a
-// field's rules against its value; Check aggregates to an error:
-//
-//	err := validate.Check(
-//		validate.Apply("age",   age,   validate.Required[int], validate.Between(18, 72)),
-//		validate.Apply("email", email, validate.Msg(validate.Email, "invalid {field}")),
-//		validate.Manual("email", "Email is taken"),
-//	)
+// field's rules against its value; Check aggregates the field Results into one error.
 //
 // Rules compose into rules via And/Or/Not/Each/Msg/WithKey/When; conditionals use
 // When (check-level) and WhenField (field-level).
@@ -23,4 +17,14 @@
 // verification is out of scope (it needs Keccak, which would end validate's
 // stdlib-only status). Untrusted-input normalization belongs to the sanitize
 // package; slug generation to the slug package.
+//
+// # Usage
+//
+//	age := 15
+//	email := "invalid"
+//	err := validate.Check(
+//		validate.Apply("age", age, validate.Min(18)),
+//		validate.Apply("email", email, validate.Msg(validate.Email, "invalid email")),
+//	)
+//	// err.Error() == "age: validation.min; email: invalid email"
 package validate

--- a/core/validate/rules_network.go
+++ b/core/validate/rules_network.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// Domain: labels of [a-z0-9] with internal hyphens, 2+ labels, TLD is alphabetic.
+// reDomain matches labels of letters/digits with internal hyphens, 2+ labels, alphabetic TLD.
 var reDomain = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$`)
 
 // IP accepts any valid IPv4 or IPv6 address.
@@ -43,7 +43,7 @@ func MAC(s string) Violation {
 	return Violation{}
 }
 
-// Domain accepts a hostname with at least two labels and an alphabetic TLD.
+// Domain accepts a hostname of at most 253 characters with at least two labels and an alphabetic TLD.
 func Domain(s string) Violation {
 	if len(s) > 253 || !reDomain.MatchString(s) {
 		return Violation{Key: "validation.domain"}

--- a/core/validate/rules_numeric.go
+++ b/core/validate/rules_numeric.go
@@ -62,7 +62,7 @@ func Negative[T number](v T) Violation {
 	return Violation{}
 }
 
-// MultipleOf requires value to be an integer multiple of n.
+// MultipleOf requires value to be an integer multiple of n. n == 0 always fails.
 func MultipleOf[T integer](n T) Rule[T] {
 	return func(v T) Violation {
 		if n == 0 || v%n != 0 {


### PR DESCRIPTION
## Description

Comment-only sweep over 20 packages under core/ via the go-doc-fix skill: removes noise comments (restated-code, section banners, stale TODOs), rewrites doc comments that had drifted from what the code actually does, and adds or refreshes doc.go package comments with machine-verified `# Usage` examples.

No code, identifiers, or logic changed — every file was independently verified comment-only (diff-only-comments check) and every doc.go usage example was compiled against the real package API.

One suspected pre-existing code gap surfaced during review, left untouched per scope (docs only): `core/random.Bytes(n)` doesn't validate `n < 0` like `Int`/`String`/`DigitCode` do, so a negative `n` panics with a raw Go runtime error instead of a clean `random: ...` message.

## Checklist

- [x] `just lint` passes
- [x] `just test` passes
- [x] New code has tests (n/a — docs-only, no new code)
- [x] Commit messages follow conventional commits