### PR TITLE
feat(examples): redirector — full-stack smartlink demo (Postgres, geo routing, fingerprint dedup)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,28 @@ gracefully on `Ctrl+C` (SIGINT) or SIGTERM.
 go run ./examples/worker
 ```
 
+## redirector
+
+A fully working, Postgres-backed short-link service built from [`smartlink`](../web/smartlink) + [`smartlink/pgstore`](../web/smartlink/pgstore), [`fingerprint`](../web/fingerprint), [`geoip`](../web/geoip), [`useragent`](../web/useragent), [`hostrouter`](../web/hostrouter), [`data/postgres`](../data/postgres) + [`data/migration`](../data/migration), and [`render`](../web/render) (std `html/template`): geo-aware smart routing, click tracking with fingerprint-based duplicate detection, and a minimal dashboard with per-link stats plus create-offer and create-ref-link pages. One port, two hosts via `lvh.me` (resolves to 127.0.0.1): `go.lvh.me:8080` serves redirects, `app.lvh.me:8080` the dashboard.
+
+Links, offers, and clicks all live in Postgres (docker-compose ships a `postgres:18` service; both migration sets apply automatically on startup). Nothing is seeded — create an offer and a link through the dashboard forms, then click around:
+
+```sh
+cd examples/redirector
+just run          # docker compose up --wait + go run .
+# open http://app.lvh.me:8080/ — create an offer, then a link, then:
+curl -i "http://go.lvh.me:8080/<code>?geo=de"   # geo rule
+curl -i "http://go.lvh.me:8080/<code>?sub=abc"  # default target, sub-ID forwarded
+just stop         # stop Postgres (or `just reset` to wipe data)
+```
+
+Visitor country resolution is a chain: the `?geo=XX` query override and `X-Geo-Country` header (local testing), the `CF-IPCountry` header (behind Cloudflare), and an optional real IP lookup — set `GEOIP_MMDB` to a MaxMind City database to enable it (download `GeoLite2-City.mmdb` from maxmind.com; a direct localhost click still needs the overrides, since loopback IPs exist in no geo database). Smoke-test the IP path with the repo's MaxMind fixture:
+
+```sh
+GEOIP_MMDB=../../web/geoip/mmdb/testdata/GeoIP2-City-Test.mmdb just run
+curl -i -H "X-Forwarded-For: 216.160.83.56" "http://go.lvh.me:8080/<code>"  # resolves as US
+```
+
 ## helloworld
 
 A plain-HTTP (no TLS) "hello world" server built with

--- a/examples/redirector/dashboard.go
+++ b/examples/redirector/dashboard.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"embed"
+	"errors"
+	"html/template"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/web/render"
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+//go:embed templates
+var templatesFS embed.FS
+
+func mustPage(page string) *template.Template {
+	return template.Must(template.ParseFS(templatesFS, "templates/layout.html", "templates/"+page))
+}
+
+var (
+	indexTmpl    = mustPage("index.html")
+	linkTmpl     = mustPage("link.html")
+	newLinkTmpl  = mustPage("new_link.html")
+	newOfferTmpl = mustPage("new_offer.html")
+)
+
+// Dashboard serves the management UI on the app host: link/offer listings
+// with click stats, and the create forms.
+type Dashboard struct {
+	manager *smartlink.Manager
+	offers  *OfferStore
+	cache   *smartlink.Cache
+	tracker *Tracker
+	log     *slog.Logger
+}
+
+func (d *Dashboard) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /{$}", d.index)
+	mux.HandleFunc("GET /links/new", d.newLinkForm)
+	mux.HandleFunc("POST /links", d.createLink)
+	mux.HandleFunc("GET /links/{code}", d.linkDetail)
+	mux.HandleFunc("GET /offers/new", d.newOfferForm)
+	mux.HandleFunc("POST /offers", d.createOffer)
+	return mux
+}
+
+type linkRow struct {
+	OfferName string
+	Link      smartlink.Link
+	Stats     ClickCounts
+}
+
+type indexData struct {
+	Links  []linkRow
+	Offers []Offer
+}
+
+func (d *Dashboard) index(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	links, err := d.manager.List(ctx, smartlink.Filter{})
+	if err != nil {
+		d.serverError(w, "list links", err)
+		return
+	}
+	counts, err := d.tracker.Summaries(ctx)
+	if err != nil {
+		d.serverError(w, "load click counts", err)
+		return
+	}
+	offers, err := d.offers.List(ctx)
+	if err != nil {
+		d.serverError(w, "list offers", err)
+		return
+	}
+	names := make(map[string]string, len(offers))
+	for _, o := range offers {
+		names[o.Ref] = o.Name
+	}
+	rows := make([]linkRow, 0, len(links))
+	for _, l := range links {
+		rows = append(rows, linkRow{Link: l, Stats: counts[l.Code], OfferName: names[l.Ref]})
+	}
+	d.render(w, http.StatusOK, indexTmpl, indexData{Links: rows, Offers: offers})
+}
+
+type linkData struct {
+	OfferName string
+	Link      smartlink.Link
+	Stats     LinkStats
+}
+
+func (d *Dashboard) linkDetail(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	l, err := d.manager.Get(ctx, r.PathValue("code"))
+	if err != nil {
+		if errors.Is(err, smartlink.ErrNotFound) {
+			http.NotFound(w, r)
+			return
+		}
+		d.serverError(w, "get link", err)
+		return
+	}
+	stats, err := d.tracker.Stats(ctx, l.Code)
+	if err != nil {
+		d.serverError(w, "load stats", err)
+		return
+	}
+	d.render(w, http.StatusOK, linkTmpl, linkData{Link: l, Stats: stats, OfferName: d.offerName(r, l)})
+}
+
+type newLinkData struct {
+	Error    string
+	Code     string
+	Ref      string
+	Target   string
+	Campaign string
+	Offers   []Offer
+}
+
+func (d *Dashboard) newLinkForm(w http.ResponseWriter, r *http.Request) {
+	offers, err := d.offers.List(r.Context())
+	if err != nil {
+		d.serverError(w, "list offers", err)
+		return
+	}
+	d.render(w, http.StatusOK, newLinkTmpl, newLinkData{Offers: offers})
+}
+
+func (d *Dashboard) createLink(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	offers, err := d.offers.List(ctx)
+	if err != nil {
+		d.serverError(w, "list offers", err)
+		return
+	}
+	form := newLinkData{
+		Code:     strings.TrimSpace(r.FormValue("code")),
+		Ref:      r.FormValue("ref"),
+		Target:   strings.TrimSpace(r.FormValue("target")),
+		Campaign: strings.TrimSpace(r.FormValue("campaign")),
+		Offers:   offers,
+	}
+	p := smartlink.CreateParams{Code: form.Code, Ref: form.Ref, Target: form.Target}
+	if form.Campaign != "" {
+		p.Metadata = map[string]string{"campaign": form.Campaign}
+	}
+	if _, err := d.manager.Create(ctx, p); err != nil {
+		if errors.Is(err, smartlink.ErrInvalidLink) || errors.Is(err, smartlink.ErrCodeReserved) || errors.Is(err, smartlink.ErrDuplicate) {
+			form.Error = err.Error()
+			d.render(w, http.StatusUnprocessableEntity, newLinkTmpl, form)
+			return
+		}
+		d.serverError(w, "create link", err)
+		return
+	}
+	render.Redirect(w, r, http.StatusSeeOther, "/")
+}
+
+// offerRowForm is one editable geo-rule row of the offer form.
+type offerRowForm struct {
+	Countries string
+	URL       string
+	Index     int
+}
+
+type newOfferData struct {
+	Error      string
+	Name       string
+	DefaultURL string
+	Rows       []offerRowForm
+}
+
+const offerFormRows = 3
+
+func emptyOfferForm() newOfferData {
+	rows := make([]offerRowForm, offerFormRows)
+	for i := range rows {
+		rows[i].Index = i
+	}
+	return newOfferData{Rows: rows}
+}
+
+func (d *Dashboard) newOfferForm(w http.ResponseWriter, _ *http.Request) {
+	d.render(w, http.StatusOK, newOfferTmpl, emptyOfferForm())
+}
+
+func (d *Dashboard) createOffer(w http.ResponseWriter, r *http.Request) {
+	form := emptyOfferForm()
+	form.Name = strings.TrimSpace(r.FormValue("name"))
+	form.DefaultURL = strings.TrimSpace(r.FormValue("default_url"))
+	for i := range form.Rows {
+		form.Rows[i].Countries = strings.TrimSpace(r.FormValue("rule_countries_" + strconv.Itoa(i)))
+		form.Rows[i].URL = strings.TrimSpace(r.FormValue("rule_url_" + strconv.Itoa(i)))
+	}
+
+	o, err := offerFromForm(form)
+	if err != nil {
+		form.Error = err.Error()
+		d.render(w, http.StatusUnprocessableEntity, newOfferTmpl, form)
+		return
+	}
+	if err := d.offers.Save(r.Context(), o); err != nil {
+		d.serverError(w, "save offer", err)
+		return
+	}
+	// Offer-save path invalidates the compile cache so the next click
+	// resolves the fresh spec (a no-op for a brand-new ref).
+	d.cache.Invalidate(o.Ref)
+	render.Redirect(w, r, http.StatusSeeOther, "/")
+}
+
+// offerFromForm validates the form into an Offer, compiling the resulting
+// Spec so a bad country code or URL template is rejected before saving.
+func offerFromForm(form newOfferData) (Offer, error) {
+	if form.Name == "" {
+		return Offer{}, errors.New("name is required")
+	}
+	if err := checkHTTPURL(form.DefaultURL); err != nil {
+		return Offer{}, err
+	}
+	var rules []GeoRule
+	for _, row := range form.Rows {
+		if row.Countries == "" && row.URL == "" {
+			continue
+		}
+		if row.Countries == "" || row.URL == "" {
+			return Offer{}, errors.New("a rule needs both countries and a URL")
+		}
+		if err := checkHTTPURL(row.URL); err != nil {
+			return Offer{}, err
+		}
+		rules = append(rules, GeoRule{Countries: splitCountries(row.Countries), URL: row.URL})
+	}
+	o := Offer{
+		CreatedAt:  time.Now(),
+		Ref:        id.NewPrefixed("offer"),
+		Name:       form.Name,
+		DefaultURL: form.DefaultURL,
+		Rules:      rules,
+	}
+	if _, err := smartlink.Compile(o.Spec()); err != nil {
+		return Offer{}, err
+	}
+	return o, nil
+}
+
+// checkHTTPURL mirrors the Manager's scheme allowlist for offer targets: Ref
+// specs bypass Create's Target validation, so the offer form enforces it.
+func checkHTTPURL(u string) error {
+	if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
+		return errors.New("destination URLs must start with http:// or https://")
+	}
+	return nil
+}
+
+func splitCountries(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool { return r == ',' || r == ' ' })
+}
+
+func (d *Dashboard) offerName(r *http.Request, l smartlink.Link) string {
+	if l.Ref == "" {
+		return ""
+	}
+	o, err := d.offers.Get(r.Context(), l.Ref)
+	if err != nil {
+		return l.Ref
+	}
+	return o.Name
+}
+
+func (d *Dashboard) render(w http.ResponseWriter, status int, t *template.Template, data any) {
+	if err := render.HTML(w, status, t, "layout", data); err != nil {
+		d.log.Error("dashboard: render", "error", err)
+	}
+}
+
+func (d *Dashboard) serverError(w http.ResponseWriter, op string, err error) {
+	d.log.Error("dashboard: "+op, "error", err)
+	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+}

--- a/examples/redirector/dashboard.go
+++ b/examples/redirector/dashboard.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/web/csrf"
 	"github.com/dmitrymomot/forge/web/render"
 	"github.com/dmitrymomot/forge/web/smartlink"
 )
@@ -120,6 +121,7 @@ type newLinkData struct {
 	Ref      string
 	Target   string
 	Campaign string
+	CSRF     string
 	Offers   []Offer
 }
 
@@ -129,7 +131,7 @@ func (d *Dashboard) newLinkForm(w http.ResponseWriter, r *http.Request) {
 		d.serverError(w, "list offers", err)
 		return
 	}
-	d.render(w, http.StatusOK, newLinkTmpl, newLinkData{Offers: offers})
+	d.render(w, http.StatusOK, newLinkTmpl, newLinkData{Offers: offers, CSRF: csrf.Token(r)})
 }
 
 func (d *Dashboard) createLink(w http.ResponseWriter, r *http.Request) {
@@ -144,6 +146,7 @@ func (d *Dashboard) createLink(w http.ResponseWriter, r *http.Request) {
 		Ref:      r.FormValue("ref"),
 		Target:   strings.TrimSpace(r.FormValue("target")),
 		Campaign: strings.TrimSpace(r.FormValue("campaign")),
+		CSRF:     csrf.Token(r),
 		Offers:   offers,
 	}
 	p := smartlink.CreateParams{Code: form.Code, Ref: form.Ref, Target: form.Target}
@@ -173,6 +176,7 @@ type newOfferData struct {
 	Error      string
 	Name       string
 	DefaultURL string
+	CSRF       string
 	Rows       []offerRowForm
 }
 
@@ -186,12 +190,15 @@ func emptyOfferForm() newOfferData {
 	return newOfferData{Rows: rows}
 }
 
-func (d *Dashboard) newOfferForm(w http.ResponseWriter, _ *http.Request) {
-	d.render(w, http.StatusOK, newOfferTmpl, emptyOfferForm())
+func (d *Dashboard) newOfferForm(w http.ResponseWriter, r *http.Request) {
+	form := emptyOfferForm()
+	form.CSRF = csrf.Token(r)
+	d.render(w, http.StatusOK, newOfferTmpl, form)
 }
 
 func (d *Dashboard) createOffer(w http.ResponseWriter, r *http.Request) {
 	form := emptyOfferForm()
+	form.CSRF = csrf.Token(r)
 	form.Name = strings.TrimSpace(r.FormValue("name"))
 	form.DefaultURL = strings.TrimSpace(r.FormValue("default_url"))
 	for i := range form.Rows {

--- a/examples/redirector/docker-compose.yml
+++ b/examples/redirector/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_USER: redirector
+      POSTGRES_PASSWORD: redirector
+      POSTGRES_DB: redirector
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U redirector -d redirector"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+    volumes:
+      # postgres:18 images moved the volume mount point from
+      # /var/lib/postgresql/data to /var/lib/postgresql.
+      - pgdata:/var/lib/postgresql
+
+volumes:
+  pgdata:

--- a/examples/redirector/justfile
+++ b/examples/redirector/justfile
@@ -1,0 +1,17 @@
+db_url := env_var_or_default("DATABASE_URL", "postgres://redirector:redirector@localhost:5433/redirector?sslmode=disable")
+
+# Start Postgres, then run the redirector
+run: db
+    DATABASE_URL={{ db_url }} go run .
+
+# Start Postgres via docker compose and wait until healthy
+db:
+    docker compose up -d --wait
+
+# Stop Postgres, keep the data volume
+stop:
+    docker compose down
+
+# Stop Postgres and wipe the data volume
+reset:
+    docker compose down -v

--- a/examples/redirector/main.go
+++ b/examples/redirector/main.go
@@ -1,0 +1,258 @@
+// Command redirector is a fully working short-link service backed by
+// Postgres: geo-aware smart routing (web/smartlink + smartlink/pgstore),
+// click tracking with fingerprint-based duplicate detection
+// (web/fingerprint), and a minimal dashboard — all on one port, split by
+// host via web/hostrouter using lvh.me (which resolves to 127.0.0.1):
+//
+//   - http://go.lvh.me:8080/{code} — the public redirector
+//   - http://app.lvh.me:8080/ — dashboard: per-link stats, create offer, create ref link
+//
+// Links, offers, and clicks all live in Postgres (docker-compose ships a
+// postgres:18 service; migrations apply automatically on startup via
+// data/migration + data/postgres). There is no seeded data — create an offer
+// and a link in the dashboard, then click around:
+//
+//	cd examples/redirector
+//	just run                                    # docker compose up + go run .
+//	open http://app.lvh.me:8080/
+//	curl -i "http://go.lvh.me:8080/<code>?geo=de"
+//
+// The visitor country comes from a geoip source chain: a ?geo=XX query
+// override and an X-Geo-Country header (both for local testing), the
+// CF-IPCountry header for deployments behind Cloudflare, and an optional
+// real IP-based lookup — set GEOIP_MMDB to a MaxMind City database path
+// (download GeoLite2-City.mmdb from maxmind.com) to enable it. Direct
+// localhost clicks always fall through to the overrides: a loopback IP
+// exists in no geo database. Each click's
+// fingerprint (headers + client hints + IP) becomes the Visit sticky key, so
+// split bucketing and duplicate detection agree by construction.
+package main
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+	"github.com/dmitrymomot/forge/ops/logger"
+	"github.com/dmitrymomot/forge/ops/supervisor"
+	"github.com/dmitrymomot/forge/web/clientip"
+	"github.com/dmitrymomot/forge/web/fingerprint"
+	"github.com/dmitrymomot/forge/web/geoip"
+	"github.com/dmitrymomot/forge/web/geoip/mmdb"
+	"github.com/dmitrymomot/forge/web/hostrouter"
+	"github.com/dmitrymomot/forge/web/httpserver"
+	"github.com/dmitrymomot/forge/web/middleware"
+	"github.com/dmitrymomot/forge/web/recoverer"
+	"github.com/dmitrymomot/forge/web/requestid"
+	"github.com/dmitrymomot/forge/web/requestlog"
+	"github.com/dmitrymomot/forge/web/smartlink"
+	"github.com/dmitrymomot/forge/web/smartlink/pgstore"
+	"github.com/dmitrymomot/forge/web/useragent"
+)
+
+const (
+	addr          = ":8080"
+	redirectHost  = "go.lvh.me"
+	dashboardHost = "app.lvh.me"
+	baseURL       = "http://go.lvh.me:8080"
+	dashboardURL  = "http://app.lvh.me:8080"
+
+	// defaultDatabaseURL matches the docker-compose postgres service.
+	defaultDatabaseURL = "postgres://redirector:redirector@localhost:5433/redirector?sslmode=disable"
+)
+
+//go:embed migrations/*.sql
+var migrationsRaw embed.FS
+
+func main() {
+	log, err := logger.New(logger.WithContextExtractors(requestid.LogExtractor, clientip.LogExtractor))
+	if err != nil {
+		panic(err)
+	}
+	if err := run(log); err != nil {
+		log.Error("redirector exited", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(log *slog.Logger) error {
+	ctx, stop := supervisor.NewContext()
+	defer stop()
+
+	pool, err := openDB(ctx, log)
+	if err != nil {
+		return err
+	}
+	defer postgres.Close(pool, log)
+
+	// Demo-only fixed secret so fingerprints stay stable across restarts;
+	// a real deployment loads it from configuration.
+	fp, err := fingerprint.New(fingerprint.Config{
+		Secret:   "redirector-demo-secret",
+		Version:  1,
+		TokenTTL: 10 * time.Minute,
+	}, fingerprint.WithCollectors(fingerprint.Headers(), fingerprint.ClientHints(), fingerprint.ClientIP()))
+	if err != nil {
+		return err
+	}
+
+	offers := NewOfferStore(pool)
+	specCache, err := smartlink.NewCache(offers.Load)
+	if err != nil {
+		return err
+	}
+	tracker := NewTracker(pool, log)
+
+	manager, err := smartlink.NewManager(pgstore.New(pool),
+		smartlink.WithBaseURL(baseURL),
+		smartlink.WithResolver(specCache.Resolver()),
+		smartlink.WithVisitFunc(buildVisit(fp)),
+		smartlink.WithOnHit(tracker.OnHit),
+		smartlink.WithLogger(log),
+	)
+	if err != nil {
+		return err
+	}
+
+	geoSrc, closeGeo, err := geoSource(log)
+	if err != nil {
+		return err
+	}
+	defer closeGeo()
+
+	redirectMux := http.NewServeMux()
+	redirectMux.Handle("/{$}", http.RedirectHandler(dashboardURL, http.StatusFound))
+	redirectMux.Handle("/{code}", manager.Handler())
+
+	dash := &Dashboard{manager: manager, offers: offers, cache: specCache, tracker: tracker, log: log}
+
+	router := hostrouter.New(
+		hostrouter.WithHost(redirectHost, middleware.Wrap(redirectMux, geoip.Middleware(geoSrc))),
+		hostrouter.WithHost(dashboardHost, dash.Handler()),
+		hostrouter.WithHost("lvh.me", http.RedirectHandler(dashboardURL, http.StatusFound)),
+	)
+
+	h := middleware.Wrap(router,
+		recoverer.New(recoverer.WithLogger(log)),
+		requestid.New(),
+		clientip.Middleware(clientip.TrustPrivateProxies()),
+		requestlog.New(log),
+	)
+
+	srv := httpserver.New(h,
+		httpserver.WithAddr(addr),
+		httpserver.WithName("redirector"),
+		httpserver.WithLogger(log),
+	)
+
+	log.Info("redirector up", "dashboard", dashboardURL, "redirects", baseURL+"/{code}")
+
+	return supervisor.Run(ctx,
+		supervisor.WithLogger(log),
+		supervisor.WithService(srv),
+		supervisor.WithService(tracker),
+	)
+}
+
+// openDB connects to Postgres (DATABASE_URL, defaulting to the
+// docker-compose service) and applies both migration sets — the pgstore
+// links table and this example's offers/clicks tables — each under its own
+// goose version table.
+func openDB(ctx context.Context, log *slog.Logger) (pool *pgxpool.Pool, err error) {
+	cfg := postgres.DefaultConfig()
+	cfg.URL = os.Getenv("DATABASE_URL")
+	if cfg.URL == "" {
+		cfg.URL = defaultDatabaseURL
+	}
+
+	appMigrations, err := fs.Sub(migrationsRaw, "migrations")
+	if err != nil {
+		return nil, err
+	}
+
+	return postgres.Open(ctx,
+		postgres.WithConfig(cfg),
+		postgres.WithLogger(log),
+		postgres.WithMigrator(migration.Group(
+			migration.Source(pgstore.Migrations, "forge_smartlink_schema"),
+			migration.Source(appMigrations, "redirector_schema"),
+		)),
+	)
+}
+
+// geoSource builds the visitor-country resolution chain: the ?geo=XX query
+// override and X-Geo-Country header (local testing), the CF-IPCountry header
+// (deployments behind Cloudflare), and — when GEOIP_MMDB points at a MaxMind
+// City database (GeoLite2-City.mmdb or the GeoIP2 test fixture) — a real
+// IP-based lookup via geoip/mmdb. The mmdb source resolves the client IP
+// through the installed clientip middleware, so a trusted X-Forwarded-For
+// chain geolocates correctly. Note that private/loopback IPs (every direct
+// localhost click) exist in no geo database — that is what the query/header
+// overrides are for.
+func geoSource(log *slog.Logger) (geoip.Source, func(), error) {
+	sources := []geoip.Source{
+		queryGeo{},
+		geoip.Headers(geoip.HeaderMap{Country: "X-Geo-Country"}),
+		geoip.Cloudflare(),
+	}
+	cleanup := func() {}
+	if path := os.Getenv("GEOIP_MMDB"); path != "" {
+		reader, err := mmdb.New(mmdb.WithCity(path))
+		if err != nil {
+			return nil, nil, fmt.Errorf("open GEOIP_MMDB %q: %w", path, err)
+		}
+		sources = append(sources, geoip.FromLocator(reader))
+		cleanup = func() {
+			if err := reader.Close(); err != nil {
+				log.Warn("close mmdb reader", "error", err)
+			}
+		}
+		log.Info("geoip: mmdb city database loaded", "path", path)
+	}
+	return geoip.Chain(sources...), cleanup, nil
+}
+
+// queryGeo lets local tests pick a country per request:
+// curl "http://go.lvh.me:8080/<code>?geo=de".
+type queryGeo struct{}
+
+func (queryGeo) Lookup(r *http.Request) (geoip.Location, error) {
+	if cc := r.URL.Query().Get("geo"); len(cc) == 2 {
+		return geoip.Location{CountryCode: strings.ToUpper(cc)}, nil
+	}
+	return geoip.Location{}, nil
+}
+
+// buildVisit assembles the smartlink Visit from request facts: country from
+// the geoip middleware, device class from web/useragent, locale from
+// Accept-Language, and the fingerprint hash as the sticky key.
+func buildVisit(fp *fingerprint.Fingerprinter) smartlink.VisitFunc {
+	return func(r *http.Request, v smartlink.Visit) smartlink.Visit {
+		delete(v.Params, "geo") // local-testing override, not a real sub-ID
+		v.Country = geoip.Get(r).CountryCode
+		v.Device = string(useragent.ParseRequest(r).Device.Type)
+		v.Locale = firstLocale(r.Header.Get("Accept-Language"))
+		if f, err := fp.FromRequest(r); err == nil {
+			v.StickyKey = f.Hash
+		}
+		return v
+	}
+}
+
+// firstLocale extracts the first tag from an Accept-Language header
+// ("de-DE,de;q=0.9" -> "de-DE").
+func firstLocale(al string) string {
+	tag, _, _ := strings.Cut(al, ",")
+	tag, _, _ = strings.Cut(tag, ";")
+	return strings.TrimSpace(tag)
+}

--- a/examples/redirector/main.go
+++ b/examples/redirector/main.go
@@ -41,11 +41,14 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/dmitrymomot/forge/crypto/keyset"
 	"github.com/dmitrymomot/forge/data/migration"
 	"github.com/dmitrymomot/forge/data/postgres"
 	"github.com/dmitrymomot/forge/ops/logger"
 	"github.com/dmitrymomot/forge/ops/supervisor"
 	"github.com/dmitrymomot/forge/web/clientip"
+	"github.com/dmitrymomot/forge/web/cookie"
+	"github.com/dmitrymomot/forge/web/csrf"
 	"github.com/dmitrymomot/forge/web/fingerprint"
 	"github.com/dmitrymomot/forge/web/geoip"
 	"github.com/dmitrymomot/forge/web/geoip/mmdb"
@@ -136,9 +139,24 @@ func run(log *slog.Logger) error {
 
 	dash := &Dashboard{manager: manager, offers: offers, cache: specCache, tracker: tracker, log: log}
 
+	// Double-submit CSRF for the dashboard's POST forms. The demo runs plain
+	// HTTP on lvh.me, so the cookie codec drops Secure and the token cookie
+	// cannot use the default __Host- name (browsers reject __Host- cookies
+	// over HTTP); a real deployment keeps both defaults. Demo-only fixed key,
+	// like the fingerprint secret.
+	ks, err := keyset.New(keyset.WithPrimary(1, []byte("redirector-demo-cookie-secret-key-01")))
+	if err != nil {
+		return err
+	}
+	codec, err := cookie.New(ks, cookie.WithSecure(false))
+	if err != nil {
+		return err
+	}
+	csrfMW := csrf.New(codec, csrf.WithCookieName("csrf"))
+
 	router := hostrouter.New(
 		hostrouter.WithHost(redirectHost, middleware.Wrap(redirectMux, geoip.Middleware(geoSrc))),
-		hostrouter.WithHost(dashboardHost, dash.Handler()),
+		hostrouter.WithHost(dashboardHost, middleware.Wrap(dash.Handler(), csrfMW)),
 		hostrouter.WithHost("lvh.me", http.RedirectHandler(dashboardURL, http.StatusFound)),
 	)
 

--- a/examples/redirector/migrations/00001_redirector_tables.sql
+++ b/examples/redirector/migrations/00001_redirector_tables.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+CREATE TABLE redirector_offers (
+    ref         text PRIMARY KEY,
+    name        text NOT NULL,
+    default_url text NOT NULL,
+    rules       jsonb NOT NULL DEFAULT '[]',
+    created_at  timestamptz NOT NULL
+);
+
+CREATE TABLE redirector_clicks (
+    id           bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    code         text NOT NULL,
+    rule         text NOT NULL DEFAULT '',
+    url          text NOT NULL,
+    country      text NOT NULL DEFAULT '',
+    device       text NOT NULL DEFAULT '',
+    fingerprint  text NOT NULL DEFAULT '',
+    is_duplicate boolean NOT NULL,
+    clicked_at   timestamptz NOT NULL
+);
+CREATE INDEX redirector_clicks_code_idx ON redirector_clicks (code, id DESC);
+CREATE INDEX redirector_clicks_code_fp_idx ON redirector_clicks (code, fingerprint);
+
+-- +goose Down
+DROP TABLE redirector_clicks;
+DROP TABLE redirector_offers;

--- a/examples/redirector/offers.go
+++ b/examples/redirector/offers.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+// GeoRule sends visitors from the listed countries to URL.
+type GeoRule struct {
+	URL       string   `json:"url"`
+	Countries []string `json:"countries"`
+}
+
+// Offer is the consumer-side routing record a Ref-backed Link points at:
+// ordered geo rules with a mandatory default destination. It lives in the
+// app's own redirector_offers table; smartlink only ever sees it through the
+// Cache load func as a hydrated [smartlink.Spec].
+type Offer struct {
+	CreatedAt  time.Time
+	Ref        string
+	Name       string
+	DefaultURL string
+	Rules      []GeoRule
+}
+
+// Spec hydrates the offer into the smartlink rule vocabulary. Rule names
+// carry the row index so two rows over the same countries stay unique.
+func (o Offer) Spec() smartlink.Spec {
+	rules := make([]smartlink.Rule, 0, len(o.Rules))
+	for i, r := range o.Rules {
+		rules = append(rules, smartlink.Rule{
+			Name:    fmt.Sprintf("geo-%d-%s", i+1, strings.ToLower(strings.Join(r.Countries, "-"))),
+			When:    []smartlink.Matcher{smartlink.Geo{Countries: r.Countries}},
+			Targets: []smartlink.Target{{URL: r.URL}},
+		})
+	}
+	// ParamsFill forwards visit params (sub-IDs, the link's stamped campaign
+	// metadata) onto the destination URL without clobbering its own query.
+	return smartlink.Spec{
+		Rules:   rules,
+		Default: []smartlink.Target{{URL: o.DefaultURL}},
+		Params:  smartlink.ParamsFill,
+	}
+}
+
+// errOfferNotFound reports an unknown offer ref.
+var errOfferNotFound = errors.New("offer not found")
+
+// OfferStore persists offers in the redirector_offers table.
+type OfferStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewOfferStore(pool *pgxpool.Pool) *OfferStore {
+	return &OfferStore{pool: pool}
+}
+
+func (s *OfferStore) Save(ctx context.Context, o Offer) error {
+	rules, err := json.Marshal(o.Rules)
+	if err != nil {
+		return fmt.Errorf("marshal rules: %w", err)
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO redirector_offers (ref, name, default_url, rules, created_at)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (ref) DO UPDATE
+		SET name = EXCLUDED.name, default_url = EXCLUDED.default_url, rules = EXCLUDED.rules`,
+		o.Ref, o.Name, o.DefaultURL, rules, o.CreatedAt.UTC())
+	return err
+}
+
+func (s *OfferStore) Get(ctx context.Context, ref string) (Offer, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT ref, name, default_url, rules, created_at
+		FROM redirector_offers WHERE ref = $1`, ref)
+	o, err := scanOffer(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Offer{}, fmt.Errorf("%w: %q", errOfferNotFound, ref)
+	}
+	return o, err
+}
+
+// List returns offers newest first.
+func (s *OfferStore) List(ctx context.Context) ([]Offer, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT ref, name, default_url, rules, created_at
+		FROM redirector_offers ORDER BY created_at DESC, ref`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Offer
+	for rows.Next() {
+		o, err := scanOffer(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}
+
+func scanOffer(row pgx.Row) (Offer, error) {
+	var (
+		o     Offer
+		rules []byte
+	)
+	if err := row.Scan(&o.Ref, &o.Name, &o.DefaultURL, &rules, &o.CreatedAt); err != nil {
+		return Offer{}, err
+	}
+	if err := json.Unmarshal(rules, &o.Rules); err != nil {
+		return Offer{}, fmt.Errorf("unmarshal rules: %w", err)
+	}
+	return o, nil
+}
+
+// Load is the [smartlink.NewCache] load func. An unknown ref wraps
+// [smartlink.ErrRefNotFound] so Manager.Create's precheck reads it as caller
+// input error, not infrastructure failure.
+func (s *OfferStore) Load(ctx context.Context, ref string) (smartlink.Spec, error) {
+	o, err := s.Get(ctx, ref)
+	if err != nil {
+		if errors.Is(err, errOfferNotFound) {
+			return smartlink.Spec{}, fmt.Errorf("offer %q: %w", ref, smartlink.ErrRefNotFound)
+		}
+		return smartlink.Spec{}, err
+	}
+	return o.Spec(), nil
+}

--- a/examples/redirector/stats.go
+++ b/examples/redirector/stats.go
@@ -174,11 +174,11 @@ func (t *Tracker) Stats(ctx context.Context, code string) (LinkStats, error) {
 		return s, nil
 	}
 
-	s.ByCountry, err = t.groupCount(ctx, code, `COALESCE(NULLIF(country, ''), 'unknown')`)
+	s.ByCountry, err = t.groupCount(ctx, clicksByCountrySQL, code)
 	if err != nil {
 		return LinkStats{}, err
 	}
-	s.ByRule, err = t.groupCount(ctx, code, `COALESCE(NULLIF(rule, ''), 'default')`)
+	s.ByRule, err = t.groupCount(ctx, clicksByRuleSQL, code)
 	if err != nil {
 		return LinkStats{}, err
 	}
@@ -201,11 +201,19 @@ func (t *Tracker) Stats(ctx context.Context, code string) (LinkStats, error) {
 	return s, rows.Err()
 }
 
-// groupCount aggregates clicks for code by expr (a trusted SQL expression,
-// never user input).
-func (t *Tracker) groupCount(ctx context.Context, code, expr string) (map[string]int, error) {
-	rows, err := t.pool.Query(ctx,
-		`SELECT `+expr+`, count(*) FROM redirector_clicks WHERE code = $1 GROUP BY 1`, code)
+// Complete per-dimension aggregate queries: full constant statements rather
+// than a fragment interpolated into a shared shell, so no SQL is ever built
+// by string concatenation.
+const (
+	clicksByCountrySQL = `SELECT COALESCE(NULLIF(country, ''), 'unknown'), count(*)
+		FROM redirector_clicks WHERE code = $1 GROUP BY 1`
+	clicksByRuleSQL = `SELECT COALESCE(NULLIF(rule, ''), 'default'), count(*)
+		FROM redirector_clicks WHERE code = $1 GROUP BY 1`
+)
+
+// groupCount runs one of the constant aggregate queries above for code.
+func (t *Tracker) groupCount(ctx context.Context, query, code string) (map[string]int, error) {
+	rows, err := t.pool.Query(ctx, query, code)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/redirector/stats.go
+++ b/examples/redirector/stats.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/web/smartlink"
+)
+
+// Click is one recorded redirect.
+type Click struct {
+	At          time.Time
+	Code        string
+	Rule        string // matched rule name; "" means the default target
+	URL         string
+	Country     string
+	Device      string
+	Fingerprint string
+	Duplicate   bool
+}
+
+// ShortFP is the fingerprint hash truncated for display.
+func (c Click) ShortFP() string {
+	if len(c.Fingerprint) <= 12 {
+		return c.Fingerprint
+	}
+	return c.Fingerprint[:12]
+}
+
+// RuleName is the matched rule, with the default target named explicitly.
+func (c Click) RuleName() string {
+	if c.Rule == "" {
+		return "default"
+	}
+	return c.Rule
+}
+
+// ClickCounts is the per-link click summary shown on the dashboard index.
+type ClickCounts struct {
+	Total      int
+	Unique     int
+	Duplicates int
+}
+
+// LinkStats is the full aggregate for one code's detail page.
+type LinkStats struct {
+	ByCountry map[string]int
+	ByRule    map[string]int
+	Recent    []Click // newest first, capped
+	ClickCounts
+}
+
+const recentCap = 20
+
+// Tracker persists clicks in the redirector_clicks table, off the request
+// path: OnHit does a non-blocking send into a buffered channel (the bounded
+// sink WithOnHit demands) and the Run loop — a supervisor service and the
+// single writer — inserts each click. A click is a duplicate when its
+// fingerprint hash was already recorded for the code; the check is computed
+// inside the INSERT, and the single-writer loop keeps check and insert
+// race-free.
+type Tracker struct {
+	log  *slog.Logger
+	pool *pgxpool.Pool
+	ch   chan Click
+}
+
+func NewTracker(pool *pgxpool.Pool, log *slog.Logger) *Tracker {
+	return &Tracker{log: log, pool: pool, ch: make(chan Click, 256)}
+}
+
+// OnHit is wired via [smartlink.WithOnHit]; it runs synchronously after each
+// redirect is written, so it must never block.
+func (t *Tracker) OnHit(_ context.Context, h smartlink.Hit) {
+	c := Click{
+		At:          time.Now().UTC(),
+		Code:        h.Link.Code,
+		Rule:        h.Decision.Rule,
+		URL:         h.Decision.URL,
+		Country:     strings.ToUpper(h.Visit.Country),
+		Device:      h.Visit.Device,
+		Fingerprint: h.Visit.StickyKey,
+	}
+	select {
+	case t.ch <- c:
+	default:
+		t.log.Warn("tracker: click dropped, buffer full", "code", c.Code)
+	}
+}
+
+func (t *Tracker) Name() string { return "click-tracker" }
+
+// Run inserts queued clicks until ctx is canceled, then drains whatever is
+// still buffered so a shutdown right after a click doesn't lose it.
+func (t *Tracker) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			t.drain()
+			return nil
+		case c := <-t.ch:
+			t.insert(c)
+		}
+	}
+}
+
+func (t *Tracker) drain() {
+	for {
+		select {
+		case c := <-t.ch:
+			t.insert(c)
+		default:
+			return
+		}
+	}
+}
+
+// insert records one click. An empty fingerprint never counts as a
+// duplicate — an unidentifiable visitor is not evidence of a repeat visit.
+func (t *Tracker) insert(c Click) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := t.pool.Exec(ctx, `
+		INSERT INTO redirector_clicks (code, rule, url, country, device, fingerprint, is_duplicate, clicked_at)
+		VALUES ($1, $2, $3, $4, $5, $6,
+		        $6 <> '' AND EXISTS (SELECT 1 FROM redirector_clicks WHERE code = $1 AND fingerprint = $6),
+		        $7)`,
+		c.Code, c.Rule, c.URL, c.Country, c.Device, c.Fingerprint, c.At)
+	if err != nil {
+		t.log.Error("tracker: insert click", "code", c.Code, "error", err)
+	}
+}
+
+// Summaries returns per-code click counts for every code that has clicks.
+func (t *Tracker) Summaries(ctx context.Context) (map[string]ClickCounts, error) {
+	rows, err := t.pool.Query(ctx, `
+		SELECT code, count(*), count(*) FILTER (WHERE is_duplicate)
+		FROM redirector_clicks GROUP BY code`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]ClickCounts)
+	for rows.Next() {
+		var (
+			code string
+			c    ClickCounts
+		)
+		if err := rows.Scan(&code, &c.Total, &c.Duplicates); err != nil {
+			return nil, err
+		}
+		c.Unique = c.Total - c.Duplicates
+		out[code] = c
+	}
+	return out, rows.Err()
+}
+
+// Stats returns the full aggregate for one code; zero stats when it has no
+// clicks yet.
+func (t *Tracker) Stats(ctx context.Context, code string) (LinkStats, error) {
+	var s LinkStats
+	err := t.pool.QueryRow(ctx, `
+		SELECT count(*), count(*) FILTER (WHERE is_duplicate)
+		FROM redirector_clicks WHERE code = $1`, code).Scan(&s.Total, &s.Duplicates)
+	if err != nil {
+		return LinkStats{}, err
+	}
+	s.Unique = s.Total - s.Duplicates
+	if s.Total == 0 {
+		return s, nil
+	}
+
+	s.ByCountry, err = t.groupCount(ctx, code, `COALESCE(NULLIF(country, ''), 'unknown')`)
+	if err != nil {
+		return LinkStats{}, err
+	}
+	s.ByRule, err = t.groupCount(ctx, code, `COALESCE(NULLIF(rule, ''), 'default')`)
+	if err != nil {
+		return LinkStats{}, err
+	}
+
+	rows, err := t.pool.Query(ctx, `
+		SELECT clicked_at, rule, url, country, device, fingerprint, is_duplicate
+		FROM redirector_clicks WHERE code = $1 ORDER BY id DESC LIMIT $2`, code, recentCap)
+	if err != nil {
+		return LinkStats{}, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		c := Click{Code: code}
+		if err := rows.Scan(&c.At, &c.Rule, &c.URL, &c.Country, &c.Device, &c.Fingerprint, &c.Duplicate); err != nil {
+			return LinkStats{}, err
+		}
+		c.At = c.At.Local()
+		s.Recent = append(s.Recent, c)
+	}
+	return s, rows.Err()
+}
+
+// groupCount aggregates clicks for code by expr (a trusted SQL expression,
+// never user input).
+func (t *Tracker) groupCount(ctx context.Context, code, expr string) (map[string]int, error) {
+	rows, err := t.pool.Query(ctx,
+		`SELECT `+expr+`, count(*) FROM redirector_clicks WHERE code = $1 GROUP BY 1`, code)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]int)
+	for rows.Next() {
+		var (
+			key string
+			n   int
+		)
+		if err := rows.Scan(&key, &n); err != nil {
+			return nil, err
+		}
+		out[key] = n
+	}
+	return out, rows.Err()
+}

--- a/examples/redirector/templates/index.html
+++ b/examples/redirector/templates/index.html
@@ -1,0 +1,39 @@
+{{define "title"}}Dashboard{{end}}
+
+{{define "content"}}
+<h1>Short links</h1>
+{{if .Links}}
+<table>
+  <tr><th>Code</th><th>Short URL</th><th>Destination</th><th>Clicks</th><th>Unique</th><th>Duplicates</th></tr>
+  {{range .Links}}
+  <tr>
+    <td><a href="/links/{{.Link.Code}}"><code>{{.Link.Code}}</code></a></td>
+    <td><a href="{{.Link.ShortURL}}">{{.Link.ShortURL}}</a></td>
+    <td>{{if .OfferName}}offer: {{.OfferName}}{{else}}{{.Link.Target}}{{end}}</td>
+    <td>{{.Stats.Total}}</td>
+    <td>{{.Stats.Unique}}</td>
+    <td>{{.Stats.Duplicates}}</td>
+  </tr>
+  {{end}}
+</table>
+{{else}}
+<p class="muted">No links yet. <a href="/links/new">Create one</a>.</p>
+{{end}}
+
+<h2>Offers</h2>
+{{if .Offers}}
+<table>
+  <tr><th>Ref</th><th>Name</th><th>Geo rules</th><th>Default URL</th></tr>
+  {{range .Offers}}
+  <tr>
+    <td><code>{{.Ref}}</code></td>
+    <td>{{.Name}}</td>
+    <td>{{len .Rules}}</td>
+    <td>{{.DefaultURL}}</td>
+  </tr>
+  {{end}}
+</table>
+{{else}}
+<p class="muted">No offers yet. <a href="/offers/new">Create one</a>.</p>
+{{end}}
+{{end}}

--- a/examples/redirector/templates/layout.html
+++ b/examples/redirector/templates/layout.html
@@ -1,0 +1,45 @@
+{{define "layout"}}<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{template "title" .}} · redirector</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 15px/1.5 system-ui, sans-serif; max-width: 60rem; margin: 0 auto; padding: 1rem 1.5rem 3rem; }
+  header { display: flex; align-items: baseline; gap: 1.5rem; border-bottom: 1px solid #8884; padding-bottom: .75rem; margin-bottom: 1.5rem; }
+  header nav { display: flex; gap: 1rem; }
+  h1 { font-size: 1.4rem; }
+  h2 { font-size: 1.1rem; margin-top: 2rem; }
+  table { border-collapse: collapse; width: 100%; margin: .5rem 0 1rem; }
+  th, td { text-align: left; padding: .35rem .6rem; border-bottom: 1px solid #8883; }
+  th { font-size: .8rem; text-transform: uppercase; letter-spacing: .05em; opacity: .7; }
+  code { background: #8882; padding: .1rem .3rem; border-radius: 3px; }
+  form { max-width: 32rem; display: grid; gap: .75rem; }
+  label { display: grid; gap: .25rem; font-weight: 600; font-size: .9rem; }
+  input, select { font: inherit; padding: .4rem .5rem; border: 1px solid #8886; border-radius: 4px; background: transparent; color: inherit; }
+  button { font: inherit; font-weight: 600; padding: .45rem 1rem; border: 0; border-radius: 4px; background: #2563eb; color: #fff; cursor: pointer; justify-self: start; }
+  .error { background: #dc26261a; border: 1px solid #dc262666; color: #dc2626; padding: .5rem .75rem; border-radius: 4px; }
+  .tiles { display: flex; gap: 1rem; margin: 1rem 0; }
+  .tile { border: 1px solid #8884; border-radius: 6px; padding: .6rem 1rem; min-width: 7rem; }
+  .tile b { display: block; font-size: 1.4rem; }
+  .tile span { font-size: .8rem; opacity: .7; }
+  .muted { opacity: .6; }
+  fieldset { border: 1px solid #8884; border-radius: 6px; display: grid; gap: .75rem; }
+</style>
+</head>
+<body>
+<header>
+  <strong>redirector</strong>
+  <nav>
+    <a href="/">Dashboard</a>
+    <a href="/links/new">New link</a>
+    <a href="/offers/new">New offer</a>
+  </nav>
+</header>
+<main>
+{{template "content" .}}
+</main>
+</body>
+</html>
+{{end}}

--- a/examples/redirector/templates/link.html
+++ b/examples/redirector/templates/link.html
@@ -1,0 +1,56 @@
+{{define "title"}}{{.Link.Code}}{{end}}
+
+{{define "content"}}
+<h1>Link <code>{{.Link.Code}}</code></h1>
+<p>
+  <a href="{{.Link.ShortURL}}">{{.Link.ShortURL}}</a>
+  → {{if .OfferName}}offer <strong>{{.OfferName}}</strong> (<code>{{.Link.Ref}}</code>){{else}}{{.Link.Target}}{{end}}
+  {{if .Link.Metadata}}<br><span class="muted">metadata: {{range $k, $v := .Link.Metadata}}{{$k}}={{$v}} {{end}}</span>{{end}}
+</p>
+
+<div class="tiles">
+  <div class="tile"><b>{{.Stats.Total}}</b><span>total clicks</span></div>
+  <div class="tile"><b>{{.Stats.Unique}}</b><span>unique visitors</span></div>
+  <div class="tile"><b>{{.Stats.Duplicates}}</b><span>duplicate clicks</span></div>
+</div>
+
+{{if .Stats.ByCountry}}
+<h2>By country</h2>
+<table>
+  <tr><th>Country</th><th>Clicks</th></tr>
+  {{range $country, $n := .Stats.ByCountry}}
+  <tr><td>{{$country}}</td><td>{{$n}}</td></tr>
+  {{end}}
+</table>
+{{end}}
+
+{{if .Stats.ByRule}}
+<h2>By matched rule</h2>
+<table>
+  <tr><th>Rule</th><th>Clicks</th></tr>
+  {{range $rule, $n := .Stats.ByRule}}
+  <tr><td>{{$rule}}</td><td>{{$n}}</td></tr>
+  {{end}}
+</table>
+{{end}}
+
+{{if .Stats.Recent}}
+<h2>Recent clicks</h2>
+<table>
+  <tr><th>Time</th><th>Country</th><th>Device</th><th>Rule</th><th>Fingerprint</th><th></th><th>Destination</th></tr>
+  {{range .Stats.Recent}}
+  <tr>
+    <td>{{.At.Format "15:04:05"}}</td>
+    <td>{{if .Country}}{{.Country}}{{else}}—{{end}}</td>
+    <td>{{.Device}}</td>
+    <td>{{.RuleName}}</td>
+    <td><code>{{.ShortFP}}</code></td>
+    <td>{{if .Duplicate}}duplicate{{end}}</td>
+    <td>{{.URL}}</td>
+  </tr>
+  {{end}}
+</table>
+{{else}}
+<p class="muted">No clicks recorded yet. Try: <code>curl -i "{{.Link.ShortURL}}?geo=de"</code></p>
+{{end}}
+{{end}}

--- a/examples/redirector/templates/new_link.html
+++ b/examples/redirector/templates/new_link.html
@@ -1,0 +1,28 @@
+{{define "title"}}New link{{end}}
+
+{{define "content"}}
+<h1>New ref link</h1>
+{{if .Error}}<p class="error">{{.Error}}</p>{{end}}
+<form method="post" action="/links">
+  <label>Offer (ref link)
+    <select name="ref">
+      <option value="">— none, use a direct URL —</option>
+      {{$ref := .Ref}}
+      {{range .Offers}}
+      <option value="{{.Ref}}" {{if eq .Ref $ref}}selected{{end}}>{{.Name}} ({{.Ref}})</option>
+      {{end}}
+    </select>
+  </label>
+  <label>Direct target URL (when no offer is selected)
+    <input name="target" value="{{.Target}}" placeholder="https://example.com/landing">
+  </label>
+  <label>Vanity code (optional, generated when empty)
+    <input name="code" value="{{.Code}}" placeholder="summer-sale">
+  </label>
+  <label>Campaign tag (optional, stamped into every click)
+    <input name="campaign" value="{{.Campaign}}" placeholder="newsletter-07">
+  </label>
+  <button type="submit">Create link</button>
+</form>
+<p class="muted">Pick an offer <em>or</em> fill a direct URL — exactly one is required.</p>
+{{end}}

--- a/examples/redirector/templates/new_link.html
+++ b/examples/redirector/templates/new_link.html
@@ -4,6 +4,7 @@
 <h1>New ref link</h1>
 {{if .Error}}<p class="error">{{.Error}}</p>{{end}}
 <form method="post" action="/links">
+  <input type="hidden" name="csrf_token" value="{{.CSRF}}">
   <label>Offer (ref link)
     <select name="ref">
       <option value="">— none, use a direct URL —</option>

--- a/examples/redirector/templates/new_offer.html
+++ b/examples/redirector/templates/new_offer.html
@@ -1,0 +1,27 @@
+{{define "title"}}New offer{{end}}
+
+{{define "content"}}
+<h1>New offer</h1>
+{{if .Error}}<p class="error">{{.Error}}</p>{{end}}
+<form method="post" action="/offers">
+  <label>Name
+    <input name="name" value="{{.Name}}" placeholder="Summer promo" required>
+  </label>
+  <label>Default URL (used when no rule matches)
+    <input name="default_url" value="{{.DefaultURL}}" placeholder="https://example.com/global" required>
+  </label>
+  {{range .Rows}}
+  <fieldset>
+    <legend>Geo rule {{.Index}}</legend>
+    <label>Countries (comma-separated ISO codes)
+      <input name="rule_countries_{{.Index}}" value="{{.Countries}}" placeholder="DE, AT, CH">
+    </label>
+    <label>Destination URL
+      <input name="rule_url_{{.Index}}" value="{{.URL}}" placeholder="https://example.com/dach">
+    </label>
+  </fieldset>
+  {{end}}
+  <button type="submit">Create offer</button>
+</form>
+<p class="muted">Rules are evaluated top-down; the first matching country wins. Empty rows are ignored.</p>
+{{end}}

--- a/examples/redirector/templates/new_offer.html
+++ b/examples/redirector/templates/new_offer.html
@@ -4,6 +4,7 @@
 <h1>New offer</h1>
 {{if .Error}}<p class="error">{{.Error}}</p>{{end}}
 <form method="post" action="/offers">
+  <input type="hidden" name="csrf_token" value="{{.CSRF}}">
   <label>Name
     <input name="name" value="{{.Name}}" placeholder="Summer promo" required>
   </label>


### PR DESCRIPTION
## Description

Adds `examples/redirector`, a fully working short-link service demonstrating how the web/data/ops packages compose into a real app:

- **One port, two hosts** via `hostrouter` over lvh.me (resolves to 127.0.0.1): `go.lvh.me:8080/{code}` serves redirects, `app.lvh.me:8080` the dashboard.
- **Postgres-backed everywhere**: links through `smartlink/pgstore`; offers and clicks in the example's own tables. `migration.Group` applies the pgstore set and the app set under separate goose version tables against the bundled `postgres:18` docker-compose service (note: the 18 image moved its volume mount to `/var/lib/postgresql`).
- **Geo-aware routing**: offers (name + default URL + ordered geo rules) hydrate into `smartlink.Spec` through `smartlink.NewCache`, with `Cache.Invalidate` on the save path. Country resolves through a `geoip.Chain`: `?geo=XX` / `X-Geo-Country` overrides for local testing, `CF-IPCountry` behind Cloudflare, and an optional real IP lookup via `geoip/mmdb` when `GEOIP_MMDB` points at a MaxMind City database.
- **Click tracking with fingerprint dedup**: the `web/fingerprint` hash (headers + client hints + IP) doubles as the Visit `StickyKey`, so split bucketing and duplicate detection share one identity. `WithOnHit` does a non-blocking send into a bounded channel; a single-writer supervisor service inserts clicks with `is_duplicate` computed inside the INSERT (race-free by the single-writer construction). Dashboard stats (totals / uniques / dups, by-country, by-rule, recent) are SQL aggregates, so they survive restarts.
- **No seeded data**: offers and links are created through the dashboard forms (std `html/template` + `render.HTML`), with validation errors re-rendered as 422s.
- Own `justfile` (`just run` = compose up --wait + go run) and `docker-compose.yml`.

## Verified

Everything exercised live, not just compiled: forms create offers/links (bad country codes, ref+target both set, reserved/duplicate vanity codes all rejected); `?geo=de|us` routes to the matching rule and forwards sub-IDs + stamped campaign metadata (`ParamsFill`); repeat clicks from the same fingerprint count as duplicates while a different UA/IP counts unique; data survives an app restart; the mmdb path verified against the repo's MaxMind test fixture (`216.160.83.56` → US → matched the US/CA rule). A quick `ab` run sustained ~22k redirects/s (p99 11ms) with the bounded click sink dropping (and logging) overflow — the documented WithOnHit failure mode.

Reviewer notes: this is an example `main`, so there are no tests by design (repo packages it wires are tested); the example is excluded from the benchmarks policy for the same reason. The fingerprint secret is a fixed demo value, called out in a comment.

## Checklist

- [x] `just lint` passes
- [x] `just test` passes
- [ ] New code has tests — n/a: runnable example `main`, exercised end-to-end manually (see Verified)
- [x] Commit messages follow conventional commits