### PR TITLE
web/smartlink: full-package review fixes + simplification pass

### DIFF
--- a/resilience/singleflight/bench_test.go
+++ b/resilience/singleflight/bench_test.go
@@ -1,0 +1,52 @@
+package singleflight_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dmitrymomot/forge/resilience/singleflight"
+)
+
+// BenchmarkDo measures the solo-leader path: each call registers, runs fn
+// inline, and deregisters — no joiners.
+func BenchmarkDo(b *testing.B) {
+	var g singleflight.Group[int]
+	ctx := context.Background()
+	fn := func(context.Context) (int, error) { return 42, nil }
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, _, err := g.Do(ctx, "k", fn); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDoDetached measures the solo-initiator path: each call registers,
+// spawns the leader goroutine, and waits on the flight's done channel.
+func BenchmarkDoDetached(b *testing.B) {
+	var g singleflight.Group[int]
+	ctx := context.Background()
+	fn := func(context.Context) (int, error) { return 42, nil }
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, _, err := g.DoDetached(ctx, "k", fn); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDoContended measures Do under parallel callers on one key, where
+// registration contends on the Group mutex and most callers join as waiters.
+func BenchmarkDoContended(b *testing.B) {
+	var g singleflight.Group[int]
+	ctx := context.Background()
+	fn := func(context.Context) (int, error) { return 42, nil }
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, _, err := g.Do(ctx, "k", fn); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/resilience/singleflight/doc.go
+++ b/resilience/singleflight/doc.go
@@ -3,6 +3,12 @@
 //
 // If fn panics, waiters receive an error and the leader's caller re-panics.
 //
+// [Group.Do] blocks every caller until the shared execution finishes.
+// [Group.DoDetached] instead runs fn in its own goroutine and bounds each
+// caller's wait by its own context — for hot paths where a stuck fn must not
+// pin requests past their deadlines while the shared work still completes
+// once.
+//
 // # Usage
 //
 //	var g singleflight.Group[User]

--- a/resilience/singleflight/singleflight.go
+++ b/resilience/singleflight/singleflight.go
@@ -26,18 +26,11 @@ type Group[V any] struct {
 // caller cancelling does not abort the shared work; each caller's own ctx still
 // bounds its wait via fn's returned error, not the wait itself.
 func (g *Group[V]) Do(ctx context.Context, key string, fn func(context.Context) (V, error)) (V, bool, error) {
-	g.mu.Lock()
-	if g.m == nil {
-		g.m = make(map[string]*call[V])
-	}
-	if c, ok := g.m[key]; ok {
-		g.mu.Unlock()
+	c, shared := g.join(key)
+	if shared {
 		<-c.done
 		return c.val, true, c.err
 	}
-	c := &call[V]{done: make(chan struct{})}
-	g.m[key] = c
-	g.mu.Unlock()
 
 	g.run(context.WithoutCancel(ctx), key, c, fn)
 	if c.panicVal != nil {
@@ -56,17 +49,10 @@ func (g *Group[V]) Do(ctx context.Context, key string, fn func(context.Context) 
 // every waiter observes; there is no caller to re-panic into. Do and
 // DoDetached share the per-key flight, so mixed callers coalesce too.
 func (g *Group[V]) DoDetached(ctx context.Context, key string, fn func(context.Context) (V, error)) (V, bool, error) {
-	g.mu.Lock()
-	if g.m == nil {
-		g.m = make(map[string]*call[V])
-	}
-	c, shared := g.m[key]
+	c, shared := g.join(key)
 	if !shared {
-		c = &call[V]{done: make(chan struct{})}
-		g.m[key] = c
 		go g.run(context.WithoutCancel(ctx), key, c, fn)
 	}
-	g.mu.Unlock()
 
 	select {
 	case <-c.done:
@@ -75,6 +61,26 @@ func (g *Group[V]) DoDetached(ctx context.Context, key string, fn func(context.C
 		var zero V
 		return zero, shared, ctx.Err()
 	}
+}
+
+// join returns key's in-flight call, or registers a fresh one when none
+// exists. shared reports whether the caller joined an existing flight rather
+// than leading a new one; the leader is responsible for running it.
+func (g *Group[V]) join(key string) (*call[V], bool) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call[V])
+	}
+	// The c != nil arm is unreachable (only non-nil calls are registered) but
+	// lets nilaway prove join's result needs no guarding at the call sites.
+	if c, ok := g.m[key]; ok && c != nil {
+		g.mu.Unlock()
+		return c, true
+	}
+	c := &call[V]{done: make(chan struct{})}
+	g.m[key] = c
+	g.mu.Unlock()
+	return c, false
 }
 
 // run executes fn into c and closes c.done exactly once, converting a panic

--- a/resilience/singleflight/singleflight.go
+++ b/resilience/singleflight/singleflight.go
@@ -10,7 +10,7 @@ type call[V any] struct {
 	val      V
 	err      error
 	panicVal any
-	wg       sync.WaitGroup
+	done     chan struct{}
 }
 
 // Group deduplicates concurrent Do calls by key. The zero value is ready to
@@ -32,33 +32,68 @@ func (g *Group[V]) Do(ctx context.Context, key string, fn func(context.Context) 
 	}
 	if c, ok := g.m[key]; ok {
 		g.mu.Unlock()
-		c.wg.Wait()
+		<-c.done
 		return c.val, true, c.err
 	}
-	c := new(call[V])
-	c.wg.Add(1)
+	c := &call[V]{done: make(chan struct{})}
 	g.m[key] = c
 	g.mu.Unlock()
 
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				c.panicVal = r
-				c.err = fmt.Errorf("singleflight: panic in fn: %v", r)
-			}
-			c.wg.Done()
-			g.mu.Lock()
-			if g.m[key] == c {
-				delete(g.m, key)
-			}
-			g.mu.Unlock()
-		}()
-		c.val, c.err = fn(context.WithoutCancel(ctx))
-	}()
+	g.run(context.WithoutCancel(ctx), key, c, fn)
 	if c.panicVal != nil {
 		panic(c.panicVal) // leader re-panics; waiters already observed c.err
 	}
 	return c.val, false, c.err
+}
+
+// DoDetached is Do with context-bounded waits: fn runs once per key in its
+// own goroutine under a cancellation-detached copy of the initiating caller's
+// ctx, and every caller — initiator and joiners alike — waits only until its
+// own ctx ends, receiving ctx.Err() while the shared execution keeps running
+// for the callers that stay. Use it when fn may outlive a request deadline
+// (a slow database read behind a redirect hot path) and no single caller may
+// be pinned past its own deadline. A panic in fn is converted to an error
+// every waiter observes; there is no caller to re-panic into. Do and
+// DoDetached share the per-key flight, so mixed callers coalesce too.
+func (g *Group[V]) DoDetached(ctx context.Context, key string, fn func(context.Context) (V, error)) (V, bool, error) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call[V])
+	}
+	c, shared := g.m[key]
+	if !shared {
+		c = &call[V]{done: make(chan struct{})}
+		g.m[key] = c
+		go g.run(context.WithoutCancel(ctx), key, c, fn)
+	}
+	g.mu.Unlock()
+
+	select {
+	case <-c.done:
+		return c.val, shared, c.err
+	case <-ctx.Done():
+		var zero V
+		return zero, shared, ctx.Err()
+	}
+}
+
+// run executes fn into c and closes c.done exactly once, converting a panic
+// to an error and deregistering the flight so the next call for key starts
+// fresh.
+func (g *Group[V]) run(ctx context.Context, key string, c *call[V], fn func(context.Context) (V, error)) {
+	defer func() {
+		if r := recover(); r != nil {
+			c.panicVal = r
+			c.err = fmt.Errorf("singleflight: panic in fn: %v", r)
+		}
+		close(c.done)
+		g.mu.Lock()
+		if g.m[key] == c {
+			delete(g.m, key)
+		}
+		g.mu.Unlock()
+	}()
+	c.val, c.err = fn(ctx)
 }
 
 // Forget drops the in-flight call for key, if any, so the next Do for that

--- a/resilience/singleflight/singleflight_test.go
+++ b/resilience/singleflight/singleflight_test.go
@@ -83,7 +83,7 @@ func TestMixedDoAndDoDetachedCoalesce(t *testing.T) {
 	var leaderShared bool
 	var wg sync.WaitGroup
 	wg.Go(func() {
-		v, shared, err := g.DoDetached(t.Context(), "k", func(context.Context) (int, error) {
+		v, shared, err := g.DoDetached(t.Context(), "k1", func(context.Context) (int, error) {
 			calls.Add(1)
 			close(entered)
 			time.Sleep(25 * time.Millisecond)
@@ -98,7 +98,7 @@ func TestMixedDoAndDoDetachedCoalesce(t *testing.T) {
 	vals := make([]int, 10)
 	for i := range joined {
 		wg.Go(func() {
-			v, shared, err := g.Do(t.Context(), "k", func(context.Context) (int, error) {
+			v, shared, err := g.Do(t.Context(), "k1", func(context.Context) (int, error) {
 				calls.Add(1)
 				return 0, nil
 			})
@@ -115,7 +115,9 @@ func TestMixedDoAndDoDetachedCoalesce(t *testing.T) {
 		assert.Equal(t, 42, vals[i])
 	}
 
-	// Vice versa: a Do-led flight is joined by a DoDetached caller.
+	// Vice versa: a Do-led flight is joined by a DoDetached caller. A distinct
+	// key — the first flight's deregistration runs in a goroutine wg does not
+	// track, so reusing "k1" could racily join its completed call.
 	calls.Store(0)
 	entered = make(chan struct{})
 	var wg2 sync.WaitGroup
@@ -123,7 +125,7 @@ func TestMixedDoAndDoDetachedCoalesce(t *testing.T) {
 	var joinerVal int
 	wg2.Go(func() {
 		<-entered
-		v, shared, err := g.DoDetached(t.Context(), "k", func(context.Context) (int, error) {
+		v, shared, err := g.DoDetached(t.Context(), "k2", func(context.Context) (int, error) {
 			calls.Add(1)
 			return 0, nil
 		})
@@ -131,7 +133,7 @@ func TestMixedDoAndDoDetachedCoalesce(t *testing.T) {
 		joinerShared = shared
 		joinerVal = v
 	})
-	v, shared, err := g.Do(t.Context(), "k", func(context.Context) (int, error) {
+	v, shared, err := g.Do(t.Context(), "k2", func(context.Context) (int, error) {
 		calls.Add(1)
 		close(entered)
 		time.Sleep(25 * time.Millisecond)

--- a/resilience/singleflight/singleflight_test.go
+++ b/resilience/singleflight/singleflight_test.go
@@ -48,6 +48,84 @@ func TestForgetAllowsReexecution(t *testing.T) {
 	assert.Equal(t, int32(2), calls.Load())
 }
 
+func TestDoDetachedCoalescesConcurrentCalls(t *testing.T) {
+	var g singleflight.Group[int]
+	var calls atomic.Int32
+	start := make(chan struct{})
+	results := make([]int, 20)
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Go(func() {
+			<-start
+			v, _, err := g.DoDetached(t.Context(), "k", func(context.Context) (int, error) {
+				calls.Add(1)
+				time.Sleep(25 * time.Millisecond)
+				return 42, nil
+			})
+			assert.NoError(t, err)
+			results[i] = v
+		})
+	}
+	close(start)
+	wg.Wait()
+	assert.Equal(t, int32(1), calls.Load())
+	for _, r := range results {
+		assert.Equal(t, 42, r)
+	}
+}
+
+func TestDoDetachedWaitBoundedByCallerContext(t *testing.T) {
+	var g singleflight.Group[int]
+	release := make(chan struct{})
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	_, _, err := g.DoDetached(ctx, "k", func(context.Context) (int, error) {
+		<-release
+		return 1, nil
+	})
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDoDetachedExecutionSurvivesCallerCancel(t *testing.T) {
+	var g singleflight.Group[int]
+	done := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, _, err := g.DoDetached(ctx, "k", func(fnCtx context.Context) (int, error) {
+		defer close(done)
+		// The detached fn must not observe the initiator's cancellation.
+		assert.NoError(t, fnCtx.Err())
+		return 1, nil
+	})
+	assert.ErrorIs(t, err, context.Canceled)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("detached fn did not run to completion after caller cancel")
+	}
+}
+
+func TestDoDetachedPanicBecomesErrorForAllWaiters(t *testing.T) {
+	var g singleflight.Group[int]
+	_, _, err := g.DoDetached(t.Context(), "k", func(context.Context) (int, error) {
+		panic("boom")
+	})
+	assert.ErrorContains(t, err, "panic in fn")
+	// Key must not be poisoned: a subsequent call re-executes and succeeds.
+	v, shared, err := g.DoDetached(t.Context(), "k", func(context.Context) (int, error) {
+		return 7, nil
+	})
+	assert.NoError(t, err)
+	assert.False(t, shared)
+	assert.Equal(t, 7, v)
+}
+
 func TestPanicInFnRePanicsAndDoesNotPoisonKey(t *testing.T) {
 	var g singleflight.Group[int]
 	assert.Panics(t, func() {

--- a/resilience/singleflight/singleflight_test.go
+++ b/resilience/singleflight/singleflight_test.go
@@ -74,6 +74,78 @@ func TestDoDetachedCoalescesConcurrentCalls(t *testing.T) {
 	}
 }
 
+func TestMixedDoAndDoDetachedCoalesce(t *testing.T) {
+	var g singleflight.Group[int]
+	var calls atomic.Int32
+
+	// A DoDetached-led flight is joined by concurrent Do callers.
+	entered := make(chan struct{})
+	var leaderShared bool
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		v, shared, err := g.DoDetached(t.Context(), "k", func(context.Context) (int, error) {
+			calls.Add(1)
+			close(entered)
+			time.Sleep(25 * time.Millisecond)
+			return 42, nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 42, v)
+		leaderShared = shared
+	})
+	<-entered // the DoDetached flight is registered and running
+	joined := make([]bool, 10)
+	vals := make([]int, 10)
+	for i := range joined {
+		wg.Go(func() {
+			v, shared, err := g.Do(t.Context(), "k", func(context.Context) (int, error) {
+				calls.Add(1)
+				return 0, nil
+			})
+			assert.NoError(t, err)
+			joined[i] = shared
+			vals[i] = v
+		})
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), calls.Load(), "mixed callers must share one execution")
+	assert.False(t, leaderShared, "the DoDetached initiator led the flight")
+	for i := range joined {
+		assert.True(t, joined[i], "Do caller %d must join the in-flight execution", i)
+		assert.Equal(t, 42, vals[i])
+	}
+
+	// Vice versa: a Do-led flight is joined by a DoDetached caller.
+	calls.Store(0)
+	entered = make(chan struct{})
+	var wg2 sync.WaitGroup
+	var joinerShared bool
+	var joinerVal int
+	wg2.Go(func() {
+		<-entered
+		v, shared, err := g.DoDetached(t.Context(), "k", func(context.Context) (int, error) {
+			calls.Add(1)
+			return 0, nil
+		})
+		assert.NoError(t, err)
+		joinerShared = shared
+		joinerVal = v
+	})
+	v, shared, err := g.Do(t.Context(), "k", func(context.Context) (int, error) {
+		calls.Add(1)
+		close(entered)
+		time.Sleep(25 * time.Millisecond)
+		return 7, nil
+	})
+	wg2.Wait()
+	assert.NoError(t, err)
+	assert.False(t, shared, "the Do leader ran fn itself")
+	assert.Equal(t, 7, v)
+	assert.Equal(t, int32(1), calls.Load(), "mixed callers must share one execution")
+	assert.True(t, joinerShared, "the DoDetached caller must join the Do-led flight")
+	assert.Equal(t, 7, joinerVal)
+}
+
 func TestDoDetachedWaitBoundedByCallerContext(t *testing.T) {
 	var g singleflight.Group[int]
 	release := make(chan struct{})

--- a/web/smartlink/cache.go
+++ b/web/smartlink/cache.go
@@ -16,12 +16,13 @@ const defaultRefTTL = 5 * time.Minute
 
 // Resolver resolves a Ref-backed Link to a Decider ready for a click decision.
 // [Cache.Resolver] returns a ready-made one; [WithResolver] wires it into a
-// Manager. Resolver does not special-case ErrNoTarget: when the
-// consumer's load func returns it for a paused or deleted offer, Resolver
-// propagates the wrapped error and leaves the mapping to dead-link handling
-// to the caller. A load func should return an error wrapping [ErrRefNotFound]
-// for a ref that names no known Spec, so [Manager.Create]'s ref precheck can
-// tell caller error from infrastructure failure.
+// Manager. Resolver does not special-case the sentinels itself: a load func
+// returns an error wrapping [ErrNoTarget] for a paused or deleted offer and
+// [ErrRefNotFound] for a ref that names no known Spec, Resolver propagates
+// them wrapped, and the caller maps them — [Manager.Handler] serves both as
+// dead links, [Manager.Create]'s ref precheck reports both as [ErrInvalidLink]
+// caller input, and every other resolver error stays an infrastructure
+// failure (500 at serve time, unwrapped from Create).
 type Resolver func(ctx context.Context, l Link) (Decider, error)
 
 // Cache is a lazy compile cache for Ref-backed Links. Offers live in the

--- a/web/smartlink/compile.go
+++ b/web/smartlink/compile.go
@@ -132,9 +132,7 @@ func compileSplit(targets []Target, salt, ruleName string) (split, error) {
 		}
 		s.targets[i] = compiledTarget{raw: t, tmpl: tmpl}
 		if tmpl.segs == nil {
-			if u, err := url.Parse(tmpl.raw); err == nil {
-				s.targets[i].lit = &litQuery{u: *u, pairs: splitQuery(u.RawQuery)}
-			}
+			s.targets[i].lit = &litQuery{u: *tmpl.elidedURL, pairs: splitQuery(tmpl.elidedURL.RawQuery)}
 		}
 	}
 	if len(targets) > 1 {

--- a/web/smartlink/doc.go
+++ b/web/smartlink/doc.go
@@ -72,7 +72,10 @@
 // [Manager.Delete] drive its lifecycle. [Manager.Handler] serves the
 // uniform per-click pipeline for both Target and Ref links: resolve the
 // code (cache read-through via [WithCache], liveness checks) — a dead or
-// unknown code redirects to [WithFallbackURL] or answers 404 — build
+// unknown code, or a Ref the resolver reports gone ([ErrNoTarget],
+// [ErrRefNotFound]), redirects to [WithFallbackURL] or answers 404, and a
+// code that could never have been minted (over 64 chars, outside the vanity
+// charset) short-circuits there without a Store roundtrip — build
 // [Visit] from the query string and [WithVisitFunc], merge the link's
 // Metadata into Visit.Params (metadata wins — it identifies the link, not
 // the click), decide (a per-hit degenerate compile for Target links under

--- a/web/smartlink/errors.go
+++ b/web/smartlink/errors.go
@@ -50,3 +50,14 @@ var (
 	// ErrScope is returned when a required tenant scope is missing.
 	ErrScope = errors.New("smartlink: scope required")
 )
+
+// refGone reports whether a resolver error is a positive "this ref leads
+// nowhere" answer — [ErrNoTarget] (paused or deleted offer) or
+// [ErrRefNotFound] (ref names no known Spec) — as opposed to an
+// infrastructure failure. It is the single definition of that split:
+// Create's ref precheck maps it to [ErrInvalidLink] caller input and
+// [Manager.Handler] serves it as a dead link, while anything else must read
+// as an outage.
+func refGone(err error) bool {
+	return errors.Is(err, ErrNoTarget) || errors.Is(err, ErrRefNotFound)
+}

--- a/web/smartlink/errors.go
+++ b/web/smartlink/errors.go
@@ -37,10 +37,12 @@ var (
 	// ErrRefNotFound is the sentinel a consumer's [Cache] load func (or a
 	// custom [Resolver]) wraps when a ref names no known Spec. Create's ref
 	// precheck maps it (and ErrNoTarget) to ErrInvalidLink — caller input —
+	// and [Manager.Handler] serves both as dead links (fallback or 404),
 	// while any other resolver error propagates unwrapped as infrastructure
 	// failure.
 	ErrRefNotFound = errors.New("smartlink: ref not found")
-	// ErrInvalidLink is returned for a malformed Link or CreateParams.
+	// ErrInvalidLink is returned for a malformed Link, CreateParams, or
+	// Store argument (e.g. a zero Deactivate time).
 	ErrInvalidLink = errors.New("smartlink: invalid link")
 	// ErrCodeReserved is returned when a caller-supplied code collides with a
 	// reserved value.

--- a/web/smartlink/handler.go
+++ b/web/smartlink/handler.go
@@ -3,6 +3,7 @@ package smartlink
 import (
 	"context"
 	"errors"
+	"maps"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,6 +18,12 @@ import (
 // pattern with a {code} wildcard (e.g. mux.Handle("/{code}", m.Handler()));
 // otherwise it falls back to the trimmed request path, so the Handler also
 // works mounted bare at "/".
+//
+// A code that could never have been minted by [Manager.Create] — over 64
+// characters or outside [A-Za-z0-9_-] — is answered as a dead link without a
+// Store roundtrip, so scans and garbage paths cost nothing. A row written to
+// the Store directly with a code outside that charset is unreachable through
+// the Handler by design; the code contract is Create's.
 //
 // Every response — success, dead link, or error — carries
 // "Cache-Control: no-store": a redirect decision can change on the next
@@ -35,6 +42,10 @@ func (m *Manager) Handler() http.Handler {
 			code = strings.Trim(r.URL.Path, "/")
 		}
 		w.Header().Set("Cache-Control", "no-store")
+		if !validCodeChars(code) {
+			m.deadLink(w, r)
+			return
+		}
 
 		ctx := r.Context()
 		l, err := m.Resolve(ctx, code)
@@ -47,11 +58,13 @@ func (m *Manager) Handler() http.Handler {
 		if m.cfg.visitFunc != nil {
 			v = m.cfg.visitFunc(r, v)
 		}
-		for k, val := range l.Metadata {
-			if v.Params == nil {
-				v.Params = make(map[string]string, len(l.Metadata))
-			}
-			v.Params[k] = val
+		if len(l.Metadata) > 0 {
+			// Merged into a fresh map — metadata wins, and the map a VisitFunc
+			// returned is never mutated behind the consumer's back.
+			merged := make(map[string]string, len(v.Params)+len(l.Metadata))
+			maps.Copy(merged, v.Params)
+			maps.Copy(merged, l.Metadata)
+			v.Params = merged
 		}
 
 		d, ok := m.decider(ctx, w, r, code, l)
@@ -77,7 +90,10 @@ func (m *Manager) Handler() http.Handler {
 func (m *Manager) decider(ctx context.Context, w http.ResponseWriter, r *http.Request, code string, l Link) (Decider, bool) {
 	switch {
 	case l.Target != "":
-		compiled, err := m.compileTarget(l)
+		// Per-hit degenerate compile, no caching in v1: a single-template
+		// compile is ~1µs (see bench_test.go), and an unbounded per-code
+		// compiled cache is a memory liability at affiliate-code cardinality.
+		compiled, err := m.compileLink(l.Code, l.Target)
 		if err != nil {
 			// Rows created through this Manager cannot fail here — Create
 			// validates Target with the same compile call. Rows written to the
@@ -98,7 +114,11 @@ func (m *Manager) decider(ctx context.Context, w http.ResponseWriter, r *http.Re
 	default:
 		resolved, err := m.cfg.resolver(ctx, l)
 		if err != nil {
-			if errors.Is(err, ErrNoTarget) {
+			// ErrNoTarget (paused/deleted offer) and ErrRefNotFound (ref names
+			// no known Spec) are both positive "this link leads nowhere"
+			// answers — dead links, like Create maps them to caller error —
+			// while anything else is an outage and must read as one.
+			if errors.Is(err, ErrNoTarget) || errors.Is(err, ErrRefNotFound) {
 				m.deadLink(w, r)
 				return nil, false
 			}
@@ -123,25 +143,6 @@ func (m *Manager) decorated(d Decider) Decider {
 		return d
 	}
 	return m.decorate(d)
-}
-
-// compileTarget compiles the degenerate single-target Spec for a
-// Target-backed Link, salted by its code so split/Percent bucketing stays
-// per-link, using the configured link param policy. It re-applies
-// checkTargetURL so a row written to the Store outside this Manager (which
-// never went through Create's validation) cannot serve a disallowed scheme
-// like "javascript:" as a redirect. No caching in v1: a single-template
-// compile is a few µs (see bench_test.go), and an unbounded per-code
-// compiled cache is a memory liability at affiliate-code cardinality.
-func (m *Manager) compileTarget(l Link) (Decider, error) {
-	compiled, err := Compile(Spec{Salt: l.Code, Default: []Target{{URL: l.Target}}, Params: m.cfg.linkParamPolicy})
-	if err != nil {
-		return nil, err
-	}
-	if err := m.checkTargetURL(&compiled.def.targets[0].tmpl); err != nil {
-		return nil, err
-	}
-	return compiled, nil
 }
 
 // resolveFailed maps a Resolve error to the dead-link path (fallback

--- a/web/smartlink/handler.go
+++ b/web/smartlink/handler.go
@@ -19,11 +19,10 @@ import (
 // otherwise it falls back to the trimmed request path, so the Handler also
 // works mounted bare at "/".
 //
-// A code that could never have been minted by [Manager.Create] — over 64
-// characters or outside [A-Za-z0-9_-] — is answered as a dead link without a
-// Store roundtrip, so scans and garbage paths cost nothing. A row written to
-// the Store directly with a code outside that charset is unreachable through
-// the Handler by design; the code contract is Create's.
+// A code that could never have been minted by [Manager.Create] is answered
+// as a dead link without a Store roundtrip — [Manager.Resolve] rejects it as
+// [ErrNotFound] before touching the Store — so scans and garbage paths cost
+// nothing.
 //
 // Every response — success, dead link, or error — carries
 // "Cache-Control: no-store": a redirect decision can change on the next
@@ -42,10 +41,6 @@ func (m *Manager) Handler() http.Handler {
 			code = strings.Trim(r.URL.Path, "/")
 		}
 		w.Header().Set("Cache-Control", "no-store")
-		if !validCodeChars(code) {
-			m.deadLink(w, r)
-			return
-		}
 
 		ctx := r.Context()
 		l, err := m.Resolve(ctx, code)
@@ -59,12 +54,19 @@ func (m *Manager) Handler() http.Handler {
 			v = m.cfg.visitFunc(r, v)
 		}
 		if len(l.Metadata) > 0 {
-			// Merged into a fresh map — metadata wins, and the map a VisitFunc
-			// returned is never mutated behind the consumer's back.
-			merged := make(map[string]string, len(v.Params)+len(l.Metadata))
-			maps.Copy(merged, v.Params)
-			maps.Copy(merged, l.Metadata)
-			v.Params = merged
+			// Metadata wins. With a VisitFunc configured the merge goes into a
+			// fresh map — the map a VisitFunc returned is never mutated behind
+			// the consumer's back; without one v.Params is the handler's own
+			// map from firstQueryValues, merged in place to keep the hot path
+			// allocation-free.
+			if m.cfg.visitFunc != nil {
+				merged := make(map[string]string, len(v.Params)+len(l.Metadata))
+				maps.Copy(merged, v.Params)
+				v.Params = merged
+			} else if v.Params == nil {
+				v.Params = make(map[string]string, len(l.Metadata))
+			}
+			maps.Copy(v.Params, l.Metadata)
 		}
 
 		d, ok := m.decider(ctx, w, r, code, l)
@@ -114,11 +116,7 @@ func (m *Manager) decider(ctx context.Context, w http.ResponseWriter, r *http.Re
 	default:
 		resolved, err := m.cfg.resolver(ctx, l)
 		if err != nil {
-			// ErrNoTarget (paused/deleted offer) and ErrRefNotFound (ref names
-			// no known Spec) are both positive "this link leads nowhere"
-			// answers — dead links, like Create maps them to caller error —
-			// while anything else is an outage and must read as one.
-			if errors.Is(err, ErrNoTarget) || errors.Is(err, ErrRefNotFound) {
+			if refGone(err) {
 				m.deadLink(w, r)
 				return nil, false
 			}

--- a/web/smartlink/handler_test.go
+++ b/web/smartlink/handler_test.go
@@ -242,6 +242,92 @@ func TestHandlerRefNoTarget(t *testing.T) {
 	})
 }
 
+// TestHandlerRefNotFound asserts a Resolver error wrapping ErrRefNotFound —
+// the ref names no known Spec anymore — is dead-link handling like
+// ErrNoTarget, not a 500: a hard-deleted offer must not turn every click
+// into an internal error.
+func TestHandlerRefNotFound(t *testing.T) {
+	t.Parallel()
+	resolver := func(context.Context, smartlink.Link) (smartlink.Decider, error) {
+		return nil, fmt.Errorf("offer lookup: %w", smartlink.ErrRefNotFound)
+	}
+	m := newTestManager(t, smartlink.WithResolver(resolver), smartlink.WithFallbackURL("https://fallback.example.com/"))
+	l, err := m.Create(context.Background(), smartlink.CreateParams{Ref: "gone-1", SkipRefCheck: true})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d (ErrRefNotFound is a dead link, not an outage)", rec.Code, http.StatusFound)
+	}
+	if got, want := rec.Header().Get("Location"), "https://fallback.example.com/"; got != want {
+		t.Fatalf("Location = %q, want %q", got, want)
+	}
+}
+
+// TestHandlerImpossibleCodeSkipsStore asserts a code Create could never have
+// minted — over 64 chars or outside [A-Za-z0-9_-] — answers as a dead link
+// without hitting the Store.
+func TestHandlerImpossibleCodeSkipsStore(t *testing.T) {
+	t.Parallel()
+	store := &countingStore{Store: smartlink.NewMemoryStore()}
+	m, err := smartlink.NewManager(store)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	for _, code := range []string{"has%20space", "caf%C3%A9", strings.Repeat("x", 65)} {
+		req := httptest.NewRequest(http.MethodGet, "/r/"+code, nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("code %q: status = %d, want %d", code, rec.Code, http.StatusNotFound)
+		}
+	}
+	if got := store.gets.Load(); got != 0 {
+		t.Fatalf("Store.Get calls = %d, want 0 (impossible codes must not reach the Store)", got)
+	}
+}
+
+// TestHandlerDoesNotMutateVisitFuncParams asserts the metadata merge builds a
+// fresh map instead of writing into whatever map the consumer's VisitFunc
+// returned — a consumer handing over a shared or reused map must not see it
+// change behind its back.
+func TestHandlerDoesNotMutateVisitFuncParams(t *testing.T) {
+	t.Parallel()
+	shared := map[string]string{"sub": "mine"}
+	visitFn := func(_ *http.Request, v smartlink.Visit) smartlink.Visit {
+		v.Params = shared
+		return v
+	}
+	m := newTestManager(t, smartlink.WithVisitFunc(visitFn))
+	l, err := m.Create(context.Background(), smartlink.CreateParams{
+		Target:   "https://dest.example.com/",
+		Metadata: map[string]string{"aff": "abc"},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	h := newMuxHandler(m.Handler())
+
+	req := httptest.NewRequest(http.MethodGet, "/r/"+l.Code, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+	if len(shared) != 1 || shared["sub"] != "mine" {
+		t.Fatalf("VisitFunc's map was mutated by the handler: %v", shared)
+	}
+}
+
 // TestHandlerResolverNilDecider asserts a resolver that returns (nil, nil)
 // at serve time (its row admitted via SkipRefCheck) answers 500 instead of
 // panicking on Decide.

--- a/web/smartlink/manager.go
+++ b/web/smartlink/manager.go
@@ -102,11 +102,11 @@ func (m *Manager) Create(ctx context.Context, p CreateParams) (Link, error) {
 	if p.Ref != "" && !p.SkipRefCheck && m.cfg.resolver != nil {
 		d, err := m.cfg.resolver(ctx, Link{Ref: p.Ref, Tenant: p.Tenant})
 		if err != nil {
-			// Only a ref the resolver positively rejects is caller input error;
-			// anything else (consumer DB down, cache backend failing) is an
-			// infrastructure failure and must not read as ErrInvalidLink to an
-			// API layer mapping it to a 4xx.
-			if errors.Is(err, ErrRefNotFound) || errors.Is(err, ErrNoTarget) {
+			// Only a ref the resolver positively rejects (see refGone) is caller
+			// input error; anything else (consumer DB down, cache backend
+			// failing) must not read as ErrInvalidLink to an API layer mapping
+			// it to a 4xx.
+			if refGone(err) {
 				return Link{}, fmt.Errorf("%w: ref %q: %w", ErrInvalidLink, p.Ref, err)
 			}
 			return Link{}, fmt.Errorf("smartlink: check ref %q: %w", p.Ref, err)
@@ -207,7 +207,9 @@ func (m *Manager) validateVanityCode(code string) error {
 // (defense in depth — a directly-inserted "javascript:" target must not
 // become a redirect).
 func (m *Manager) compileLink(salt, target string) (*Compiled, error) {
-	compiled, err := Compile(Spec{Salt: salt, Default: []Target{{URL: target}}, Params: m.cfg.linkParamPolicy})
+	// The Manager's clock is the clock for everything it compiles itself, so
+	// a mocked WithManagerClock can never disagree with rule evaluation.
+	compiled, err := Compile(Spec{Salt: salt, Default: []Target{{URL: target}}, Params: m.cfg.linkParamPolicy}, WithClock(m.cfg.clock))
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidLink, err)
 	}

--- a/web/smartlink/manager.go
+++ b/web/smartlink/manager.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"net/url"
 	"slices"
 	"sync/atomic"
 	"time"
 
 	"github.com/dmitrymomot/forge/resilience/cache"
+	"github.com/dmitrymomot/forge/resilience/singleflight"
 )
 
 // maxCodeAttempts caps how many times Create retries a colliding generated
@@ -29,10 +29,11 @@ type Manager struct {
 	// decorate is the precomputed WithDecorators chain the Handler wraps
 	// around every link's Decider; nil when none are configured.
 	decorate Decorator
-	// flight dedups concurrent cache-miss lookups per code, and cacheGen
-	// guards their write-backs against racing lifecycle mutations (see
-	// lookup and invalidateCache).
-	flight   lookupFlight
+	// flight dedups concurrent cache-miss lookups per code (DoDetached, so a
+	// stuck Store read never pins a request past its own deadline), and
+	// cacheGen guards their write-backs against racing lifecycle mutations
+	// (see lookup and invalidateCache).
+	flight   singleflight.Group[Link]
 	cfg      managerConfig
 	cacheGen atomic.Uint64
 }
@@ -94,7 +95,7 @@ func (m *Manager) Create(ctx context.Context, p CreateParams) (Link, error) {
 		}
 	}
 	if p.Target != "" {
-		if err := m.validateTarget(p.Target); err != nil {
+		if _, err := m.compileLink("", p.Target); err != nil {
 			return Link{}, err
 		}
 	}
@@ -128,7 +129,7 @@ func (m *Manager) Create(ctx context.Context, p CreateParams) (Link, error) {
 		// Truncated to microseconds — Postgres timestamptz precision — so the
 		// returned Link carries the same instant a later Get reads back and
 		// List ordering agrees across Store implementations.
-		CreatedAt: time.Now().UTC().Truncate(time.Microsecond),
+		CreatedAt: m.cfg.clock.Now().UTC().Truncate(time.Microsecond),
 	}
 
 	if l.Code != "" {
@@ -195,29 +196,35 @@ func (m *Manager) validateVanityCode(code string) error {
 	return nil
 }
 
-// validateTarget compiles raw as the sole default target of a degenerate
-// Spec — surfacing template errors (bad macro, malformed template) as
-// ErrInvalidLink — then applies the URL policy checks via checkTargetURL.
-func (m *Manager) validateTarget(raw string) error {
-	compiled, err := Compile(Spec{Default: []Target{{URL: raw}}, Params: m.cfg.linkParamPolicy})
+// compileLink compiles target as the sole default target of a degenerate
+// Spec under the configured link param policy — surfacing template errors
+// (bad macro, malformed template) as ErrInvalidLink — then applies the URL
+// policy checks via checkTargetURL. It is the single definition of what a
+// valid Target-backed Link is: Create validates through it (salt irrelevant,
+// result discarded) and [Manager.decider] serves through it (salted by the
+// link code so split/Percent bucketing stays per-link), so a row written to
+// the Store outside this Manager faces the same scheme policy at serve time
+// (defense in depth — a directly-inserted "javascript:" target must not
+// become a redirect).
+func (m *Manager) compileLink(salt, target string) (*Compiled, error) {
+	compiled, err := Compile(Spec{Salt: salt, Default: []Target{{URL: target}}, Params: m.cfg.linkParamPolicy})
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrInvalidLink, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidLink, err)
 	}
-	return m.checkTargetURL(&compiled.def.targets[0].tmpl)
+	if err := m.checkTargetURL(&compiled.def.targets[0].tmpl); err != nil {
+		return nil, err
+	}
+	return compiled, nil
 }
 
-// checkTargetURL enforces the URL policy on a compiled template: its
-// macro-elided scheme must be on the allowlist and non-empty, and its host
-// non-empty unless the authority is itself (at least partly) a macro, in
-// which case a dynamic-host template stays legal. Shared by Create validation
-// and the per-hit compileTarget path, so a row written to the Store outside
-// this Manager faces the same scheme policy at serve time (defense in depth —
-// a directly-inserted "javascript:" target must not become a redirect).
+// checkTargetURL enforces the URL policy on a compiled template, reading the
+// parse Compile already did: the macro-elided scheme must be on the
+// allowlist and non-empty, and the host non-empty unless the authority is
+// itself (at least partly) a macro, in which case a dynamic-host template
+// stays legal. Reached through [Manager.compileLink] from both Create
+// validation and the per-hit serve path.
 func (m *Manager) checkTargetURL(t *template) error {
-	u, err := url.Parse(t.elided)
-	if err != nil {
-		return fmt.Errorf("%w: %w", ErrInvalidLink, err)
-	}
+	u := t.elidedURL
 	if u.Scheme == "" || !slices.Contains(m.cfg.schemes, u.Scheme) {
 		return fmt.Errorf("%w: scheme %q not allowed", ErrInvalidLink, u.Scheme)
 	}
@@ -273,7 +280,7 @@ func (m *Manager) List(ctx context.Context, f Filter) ([]Link, error) {
 // evicts any cached entry for code (see [Manager.invalidateCache]).
 func (m *Manager) Deactivate(ctx context.Context, code string) error {
 	return m.mutateLink(ctx, code, func(ctx context.Context, tenant string) error {
-		return m.store.Deactivate(ctx, code, tenant, time.Now().UTC())
+		return m.store.Deactivate(ctx, code, tenant, m.cfg.clock.Now().UTC())
 	})
 }
 

--- a/web/smartlink/manager_options.go
+++ b/web/smartlink/manager_options.go
@@ -286,9 +286,11 @@ func WithRedirectStatus(code int) ManagerOption {
 // WithManagerClock sets the clock the Manager reads for every timestamp it
 // takes itself: the CreatedAt stamp in Create, the DeactivatedAt stamp in
 // Deactivate, and the ExpiresAt liveness check in [Manager.Resolve] (and so
-// [Manager.Handler]). Defaults to clock.System(). It is distinct from the
-// engine-level [WithClock], which governs TimeWindow matcher evaluation
-// inside a compiled Spec. A nil c is ignored.
+// [Manager.Handler]). Defaults to clock.System(). The Manager also passes it
+// as the engine-level [WithClock] to every Spec it compiles itself (Target
+// links), so under a mock the lifecycle checks and TimeWindow evaluation
+// read one time source; a [Cache]'s compiles are configured separately via
+// [WithCompileOptions]. A nil c is ignored.
 func WithManagerClock(c clock.Clock) ManagerOption {
 	return func(cfg *managerConfig) {
 		if c != nil {

--- a/web/smartlink/manager_options.go
+++ b/web/smartlink/manager_options.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/core/id"
 	"github.com/dmitrymomot/forge/ops/logger"
 	"github.com/dmitrymomot/forge/resilience/cache"
@@ -42,6 +43,7 @@ type managerConfig struct {
 	onHit           func(context.Context, Hit)
 	cacheStore      cache.Store
 	logger          *slog.Logger
+	clock           clock.Clock
 	reserved        map[string]struct{}
 	baseURL         string
 	fallbackURL     string
@@ -66,6 +68,7 @@ func newManagerConfig() *managerConfig {
 		linkParamPolicy: ParamsFill,
 		redirectStatus:  http.StatusFound,
 		logger:          logger.NewNope(),
+		clock:           clock.System(),
 	}
 }
 
@@ -126,10 +129,20 @@ func validateAbsoluteHTTPURL(u string) error {
 // redirect, so a row written to the Store directly cannot smuggle a
 // disallowed scheme past the allowlist. Scheme comparison is
 // case-insensitive, since [url.Parse] always lowercases the parsed scheme.
+// An empty list or an empty entry is a NewManager error — it would silently
+// reject every Target on Create.
 func WithSchemes(s ...string) ManagerOption {
 	return func(c *managerConfig) {
-		schemes := slices.Clone(s)
-		for i, sch := range schemes {
+		if len(s) == 0 {
+			c.errs = append(c.errs, errors.New("smartlink: WithSchemes needs at least one scheme"))
+			return
+		}
+		schemes := make([]string, len(s))
+		for i, sch := range s {
+			if sch == "" {
+				c.errs = append(c.errs, errors.New("smartlink: WithSchemes has an empty scheme"))
+				return
+			}
 			schemes[i] = strings.ToLower(sch)
 		}
 		c.schemes = schemes
@@ -221,8 +234,14 @@ func WithOnHit(f func(context.Context, Hit)) ManagerOption {
 // entry that survives a failed eviction (see [Manager.invalidateCache])
 // serve forever instead of bounding its staleness — a non-positive ttl is a
 // NewManager error.
+// A nil cs is a NewManager error, not a silent fall-back to uncached: a
+// caller who asked for a cache must never run without one.
 func WithCache(cs cache.Store, ttl time.Duration) ManagerOption {
 	return func(c *managerConfig) {
+		if cs == nil {
+			c.errs = append(c.errs, errors.New("smartlink: nil cache store"))
+			return
+		}
 		if ttl <= 0 {
 			c.errs = append(c.errs, fmt.Errorf("smartlink: cache ttl must be positive, got %s", ttl))
 			return
@@ -233,8 +252,9 @@ func WithCache(cs cache.Store, ttl time.Duration) ManagerOption {
 }
 
 // WithFallbackURL sets the destination [Manager.Handler] redirects to for a
-// dead link (unknown, expired, or deactivated code, or a Ref the resolver
-// reports as [ErrNoTarget]). Without it, dead links answer 404. Like
+// dead link (unknown, malformed, expired, or deactivated code, or a Ref the
+// resolver reports as [ErrNoTarget] or [ErrRefNotFound]). Without it, dead
+// links answer 404. Like
 // [WithBaseURL], it must be an absolute http(s) URL (scheme and host): a
 // typo'd relative value would silently redirect relative to the handler's
 // own path instead of failing construction.
@@ -260,6 +280,20 @@ func WithRedirectStatus(code int) ManagerOption {
 			return
 		}
 		c.redirectStatus = code
+	}
+}
+
+// WithManagerClock sets the clock the Manager reads for every timestamp it
+// takes itself: the CreatedAt stamp in Create, the DeactivatedAt stamp in
+// Deactivate, and the ExpiresAt liveness check in [Manager.Resolve] (and so
+// [Manager.Handler]). Defaults to clock.System(). It is distinct from the
+// engine-level [WithClock], which governs TimeWindow matcher evaluation
+// inside a compiled Spec. A nil c is ignored.
+func WithManagerClock(c clock.Clock) ManagerOption {
+	return func(cfg *managerConfig) {
+		if c != nil {
+			cfg.clock = c
+		}
 	}
 }
 

--- a/web/smartlink/manager_test.go
+++ b/web/smartlink/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/core/id"
 	"github.com/dmitrymomot/forge/resilience/cache"
 	"github.com/dmitrymomot/forge/web/smartlink"
@@ -72,6 +73,72 @@ func TestNewManagerBadFallbackURL(t *testing.T) {
 	}
 	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithFallbackURL("https://fallback.example.com/")); err != nil {
 		t.Fatalf("NewManager(WithFallbackURL(valid)) error = %v, want nil", err)
+	}
+}
+
+// TestWithManagerClock asserts the Manager takes every timestamp it reads or
+// stamps — CreatedAt, DeactivatedAt, the Resolve expiry check — from the
+// configured clock, so link lifecycle is fully deterministic under test.
+func TestWithManagerClock(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	mock := clock.NewMock(start)
+	m := newTestManager(t, smartlink.WithManagerClock(mock))
+	ctx := context.Background()
+
+	l, err := m.Create(ctx, smartlink.CreateParams{
+		Target:    "https://dest.example.com/",
+		ExpiresAt: start.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	if !l.CreatedAt.Equal(start) {
+		t.Fatalf("CreatedAt = %v, want mock time %v", l.CreatedAt, start)
+	}
+	if _, err := m.Resolve(ctx, l.Code); err != nil {
+		t.Fatalf("Resolve() before expiry error = %v, want nil", err)
+	}
+
+	mock.Advance(2 * time.Hour)
+	if _, err := m.Resolve(ctx, l.Code); !errors.Is(err, smartlink.ErrLinkExpired) {
+		t.Fatalf("Resolve() after mock advance = %v, want ErrLinkExpired", err)
+	}
+
+	if err := m.Deactivate(ctx, l.Code); err != nil {
+		t.Fatalf("Deactivate() error = %v, want nil", err)
+	}
+	got, err := m.Get(ctx, l.Code)
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if want := start.Add(2 * time.Hour); !got.DeactivatedAt.Equal(want) {
+		t.Fatalf("DeactivatedAt = %v, want mock time %v", got.DeactivatedAt, want)
+	}
+}
+
+// TestNewManagerRejectsEmptySchemes asserts WithSchemes fails construction
+// on an empty list or an empty entry — either would silently reject every
+// Target on Create instead of surfacing the misconfiguration.
+func TestNewManagerRejectsEmptySchemes(t *testing.T) {
+	t.Parallel()
+	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithSchemes()); err == nil {
+		t.Fatal("NewManager(WithSchemes()) error = nil, want error")
+	}
+	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithSchemes("https", "")); err == nil {
+		t.Fatal(`NewManager(WithSchemes("https", "")) error = nil, want error`)
+	}
+	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithSchemes("HTTPS")); err != nil {
+		t.Fatalf("NewManager(WithSchemes(valid)) error = %v, want nil", err)
+	}
+}
+
+// TestNewManagerRejectsNilCacheStore asserts WithCache fails construction on
+// a nil store rather than silently running uncached.
+func TestNewManagerRejectsNilCacheStore(t *testing.T) {
+	t.Parallel()
+	if _, err := smartlink.NewManager(smartlink.NewMemoryStore(), smartlink.WithCache(nil, time.Minute)); err == nil {
+		t.Fatal("NewManager(WithCache(nil)) error = nil, want error")
 	}
 }
 

--- a/web/smartlink/memory.go
+++ b/web/smartlink/memory.go
@@ -3,6 +3,7 @@ package smartlink
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"maps"
 	"slices"
 	"sync"
@@ -73,15 +74,12 @@ func (s *MemoryStore) List(_ context.Context, f Filter) ([]Link, error) {
 	return out, nil
 }
 
-// Deactivate implements Store. A zero at is a no-op on DeactivatedAt (it
-// never reactivates an already-deactivated link), but the existence and
-// tenant predicate are still enforced.
+// Deactivate implements Store.
 func (s *MemoryStore) Deactivate(_ context.Context, code, tenant string, at time.Time) error {
-	return s.mutate(code, tenant, func(l *Link) {
-		if !at.IsZero() {
-			l.DeactivatedAt = at
-		}
-	})
+	if at.IsZero() {
+		return fmt.Errorf("%w: Deactivate needs a non-zero time", ErrInvalidLink)
+	}
+	return s.mutate(code, tenant, func(l *Link) { l.DeactivatedAt = at })
 }
 
 // Activate implements Store.

--- a/web/smartlink/memory_test.go
+++ b/web/smartlink/memory_test.go
@@ -134,30 +134,20 @@ func TestMemoryStoreTenantPredicate(t *testing.T) {
 		}
 	})
 
-	t.Run("deactivate zero at leaves active", func(t *testing.T) {
-		t.Parallel()
-		s := newStore(t)
-		if err := s.Deactivate(ctx, "code1", "owner", time.Time{}); err != nil {
-			t.Fatalf("Deactivate(zero at) = %v, want nil", err)
-		}
-		got, _ := s.Get(ctx, "code1")
-		if !got.DeactivatedAt.IsZero() {
-			t.Fatalf("DeactivatedAt = %v, want zero (still active)", got.DeactivatedAt)
-		}
-	})
-
-	t.Run("deactivate zero at does not reactivate", func(t *testing.T) {
+	t.Run("deactivate zero at rejected", func(t *testing.T) {
 		t.Parallel()
 		s := newStore(t)
 		if err := s.Deactivate(ctx, "code1", "owner", at); err != nil {
 			t.Fatalf("Deactivate() = %v, want nil", err)
 		}
-		if err := s.Deactivate(ctx, "code1", "owner", time.Time{}); err != nil {
-			t.Fatalf("Deactivate(zero at) = %v, want nil", err)
+		// A zero at would store "active"; the contract rejects it before the
+		// record is touched, so it can never silently reactivate.
+		if err := s.Deactivate(ctx, "code1", "owner", time.Time{}); !errors.Is(err, smartlink.ErrInvalidLink) {
+			t.Fatalf("Deactivate(zero at) = %v, want ErrInvalidLink", err)
 		}
 		got, _ := s.Get(ctx, "code1")
 		if !got.DeactivatedAt.Equal(at) {
-			t.Fatalf("DeactivatedAt = %v, want unchanged %v (zero at must not reactivate)", got.DeactivatedAt, at)
+			t.Fatalf("DeactivatedAt = %v, want unchanged %v", got.DeactivatedAt, at)
 		}
 	})
 

--- a/web/smartlink/pgstore/pgstore.go
+++ b/web/smartlink/pgstore/pgstore.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"time"
 
@@ -104,19 +105,18 @@ func (s *Store) List(ctx context.Context, f smartlink.Filter) ([]smartlink.Link,
 	return out, rows.Err()
 }
 
-// deactivateSQL leaves deactivated_at untouched when $3 is NULL (a zero at),
-// so Deactivate never reactivates an already-deactivated link, while still
-// enforcing the tenant predicate atomically with the write.
 const deactivateSQL = `
-UPDATE forge_smart_links
-SET deactivated_at = CASE WHEN $3::timestamptz IS NULL THEN deactivated_at ELSE $3 END
+UPDATE forge_smart_links SET deactivated_at = $3
 WHERE code = $1 AND ($2 = '' OR tenant = $2)`
 
 // Deactivate sets DeactivatedAt to at on code, scoped to tenant. A zero at
-// leaves DeactivatedAt unchanged (never reactivates) but still enforces the
-// code/tenant predicate.
+// is rejected per the Store contract — it would write NULL and silently
+// reactivate the link.
 func (s *Store) Deactivate(ctx context.Context, code, tenant string, at time.Time) error {
-	return s.exec(ctx, deactivateSQL, code, tenant, nullTime(at))
+	if at.IsZero() {
+		return fmt.Errorf("%w: Deactivate needs a non-zero time", smartlink.ErrInvalidLink)
+	}
+	return s.exec(ctx, deactivateSQL, code, tenant, at)
 }
 
 const activateSQL = `

--- a/web/smartlink/pgstore/pgstore_test.go
+++ b/web/smartlink/pgstore/pgstore_test.go
@@ -159,27 +159,16 @@ func TestPg_TenantPredicateMutators(t *testing.T) {
 		assert.True(t, got.DeactivatedAt.Equal(at))
 	})
 
-	t.Run("deactivate zero at leaves active", func(t *testing.T) {
-		s, c, owner := setup(t)
-		require.NoError(t, s.Deactivate(ctx, c, owner, time.Time{}))
-		got, err := s.Get(ctx, c)
-		require.NoError(t, err)
-		assert.True(t, got.DeactivatedAt.IsZero())
-	})
-
-	t.Run("deactivate zero at does not reactivate", func(t *testing.T) {
+	t.Run("deactivate zero at rejected", func(t *testing.T) {
 		s, c, owner := setup(t)
 		require.NoError(t, s.Deactivate(ctx, c, owner, at))
-		require.NoError(t, s.Deactivate(ctx, c, owner, time.Time{}))
+		// A zero at would write NULL and silently reactivate; the contract
+		// rejects it before the record is touched.
+		err := s.Deactivate(ctx, c, owner, time.Time{})
+		assert.ErrorIs(t, err, smartlink.ErrInvalidLink)
 		got, err := s.Get(ctx, c)
 		require.NoError(t, err)
 		assert.True(t, got.DeactivatedAt.Equal(at))
-	})
-
-	t.Run("deactivate zero at still enforces predicate", func(t *testing.T) {
-		s, c, _ := setup(t)
-		err := s.Deactivate(ctx, c, "intruder", time.Time{})
-		assert.ErrorIs(t, err, smartlink.ErrNotFound)
 	})
 
 	t.Run("activate wrong tenant", func(t *testing.T) {

--- a/web/smartlink/resolve.go
+++ b/web/smartlink/resolve.go
@@ -3,9 +3,6 @@ package smartlink
 import (
 	"context"
 	"errors"
-	"fmt"
-	"sync"
-	"time"
 
 	"github.com/dmitrymomot/forge/resilience/cache"
 )
@@ -30,7 +27,7 @@ func (m *Manager) Resolve(ctx context.Context, code string) (Link, error) {
 	if !l.DeactivatedAt.IsZero() {
 		return Link{}, ErrLinkDeactivated
 	}
-	if !l.ExpiresAt.IsZero() && !l.ExpiresAt.After(time.Now()) {
+	if !l.ExpiresAt.IsZero() && !l.ExpiresAt.After(m.cfg.clock.Now()) {
 		return Link{}, ErrLinkExpired
 	}
 	l.ShortURL = m.ShortURL(l.Code)
@@ -44,16 +41,18 @@ func (m *Manager) Resolve(ctx context.Context, code string) (Link, error) {
 // source of truth, so a bad cache backend degrades to "always hit the
 // Store", not "links stop resolving".
 //
-// Concurrent misses on the same code share one Store read (see lookupFlight),
-// so a hot code whose entry just expired costs one query, not one per
-// waiting request. The write-back is guarded against racing lifecycle
-// mutations: the fill snapshots cacheGen before the Store read, writes the
-// entry, and re-checks — invalidateCache bumps cacheGen before its eviction,
-// so a fill that raced a mutation either sees the bump and evicts its own
-// (possibly stale) write, or wrote early enough that the mutation's eviction
-// removes it. Without this, an in-flight fill could re-cache a deleted
-// link's record after its code was reused by a new Create and serve the
-// previous owner's target for a full TTL.
+// Concurrent misses on the same code share one Store read — coalesced via
+// [singleflight.Group.DoDetached], so each waiting request's wait stays
+// bounded by its own ctx while the read completes once — and a hot code
+// whose entry just expired costs one query, not one per waiting request. The
+// write-back is guarded against racing lifecycle mutations: the fill
+// snapshots cacheGen before the Store read, writes the entry, and
+// re-checks — invalidateCache bumps cacheGen before its eviction, so a fill
+// that raced a mutation either sees the bump and evicts its own (possibly
+// stale) write, or wrote early enough that the mutation's eviction removes
+// it. Without this, an in-flight fill could re-cache a deleted link's record
+// after its code was reused by a new Create and serve the previous owner's
+// target for a full TTL.
 func (m *Manager) lookup(ctx context.Context, code string) (Link, error) {
 	if m.links == nil {
 		return m.store.Get(ctx, code)
@@ -63,7 +62,7 @@ func (m *Manager) lookup(ctx context.Context, code string) (Link, error) {
 		return l, nil
 	}
 
-	return m.flight.do(ctx, code, func(ctx context.Context) (Link, error) {
+	l, _, err := m.flight.DoDetached(ctx, code, func(ctx context.Context) (Link, error) {
 		gen := m.cacheGen.Load()
 		l, err := m.store.Get(ctx, code)
 		if err != nil {
@@ -77,69 +76,7 @@ func (m *Manager) lookup(ctx context.Context, code string) (Link, error) {
 		}
 		return l, nil
 	})
-}
-
-// lookupFlight coalesces concurrent cache-miss lookups per code. It exists
-// instead of resilience/singleflight because that Group's waiters block
-// without regard for their context: a stuck Store read would pin every
-// redirect request for that code indefinitely. Here the shared read runs
-// detached in one goroutine per key and every caller — leader and joiners
-// alike — selects on completion versus its own ctx, so each request's wait is
-// bounded by its own deadline while the read still completes once for the
-// callers that stay.
-type lookupFlight struct {
-	m  map[string]*lookupCall
-	mu sync.Mutex
-}
-
-// lookupCall is one in-flight coalesced lookup; done is closed after link and
-// err are set.
-type lookupCall struct {
-	err  error
-	done chan struct{}
-	link Link
-}
-
-// do returns the result of fn for key, starting one detached execution when
-// none is in flight and otherwise joining the existing one. A caller whose
-// ctx ends first gets its ctx error; the shared execution keeps running for
-// the others and is deregistered when it completes.
-func (f *lookupFlight) do(ctx context.Context, key string, fn func(context.Context) (Link, error)) (Link, error) {
-	f.mu.Lock()
-	if f.m == nil {
-		f.m = make(map[string]*lookupCall)
-	}
-	c, ok := f.m[key]
-	if !ok {
-		c = &lookupCall{done: make(chan struct{})}
-		f.m[key] = c
-		go f.run(context.WithoutCancel(ctx), key, c, fn)
-	}
-	f.mu.Unlock()
-
-	select {
-	case <-c.done:
-		return c.link, c.err
-	case <-ctx.Done():
-		return Link{}, ctx.Err()
-	}
-}
-
-// run executes fn into c and closes c.done exactly once, converting a panic
-// to an error every waiter observes (run has no caller to re-panic into).
-func (f *lookupFlight) run(ctx context.Context, key string, c *lookupCall, fn func(context.Context) (Link, error)) {
-	defer func() {
-		if r := recover(); r != nil {
-			c.link, c.err = Link{}, fmt.Errorf("smartlink: lookup %q: panic during coalesced fill: %v", key, r)
-		}
-		close(c.done)
-		f.mu.Lock()
-		if f.m[key] == c {
-			delete(f.m, key)
-		}
-		f.mu.Unlock()
-	}()
-	c.link, c.err = fn(ctx)
+	return l, err
 }
 
 // cacheGet attempts the cache read-through hit path, reporting ok == false

--- a/web/smartlink/resolve.go
+++ b/web/smartlink/resolve.go
@@ -16,10 +16,19 @@ const cachePrefix = "smartlink:code:"
 // surfaces [ErrLinkDeactivated]; one whose ExpiresAt has passed surfaces
 // [ErrLinkExpired]; an unknown code surfaces [ErrNotFound] from the Store.
 //
+// A code that could never have been minted by [Manager.Create] — over 64
+// characters or outside [A-Za-z0-9_-] — is [ErrNotFound] without a Store
+// roundtrip, so scans and garbage input cost nothing. A row written to the
+// Store directly with a code outside that charset is unreachable through
+// Resolve by design; the code contract is Create's.
+//
 // Resolve is the public, unscoped read path: a code is a public URL, so
 // unlike the management ops it never consults [WithScope]. The returned
 // Link has ShortURL populated (see [Manager.ShortURL]).
 func (m *Manager) Resolve(ctx context.Context, code string) (Link, error) {
+	if !validCodeChars(code) {
+		return Link{}, ErrNotFound
+	}
 	l, err := m.lookup(ctx, code)
 	if err != nil {
 		return Link{}, err

--- a/web/smartlink/store.go
+++ b/web/smartlink/store.go
@@ -27,9 +27,10 @@ type Store interface {
 	// Code ascending to break ties.
 	List(ctx context.Context, f Filter) ([]Link, error)
 
-	// Deactivate sets DeactivatedAt to at on code, scoped to tenant. A zero
-	// at leaves DeactivatedAt unchanged — it never activates or deactivates
-	// anything — while still enforcing the code/tenant predicate.
+	// Deactivate sets DeactivatedAt to at on code, scoped to tenant. at must
+	// be non-zero — a zero DeactivatedAt means "active", so storing it would
+	// silently reactivate — and implementations reject it with an error
+	// wrapping ErrInvalidLink before touching the record.
 	Deactivate(ctx context.Context, code, tenant string, at time.Time) error
 
 	// Activate clears DeactivatedAt on code, scoped to tenant.

--- a/web/smartlink/template.go
+++ b/web/smartlink/template.go
@@ -45,10 +45,13 @@ type segment struct {
 
 // template is a compiled URL template. A nil segs means the URL is a plain
 // literal and renders with zero work. elided is the macro-elided form (equal
-// to raw for a literal) and authMacro reports whether any macro sits in the
-// authority segment — both computed here once so validation layers never
-// re-scan the raw template with a second parser.
+// to raw for a literal), elidedURL its one url.Parse — reused by
+// checkTargetURL and the literal-target query precompute instead of
+// re-parsing the same string per compile — and authMacro reports whether any
+// macro sits in the authority segment; all computed here once so validation
+// layers never re-scan the raw template with a second parser.
 type template struct {
+	elidedURL *url.URL
 	raw       string
 	elided    string
 	segs      []segment
@@ -60,10 +63,11 @@ type template struct {
 // validates the macro-elided template parses as a URL.
 func parseTemplate(raw, where string) (template, error) {
 	if !strings.ContainsRune(raw, '{') && !strings.ContainsRune(raw, '}') {
-		if _, err := url.Parse(raw); err != nil {
+		u, err := url.Parse(raw)
+		if err != nil {
 			return template{}, fmt.Errorf("%w: %s: %v", ErrInvalidTemplate, where, err)
 		}
-		return template{raw: raw, elided: raw}, nil
+		return template{raw: raw, elided: raw, elidedURL: u}, nil
 	}
 
 	var segs []segment
@@ -104,10 +108,11 @@ func parseTemplate(raw, where string) (template, error) {
 		segs = append(segs, segment{literal: rest})
 		elided.WriteString(rest)
 	}
-	if _, err := url.Parse(elided.String()); err != nil {
+	u, err := url.Parse(elided.String())
+	if err != nil {
 		return template{}, fmt.Errorf("%w: %s: %v", ErrInvalidTemplate, where, err)
 	}
-	return template{raw: raw, elided: elided.String(), segs: segs, authMacro: authMacro}, nil
+	return template{raw: raw, elided: elided.String(), elidedURL: u, segs: segs, authMacro: authMacro}, nil
 }
 
 // escapeModeFor derives a macro's escaping from the macro-elided literal
@@ -179,7 +184,9 @@ func (t template) render(v *Visit) string {
 				b.WriteString(val)
 			}
 		case escPath:
-			writePathEscaped(&b, val)
+			// ':' additionally encoded: in the first segment of a relative
+			// template it would otherwise reparse as a scheme delimiter.
+			b.WriteString(strings.ReplaceAll(url.PathEscape(val), ":", "%3A"))
 		case escQuery:
 			b.WriteString(url.QueryEscape(val))
 		}
@@ -199,21 +206,4 @@ func isHostSafe(s string) bool {
 		return false
 	}
 	return true
-}
-
-// writePathEscaped writes url.PathEscape output with ':' additionally
-// encoded: a ':' in the first segment of a relative template would otherwise
-// reparse as a scheme delimiter.
-func writePathEscaped(b *strings.Builder, s string) {
-	escaped := url.PathEscape(s)
-	for {
-		i := strings.IndexByte(escaped, ':')
-		if i < 0 {
-			b.WriteString(escaped)
-			return
-		}
-		b.WriteString(escaped[:i])
-		b.WriteString("%3A")
-		escaped = escaped[i+1:]
-	}
 }

--- a/web/smartlink/template.go
+++ b/web/smartlink/template.go
@@ -44,16 +44,15 @@ type segment struct {
 }
 
 // template is a compiled URL template. A nil segs means the URL is a plain
-// literal and renders with zero work. elided is the macro-elided form (equal
-// to raw for a literal), elidedURL its one url.Parse — reused by
-// checkTargetURL and the literal-target query precompute instead of
-// re-parsing the same string per compile — and authMacro reports whether any
-// macro sits in the authority segment; all computed here once so validation
-// layers never re-scan the raw template with a second parser.
+// literal and renders with zero work. elidedURL is the one url.Parse of the
+// macro-elided form (raw itself for a literal) — reused by checkTargetURL
+// and the literal-target query precompute instead of re-parsing the same
+// string per compile — and authMacro reports whether any macro sits in the
+// authority segment; all computed here once so validation layers never
+// re-scan the raw template with a second parser.
 type template struct {
 	elidedURL *url.URL
 	raw       string
-	elided    string
 	segs      []segment
 	authMacro bool
 }
@@ -67,7 +66,7 @@ func parseTemplate(raw, where string) (template, error) {
 		if err != nil {
 			return template{}, fmt.Errorf("%w: %s: %v", ErrInvalidTemplate, where, err)
 		}
-		return template{raw: raw, elided: raw, elidedURL: u}, nil
+		return template{raw: raw, elidedURL: u}, nil
 	}
 
 	var segs []segment
@@ -112,7 +111,7 @@ func parseTemplate(raw, where string) (template, error) {
 	if err != nil {
 		return template{}, fmt.Errorf("%w: %s: %v", ErrInvalidTemplate, where, err)
 	}
-	return template{raw: raw, elided: elided.String(), elidedURL: u, segs: segs, authMacro: authMacro}, nil
+	return template{raw: raw, elidedURL: u, segs: segs, authMacro: authMacro}, nil
 }
 
 // escapeModeFor derives a macro's escaping from the macro-elided literal


### PR DESCRIPTION
## What

Follow-up hardening and cleanup for `web/smartlink` after the PR #71 review cycle, plus a ctx-bounded coalescing primitive in `resilience/singleflight`.

### Review fixes (first 4 commits)

- **`resilience/singleflight.DoDetached`**: new ctx-bounded variant of `Do` — fn runs once per key in its own goroutine under a cancellation-detached ctx; every caller (initiator and joiners) waits only until its own ctx ends while the shared execution keeps running. `Do` and `DoDetached` share the per-key flight, so mixed callers coalesce.
- **`web/smartlink` adopts it**: the bespoke `lookupFlight` in `resolve.go` is deleted; cache-miss coalescing now goes through the shared primitive.
- **Dead Ref link is a 404, not a 500**: a resolver's positive "leads nowhere" answers (`ErrNoTarget`, `ErrRefNotFound`) serve as dead links (fallback or 404) instead of internal errors; infrastructure failures still read as outages.
- **Stores reject a zero `Deactivate` time** (`ErrInvalidLink` in memory + pgstore) so a direct Store call can't silently reactivate a link.
- **Parse a target template's elided URL once**: `template.elidedURL` caches the one `url.Parse`, reused by `checkTargetURL` and the literal-target query precompute.

### Simplification pass (last 2 commits)

A 4-angle cleanup review (reuse / simplification / efficiency / altitude) was run over the branch diff and its surviving findings applied:

- `Do`/`DoDetached` flight registration deduped into one `join` helper; the package also gains its previously-missing `bench_test.go`.
- Dead `template.elided` field deleted (both readers had moved to `elidedURL`).
- The impossible-code fast-reject moved from `Handler` into `Manager.Resolve`, so non-HTTP callers also skip the Store roundtrip for codes Create could never have minted; the Handler serves it through its existing `ErrNotFound` mapping.
- `refGone` is now the single definition of the caller-error-vs-outage split for resolver errors, shared by Create's ref precheck and the Handler decider.
- Link metadata merges in place when no `VisitFunc` is configured; the defensive fresh-map copy only guards maps a `VisitFunc` could own.
- `compileLink` threads the Manager clock into `Compile`, so a mocked `WithManagerClock` governs TimeWindow evaluation in Manager-compiled Specs too.

## Benchmarks (before → after the simplification pass, benchstat n=10–15, M3 Max)

| Benchmark | time/op | B/op | allocs/op |
|---|---|---|---|
| smartlink HandlerTarget | −3.75% (2.74µs → 2.63µs) | −4.07% | 44 → 42 |
| smartlink HandlerRef / ResolveDecideTarget | flat | flat | flat |
| singleflight Do / DoDetached / DoContended | flat (Do p=0.134, n=15) | flat | flat |

## Reviewer notes

- `Manager.Resolve` now returns `ErrNotFound` for out-of-charset codes without touching the Store. This extends the already-documented Handler contract ("the code contract is Create's") package-wide; a row written to the Store directly with an out-of-charset code becomes unreachable through Resolve as well.
- The `c != nil` arm in `singleflight.join` is unreachable and exists to let nilaway prove the result needs no guarding at call sites.
- Tests run with `-race`; `just lint` (golangci-lint, vet, nilaway, integration tags) is clean.