### PR TITLE
feat(web/tenant): transport-layer tenant resolution package

### DIFF
--- a/web/tenant/bench_test.go
+++ b/web/tenant/bench_test.go
@@ -1,0 +1,106 @@
+package tenant_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/tenant"
+)
+
+func BenchmarkSubdomain(b *testing.B) {
+	derive := tenant.Subdomain("app.example.com", tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"}))
+	r := newRequest("acme.app.example.com", "/")
+	b.ReportAllocs()
+	for b.Loop() {
+		if id, _ := derive(r); id == "" {
+			b.Fatal("expected resolution")
+		}
+	}
+}
+
+func BenchmarkSubdomainMiss(b *testing.B) {
+	derive := tenant.Subdomain("app.example.com", tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"}))
+	r := newRequest("other.example.org", "/")
+	b.ReportAllocs()
+	for b.Loop() {
+		if id, _ := derive(r); id != "" {
+			b.Fatal("unexpected resolution")
+		}
+	}
+}
+
+func BenchmarkHeader(b *testing.B) {
+	derive := tenant.Header("X-Tenant-ID")
+	r := newRequest("example.com", "/")
+	r.Header.Set("X-Tenant-ID", "acme")
+	b.ReportAllocs()
+	for b.Loop() {
+		if id, _ := derive(r); id == "" {
+			b.Fatal("expected resolution")
+		}
+	}
+}
+
+func BenchmarkPathPrefix(b *testing.B) {
+	derive := tenant.PathPrefix("/t")
+	r := newRequest("example.com", "/t/acme/dashboard")
+	b.ReportAllocs()
+	for b.Loop() {
+		if id, _ := derive(r); id == "" {
+			b.Fatal("expected resolution")
+		}
+	}
+}
+
+func BenchmarkDomainStatic(b *testing.B) {
+	derive := tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "acme"}))
+	r := newRequest("shop.acme.com", "/")
+	b.ReportAllocs()
+	for b.Loop() {
+		if id, _ := derive(r); id == "" {
+			b.Fatal("expected resolution")
+		}
+	}
+}
+
+func BenchmarkResolve(b *testing.B) {
+	rv := tenant.New(
+		tenant.WithSources(
+			tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "t_01acme"})),
+			tenant.Subdomain("app.example.com", tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"})),
+		),
+		tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error { return nil })),
+	)
+	r := newRequest("acme.app.example.com", "/")
+	b.ReportAllocs()
+	for b.Loop() {
+		if id, _ := rv.Resolve(r); id == "" {
+			b.Fatal("expected resolution")
+		}
+	}
+}
+
+func BenchmarkMiddleware(b *testing.B) {
+	h := tenant.New(tenant.WithSources(
+		tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "t_01acme"})),
+		tenant.Subdomain("app.example.com", tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"})),
+	)).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	r := newRequest("acme.app.example.com", "/")
+	w := httptest.NewRecorder()
+	b.ReportAllocs()
+	for b.Loop() {
+		h.ServeHTTP(w, r)
+	}
+}
+
+func BenchmarkFromContext(b *testing.B) {
+	ctx := tenant.NewContext(context.Background(), "acme")
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, ok := tenant.FromContext(ctx); !ok {
+			b.Fatal("expected tenant")
+		}
+	}
+}

--- a/web/tenant/bench_test.go
+++ b/web/tenant/bench_test.go
@@ -9,81 +9,96 @@ import (
 	"github.com/dmitrymomot/forge/web/tenant"
 )
 
+// benchLookup resolves subdomain "acme" and domain "shop.acme.com" to fixed
+// IDs and echoes KindID values, mimicking a consumer's single-query lookup.
+var benchLookup = tenant.LookupFunc(func(_ context.Context, ident tenant.Identifier) (string, error) {
+	switch ident.Kind {
+	case tenant.KindSubdomain:
+		if ident.Value == "acme" {
+			return "t_01acme", nil
+		}
+	case tenant.KindDomain:
+		if ident.Value == "shop.acme.com" {
+			return "t_01acme", nil
+		}
+	case tenant.KindID:
+		return ident.Value, nil
+	}
+	return "", tenant.ErrTenantNotFound
+})
+
 func BenchmarkSubdomain(b *testing.B) {
-	derive := tenant.Subdomain("app.example.com", tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"}))
+	extract := tenant.Subdomain("app.example.com")
 	r := newRequest("acme.app.example.com", "/")
 	b.ReportAllocs()
 	for b.Loop() {
-		if id, _ := derive(r); id == "" {
-			b.Fatal("expected resolution")
+		if _, ok := extract(r); !ok {
+			b.Fatal("expected extraction")
 		}
 	}
 }
 
 func BenchmarkSubdomainMiss(b *testing.B) {
-	derive := tenant.Subdomain("app.example.com", tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"}))
+	extract := tenant.Subdomain("app.example.com")
 	r := newRequest("other.example.org", "/")
 	b.ReportAllocs()
 	for b.Loop() {
-		if id, _ := derive(r); id != "" {
-			b.Fatal("unexpected resolution")
+		if _, ok := extract(r); ok {
+			b.Fatal("unexpected extraction")
+		}
+	}
+}
+
+func BenchmarkDomain(b *testing.B) {
+	extract := tenant.Domain()
+	r := newRequest("shop.acme.com", "/")
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, ok := extract(r); !ok {
+			b.Fatal("expected extraction")
 		}
 	}
 }
 
 func BenchmarkHeader(b *testing.B) {
-	derive := tenant.Header("X-Tenant-ID")
+	extract := tenant.Header("X-Tenant-ID")
 	r := newRequest("example.com", "/")
-	r.Header.Set("X-Tenant-ID", "acme")
+	r.Header.Set("X-Tenant-ID", "t_01acme")
 	b.ReportAllocs()
 	for b.Loop() {
-		if id, _ := derive(r); id == "" {
-			b.Fatal("expected resolution")
+		if _, ok := extract(r); !ok {
+			b.Fatal("expected extraction")
 		}
 	}
 }
 
 func BenchmarkQuery(b *testing.B) {
-	derive := tenant.Query("tenant")
-	r := newRequest("example.com", "/orders?tenant=acme")
+	extract := tenant.Query("tenant")
+	r := newRequest("example.com", "/orders?utm_source=x&tenant=t_01acme")
 	b.ReportAllocs()
 	for b.Loop() {
-		if id, _ := derive(r); id == "" {
-			b.Fatal("expected resolution")
+		if _, ok := extract(r); !ok {
+			b.Fatal("expected extraction")
 		}
 	}
 }
 
 func BenchmarkPathPrefix(b *testing.B) {
-	derive := tenant.PathPrefix("/t")
+	extract := tenant.PathPrefix("/t")
 	r := newRequest("example.com", "/t/acme/dashboard")
 	b.ReportAllocs()
 	for b.Loop() {
-		if id, _ := derive(r); id == "" {
-			b.Fatal("expected resolution")
-		}
-	}
-}
-
-func BenchmarkDomainStatic(b *testing.B) {
-	derive := tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "acme"}))
-	r := newRequest("shop.acme.com", "/")
-	b.ReportAllocs()
-	for b.Loop() {
-		if id, _ := derive(r); id == "" {
-			b.Fatal("expected resolution")
+		if _, ok := extract(r); !ok {
+			b.Fatal("expected extraction")
 		}
 	}
 }
 
 func BenchmarkResolve(b *testing.B) {
-	rv := tenant.New(
-		tenant.WithSources(
-			tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "t_01acme"})),
-			tenant.Subdomain("app.example.com", tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"})),
-		),
-		tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error { return nil })),
-	)
+	rv := tenant.New(benchLookup, tenant.WithSources(
+		tenant.Domain(),
+		tenant.Subdomain("app.example.com"),
+	))
 	r := newRequest("acme.app.example.com", "/")
 	b.ReportAllocs()
 	for b.Loop() {
@@ -94,9 +109,9 @@ func BenchmarkResolve(b *testing.B) {
 }
 
 func BenchmarkMiddleware(b *testing.B) {
-	h := tenant.New(tenant.WithSources(
-		tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "t_01acme"})),
-		tenant.Subdomain("app.example.com", tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"})),
+	h := tenant.New(benchLookup, tenant.WithSources(
+		tenant.Domain(),
+		tenant.Subdomain("app.example.com"),
 	)).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	r := newRequest("acme.app.example.com", "/")
 	w := httptest.NewRecorder()

--- a/web/tenant/bench_test.go
+++ b/web/tenant/bench_test.go
@@ -43,6 +43,17 @@ func BenchmarkHeader(b *testing.B) {
 	}
 }
 
+func BenchmarkQuery(b *testing.B) {
+	derive := tenant.Query("tenant")
+	r := newRequest("example.com", "/orders?tenant=acme")
+	b.ReportAllocs()
+	for b.Loop() {
+		if id, _ := derive(r); id == "" {
+			b.Fatal("expected resolution")
+		}
+	}
+}
+
 func BenchmarkPathPrefix(b *testing.B) {
 	derive := tenant.PathPrefix("/t")
 	r := newRequest("example.com", "/t/acme/dashboard")

--- a/web/tenant/context.go
+++ b/web/tenant/context.go
@@ -1,0 +1,36 @@
+package tenant
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/core/ctxkey"
+)
+
+var idKey = ctxkey.New[string]("tenant")
+
+// NewContext returns a copy of ctx carrying the tenant ID. It is the
+// transport-agnostic carrier: HTTP middleware stamps it automatically, queue
+// handlers and cron jobs stamp it themselves before touching tenant data.
+func NewContext(ctx context.Context, id string) context.Context {
+	return idKey.With(ctx, id)
+}
+
+// FromContext returns the tenant ID carried by ctx. ok is false when no
+// tenant was stamped or the stamped ID is empty.
+func FromContext(ctx context.Context) (string, bool) {
+	id, ok := idKey.From(ctx)
+	return id, ok && id != ""
+}
+
+// Scope returns the tenant ID from ctx, failing closed with ErrNoTenant when
+// absent or empty. Its signature matches the WithScope option of every other
+// forge package, so it plugs in directly:
+//
+//	mgr := apikey.New(store, apikey.WithScope(tenant.Scope))
+func Scope(ctx context.Context) (string, error) {
+	id, ok := FromContext(ctx)
+	if !ok {
+		return "", ErrNoTenant
+	}
+	return id, nil
+}

--- a/web/tenant/context_test.go
+++ b/web/tenant/context_test.go
@@ -1,0 +1,68 @@
+package tenant_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/web/tenant"
+)
+
+func TestContextCarrier(t *testing.T) {
+	t.Parallel()
+
+	t.Run("round trip", func(t *testing.T) {
+		t.Parallel()
+		ctx := tenant.NewContext(context.Background(), "acme")
+		id, ok := tenant.FromContext(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		id, ok := tenant.FromContext(context.Background())
+		assert.False(t, ok)
+		assert.Empty(t, id)
+	})
+
+	t.Run("empty ID reads as absent", func(t *testing.T) {
+		t.Parallel()
+		ctx := tenant.NewContext(context.Background(), "")
+		_, ok := tenant.FromContext(ctx)
+		assert.False(t, ok)
+	})
+
+	t.Run("inner stamp wins", func(t *testing.T) {
+		t.Parallel()
+		ctx := tenant.NewContext(tenant.NewContext(context.Background(), "outer"), "inner")
+		id, ok := tenant.FromContext(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, "inner", id)
+	})
+}
+
+func TestScope(t *testing.T) {
+	t.Parallel()
+
+	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+		id, err := tenant.Scope(tenant.NewContext(context.Background(), "acme"))
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("fails closed when absent", func(t *testing.T) {
+		t.Parallel()
+		_, err := tenant.Scope(context.Background())
+		require.ErrorIs(t, err, tenant.ErrNoTenant)
+	})
+
+	t.Run("fails closed on empty ID", func(t *testing.T) {
+		t.Parallel()
+		_, err := tenant.Scope(tenant.NewContext(context.Background(), ""))
+		require.ErrorIs(t, err, tenant.ErrNoTenant)
+	})
+}

--- a/web/tenant/doc.go
+++ b/web/tenant/doc.go
@@ -1,0 +1,60 @@
+// Package tenant resolves which tenant an inbound HTTP request belongs to
+// and carries the tenant ID through context transport-agnostically. It is
+// pure transport layer: the package derives a candidate identifier from the
+// request, validates it through consumer-owned seams, and yields the
+// canonical tenant ID — how that ID scopes storage is each consumer
+// package's concern (wire tenant.Scope into their WithScope options).
+//
+// Resolution is a precedence-ordered chain of Source funcs configured on a
+// Resolver, and every source yields the canonical tenant ID (uuid/ulid/short
+// id — whatever the consumer's tenants table keys on), never an alias:
+// subdomain labels and custom domains are translated through the
+// storage-agnostic SubdomainLookup/DomainLookup seams, and Map adds the same
+// translation to any other source. Shipped sources cover the common SaaS
+// shapes: subdomain against a base domain, custom domain, header, cookie,
+// query parameter, path prefix, and a context passthrough for identities
+// derived upstream (e.g. from an API key). The first source deriving a
+// non-empty ID wins; the optional Validator seam then rejects tenants that
+// exist but must not serve traffic (soft-deleted, disabled, suspended).
+//
+// The carrier is plain context: HTTP middleware stamps it, queue handlers
+// and cron jobs call NewContext/FromContext directly — no transport
+// assumptions. Scope is the fail-closed read used as the scope hook by every
+// other forge package's WithScope option.
+//
+// Single-tenant apps skip the package entirely; multi-tenant apps opt in per
+// route. Nothing is implicit: an unresolved request passes through
+// untenanted (add Require where tenancy is mandatory), while a resolved but
+// invalid tenant fails closed with a 404.
+//
+// # Usage
+//
+//	// Real apps back these seams with their tenants table.
+//	domains := tenant.StaticDomains(map[string]string{"shop.acme.com": "01JT9GA6Z3"})
+//	subdomains := tenant.StaticSubdomains(map[string]string{"acme": "01JT9GA6Z3"})
+//
+//	resolver := tenant.New(
+//		tenant.WithSources(
+//			tenant.Domain(domains),                          // custom domains win,
+//			tenant.Subdomain("app.example.com", subdomains), // then acme.app.example.com
+//		),
+//		tenant.WithValidator(tenant.ValidatorFunc(func(ctx context.Context, id string) error {
+//			return nil // consult your tenants table: ErrTenantNotFound / ErrTenantInactive
+//		})),
+//	)
+//
+//	mux := http.NewServeMux()
+//	mux.Handle("/orders", tenant.Require(http.HandlerFunc(listOrders)))
+//	handler := resolver.Middleware()(mux)
+//
+//	// In any handler or job:
+//	func listOrders(w http.ResponseWriter, r *http.Request) {
+//		id, err := tenant.Scope(r.Context())
+//		if err != nil { /* fail closed — never fall back to an unscoped view */ }
+//		_ = id
+//	}
+//
+// Queue handlers carry tenancy the same way: the producer stamps the job's
+// context (or payload), the consumer restores it with NewContext, and Scope
+// works unchanged.
+package tenant

--- a/web/tenant/doc.go
+++ b/web/tenant/doc.go
@@ -1,21 +1,21 @@
 // Package tenant resolves which tenant an inbound HTTP request belongs to
 // and carries the tenant ID through context transport-agnostically. It is
-// pure transport layer: the package derives a candidate identifier from the
-// request, validates it through consumer-owned seams, and yields the
-// canonical tenant ID — how that ID scopes storage is each consumer
-// package's concern (wire tenant.Scope into their WithScope options).
+// pure transport layer, split in two like auth/guard: Sources extract a
+// candidate identifier from the request (pure, no I/O), and the single
+// consumer-owned Lookup seam translates it to a live canonical tenant ID —
+// existence and status (soft-deleted, disabled) are one call, typically one
+// query. How the ID scopes storage is each consumer package's concern (wire
+// tenant.Scope into their WithScope options).
 //
-// Resolution is a precedence-ordered chain of Source funcs configured on a
-// Resolver, and every source yields the canonical tenant ID (uuid/ulid/short
-// id — whatever the consumer's tenants table keys on), never an alias:
-// subdomain labels and custom domains are translated through the
-// storage-agnostic SubdomainLookup/DomainLookup seams, and Map adds the same
-// translation to any other source. Shipped sources cover the common SaaS
-// shapes: subdomain against a base domain, custom domain, header, cookie,
-// query parameter, path prefix, and a context passthrough for identities
-// derived upstream (e.g. from an API key). The first source deriving a
-// non-empty ID wins; the optional Validator seam then rejects tenants that
-// exist but must not serve traffic (soft-deleted, disabled, suspended).
+// Shipped sources cover the common SaaS shapes — subdomain against a base
+// domain, custom domain, header, cookie, query parameter, path prefix, and
+// a context passthrough for identities derived upstream (e.g. from an API
+// key) — each tagging its value with a Kind (subdomain label, full domain,
+// path segment, canonical ID) so one Lookup implementation can interpret
+// every namespace; any func matching the Source signature adds a custom
+// source with its own Kind. Sources run in precedence order: the first
+// extracted identifier the Lookup resolves wins, ErrTenantNotFound moves to
+// the next source, ErrTenantInactive and infrastructure errors fail closed.
 //
 // The carrier is plain context: HTTP middleware stamps it, queue handlers
 // and cron jobs call NewContext/FromContext directly — no transport
@@ -24,24 +24,26 @@
 //
 // Single-tenant apps skip the package entirely; multi-tenant apps opt in per
 // route. Nothing is implicit: an unresolved request passes through
-// untenanted (add Require where tenancy is mandatory), while a resolved but
-// invalid tenant fails closed with a 404.
+// untenanted (add Require where tenancy is mandatory), while an inactive
+// tenant fails closed with a 404.
 //
 // # Usage
 //
-//	// Real apps back these seams with their tenants table.
-//	domains := tenant.StaticDomains(map[string]string{"shop.acme.com": "01JT9GA6Z3"})
-//	subdomains := tenant.StaticSubdomains(map[string]string{"acme": "01JT9GA6Z3"})
+//	// One seam answers "which tenant" and "may it serve" — usually one query
+//	// per request against the consumer's tenants table.
+//	lookup := tenant.LookupFunc(func(ctx context.Context, ident tenant.Identifier) (string, error) {
+//		switch ident.Kind {
+//		case tenant.KindDomain: // SELECT tenant_id FROM tenant_domains WHERE domain=$1 AND ...
+//		case tenant.KindSubdomain: // SELECT id FROM tenants WHERE subdomain=$1 AND deleted_at IS NULL
+//		case tenant.KindID: // SELECT id FROM tenants WHERE id=$1 AND deleted_at IS NULL
+//		}
+//		return "", tenant.ErrTenantNotFound
+//	})
 //
-//	resolver := tenant.New(
-//		tenant.WithSources(
-//			tenant.Domain(domains),                          // custom domains win,
-//			tenant.Subdomain("app.example.com", subdomains), // then acme.app.example.com
-//		),
-//		tenant.WithValidator(tenant.ValidatorFunc(func(ctx context.Context, id string) error {
-//			return nil // consult your tenants table: ErrTenantNotFound / ErrTenantInactive
-//		})),
-//	)
+//	resolver := tenant.New(lookup, tenant.WithSources(
+//		tenant.Domain(),                     // custom domains win,
+//		tenant.Subdomain("app.example.com"), // then acme.app.example.com
+//	))
 //
 //	mux := http.NewServeMux()
 //	mux.Handle("/orders", tenant.Require(http.HandlerFunc(listOrders)))

--- a/web/tenant/errors.go
+++ b/web/tenant/errors.go
@@ -4,19 +4,20 @@ import "errors"
 
 var (
 	// ErrNoTenant is returned by Scope when the context carries no tenant and
-	// by Resolver.Resolve when no source yields an identifier. Fail-closed:
+	// by Resolver.Resolve when no source yields a live tenant. Fail-closed:
 	// callers must not fall back to an unscoped view of the data.
 	ErrNoTenant = errors.New("tenant: no tenant in context")
 
-	// ErrTenantNotFound is returned by a DomainLookup or SubdomainLookup (and
-	// by Map translation funcs) when an alias maps to no tenant — the source
-	// treats it as "not resolved" and the chain continues — and by a Validator
-	// when a resolved ID identifies no tenant, which rejects the request.
+	// ErrTenantNotFound is returned by a Lookup when the identifier maps to
+	// no live tenant. The Resolver treats it as "not resolved" and continues
+	// with the next source — a request may legitimately carry a non-tenant
+	// identifier (the marketing host, an unknown subdomain).
 	ErrTenantNotFound = errors.New("tenant: tenant not found")
 
-	// ErrTenantInactive is returned by a Validator when the tenant exists but
+	// ErrTenantInactive is returned by a Lookup when the tenant exists but
 	// must not serve traffic (soft-deleted, disabled, suspended). Resolution
-	// fails closed: the request is rejected, never passed through untenanted.
+	// fails closed: the request is rejected, never passed through untenanted
+	// and never retried against later sources.
 	ErrTenantInactive = errors.New("tenant: tenant inactive")
 )
 
@@ -26,16 +27,15 @@ var (
 	// ErrEmptyName is used when Subdomain, Header, Cookie, or Query is
 	// constructed with an empty (after normalization) base domain or name.
 	ErrEmptyName = errors.New("tenant: empty base domain or name")
-	// ErrNilLookup is used when Domain or Subdomain is constructed with a nil
-	// lookup, or Map with a nil translation func.
+	// ErrNilLookup is used when New is called with a nil Lookup.
 	ErrNilLookup = errors.New("tenant: nil lookup")
 	// ErrInvalidPrefix is used when PathPrefix is constructed with a prefix
 	// that is neither empty nor starting with "/", or that ends with "/".
 	ErrInvalidPrefix = errors.New("tenant: invalid path prefix")
-	// ErrNilSource is used when WithSources or Map receives a nil Source.
+	// ErrNilSource is used when WithSources receives a nil Source.
 	ErrNilSource = errors.New("tenant: nil source")
 	// ErrNoSources is used when New is called without any WithSources option.
 	ErrNoSources = errors.New("tenant: no sources configured")
-	// ErrNilComponent is used when WithValidator or WithErrorHandler receives nil.
+	// ErrNilComponent is used when WithErrorHandler receives nil.
 	ErrNilComponent = errors.New("tenant: nil component")
 )

--- a/web/tenant/errors.go
+++ b/web/tenant/errors.go
@@ -1,0 +1,41 @@
+package tenant
+
+import "errors"
+
+var (
+	// ErrNoTenant is returned by Scope when the context carries no tenant and
+	// by Resolver.Resolve when no source yields an identifier. Fail-closed:
+	// callers must not fall back to an unscoped view of the data.
+	ErrNoTenant = errors.New("tenant: no tenant in context")
+
+	// ErrTenantNotFound is returned by a DomainLookup or SubdomainLookup (and
+	// by Map translation funcs) when an alias maps to no tenant — the source
+	// treats it as "not resolved" and the chain continues — and by a Validator
+	// when a resolved ID identifies no tenant, which rejects the request.
+	ErrTenantNotFound = errors.New("tenant: tenant not found")
+
+	// ErrTenantInactive is returned by a Validator when the tenant exists but
+	// must not serve traffic (soft-deleted, disabled, suspended). Resolution
+	// fails closed: the request is rejected, never passed through untenanted.
+	ErrTenantInactive = errors.New("tenant: tenant inactive")
+)
+
+// Sentinel errors used as panic payloads by source constructors, options, and
+// New when misconfigured. Recover and match them with errors.Is.
+var (
+	// ErrEmptyName is used when Subdomain, Header, Cookie, or Query is
+	// constructed with an empty (after normalization) base domain or name.
+	ErrEmptyName = errors.New("tenant: empty base domain or name")
+	// ErrNilLookup is used when Domain or Subdomain is constructed with a nil
+	// lookup, or Map with a nil translation func.
+	ErrNilLookup = errors.New("tenant: nil lookup")
+	// ErrInvalidPrefix is used when PathPrefix is constructed with a prefix
+	// that is neither empty nor starting with "/", or that ends with "/".
+	ErrInvalidPrefix = errors.New("tenant: invalid path prefix")
+	// ErrNilSource is used when WithSources or Map receives a nil Source.
+	ErrNilSource = errors.New("tenant: nil source")
+	// ErrNoSources is used when New is called without any WithSources option.
+	ErrNoSources = errors.New("tenant: no sources configured")
+	// ErrNilComponent is used when WithValidator or WithErrorHandler receives nil.
+	ErrNilComponent = errors.New("tenant: nil component")
+)

--- a/web/tenant/fuzz_test.go
+++ b/web/tenant/fuzz_test.go
@@ -1,0 +1,78 @@
+package tenant_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/tenant"
+)
+
+// FuzzSubdomain asserts the source never panics or errors and that any
+// derived label is a single dot-free DNS label sitting directly in front of
+// the base domain. The echo lookup returns the label itself so the
+// properties check pure extraction.
+func FuzzSubdomain(f *testing.F) {
+	f.Add("acme.app.example.com")
+	f.Add("app.example.com")
+	f.Add("a.b.app.example.com")
+	f.Add("ACME.App.Example.COM:8443")
+	f.Add("[::1]:8080")
+	f.Add("acme.app.example.com.")
+	f.Add(".app.example.com")
+	f.Add("xn--bcher-kva.app.example.com")
+
+	echo := subdomainLookupFunc(func(_ context.Context, subdomain string) (string, error) {
+		return subdomain, nil
+	})
+	derive := tenant.Subdomain("app.example.com", echo)
+	f.Fuzz(func(t *testing.T, host string) {
+		r := newRequest("example.com", "/")
+		r.Host = host
+		id, err := derive(r)
+		if err != nil {
+			t.Fatalf("Subdomain returned error for host %q: %v", host, err)
+		}
+		if id == "" {
+			return
+		}
+		if strings.ContainsRune(id, '.') {
+			t.Fatalf("derived label %q contains a dot (host %q)", id, host)
+		}
+		if !strings.Contains(strings.ToLower(host), id+".app.example.com") {
+			t.Fatalf("derived label %q not found in host %q", id, host)
+		}
+	})
+}
+
+// FuzzPathPrefix asserts the source never panics or errors and that any
+// derived segment is slash-free and present in the path.
+func FuzzPathPrefix(f *testing.F) {
+	f.Add("/t/acme/dashboard")
+	f.Add("/t/acme")
+	f.Add("/t/")
+	f.Add("/t")
+	f.Add("/team/acme")
+	f.Add("/")
+	f.Add("")
+	f.Add("/t//double")
+
+	derive := tenant.PathPrefix("/t")
+	f.Fuzz(func(t *testing.T, path string) {
+		r := newRequest("example.com", "/")
+		r.URL.Path = path
+		id, err := derive(r)
+		if err != nil {
+			t.Fatalf("PathPrefix returned error for path %q: %v", path, err)
+		}
+		if id == "" {
+			return
+		}
+		if strings.ContainsRune(id, '/') {
+			t.Fatalf("derived segment %q contains a slash (path %q)", id, path)
+		}
+		if !strings.HasPrefix(path, "/t/"+id) {
+			t.Fatalf("derived segment %q is not the segment after /t in %q", id, path)
+		}
+	})
+}

--- a/web/tenant/fuzz_test.go
+++ b/web/tenant/fuzz_test.go
@@ -1,17 +1,16 @@
 package tenant_test
 
 import (
-	"context"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/dmitrymomot/forge/web/tenant"
 )
 
-// FuzzSubdomain asserts the source never panics or errors and that any
-// derived label is a single dot-free DNS label sitting directly in front of
-// the base domain. The echo lookup returns the label itself so the
-// properties check pure extraction.
+// FuzzSubdomain asserts the source never panics and that any extracted label
+// is a single dot-free DNS label sitting directly in front of the base
+// domain, tagged KindSubdomain.
 func FuzzSubdomain(f *testing.F) {
 	f.Add("acme.app.example.com")
 	f.Add("app.example.com")
@@ -22,31 +21,64 @@ func FuzzSubdomain(f *testing.F) {
 	f.Add(".app.example.com")
 	f.Add("xn--bcher-kva.app.example.com")
 
-	echo := subdomainLookupFunc(func(_ context.Context, subdomain string) (string, error) {
-		return subdomain, nil
-	})
-	derive := tenant.Subdomain("app.example.com", echo)
+	extract := tenant.Subdomain("app.example.com")
 	f.Fuzz(func(t *testing.T, host string) {
 		r := newRequest("example.com", "/")
 		r.Host = host
-		id, err := derive(r)
-		if err != nil {
-			t.Fatalf("Subdomain returned error for host %q: %v", host, err)
-		}
-		if id == "" {
+		ident, ok := extract(r)
+		if !ok {
+			if ident != (tenant.Identifier{}) {
+				t.Fatalf("not-present extraction returned non-zero identifier %+v (host %q)", ident, host)
+			}
 			return
 		}
-		if strings.ContainsRune(id, '.') {
-			t.Fatalf("derived label %q contains a dot (host %q)", id, host)
+		if ident.Kind != tenant.KindSubdomain || ident.Value == "" {
+			t.Fatalf("extracted identifier %+v malformed (host %q)", ident, host)
 		}
-		if !strings.Contains(strings.ToLower(host), id+".app.example.com") {
-			t.Fatalf("derived label %q not found in host %q", id, host)
+		if strings.ContainsRune(ident.Value, '.') {
+			t.Fatalf("extracted label %q contains a dot (host %q)", ident.Value, host)
+		}
+		if !strings.Contains(strings.ToLower(host), ident.Value+".app.example.com") {
+			t.Fatalf("extracted label %q not found in host %q", ident.Value, host)
 		}
 	})
 }
 
-// FuzzPathPrefix asserts the source never panics or errors and that any
-// derived segment is slash-free and present in the path.
+// FuzzQuery asserts the RawQuery scan never panics and agrees with
+// r.URL.Query() whenever net/url parses the query cleanly (the scan is
+// deliberately more lenient on inputs net/url rejects wholesale).
+func FuzzQuery(f *testing.F) {
+	f.Add("tenant=t_123")
+	f.Add("a=1&tenant=t_123")
+	f.Add("tenant=%74_123")
+	f.Add("%74enant=x")
+	f.Add("tenant=a;b=c")
+	f.Add("tenant=%zz")
+	f.Add("tenant=+x")
+	f.Add("")
+
+	extract := tenant.Query("tenant")
+	f.Fuzz(func(t *testing.T, rawQuery string) {
+		r := newRequest("example.com", "/")
+		r.URL.RawQuery = rawQuery
+		ident, ok := extract(r)
+		if ok && (ident.Kind != tenant.KindID || ident.Value == "") {
+			t.Fatalf("extracted identifier %+v malformed (query %q)", ident, rawQuery)
+		}
+		vals, err := url.ParseQuery(rawQuery)
+		if err != nil {
+			return // net/url rejects the whole string; the lenient scan may still extract
+		}
+		if want := vals.Get("tenant"); want != "" {
+			if !ok || ident.Value != want {
+				t.Fatalf("scan got (%q, %v), url.Values got %q (query %q)", ident.Value, ok, want, rawQuery)
+			}
+		}
+	})
+}
+
+// FuzzPathPrefix asserts the source never panics and that any extracted
+// segment is slash-free, present in the path, and tagged KindPath.
 func FuzzPathPrefix(f *testing.F) {
 	f.Add("/t/acme/dashboard")
 	f.Add("/t/acme")
@@ -57,22 +89,22 @@ func FuzzPathPrefix(f *testing.F) {
 	f.Add("")
 	f.Add("/t//double")
 
-	derive := tenant.PathPrefix("/t")
+	extract := tenant.PathPrefix("/t")
 	f.Fuzz(func(t *testing.T, path string) {
 		r := newRequest("example.com", "/")
 		r.URL.Path = path
-		id, err := derive(r)
-		if err != nil {
-			t.Fatalf("PathPrefix returned error for path %q: %v", path, err)
-		}
-		if id == "" {
+		ident, ok := extract(r)
+		if !ok {
 			return
 		}
-		if strings.ContainsRune(id, '/') {
-			t.Fatalf("derived segment %q contains a slash (path %q)", id, path)
+		if ident.Kind != tenant.KindPath || ident.Value == "" {
+			t.Fatalf("extracted identifier %+v malformed (path %q)", ident, path)
 		}
-		if !strings.HasPrefix(path, "/t/"+id) {
-			t.Fatalf("derived segment %q is not the segment after /t in %q", id, path)
+		if strings.ContainsRune(ident.Value, '/') {
+			t.Fatalf("extracted segment %q contains a slash (path %q)", ident.Value, path)
+		}
+		if !strings.HasPrefix(path, "/t/"+ident.Value) {
+			t.Fatalf("extracted segment %q is not the segment after /t in %q", ident.Value, path)
 		}
 	})
 }

--- a/web/tenant/options.go
+++ b/web/tenant/options.go
@@ -1,0 +1,76 @@
+package tenant
+
+import (
+	"log/slog"
+
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+type config struct {
+	validate Validator
+	onError  ErrorHandler
+	log      *slog.Logger
+	sources  []Source
+}
+
+// Option configures New. Options apply in order and panic on invalid input.
+type Option func(*config)
+
+func newConfig(opts ...Option) config {
+	c := config{
+		onError: defaultErrorHandler,
+		log:     logger.NewNope(),
+	}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// WithSources appends sources to the precedence chain in the order given;
+// repeated calls keep appending. The first source deriving a non-empty ID
+// wins. Panics with ErrNilSource when any source is nil.
+func WithSources(sources ...Source) Option {
+	for _, src := range sources {
+		if src == nil {
+			panic(ErrNilSource)
+		}
+	}
+	return func(c *config) {
+		c.sources = append(c.sources, sources...)
+	}
+}
+
+// WithValidator installs the tenant status check run on every resolved ID —
+// the seam where "is this tenant soft-deleted or disabled" lives. Without
+// it, resolution trusts the sources (fine when every source already
+// translates through a lookup that only returns live tenants). Last wins.
+// Panics with ErrNilComponent when v is nil.
+func WithValidator(v Validator) Option {
+	if v == nil {
+		panic(ErrNilComponent)
+	}
+	return func(c *config) { c.validate = v }
+}
+
+// WithErrorHandler replaces the response written when resolution fails
+// (e.g. to render problem+json instead of the plain-text defaults). It does
+// not run when nothing resolves — that passes through untenanted. Last
+// wins. Panics with ErrNilComponent when h is nil.
+func WithErrorHandler(h ErrorHandler) Option {
+	if h == nil {
+		panic(ErrNilComponent)
+	}
+	return func(c *config) { c.onError = h }
+}
+
+// WithLogger sets the logger used by Middleware when resolution fails
+// (Debug for tenant-rejection errors, Error for infrastructure errors).
+// Defaults to a no-op logger. A nil logger is ignored.
+func WithLogger(l *slog.Logger) Option {
+	return func(c *config) {
+		if l != nil {
+			c.log = l
+		}
+	}
+}

--- a/web/tenant/options.go
+++ b/web/tenant/options.go
@@ -7,10 +7,9 @@ import (
 )
 
 type config struct {
-	validate Validator
-	onError  ErrorHandler
-	log      *slog.Logger
-	sources  []Source
+	onError ErrorHandler
+	log     *slog.Logger
+	sources []Source
 }
 
 // Option configures New. Options apply in order and panic on invalid input.
@@ -28,8 +27,9 @@ func newConfig(opts ...Option) config {
 }
 
 // WithSources appends sources to the precedence chain in the order given;
-// repeated calls keep appending. The first source deriving a non-empty ID
-// wins. Panics with ErrNilSource when any source is nil.
+// repeated calls keep appending. The first source extracting an identifier
+// the Lookup resolves to a live tenant wins. Panics with ErrNilSource when
+// any source is nil.
 func WithSources(sources ...Source) Option {
 	for _, src := range sources {
 		if src == nil {
@@ -39,18 +39,6 @@ func WithSources(sources ...Source) Option {
 	return func(c *config) {
 		c.sources = append(c.sources, sources...)
 	}
-}
-
-// WithValidator installs the tenant status check run on every resolved ID —
-// the seam where "is this tenant soft-deleted or disabled" lives. Without
-// it, resolution trusts the sources (fine when every source already
-// translates through a lookup that only returns live tenants). Last wins.
-// Panics with ErrNilComponent when v is nil.
-func WithValidator(v Validator) Option {
-	if v == nil {
-		panic(ErrNilComponent)
-	}
-	return func(c *config) { c.validate = v }
 }
 
 // WithErrorHandler replaces the response written when resolution fails

--- a/web/tenant/resolver.go
+++ b/web/tenant/resolver.go
@@ -1,0 +1,162 @@
+package tenant
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+// Validator checks that a resolved tenant ID identifies a tenant allowed to
+// serve traffic. It is the status seam: implementations consult whatever
+// system of record the consumer has (their tenants table, a cache, a control
+// plane) and return nil for a live tenant, ErrTenantNotFound when the ID
+// identifies no tenant, ErrTenantInactive when the tenant is soft-deleted,
+// disabled, or suspended, and any other error for infrastructure failure.
+// All non-nil errors fail resolution closed — a request with an invalid
+// tenant is rejected, never passed through untenanted.
+type Validator interface {
+	ValidateTenant(ctx context.Context, id string) error
+}
+
+// ValidatorFunc adapts a plain function to the Validator interface.
+type ValidatorFunc func(ctx context.Context, id string) error
+
+// ValidateTenant calls f(ctx, id).
+func (f ValidatorFunc) ValidateTenant(ctx context.Context, id string) error { return f(ctx, id) }
+
+// ErrorHandler writes the HTTP response when Middleware fails to resolve a
+// tenant for a reason other than "nothing resolved". err is the error
+// returned by Resolve; match it with errors.Is against ErrTenantNotFound,
+// ErrTenantInactive, and infrastructure errors from sources and validators.
+type ErrorHandler func(w http.ResponseWriter, r *http.Request, err error)
+
+// Resolver derives, validates, and returns the canonical tenant ID for HTTP
+// requests. Construct it with New; the zero value is not usable.
+type Resolver struct {
+	validate Validator
+	onError  ErrorHandler
+	log      *slog.Logger
+	sources  []Source
+}
+
+// New builds a Resolver from options. At least one Source must be configured
+// via WithSources or New panics with ErrNoSources. Sources run in the order
+// given: the first one deriving a non-empty ID wins, and that ID is then
+// checked by the WithValidator seam when one is configured.
+func New(opts ...Option) *Resolver {
+	c := newConfig(opts...)
+	if len(c.sources) == 0 {
+		panic(ErrNoSources)
+	}
+	return &Resolver{
+		sources:  c.sources,
+		validate: c.validate,
+		onError:  c.onError,
+		log:      c.log,
+	}
+}
+
+// Resolve derives the tenant ID for r through the source chain and validates
+// it. The first source deriving a non-empty ID wins; the chain does not
+// continue past a validation failure — a resolved-but-invalid tenant fails
+// closed with the validator's error (ErrTenantNotFound, ErrTenantInactive,
+// or an infrastructure error). A source error also stops the chain. When no
+// source derives anything, Resolve returns ErrNoTenant.
+func (rv *Resolver) Resolve(r *http.Request) (string, error) {
+	id, resolved, err := rv.resolve(r)
+	if err == nil && !resolved {
+		return "", ErrNoTenant
+	}
+	return id, err
+}
+
+// resolve reports "nothing resolved" through the resolved flag rather than a
+// sentinel so Middleware's passthrough decision cannot be forged by a source
+// or validator returning ErrNoTenant — any error, whatever its identity,
+// fails closed.
+func (rv *Resolver) resolve(r *http.Request) (id string, resolved bool, err error) {
+	for _, src := range rv.sources {
+		id, err := src(r)
+		if err != nil {
+			return "", false, err
+		}
+		if id == "" {
+			continue
+		}
+		if rv.validate != nil {
+			if err := rv.validate.ValidateTenant(r.Context(), id); err != nil {
+				return "", false, err
+			}
+		}
+		return id, true, nil
+	}
+	return "", false, nil
+}
+
+// Middleware resolves the tenant for each request and stamps it on the
+// request context via NewContext, overriding any tenant already there (give
+// a pre-existing context tenant an explicit slot with the Context source).
+// When nothing resolves, the request passes through unchanged: a tenant
+// stamped by an upstream middleware is preserved, and a request with none
+// stays untenanted so single-tenant routes coexist — add Require where
+// tenancy is mandatory. Any failure is delegated to the error handler
+// (default: 404 for ErrTenantNotFound/ErrTenantInactive, 500 otherwise) and
+// next is not called.
+//
+// Because resolution overrides upstream identity, any client-controlled
+// source (Header, Cookie, Query, PathPrefix) placed before Context() lets a
+// client swap an authenticated tenant for a different live one — order
+// Context() first when an upstream middleware stamps a verified tenant, and
+// enforce membership downstream regardless.
+func (rv *Resolver) Middleware() middleware.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id, resolved, err := rv.resolve(r)
+			switch {
+			case err == nil && resolved:
+				next.ServeHTTP(w, r.WithContext(NewContext(r.Context(), id)))
+			case err == nil:
+				next.ServeHTTP(w, r)
+			default:
+				level := slog.LevelError
+				if errors.Is(err, ErrTenantNotFound) || errors.Is(err, ErrTenantInactive) {
+					level = slog.LevelDebug
+				}
+				if rv.log.Enabled(r.Context(), level) {
+					rv.log.LogAttrs(r.Context(), level, "tenant: resolution failed",
+						slog.Any("error", err), slog.String("host", r.Host))
+				}
+				rv.onError(w, r, err)
+			}
+		})
+	}
+}
+
+// Require is a guard middleware responding 404 Not Found when the request
+// context carries no tenant. 404 — not 401/403 — because an unresolved
+// tenant host has nothing there, and the status leaks nothing about
+// tenancy. Place it after Middleware on routes where tenancy is mandatory:
+//
+//	middleware.Chain(resolver.Middleware(), tenant.Require)
+func Require(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := FromContext(r.Context()); !ok {
+			http.NotFound(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// defaultErrorHandler maps rejection errors to 404 (leaking nothing about
+// why the tenant is unavailable) and everything else to a generic 500.
+func defaultErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, ErrTenantNotFound) || errors.Is(err, ErrTenantInactive) {
+		http.NotFound(w, r)
+		return
+	}
+	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+}

--- a/web/tenant/resolver.go
+++ b/web/tenant/resolver.go
@@ -77,7 +77,7 @@ func (rv *Resolver) Resolve(r *http.Request) (string, error) {
 // sentinel so Middleware's passthrough decision cannot be forged by a source
 // or validator returning ErrNoTenant — any error, whatever its identity,
 // fails closed.
-func (rv *Resolver) resolve(r *http.Request) (id string, resolved bool, err error) {
+func (rv *Resolver) resolve(r *http.Request) (string, bool, error) {
 	for _, src := range rv.sources {
 		id, err := src(r)
 		if err != nil {

--- a/web/tenant/resolver.go
+++ b/web/tenant/resolver.go
@@ -3,68 +3,85 @@ package tenant
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 
 	"github.com/dmitrymomot/forge/web/middleware"
 )
 
-// Validator checks that a resolved tenant ID identifies a tenant allowed to
-// serve traffic. It is the status seam: implementations consult whatever
-// system of record the consumer has (their tenants table, a cache, a control
-// plane) and return nil for a live tenant, ErrTenantNotFound when the ID
-// identifies no tenant, ErrTenantInactive when the tenant is soft-deleted,
-// disabled, or suspended, and any other error for infrastructure failure.
-// All non-nil errors fail resolution closed — a request with an invalid
-// tenant is rejected, never passed through untenanted.
-type Validator interface {
-	ValidateTenant(ctx context.Context, id string) error
+// Lookup is the single consumer seam: it translates an extracted Identifier
+// into a live canonical tenant ID, answering "which tenant" and "may it
+// serve traffic" in one call (typically one query). Implementations switch
+// on ident.Kind and return:
+//
+//   - the canonical tenant ID for a live tenant;
+//   - ErrTenantNotFound when the identifier maps to no live tenant — the
+//     Resolver continues with the next source (a request may legitimately
+//     carry a non-tenant host, e.g. the marketing site);
+//   - ErrTenantInactive when the tenant exists but must not serve traffic
+//     (soft-deleted, disabled, suspended) — resolution fails closed;
+//   - any other error for infrastructure failure — resolution fails closed.
+//
+// Implementations must be safe for concurrent use.
+type Lookup interface {
+	LookupTenant(ctx context.Context, ident Identifier) (string, error)
 }
 
-// ValidatorFunc adapts a plain function to the Validator interface.
-type ValidatorFunc func(ctx context.Context, id string) error
+// LookupFunc adapts a plain function to the Lookup interface.
+type LookupFunc func(ctx context.Context, ident Identifier) (string, error)
 
-// ValidateTenant calls f(ctx, id).
-func (f ValidatorFunc) ValidateTenant(ctx context.Context, id string) error { return f(ctx, id) }
+// LookupTenant implements Lookup.
+func (f LookupFunc) LookupTenant(ctx context.Context, ident Identifier) (string, error) {
+	return f(ctx, ident)
+}
 
 // ErrorHandler writes the HTTP response when Middleware fails to resolve a
 // tenant for a reason other than "nothing resolved". err is the error
-// returned by Resolve; match it with errors.Is against ErrTenantNotFound,
-// ErrTenantInactive, and infrastructure errors from sources and validators.
+// returned by Resolve; match it with errors.Is against ErrTenantInactive
+// and infrastructure errors from the Lookup.
 type ErrorHandler func(w http.ResponseWriter, r *http.Request, err error)
+
+// errEmptyID guards against a Lookup returning ("", nil) — a consumer bug;
+// resolution fails closed rather than admitting an empty tenant.
+var errEmptyID = errors.New("tenant: lookup returned an empty tenant id")
 
 // Resolver derives, validates, and returns the canonical tenant ID for HTTP
 // requests. Construct it with New; the zero value is not usable.
 type Resolver struct {
-	validate Validator
-	onError  ErrorHandler
-	log      *slog.Logger
-	sources  []Source
+	lookup  Lookup
+	onError ErrorHandler
+	log     *slog.Logger
+	sources []Source
 }
 
-// New builds a Resolver from options. At least one Source must be configured
-// via WithSources or New panics with ErrNoSources. Sources run in the order
-// given: the first one deriving a non-empty ID wins, and that ID is then
-// checked by the WithValidator seam when one is configured.
-func New(opts ...Option) *Resolver {
+// New builds a Resolver over the given Lookup. At least one Source must be
+// configured via WithSources or New panics with ErrNoSources; a nil lookup
+// panics with ErrNilLookup — both are wiring bugs. Sources run in the order
+// given: the first one extracting an identifier that the Lookup resolves to
+// a live tenant wins.
+func New(lookup Lookup, opts ...Option) *Resolver {
+	if lookup == nil {
+		panic(ErrNilLookup)
+	}
 	c := newConfig(opts...)
 	if len(c.sources) == 0 {
 		panic(ErrNoSources)
 	}
 	return &Resolver{
-		sources:  c.sources,
-		validate: c.validate,
-		onError:  c.onError,
-		log:      c.log,
+		lookup:  lookup,
+		onError: c.onError,
+		log:     c.log,
+		sources: c.sources,
 	}
 }
 
-// Resolve derives the tenant ID for r through the source chain and validates
-// it. The first source deriving a non-empty ID wins; the chain does not
-// continue past a validation failure — a resolved-but-invalid tenant fails
-// closed with the validator's error (ErrTenantNotFound, ErrTenantInactive,
-// or an infrastructure error). A source error also stops the chain. When no
-// source derives anything, Resolve returns ErrNoTenant.
+// Resolve derives the tenant ID for r: each source in turn extracts a
+// candidate identifier, and the Lookup translates it to a live canonical
+// ID. ErrTenantNotFound from the Lookup means "this identifier belongs to
+// no live tenant" and the chain continues with the next source; any other
+// Lookup error fails closed and stops the chain. When no source yields a
+// live tenant, Resolve returns ErrNoTenant.
 func (rv *Resolver) Resolve(r *http.Request) (string, error) {
 	id, resolved, err := rv.resolve(r)
 	if err == nil && !resolved {
@@ -74,22 +91,23 @@ func (rv *Resolver) Resolve(r *http.Request) (string, error) {
 }
 
 // resolve reports "nothing resolved" through the resolved flag rather than a
-// sentinel so Middleware's passthrough decision cannot be forged by a source
-// or validator returning ErrNoTenant — any error, whatever its identity,
-// fails closed.
+// sentinel so Middleware's passthrough decision cannot be forged by a Lookup
+// returning ErrNoTenant — any error, whatever its identity, fails closed.
 func (rv *Resolver) resolve(r *http.Request) (string, bool, error) {
 	for _, src := range rv.sources {
-		id, err := src(r)
+		ident, ok := src(r)
+		if !ok || ident.Value == "" {
+			continue
+		}
+		id, err := rv.lookup.LookupTenant(r.Context(), ident)
 		if err != nil {
+			if errors.Is(err, ErrTenantNotFound) {
+				continue
+			}
 			return "", false, err
 		}
 		if id == "" {
-			continue
-		}
-		if rv.validate != nil {
-			if err := rv.validate.ValidateTenant(r.Context(), id); err != nil {
-				return "", false, err
-			}
+			return "", false, fmt.Errorf("%w (%s %q)", errEmptyID, ident.Kind, ident.Value)
 		}
 		return id, true, nil
 	}
@@ -103,8 +121,8 @@ func (rv *Resolver) resolve(r *http.Request) (string, bool, error) {
 // stamped by an upstream middleware is preserved, and a request with none
 // stays untenanted so single-tenant routes coexist — add Require where
 // tenancy is mandatory. Any failure is delegated to the error handler
-// (default: 404 for ErrTenantNotFound/ErrTenantInactive, 500 otherwise) and
-// next is not called.
+// (default: 404 for ErrTenantInactive, 500 otherwise) and next is not
+// called.
 //
 // Because resolution overrides upstream identity, any client-controlled
 // source (Header, Cookie, Query, PathPrefix) placed before Context() lets a
@@ -122,7 +140,7 @@ func (rv *Resolver) Middleware() middleware.Middleware {
 				next.ServeHTTP(w, r)
 			default:
 				level := slog.LevelError
-				if errors.Is(err, ErrTenantNotFound) || errors.Is(err, ErrTenantInactive) {
+				if errors.Is(err, ErrTenantInactive) {
 					level = slog.LevelDebug
 				}
 				if rv.log.Enabled(r.Context(), level) {
@@ -154,7 +172,7 @@ func Require(next http.Handler) http.Handler {
 // defaultErrorHandler maps rejection errors to 404 (leaking nothing about
 // why the tenant is unavailable) and everything else to a generic 500.
 func defaultErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
-	if errors.Is(err, ErrTenantNotFound) || errors.Is(err, ErrTenantInactive) {
+	if errors.Is(err, ErrTenantInactive) {
 		http.NotFound(w, r)
 		return
 	}

--- a/web/tenant/resolver_test.go
+++ b/web/tenant/resolver_test.go
@@ -1,0 +1,411 @@
+package tenant_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/web/tenant"
+)
+
+// captureTenant records the tenant seen by the wrapped handler.
+func captureTenant(id *string, ok *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*id, *ok = tenant.FromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no sources panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrNoSources, func() { tenant.New() })
+	})
+
+	t.Run("nil source panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrNilSource, func() {
+			tenant.WithSources(tenant.Context(), nil)
+		})
+	})
+
+	t.Run("nil validator panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrNilComponent, func() { tenant.WithValidator(nil) })
+	})
+
+	t.Run("nil error handler panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrNilComponent, func() { tenant.WithErrorHandler(nil) })
+	})
+}
+
+func TestResolve(t *testing.T) {
+	t.Parallel()
+
+	t.Run("first non-empty source wins", func(t *testing.T) {
+		t.Parallel()
+		rv := tenant.New(tenant.WithSources(
+			tenant.Header("X-Missing"),
+			tenant.Header("X-First"),
+			tenant.Header("X-Second"),
+		))
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-First", "alpha")
+		r.Header.Set("X-Second", "beta")
+		id, err := rv.Resolve(r)
+		require.NoError(t, err)
+		assert.Equal(t, "alpha", id)
+	})
+
+	t.Run("repeated WithSources appends in order", func(t *testing.T) {
+		t.Parallel()
+		rv := tenant.New(
+			tenant.WithSources(tenant.Header("X-First")),
+			tenant.WithSources(tenant.Header("X-Second")),
+		)
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Second", "beta")
+		id, err := rv.Resolve(r)
+		require.NoError(t, err)
+		assert.Equal(t, "beta", id)
+
+		r.Header.Set("X-First", "alpha")
+		id, err = rv.Resolve(r)
+		require.NoError(t, err)
+		assert.Equal(t, "alpha", id)
+	})
+
+	t.Run("nothing resolves returns ErrNoTenant", func(t *testing.T) {
+		t.Parallel()
+		rv := tenant.New(tenant.WithSources(tenant.Header("X-Tenant-ID")))
+		_, err := rv.Resolve(newRequest("example.com", "/"))
+		require.ErrorIs(t, err, tenant.ErrNoTenant)
+	})
+
+	t.Run("source error stops chain", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("lookup down")
+		rv := tenant.New(tenant.WithSources(
+			func(*http.Request) (string, error) { return "", boom },
+			tenant.Header("X-Tenant-ID"),
+		))
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "acme")
+		_, err := rv.Resolve(r)
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("validator approves resolved ID", func(t *testing.T) {
+		t.Parallel()
+		var got string
+		rv := tenant.New(
+			tenant.WithSources(tenant.Header("X-Tenant-ID")),
+			tenant.WithValidator(tenant.ValidatorFunc(func(_ context.Context, id string) error {
+				got = id
+				return nil
+			})),
+		)
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "acme")
+		id, err := rv.Resolve(r)
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+		assert.Equal(t, "acme", got)
+	})
+
+	t.Run("validator rejection fails closed without trying later sources", func(t *testing.T) {
+		t.Parallel()
+		rv := tenant.New(
+			tenant.WithSources(
+				tenant.Header("X-Stale"),
+				tenant.Header("X-Live"),
+			),
+			tenant.WithValidator(tenant.ValidatorFunc(func(_ context.Context, id string) error {
+				if id == "stale" {
+					return tenant.ErrTenantInactive
+				}
+				return nil
+			})),
+		)
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Stale", "stale")
+		r.Header.Set("X-Live", "live")
+		_, err := rv.Resolve(r)
+		require.ErrorIs(t, err, tenant.ErrTenantInactive)
+	})
+
+	t.Run("validator not-found fails closed", func(t *testing.T) {
+		t.Parallel()
+		rv := tenant.New(
+			tenant.WithSources(tenant.Header("X-Tenant-ID")),
+			tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error {
+				return tenant.ErrTenantNotFound
+			})),
+		)
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "ghost")
+		_, err := rv.Resolve(r)
+		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
+	})
+
+	t.Run("validator skipped when nothing resolves", func(t *testing.T) {
+		t.Parallel()
+		rv := tenant.New(
+			tenant.WithSources(tenant.Header("X-Tenant-ID")),
+			tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error {
+				t.Fatal("validator must not run without a resolved ID")
+				return nil
+			})),
+		)
+		_, err := rv.Resolve(newRequest("example.com", "/"))
+		require.ErrorIs(t, err, tenant.ErrNoTenant)
+	})
+}
+
+func TestMiddleware(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stamps resolved tenant", func(t *testing.T) {
+		t.Parallel()
+		var id string
+		var ok bool
+		h := tenant.New(tenant.WithSources(tenant.Header("X-Tenant-ID"))).
+			Middleware()(captureTenant(&id, &ok))
+
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "acme")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		require.True(t, ok)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("unresolved passes through untenanted", func(t *testing.T) {
+		t.Parallel()
+		var id string
+		var ok bool
+		h := tenant.New(tenant.WithSources(tenant.Header("X-Tenant-ID"))).
+			Middleware()(captureTenant(&id, &ok))
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newRequest("example.com", "/"))
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.False(t, ok)
+	})
+
+	t.Run("source error responds 500 and skips next", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		boom := errors.New("lookup down")
+		h := tenant.New(tenant.WithSources(func(*http.Request) (string, error) { return "", boom })).
+			Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newRequest("example.com", "/"))
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.False(t, called)
+	})
+
+	t.Run("validator rejection responds 404 and skips next", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		h := tenant.New(
+			tenant.WithSources(tenant.Header("X-Tenant-ID")),
+			tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error {
+				return tenant.ErrTenantInactive
+			})),
+		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
+
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "acme")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.False(t, called)
+	})
+
+	t.Run("custom error handler receives the resolution error", func(t *testing.T) {
+		t.Parallel()
+		var got error
+		h := tenant.New(
+			tenant.WithSources(tenant.Header("X-Tenant-ID")),
+			tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error {
+				return tenant.ErrTenantNotFound
+			})),
+			tenant.WithErrorHandler(func(w http.ResponseWriter, _ *http.Request, err error) {
+				got = err
+				w.WriteHeader(http.StatusTeapot)
+			}),
+		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "ghost")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusTeapot, w.Code)
+		require.ErrorIs(t, got, tenant.ErrTenantNotFound)
+	})
+
+	t.Run("ErrNoTenant from a source fails closed, never passes through", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		h := tenant.New(tenant.WithSources(func(*http.Request) (string, error) {
+			return "", tenant.ErrNoTenant
+		})).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newRequest("example.com", "/"))
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.False(t, called)
+	})
+
+	t.Run("ErrNoTenant from the validator fails closed, never passes through", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		h := tenant.New(
+			tenant.WithSources(tenant.Header("X-Tenant-ID")),
+			tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error {
+				return tenant.ErrNoTenant
+			})),
+		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
+
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "acme")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.False(t, called)
+	})
+
+	t.Run("rejections log at debug, infrastructure errors at error", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		h := tenant.New(
+			tenant.WithSources(tenant.Header("X-Tenant-ID")),
+			tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error {
+				return tenant.ErrTenantInactive
+			})),
+			tenant.WithLogger(log),
+		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "acme")
+		h.ServeHTTP(httptest.NewRecorder(), r)
+		assert.Contains(t, buf.String(), "tenant: resolution failed")
+		assert.Contains(t, buf.String(), "level=DEBUG")
+
+		buf.Reset()
+		h = tenant.New(
+			tenant.WithSources(func(*http.Request) (string, error) { return "", errors.New("db down") }),
+			tenant.WithLogger(log),
+		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		h.ServeHTTP(httptest.NewRecorder(), newRequest("example.com", "/"))
+		assert.Contains(t, buf.String(), "tenant: resolution failed")
+		assert.Contains(t, buf.String(), "level=ERROR")
+	})
+
+	t.Run("nil logger is ignored", func(t *testing.T) {
+		t.Parallel()
+		h := tenant.New(
+			tenant.WithSources(func(*http.Request) (string, error) { return "", errors.New("db down") }),
+			tenant.WithLogger(nil),
+		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+		w := httptest.NewRecorder()
+		assert.NotPanics(t, func() { h.ServeHTTP(w, newRequest("example.com", "/")) })
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("resolution overrides pre-existing context tenant", func(t *testing.T) {
+		t.Parallel()
+		var id string
+		var ok bool
+		h := tenant.New(tenant.WithSources(tenant.Header("X-Tenant-ID"))).
+			Middleware()(captureTenant(&id, &ok))
+
+		r := newRequest("example.com", "/")
+		r = r.WithContext(tenant.NewContext(r.Context(), "upstream"))
+		r.Header.Set("X-Tenant-ID", "resolved")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		require.True(t, ok)
+		assert.Equal(t, "resolved", id)
+	})
+
+	t.Run("Context source slots upstream tenant into precedence", func(t *testing.T) {
+		t.Parallel()
+		var id string
+		var ok bool
+		h := tenant.New(tenant.WithSources(tenant.Context(), tenant.Header("X-Tenant-ID"))).
+			Middleware()(captureTenant(&id, &ok))
+
+		r := newRequest("example.com", "/")
+		r = r.WithContext(tenant.NewContext(r.Context(), "upstream"))
+		r.Header.Set("X-Tenant-ID", "header")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		require.True(t, ok)
+		assert.Equal(t, "upstream", id)
+	})
+
+	t.Run("upstream tenant survives when nothing resolves", func(t *testing.T) {
+		t.Parallel()
+		var id string
+		var ok bool
+		h := tenant.New(tenant.WithSources(tenant.Header("X-Tenant-ID"))).
+			Middleware()(captureTenant(&id, &ok))
+
+		r := newRequest("example.com", "/")
+		r = r.WithContext(tenant.NewContext(r.Context(), "upstream"))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		require.True(t, ok)
+		assert.Equal(t, "upstream", id)
+	})
+}
+
+func TestRequire(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("tenanted request passes", func(t *testing.T) {
+		t.Parallel()
+		r := newRequest("example.com", "/")
+		r = r.WithContext(tenant.NewContext(r.Context(), "acme"))
+		w := httptest.NewRecorder()
+		tenant.Require(next).ServeHTTP(w, r)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("untenanted request gets 404", func(t *testing.T) {
+		t.Parallel()
+		w := httptest.NewRecorder()
+		tenant.Require(next).ServeHTTP(w, newRequest("example.com", "/"))
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}

--- a/web/tenant/resolver_test.go
+++ b/web/tenant/resolver_test.go
@@ -15,6 +15,22 @@ import (
 	"github.com/dmitrymomot/forge/web/tenant"
 )
 
+// idLookup resolves KindID identifiers against a fixed set of live tenants;
+// everything else is not found. The default consumer shape for tests.
+func idLookup(live ...string) tenant.Lookup {
+	return tenant.LookupFunc(func(_ context.Context, ident tenant.Identifier) (string, error) {
+		if ident.Kind != tenant.KindID {
+			return "", tenant.ErrTenantNotFound
+		}
+		for _, id := range live {
+			if ident.Value == id {
+				return id, nil
+			}
+		}
+		return "", tenant.ErrTenantNotFound
+	})
+}
+
 // captureTenant records the tenant seen by the wrapped handler.
 func captureTenant(id *string, ok *bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -26,9 +42,16 @@ func captureTenant(id *string, ok *bool) http.Handler {
 func TestNew(t *testing.T) {
 	t.Parallel()
 
+	t.Run("nil lookup panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrNilLookup, func() {
+			tenant.New(nil, tenant.WithSources(tenant.Context()))
+		})
+	})
+
 	t.Run("no sources panics", func(t *testing.T) {
 		t.Parallel()
-		assert.PanicsWithValue(t, tenant.ErrNoSources, func() { tenant.New() })
+		assert.PanicsWithValue(t, tenant.ErrNoSources, func() { tenant.New(idLookup()) })
 	})
 
 	t.Run("nil source panics", func(t *testing.T) {
@@ -36,11 +59,6 @@ func TestNew(t *testing.T) {
 		assert.PanicsWithValue(t, tenant.ErrNilSource, func() {
 			tenant.WithSources(tenant.Context(), nil)
 		})
-	})
-
-	t.Run("nil validator panics", func(t *testing.T) {
-		t.Parallel()
-		assert.PanicsWithValue(t, tenant.ErrNilComponent, func() { tenant.WithValidator(nil) })
 	})
 
 	t.Run("nil error handler panics", func(t *testing.T) {
@@ -52,9 +70,9 @@ func TestNew(t *testing.T) {
 func TestResolve(t *testing.T) {
 	t.Parallel()
 
-	t.Run("first non-empty source wins", func(t *testing.T) {
+	t.Run("first extracted identifier wins", func(t *testing.T) {
 		t.Parallel()
-		rv := tenant.New(tenant.WithSources(
+		rv := tenant.New(idLookup("alpha", "beta"), tenant.WithSources(
 			tenant.Header("X-Missing"),
 			tenant.Header("X-First"),
 			tenant.Header("X-Second"),
@@ -67,9 +85,44 @@ func TestResolve(t *testing.T) {
 		assert.Equal(t, "alpha", id)
 	})
 
-	t.Run("repeated WithSources appends in order", func(t *testing.T) {
+	t.Run("lookup receives the tagged identifier", func(t *testing.T) {
+		t.Parallel()
+		var got tenant.Identifier
+		rv := tenant.New(
+			tenant.LookupFunc(func(_ context.Context, ident tenant.Identifier) (string, error) {
+				got = ident
+				return "t_01acme", nil
+			}),
+			tenant.WithSources(tenant.Subdomain("app.example.com")),
+		)
+		id, err := rv.Resolve(newRequest("ACME.app.example.com:8443", "/"))
+		require.NoError(t, err)
+		assert.Equal(t, "t_01acme", id)
+		assert.Equal(t, tenant.Identifier{Kind: tenant.KindSubdomain, Value: "acme"}, got)
+	})
+
+	t.Run("not found continues chain to a later source", func(t *testing.T) {
 		t.Parallel()
 		rv := tenant.New(
+			tenant.LookupFunc(func(_ context.Context, ident tenant.Identifier) (string, error) {
+				if ident.Kind == tenant.KindSubdomain && ident.Value == "acme" {
+					return "t_01acme", nil
+				}
+				return "", tenant.ErrTenantNotFound
+			}),
+			tenant.WithSources(
+				tenant.Domain(), // extracts on every host; lookup says not found
+				tenant.Subdomain("app.example.com"),
+			),
+		)
+		id, err := rv.Resolve(newRequest("acme.app.example.com", "/"))
+		require.NoError(t, err)
+		assert.Equal(t, "t_01acme", id)
+	})
+
+	t.Run("repeated WithSources appends in order", func(t *testing.T) {
+		t.Parallel()
+		rv := tenant.New(idLookup("alpha", "beta"),
 			tenant.WithSources(tenant.Header("X-First")),
 			tenant.WithSources(tenant.Header("X-Second")),
 		)
@@ -85,57 +138,38 @@ func TestResolve(t *testing.T) {
 		assert.Equal(t, "alpha", id)
 	})
 
-	t.Run("nothing resolves returns ErrNoTenant", func(t *testing.T) {
+	t.Run("nothing extracts returns ErrNoTenant without calling lookup", func(t *testing.T) {
 		t.Parallel()
-		rv := tenant.New(tenant.WithSources(tenant.Header("X-Tenant-ID")))
+		rv := tenant.New(
+			tenant.LookupFunc(func(context.Context, tenant.Identifier) (string, error) {
+				t.Fatal("lookup must not run without an extracted identifier")
+				return "", nil
+			}),
+			tenant.WithSources(tenant.Header("X-Tenant-ID")),
+		)
 		_, err := rv.Resolve(newRequest("example.com", "/"))
 		require.ErrorIs(t, err, tenant.ErrNoTenant)
 	})
 
-	t.Run("source error stops chain", func(t *testing.T) {
+	t.Run("nothing resolves returns ErrNoTenant", func(t *testing.T) {
 		t.Parallel()
-		boom := errors.New("lookup down")
-		rv := tenant.New(tenant.WithSources(
-			func(*http.Request) (string, error) { return "", boom },
-			tenant.Header("X-Tenant-ID"),
-		))
+		rv := tenant.New(idLookup(), tenant.WithSources(tenant.Header("X-Tenant-ID")))
 		r := newRequest("example.com", "/")
-		r.Header.Set("X-Tenant-ID", "acme")
+		r.Header.Set("X-Tenant-ID", "ghost")
 		_, err := rv.Resolve(r)
-		require.ErrorIs(t, err, boom)
+		require.ErrorIs(t, err, tenant.ErrNoTenant)
 	})
 
-	t.Run("validator approves resolved ID", func(t *testing.T) {
-		t.Parallel()
-		var got string
-		rv := tenant.New(
-			tenant.WithSources(tenant.Header("X-Tenant-ID")),
-			tenant.WithValidator(tenant.ValidatorFunc(func(_ context.Context, id string) error {
-				got = id
-				return nil
-			})),
-		)
-		r := newRequest("example.com", "/")
-		r.Header.Set("X-Tenant-ID", "acme")
-		id, err := rv.Resolve(r)
-		require.NoError(t, err)
-		assert.Equal(t, "acme", id)
-		assert.Equal(t, "acme", got)
-	})
-
-	t.Run("validator rejection fails closed without trying later sources", func(t *testing.T) {
+	t.Run("inactive fails closed without trying later sources", func(t *testing.T) {
 		t.Parallel()
 		rv := tenant.New(
-			tenant.WithSources(
-				tenant.Header("X-Stale"),
-				tenant.Header("X-Live"),
-			),
-			tenant.WithValidator(tenant.ValidatorFunc(func(_ context.Context, id string) error {
-				if id == "stale" {
-					return tenant.ErrTenantInactive
+			tenant.LookupFunc(func(_ context.Context, ident tenant.Identifier) (string, error) {
+				if ident.Value == "stale" {
+					return "", tenant.ErrTenantInactive
 				}
-				return nil
-			})),
+				return ident.Value, nil
+			}),
+			tenant.WithSources(tenant.Header("X-Stale"), tenant.Header("X-Live")),
 		)
 		r := newRequest("example.com", "/")
 		r.Header.Set("X-Stale", "stale")
@@ -144,31 +178,36 @@ func TestResolve(t *testing.T) {
 		require.ErrorIs(t, err, tenant.ErrTenantInactive)
 	})
 
-	t.Run("validator not-found fails closed", func(t *testing.T) {
+	t.Run("infrastructure error fails closed", func(t *testing.T) {
 		t.Parallel()
+		boom := errors.New("db down")
 		rv := tenant.New(
-			tenant.WithSources(tenant.Header("X-Tenant-ID")),
-			tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error {
-				return tenant.ErrTenantNotFound
-			})),
+			tenant.LookupFunc(func(context.Context, tenant.Identifier) (string, error) {
+				return "", boom
+			}),
+			tenant.WithSources(tenant.Header("X-Tenant-ID"), tenant.Header("X-Backup")),
 		)
 		r := newRequest("example.com", "/")
-		r.Header.Set("X-Tenant-ID", "ghost")
+		r.Header.Set("X-Tenant-ID", "acme")
+		r.Header.Set("X-Backup", "other")
 		_, err := rv.Resolve(r)
-		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
+		require.ErrorIs(t, err, boom)
 	})
 
-	t.Run("validator skipped when nothing resolves", func(t *testing.T) {
+	t.Run("empty id with nil error fails closed as a lookup bug", func(t *testing.T) {
 		t.Parallel()
 		rv := tenant.New(
+			tenant.LookupFunc(func(context.Context, tenant.Identifier) (string, error) {
+				return "", nil
+			}),
 			tenant.WithSources(tenant.Header("X-Tenant-ID")),
-			tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error {
-				t.Fatal("validator must not run without a resolved ID")
-				return nil
-			})),
 		)
-		_, err := rv.Resolve(newRequest("example.com", "/"))
-		require.ErrorIs(t, err, tenant.ErrNoTenant)
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "acme")
+		_, err := rv.Resolve(r)
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, tenant.ErrNoTenant)
+		assert.NotErrorIs(t, err, tenant.ErrTenantNotFound)
 	})
 }
 
@@ -179,7 +218,7 @@ func TestMiddleware(t *testing.T) {
 		t.Parallel()
 		var id string
 		var ok bool
-		h := tenant.New(tenant.WithSources(tenant.Header("X-Tenant-ID"))).
+		h := tenant.New(idLookup("acme"), tenant.WithSources(tenant.Header("X-Tenant-ID"))).
 			Middleware()(captureTenant(&id, &ok))
 
 		r := newRequest("example.com", "/")
@@ -196,7 +235,7 @@ func TestMiddleware(t *testing.T) {
 		t.Parallel()
 		var id string
 		var ok bool
-		h := tenant.New(tenant.WithSources(tenant.Header("X-Tenant-ID"))).
+		h := tenant.New(idLookup(), tenant.WithSources(tenant.Header("X-Tenant-ID"))).
 			Middleware()(captureTenant(&id, &ok))
 
 		w := httptest.NewRecorder()
@@ -206,28 +245,49 @@ func TestMiddleware(t *testing.T) {
 		assert.False(t, ok)
 	})
 
-	t.Run("source error responds 500 and skips next", func(t *testing.T) {
+	t.Run("not found on every source passes through untenanted", func(t *testing.T) {
+		t.Parallel()
+		var id string
+		var ok bool
+		h := tenant.New(idLookup(), tenant.WithSources(tenant.Domain(), tenant.Header("X-Tenant-ID"))).
+			Middleware()(captureTenant(&id, &ok))
+
+		r := newRequest("marketing.example.com", "/")
+		r.Header.Set("X-Tenant-ID", "ghost")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.False(t, ok)
+	})
+
+	t.Run("infrastructure error responds 500 and skips next", func(t *testing.T) {
 		t.Parallel()
 		called := false
-		boom := errors.New("lookup down")
-		h := tenant.New(tenant.WithSources(func(*http.Request) (string, error) { return "", boom })).
-			Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
+		h := tenant.New(
+			tenant.LookupFunc(func(context.Context, tenant.Identifier) (string, error) {
+				return "", errors.New("db down")
+			}),
+			tenant.WithSources(tenant.Header("X-Tenant-ID")),
+		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
 
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "acme")
 		w := httptest.NewRecorder()
-		h.ServeHTTP(w, newRequest("example.com", "/"))
+		h.ServeHTTP(w, r)
 
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 		assert.False(t, called)
 	})
 
-	t.Run("validator rejection responds 404 and skips next", func(t *testing.T) {
+	t.Run("inactive tenant responds 404 and skips next", func(t *testing.T) {
 		t.Parallel()
 		called := false
 		h := tenant.New(
+			tenant.LookupFunc(func(context.Context, tenant.Identifier) (string, error) {
+				return "", tenant.ErrTenantInactive
+			}),
 			tenant.WithSources(tenant.Header("X-Tenant-ID")),
-			tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error {
-				return tenant.ErrTenantInactive
-			})),
 		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
 
 		r := newRequest("example.com", "/")
@@ -239,51 +299,14 @@ func TestMiddleware(t *testing.T) {
 		assert.False(t, called)
 	})
 
-	t.Run("custom error handler receives the resolution error", func(t *testing.T) {
+	t.Run("ErrNoTenant from the lookup fails closed, never passes through", func(t *testing.T) {
 		t.Parallel()
-		var got error
+		called := false
 		h := tenant.New(
-			tenant.WithSources(tenant.Header("X-Tenant-ID")),
-			tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error {
-				return tenant.ErrTenantNotFound
-			})),
-			tenant.WithErrorHandler(func(w http.ResponseWriter, _ *http.Request, err error) {
-				got = err
-				w.WriteHeader(http.StatusTeapot)
+			tenant.LookupFunc(func(context.Context, tenant.Identifier) (string, error) {
+				return "", tenant.ErrNoTenant
 			}),
-		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-
-		r := newRequest("example.com", "/")
-		r.Header.Set("X-Tenant-ID", "ghost")
-		w := httptest.NewRecorder()
-		h.ServeHTTP(w, r)
-
-		assert.Equal(t, http.StatusTeapot, w.Code)
-		require.ErrorIs(t, got, tenant.ErrTenantNotFound)
-	})
-
-	t.Run("ErrNoTenant from a source fails closed, never passes through", func(t *testing.T) {
-		t.Parallel()
-		called := false
-		h := tenant.New(tenant.WithSources(func(*http.Request) (string, error) {
-			return "", tenant.ErrNoTenant
-		})).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
-
-		w := httptest.NewRecorder()
-		h.ServeHTTP(w, newRequest("example.com", "/"))
-
-		assert.Equal(t, http.StatusInternalServerError, w.Code)
-		assert.False(t, called)
-	})
-
-	t.Run("ErrNoTenant from the validator fails closed, never passes through", func(t *testing.T) {
-		t.Parallel()
-		called := false
-		h := tenant.New(
 			tenant.WithSources(tenant.Header("X-Tenant-ID")),
-			tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error {
-				return tenant.ErrNoTenant
-			})),
 		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
 
 		r := newRequest("example.com", "/")
@@ -295,16 +318,39 @@ func TestMiddleware(t *testing.T) {
 		assert.False(t, called)
 	})
 
+	t.Run("custom error handler receives the resolution error", func(t *testing.T) {
+		t.Parallel()
+		var got error
+		h := tenant.New(
+			tenant.LookupFunc(func(context.Context, tenant.Identifier) (string, error) {
+				return "", tenant.ErrTenantInactive
+			}),
+			tenant.WithSources(tenant.Header("X-Tenant-ID")),
+			tenant.WithErrorHandler(func(w http.ResponseWriter, _ *http.Request, err error) {
+				got = err
+				w.WriteHeader(http.StatusTeapot)
+			}),
+		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "acme")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusTeapot, w.Code)
+		require.ErrorIs(t, got, tenant.ErrTenantInactive)
+	})
+
 	t.Run("rejections log at debug, infrastructure errors at error", func(t *testing.T) {
 		t.Parallel()
 		var buf bytes.Buffer
 		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-		h := tenant.New(
+		inactive := tenant.LookupFunc(func(context.Context, tenant.Identifier) (string, error) {
+			return "", tenant.ErrTenantInactive
+		})
+		h := tenant.New(inactive,
 			tenant.WithSources(tenant.Header("X-Tenant-ID")),
-			tenant.WithValidator(tenant.ValidatorFunc(func(context.Context, string) error {
-				return tenant.ErrTenantInactive
-			})),
 			tenant.WithLogger(log),
 		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 		r := newRequest("example.com", "/")
@@ -314,11 +360,14 @@ func TestMiddleware(t *testing.T) {
 		assert.Contains(t, buf.String(), "level=DEBUG")
 
 		buf.Reset()
-		h = tenant.New(
-			tenant.WithSources(func(*http.Request) (string, error) { return "", errors.New("db down") }),
+		broken := tenant.LookupFunc(func(context.Context, tenant.Identifier) (string, error) {
+			return "", errors.New("db down")
+		})
+		h = tenant.New(broken,
+			tenant.WithSources(tenant.Header("X-Tenant-ID")),
 			tenant.WithLogger(log),
 		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-		h.ServeHTTP(httptest.NewRecorder(), newRequest("example.com", "/"))
+		h.ServeHTTP(httptest.NewRecorder(), r)
 		assert.Contains(t, buf.String(), "tenant: resolution failed")
 		assert.Contains(t, buf.String(), "level=ERROR")
 	})
@@ -326,12 +375,17 @@ func TestMiddleware(t *testing.T) {
 	t.Run("nil logger is ignored", func(t *testing.T) {
 		t.Parallel()
 		h := tenant.New(
-			tenant.WithSources(func(*http.Request) (string, error) { return "", errors.New("db down") }),
+			tenant.LookupFunc(func(context.Context, tenant.Identifier) (string, error) {
+				return "", errors.New("db down")
+			}),
+			tenant.WithSources(tenant.Header("X-Tenant-ID")),
 			tenant.WithLogger(nil),
 		).Middleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "acme")
 		w := httptest.NewRecorder()
-		assert.NotPanics(t, func() { h.ServeHTTP(w, newRequest("example.com", "/")) })
+		assert.NotPanics(t, func() { h.ServeHTTP(w, r) })
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 	})
 
@@ -339,7 +393,7 @@ func TestMiddleware(t *testing.T) {
 		t.Parallel()
 		var id string
 		var ok bool
-		h := tenant.New(tenant.WithSources(tenant.Header("X-Tenant-ID"))).
+		h := tenant.New(idLookup("resolved"), tenant.WithSources(tenant.Header("X-Tenant-ID"))).
 			Middleware()(captureTenant(&id, &ok))
 
 		r := newRequest("example.com", "/")
@@ -356,7 +410,8 @@ func TestMiddleware(t *testing.T) {
 		t.Parallel()
 		var id string
 		var ok bool
-		h := tenant.New(tenant.WithSources(tenant.Context(), tenant.Header("X-Tenant-ID"))).
+		h := tenant.New(idLookup("upstream", "header"),
+			tenant.WithSources(tenant.Context(), tenant.Header("X-Tenant-ID"))).
 			Middleware()(captureTenant(&id, &ok))
 
 		r := newRequest("example.com", "/")
@@ -373,7 +428,7 @@ func TestMiddleware(t *testing.T) {
 		t.Parallel()
 		var id string
 		var ok bool
-		h := tenant.New(tenant.WithSources(tenant.Header("X-Tenant-ID"))).
+		h := tenant.New(idLookup(), tenant.WithSources(tenant.Header("X-Tenant-ID"))).
 			Middleware()(captureTenant(&id, &ok))
 
 		r := newRequest("example.com", "/")

--- a/web/tenant/source.go
+++ b/web/tenant/source.go
@@ -1,113 +1,98 @@
 package tenant
 
 import (
-	"context"
-	"errors"
 	"net/http"
 	"net/textproto"
+	"net/url"
 	"strings"
 )
 
-// Source derives a candidate tenant identifier from an HTTP request.
-// Returning ("", nil) means "not resolved" and the Resolver tries the next
-// source in the chain; a non-empty value resolves the request; a non-nil
-// error stops the chain and fails resolution.
-//
-// Every source is expected to yield the canonical tenant ID (uuid/ulid/short
-// id — whatever the consumer's tenants table keys on), never an alias: a
-// subdomain label, custom domain, or URL slug is an alias, and Subdomain and
-// Domain translate aliases through their lookup seams while Map decorates any
-// other Source with the same translation step.
-type Source func(r *http.Request) (string, error)
+// Kind names the namespace an extracted identifier value lives in, so one
+// Lookup implementation can interpret every source: a subdomain label is not
+// a tenant ID is not a custom domain. Kind is a plain string type — a custom
+// Source may invent its own kind and handle it in the consumer's Lookup.
+type Kind string
 
-// DomainLookup maps a full custom domain to a tenant ID. Implementations
-// return ErrTenantNotFound when the domain maps to no tenant; any other
-// error is treated as infrastructure failure and stops resolution.
-type DomainLookup interface {
-	TenantByDomain(ctx context.Context, domain string) (string, error)
+const (
+	// KindID marks a value expected to be the canonical tenant ID itself
+	// (uuid/ulid/short id — whatever the consumer's tenants table keys on).
+	// Yielded by Header, Cookie, Query, and Context.
+	KindID Kind = "id"
+	// KindDomain marks a full custom domain ("shop.acme.com"). Yielded by
+	// Domain.
+	KindDomain Kind = "domain"
+	// KindSubdomain marks a single subdomain label ("acme"). Yielded by
+	// Subdomain.
+	KindSubdomain Kind = "subdomain"
+	// KindPath marks a URL path segment — a slug or an ID, whichever the
+	// consumer's URL scheme puts there. Yielded by PathPrefix.
+	KindPath Kind = "path"
+)
+
+// Identifier is a candidate tenant identifier extracted from a request:
+// a raw value tagged with the namespace it lives in. The Lookup seam
+// translates it to a live canonical tenant ID.
+type Identifier struct {
+	Kind  Kind
+	Value string
 }
 
-// SubdomainLookup maps a subdomain label ("acme") to a tenant ID.
-// Implementations return ErrTenantNotFound when the label maps to no
-// tenant; any other error is treated as infrastructure failure and stops
-// resolution.
-type SubdomainLookup interface {
-	TenantBySubdomain(ctx context.Context, subdomain string) (string, error)
-}
+// Source extracts a candidate tenant identifier from a request. ok=false
+// means "not present" — the Resolver tries the next source in the chain; it
+// never means "present but bad" (that judgment belongs to the Lookup).
+// Sources are pure: no I/O, no errors — all knowledge of what exists lives
+// behind the Lookup seam.
+type Source func(r *http.Request) (ident Identifier, ok bool)
 
-// Subdomain derives the tenant from the first DNS label in front of base,
-// translated to a tenant ID through lookup: with base "app.example.com",
-// host "acme.app.example.com" looks up "acme". The bare base and nested
-// labels ("a.b.app.example.com") do not resolve. Hosts are compared
-// case-insensitively with any port, IPv6 brackets, and trailing FQDN dot
-// stripped.
+// Subdomain extracts the first DNS label in front of base as KindSubdomain:
+// with base "app.example.com", host "acme.app.example.com" yields "acme".
+// The bare base and nested labels ("a.b.app.example.com") do not extract.
+// Hosts are compared case-insensitively with any port, IPv6 brackets, and
+// trailing FQDN dot stripped.
 //
-// Reserved names (www, api, ...) are not special-cased — the lookup decides:
+// Reserved names (www, api, ...) are not special-cased — the Lookup decides:
 // return ErrTenantNotFound for them and the chain continues. Panics with
-// ErrEmptyName when base normalizes to "" and with ErrNilLookup when lookup
-// is nil.
-func Subdomain(base string, lookup SubdomainLookup) Source {
+// ErrEmptyName when base normalizes to "".
+func Subdomain(base string) Source {
 	base = normalizeHost(base)
 	if base == "" {
 		panic(ErrEmptyName)
 	}
-	if lookup == nil {
-		panic(ErrNilLookup)
-	}
-	return func(r *http.Request) (string, error) {
+	return func(r *http.Request) (Identifier, bool) {
 		host := normalizeHost(r.Host)
 		rest, ok := strings.CutSuffix(host, base)
 		if !ok || len(rest) < 2 || rest[len(rest)-1] != '.' {
-			return "", nil
+			return Identifier{}, false
 		}
 		label := rest[:len(rest)-1]
 		if strings.IndexByte(label, '.') >= 0 {
-			return "", nil
+			return Identifier{}, false
 		}
-		id, err := lookup.TenantBySubdomain(r.Context(), label)
-		if err != nil {
-			if errors.Is(err, ErrTenantNotFound) {
-				return "", nil
-			}
-			return "", err
-		}
-		return id, nil
+		return Identifier{Kind: KindSubdomain, Value: label}, true
 	}
 }
 
-// Domain derives the tenant by looking up the full (normalized) request host
-// through lookup — the custom-domain path of a white-label SaaS.
-// ErrTenantNotFound from the lookup means "not resolved" and the chain
-// continues; any other error stops the chain. Panics with ErrNilLookup when
-// lookup is nil.
-func Domain(lookup DomainLookup) Source {
-	if lookup == nil {
-		panic(ErrNilLookup)
-	}
-	return func(r *http.Request) (string, error) {
+// Domain extracts the full (normalized) request host as KindDomain — the
+// custom-domain path of a white-label SaaS. It extracts on every request
+// with a host, so the Lookup's ErrTenantNotFound (which continues the chain)
+// is what lets non-tenant hosts — the marketing site, the platform base
+// domain — fall through to later sources or untenanted passthrough.
+func Domain() Source {
+	return func(r *http.Request) (Identifier, bool) {
 		host := normalizeHost(r.Host)
 		if host == "" {
-			return "", nil
+			return Identifier{}, false
 		}
-		id, err := lookup.TenantByDomain(r.Context(), host)
-		if err != nil {
-			if errors.Is(err, ErrTenantNotFound) {
-				return "", nil
-			}
-			return "", err
-		}
-		return id, nil
+		return Identifier{Kind: KindDomain, Value: host}, true
 	}
 }
 
-// Header derives the tenant from a request header, e.g. "X-Tenant-ID". The
-// header is expected to carry the tenant ID itself; wrap with Map when it
-// carries an alias instead.
+// Header extracts a request header's value as KindID, e.g. "X-Tenant-ID".
 //
 // The value is attacker-controlled on any edge-facing listener: use this
 // source only behind a trusted gateway that sets or strips the header, or
-// for internal service-to-service traffic, and pair it with a Validator.
-// Panics with ErrEmptyName when name is empty.
+// for internal service-to-service traffic — the Lookup still gates which
+// IDs are live. Panics with ErrEmptyName when name is empty.
 func Header(name string) Source {
 	if name == "" {
 		panic(ErrEmptyName)
@@ -116,160 +101,113 @@ func Header(name string) Source {
 	// fast path on every request ("X-Tenant-ID" would otherwise allocate as
 	// its canonical form is "X-Tenant-Id").
 	name = textproto.CanonicalMIMEHeaderKey(name)
-	return func(r *http.Request) (string, error) {
-		return r.Header.Get(name), nil
+	return func(r *http.Request) (Identifier, bool) {
+		v := r.Header.Get(name)
+		return Identifier{Kind: KindID, Value: v}, v != ""
 	}
 }
 
-// Cookie derives the tenant from a cookie expected to carry the tenant ID
-// itself (wrap with Map for aliases). Like Header, the value is
-// client-controlled — pair it with a Validator and authorization checks
-// downstream. Panics with ErrEmptyName when name is empty.
+// Cookie extracts a cookie's value as KindID. Like Header, the value is
+// client-controlled — the Lookup gates which IDs are live; enforce
+// membership downstream. Panics with ErrEmptyName when name is empty.
 func Cookie(name string) Source {
 	if name == "" {
 		panic(ErrEmptyName)
 	}
-	return func(r *http.Request) (string, error) {
+	return func(r *http.Request) (Identifier, bool) {
 		c, err := r.Cookie(name)
-		if err != nil { // only http.ErrNoCookie is possible
-			return "", nil
+		if err != nil || c.Value == "" { // only http.ErrNoCookie is possible
+			return Identifier{}, false
 		}
-		return c.Value, nil
+		return Identifier{Kind: KindID, Value: c.Value}, true
 	}
 }
 
-// Query derives the tenant from a URL query parameter expected to carry the
-// tenant ID itself (wrap with Map for aliases). Like Header, the value is
-// client-controlled — pair it with a Validator. Panics with ErrEmptyName
-// when name is empty.
+// Query extracts a URL query parameter's value as KindID. Like Header, the
+// value is client-controlled. Panics with ErrEmptyName when name is empty.
+//
+// It scans RawQuery directly instead of calling r.URL.Query(), which would
+// allocate the full url.Values map per request (guard.Query precedent;
+// benchmark in the PR). Semicolon-separated pairs are skipped, matching
+// net/url's rejection of ";" in query strings.
 func Query(name string) Source {
 	if name == "" {
 		panic(ErrEmptyName)
 	}
-	return func(r *http.Request) (string, error) {
-		return r.URL.Query().Get(name), nil
+	return func(r *http.Request) (Identifier, bool) {
+		q := r.URL.RawQuery
+		for q != "" {
+			var pair string
+			pair, q, _ = strings.Cut(q, "&")
+			if strings.Contains(pair, ";") {
+				continue
+			}
+			k, v, _ := strings.Cut(pair, "=")
+			if strings.ContainsAny(k, "%+") {
+				dec, err := url.QueryUnescape(k)
+				if err != nil {
+					continue
+				}
+				k = dec
+			}
+			if k != name {
+				continue
+			}
+			if strings.ContainsAny(v, "%+") {
+				dec, err := url.QueryUnescape(v)
+				if err != nil {
+					continue
+				}
+				v = dec
+			}
+			return Identifier{Kind: KindID, Value: v}, v != ""
+		}
+		return Identifier{}, false
 	}
 }
 
-// PathPrefix derives the tenant from the path segment following prefix:
-// PathPrefix("/t") resolves "t_123" from "/t/t_123/dashboard", and
-// PathPrefix("") resolves the first segment. The segment is expected to
-// carry the tenant ID itself; wrap with Map when your URLs carry slugs. Like
-// Header, the value is client-controlled — pair it with a Validator and
-// authorization checks downstream. The path is never rewritten — stripping
-// the prefix stays a routing concern. prefix must be empty or start with
-// "/" and not end with "/"; otherwise the constructor panics with
+// PathPrefix extracts the path segment following prefix as KindPath:
+// PathPrefix("/t") yields "acme" from "/t/acme/dashboard", and
+// PathPrefix("") yields the first segment. Whether the segment is a slug or
+// the ID itself is the consumer's URL scheme — the Lookup interprets
+// KindPath accordingly. The value is client-controlled; the Lookup gates
+// which tenants are live. The path is never rewritten — stripping the
+// prefix stays a routing concern. prefix must be empty or start with "/"
+// and not end with "/"; otherwise the constructor panics with
 // ErrInvalidPrefix.
 func PathPrefix(prefix string) Source {
 	if prefix != "" && (prefix[0] != '/' || prefix[len(prefix)-1] == '/') {
 		panic(ErrInvalidPrefix)
 	}
-	return func(r *http.Request) (string, error) {
+	return func(r *http.Request) (Identifier, bool) {
 		rest, ok := strings.CutPrefix(r.URL.Path, prefix)
 		if !ok || len(rest) < 2 || rest[0] != '/' {
-			return "", nil
+			return Identifier{}, false
 		}
 		seg := rest[1:]
 		if i := strings.IndexByte(seg, '/'); i >= 0 {
 			seg = seg[:i]
 		}
-		return seg, nil
+		if seg == "" { // "/t//x": empty segment is not an identifier
+			return Identifier{}, false
+		}
+		return Identifier{Kind: KindPath, Value: seg}, true
 	}
 }
 
-// Context derives a tenant already stamped on the request context by an
+// Context extracts a tenant already stamped on the request context by an
 // upstream middleware — e.g. API-key authentication that called NewContext
-// after verifying the key. The middleware overrides any pre-existing context
-// tenant, so this source is how a context-derived tenant gets an explicit
-// slot in the precedence order.
+// after verifying the key — as KindID. Middleware overrides any pre-existing
+// context tenant, so this source is how a context-derived tenant gets an
+// explicit slot in the precedence order; list it first so client-controlled
+// sources cannot override an authenticated identity. The ID still goes
+// through the Lookup: a KindID branch may fast-path a trusted upstream or
+// re-check status, the consumer decides.
 func Context() Source {
-	return func(r *http.Request) (string, error) {
-		id, _ := FromContext(r.Context())
-		return id, nil
+	return func(r *http.Request) (Identifier, bool) {
+		id, ok := FromContext(r.Context())
+		return Identifier{Kind: KindID, Value: id}, ok
 	}
-}
-
-// Map decorates src, translating every value it derives through fn — the
-// alias→tenant-ID step for sources that see aliases the shipped lookups
-// don't cover, e.g. a slug in the URL path:
-//
-//	tenant.Map(tenant.PathPrefix("/t"), func(ctx context.Context, slug string) (string, error) {
-//		return tenants.IDBySlug(ctx, slug) // ErrTenantNotFound to continue the chain
-//	})
-//
-// fn runs only when src derived a non-empty value; ErrTenantNotFound from fn
-// means "not resolved" and the chain continues, any other error stops the
-// chain. Panics with ErrNilSource when src is nil and ErrNilLookup when fn
-// is nil.
-func Map(src Source, fn func(ctx context.Context, value string) (string, error)) Source {
-	if src == nil {
-		panic(ErrNilSource)
-	}
-	if fn == nil {
-		panic(ErrNilLookup)
-	}
-	return func(r *http.Request) (string, error) {
-		value, err := src(r)
-		if err != nil || value == "" {
-			return "", err
-		}
-		id, err := fn(r.Context(), value)
-		if err != nil {
-			if errors.Is(err, ErrTenantNotFound) {
-				return "", nil
-			}
-			return "", err
-		}
-		return id, nil
-	}
-}
-
-// staticDomains is the in-memory DomainLookup for tests and development.
-type staticDomains map[string]string
-
-// StaticDomains returns an immutable in-memory DomainLookup for tests and
-// development, mapping custom domains to tenant IDs. Keys are normalized
-// like request hosts (lowercased, port and trailing dot stripped); entries
-// with an empty tenant ID are dropped.
-func StaticDomains(domains map[string]string) DomainLookup {
-	s := make(staticDomains, len(domains))
-	for domain, id := range domains {
-		if d := normalizeHost(domain); d != "" && id != "" {
-			s[d] = id
-		}
-	}
-	return s
-}
-
-func (s staticDomains) TenantByDomain(_ context.Context, domain string) (string, error) {
-	if id, ok := s[normalizeHost(domain)]; ok {
-		return id, nil
-	}
-	return "", ErrTenantNotFound
-}
-
-// staticSubdomains is the in-memory SubdomainLookup for tests and development.
-type staticSubdomains map[string]string
-
-// StaticSubdomains returns an immutable in-memory SubdomainLookup for tests
-// and development, mapping subdomain labels to tenant IDs. Keys are
-// lowercased to match the normalized labels the Subdomain source looks up;
-// entries with an empty key or tenant ID are dropped.
-func StaticSubdomains(subdomains map[string]string) SubdomainLookup {
-	s := make(staticSubdomains, len(subdomains))
-	for label, id := range subdomains {
-		if label != "" && id != "" {
-			s[strings.ToLower(label)] = id
-		}
-	}
-	return s
-}
-
-func (s staticSubdomains) TenantBySubdomain(_ context.Context, subdomain string) (string, error) {
-	if id, ok := s[subdomain]; ok {
-		return id, nil
-	}
-	return "", ErrTenantNotFound
 }
 
 // normalizeHost lowercases the host, strips any port, removes IPv6 brackets,

--- a/web/tenant/source.go
+++ b/web/tenant/source.go
@@ -1,0 +1,298 @@
+package tenant
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/textproto"
+	"strings"
+)
+
+// Source derives a candidate tenant identifier from an HTTP request.
+// Returning ("", nil) means "not resolved" and the Resolver tries the next
+// source in the chain; a non-empty value resolves the request; a non-nil
+// error stops the chain and fails resolution.
+//
+// Every source is expected to yield the canonical tenant ID (uuid/ulid/short
+// id — whatever the consumer's tenants table keys on), never an alias: a
+// subdomain label, custom domain, or URL slug is an alias, and Subdomain and
+// Domain translate aliases through their lookup seams while Map decorates any
+// other Source with the same translation step.
+type Source func(r *http.Request) (string, error)
+
+// DomainLookup maps a full custom domain to a tenant ID. Implementations
+// return ErrTenantNotFound when the domain maps to no tenant; any other
+// error is treated as infrastructure failure and stops resolution.
+type DomainLookup interface {
+	TenantByDomain(ctx context.Context, domain string) (string, error)
+}
+
+// SubdomainLookup maps a subdomain label ("acme") to a tenant ID.
+// Implementations return ErrTenantNotFound when the label maps to no
+// tenant; any other error is treated as infrastructure failure and stops
+// resolution.
+type SubdomainLookup interface {
+	TenantBySubdomain(ctx context.Context, subdomain string) (string, error)
+}
+
+// Subdomain derives the tenant from the first DNS label in front of base,
+// translated to a tenant ID through lookup: with base "app.example.com",
+// host "acme.app.example.com" looks up "acme". The bare base and nested
+// labels ("a.b.app.example.com") do not resolve. Hosts are compared
+// case-insensitively with any port, IPv6 brackets, and trailing FQDN dot
+// stripped.
+//
+// Reserved names (www, api, ...) are not special-cased — the lookup decides:
+// return ErrTenantNotFound for them and the chain continues. Panics with
+// ErrEmptyName when base normalizes to "" and with ErrNilLookup when lookup
+// is nil.
+func Subdomain(base string, lookup SubdomainLookup) Source {
+	base = normalizeHost(base)
+	if base == "" {
+		panic(ErrEmptyName)
+	}
+	if lookup == nil {
+		panic(ErrNilLookup)
+	}
+	return func(r *http.Request) (string, error) {
+		host := normalizeHost(r.Host)
+		rest, ok := strings.CutSuffix(host, base)
+		if !ok || len(rest) < 2 || rest[len(rest)-1] != '.' {
+			return "", nil
+		}
+		label := rest[:len(rest)-1]
+		if strings.IndexByte(label, '.') >= 0 {
+			return "", nil
+		}
+		id, err := lookup.TenantBySubdomain(r.Context(), label)
+		if err != nil {
+			if errors.Is(err, ErrTenantNotFound) {
+				return "", nil
+			}
+			return "", err
+		}
+		return id, nil
+	}
+}
+
+// Domain derives the tenant by looking up the full (normalized) request host
+// through lookup — the custom-domain path of a white-label SaaS.
+// ErrTenantNotFound from the lookup means "not resolved" and the chain
+// continues; any other error stops the chain. Panics with ErrNilLookup when
+// lookup is nil.
+func Domain(lookup DomainLookup) Source {
+	if lookup == nil {
+		panic(ErrNilLookup)
+	}
+	return func(r *http.Request) (string, error) {
+		host := normalizeHost(r.Host)
+		if host == "" {
+			return "", nil
+		}
+		id, err := lookup.TenantByDomain(r.Context(), host)
+		if err != nil {
+			if errors.Is(err, ErrTenantNotFound) {
+				return "", nil
+			}
+			return "", err
+		}
+		return id, nil
+	}
+}
+
+// Header derives the tenant from a request header, e.g. "X-Tenant-ID". The
+// header is expected to carry the tenant ID itself; wrap with Map when it
+// carries an alias instead.
+//
+// The value is attacker-controlled on any edge-facing listener: use this
+// source only behind a trusted gateway that sets or strips the header, or
+// for internal service-to-service traffic, and pair it with a Validator.
+// Panics with ErrEmptyName when name is empty.
+func Header(name string) Source {
+	if name == "" {
+		panic(ErrEmptyName)
+	}
+	// Pre-canonicalize so Header.Get's own canonicalization hits its no-alloc
+	// fast path on every request ("X-Tenant-ID" would otherwise allocate as
+	// its canonical form is "X-Tenant-Id").
+	name = textproto.CanonicalMIMEHeaderKey(name)
+	return func(r *http.Request) (string, error) {
+		return r.Header.Get(name), nil
+	}
+}
+
+// Cookie derives the tenant from a cookie expected to carry the tenant ID
+// itself (wrap with Map for aliases). Like Header, the value is
+// client-controlled — pair it with a Validator and authorization checks
+// downstream. Panics with ErrEmptyName when name is empty.
+func Cookie(name string) Source {
+	if name == "" {
+		panic(ErrEmptyName)
+	}
+	return func(r *http.Request) (string, error) {
+		c, err := r.Cookie(name)
+		if err != nil { // only http.ErrNoCookie is possible
+			return "", nil
+		}
+		return c.Value, nil
+	}
+}
+
+// Query derives the tenant from a URL query parameter expected to carry the
+// tenant ID itself (wrap with Map for aliases). Like Header, the value is
+// client-controlled — pair it with a Validator. Panics with ErrEmptyName
+// when name is empty.
+func Query(name string) Source {
+	if name == "" {
+		panic(ErrEmptyName)
+	}
+	return func(r *http.Request) (string, error) {
+		return r.URL.Query().Get(name), nil
+	}
+}
+
+// PathPrefix derives the tenant from the path segment following prefix:
+// PathPrefix("/t") resolves "t_123" from "/t/t_123/dashboard", and
+// PathPrefix("") resolves the first segment. The segment is expected to
+// carry the tenant ID itself; wrap with Map when your URLs carry slugs. Like
+// Header, the value is client-controlled — pair it with a Validator and
+// authorization checks downstream. The path is never rewritten — stripping
+// the prefix stays a routing concern. prefix must be empty or start with
+// "/" and not end with "/"; otherwise the constructor panics with
+// ErrInvalidPrefix.
+func PathPrefix(prefix string) Source {
+	if prefix != "" && (prefix[0] != '/' || prefix[len(prefix)-1] == '/') {
+		panic(ErrInvalidPrefix)
+	}
+	return func(r *http.Request) (string, error) {
+		rest, ok := strings.CutPrefix(r.URL.Path, prefix)
+		if !ok || len(rest) < 2 || rest[0] != '/' {
+			return "", nil
+		}
+		seg := rest[1:]
+		if i := strings.IndexByte(seg, '/'); i >= 0 {
+			seg = seg[:i]
+		}
+		return seg, nil
+	}
+}
+
+// Context derives a tenant already stamped on the request context by an
+// upstream middleware — e.g. API-key authentication that called NewContext
+// after verifying the key. The middleware overrides any pre-existing context
+// tenant, so this source is how a context-derived tenant gets an explicit
+// slot in the precedence order.
+func Context() Source {
+	return func(r *http.Request) (string, error) {
+		id, _ := FromContext(r.Context())
+		return id, nil
+	}
+}
+
+// Map decorates src, translating every value it derives through fn — the
+// alias→tenant-ID step for sources that see aliases the shipped lookups
+// don't cover, e.g. a slug in the URL path:
+//
+//	tenant.Map(tenant.PathPrefix("/t"), func(ctx context.Context, slug string) (string, error) {
+//		return tenants.IDBySlug(ctx, slug) // ErrTenantNotFound to continue the chain
+//	})
+//
+// fn runs only when src derived a non-empty value; ErrTenantNotFound from fn
+// means "not resolved" and the chain continues, any other error stops the
+// chain. Panics with ErrNilSource when src is nil and ErrNilLookup when fn
+// is nil.
+func Map(src Source, fn func(ctx context.Context, value string) (string, error)) Source {
+	if src == nil {
+		panic(ErrNilSource)
+	}
+	if fn == nil {
+		panic(ErrNilLookup)
+	}
+	return func(r *http.Request) (string, error) {
+		value, err := src(r)
+		if err != nil || value == "" {
+			return "", err
+		}
+		id, err := fn(r.Context(), value)
+		if err != nil {
+			if errors.Is(err, ErrTenantNotFound) {
+				return "", nil
+			}
+			return "", err
+		}
+		return id, nil
+	}
+}
+
+// staticDomains is the in-memory DomainLookup for tests and development.
+type staticDomains map[string]string
+
+// StaticDomains returns an immutable in-memory DomainLookup for tests and
+// development, mapping custom domains to tenant IDs. Keys are normalized
+// like request hosts (lowercased, port and trailing dot stripped); entries
+// with an empty tenant ID are dropped.
+func StaticDomains(domains map[string]string) DomainLookup {
+	s := make(staticDomains, len(domains))
+	for domain, id := range domains {
+		if d := normalizeHost(domain); d != "" && id != "" {
+			s[d] = id
+		}
+	}
+	return s
+}
+
+func (s staticDomains) TenantByDomain(_ context.Context, domain string) (string, error) {
+	if id, ok := s[normalizeHost(domain)]; ok {
+		return id, nil
+	}
+	return "", ErrTenantNotFound
+}
+
+// staticSubdomains is the in-memory SubdomainLookup for tests and development.
+type staticSubdomains map[string]string
+
+// StaticSubdomains returns an immutable in-memory SubdomainLookup for tests
+// and development, mapping subdomain labels to tenant IDs. Keys are
+// lowercased to match the normalized labels the Subdomain source looks up;
+// entries with an empty key or tenant ID are dropped.
+func StaticSubdomains(subdomains map[string]string) SubdomainLookup {
+	s := make(staticSubdomains, len(subdomains))
+	for label, id := range subdomains {
+		if label != "" && id != "" {
+			s[strings.ToLower(label)] = id
+		}
+	}
+	return s
+}
+
+func (s staticSubdomains) TenantBySubdomain(_ context.Context, subdomain string) (string, error) {
+	if id, ok := s[subdomain]; ok {
+		return id, nil
+	}
+	return "", ErrTenantNotFound
+}
+
+// normalizeHost lowercases the host, strips any port, removes IPv6 brackets,
+// and trims a trailing FQDN dot. It allocates only on strings.ToLower's slow
+// path (uppercase input); an already-lowercase host returns sub-slices with
+// no copy.
+//
+// net.SplitHostPort is deliberately avoided: it allocates an *AddrError
+// whenever the host has no port (the common proxied/HTTP2 case).
+func normalizeHost(host string) string {
+	if host == "" {
+		return ""
+	}
+	if host[0] == '[' { // IPv6 literal: "[::1]" or "[::1]:8080"
+		i := strings.IndexByte(host, ']')
+		if i < 0 {
+			return "" // malformed: opening '[' with no closing ']'
+		}
+		host = host[1:i] // inside brackets; drops "]" and any ":port" after it
+	} else if i := strings.LastIndexByte(host, ':'); i >= 0 &&
+		strings.IndexByte(host, ':') == i {
+		host = host[:i] // exactly one colon => host:port (not bracketless IPv6)
+	}
+	host = strings.TrimSuffix(host, ".") // rooted FQDN "example.com."
+	return strings.ToLower(host)
+}

--- a/web/tenant/source.go
+++ b/web/tenant/source.go
@@ -130,6 +130,11 @@ func Cookie(name string) Source {
 // allocate the full url.Values map per request (guard.Query precedent;
 // benchmark in the PR). Semicolon-separated pairs are skipped, matching
 // net/url's rejection of ";" in query strings.
+//
+// Unlike r.URL.Query(), the scan does not enforce net/url's 10,000-parameter
+// cap, so it still extracts an identifier from a pathologically long query
+// string (a benign divergence — the Lookup gates which tenants resolve, so
+// extraction is not a bypass).
 func Query(name string) Source {
 	if name == "" {
 		panic(ErrEmptyName)
@@ -200,9 +205,13 @@ func PathPrefix(prefix string) Source {
 // after verifying the key — as KindID. Middleware overrides any pre-existing
 // context tenant, so this source is how a context-derived tenant gets an
 // explicit slot in the precedence order; list it first so client-controlled
-// sources cannot override an authenticated identity. The ID still goes
-// through the Lookup: a KindID branch may fast-path a trusted upstream or
-// re-check status, the consumer decides.
+// sources cannot override an authenticated identity.
+//
+// The ID goes through the Lookup like any other KindID value — deliberately,
+// so a tenant suspended mid-session stops resolving on the next request even
+// though upstream auth already vouched for it. A consumer who wants to exempt
+// upstream-verified IDs from that re-check can wire a custom source with its
+// own Kind and fast-path it in their Lookup.
 func Context() Source {
 	return func(r *http.Request) (Identifier, bool) {
 		id, ok := FromContext(r.Context())

--- a/web/tenant/source_test.go
+++ b/web/tenant/source_test.go
@@ -1,0 +1,464 @@
+package tenant_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/web/tenant"
+)
+
+func newRequest(host, path string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "http://placeholder"+path, nil)
+	r.Host = host
+	return r
+}
+
+type subdomainLookupFunc func(ctx context.Context, subdomain string) (string, error)
+
+func (f subdomainLookupFunc) TenantBySubdomain(ctx context.Context, subdomain string) (string, error) {
+	return f(ctx, subdomain)
+}
+
+func TestSubdomain(t *testing.T) {
+	t.Parallel()
+
+	lookup := tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"})
+	derive := tenant.Subdomain("app.example.com", lookup)
+	tests := []struct{ name, host, want string }{
+		{"single label", "acme.app.example.com", "t_01acme"},
+		{"unknown label continues chain", "other.app.example.com", ""},
+		{"bare base", "app.example.com", ""},
+		{"nested labels", "a.b.app.example.com", ""},
+		{"unrelated host", "other.example.org", ""},
+		{"suffix but not label boundary", "notapp.example.com", ""},
+		{"embedded base not suffix", "app.example.com.evil.io", ""},
+		{"with port", "acme.app.example.com:8443", "t_01acme"},
+		{"uppercase", "ACME.App.Example.COM", "t_01acme"},
+		{"trailing FQDN dot", "acme.app.example.com.", "t_01acme"},
+		{"empty host", "", ""},
+		{"dot only prefix", ".app.example.com", ""},
+		{"ipv6 literal", "[::1]:8080", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			id, err := derive(newRequest(tt.host, "/"))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, id)
+		})
+	}
+
+	t.Run("base is normalized at construction", func(t *testing.T) {
+		t.Parallel()
+		derive := tenant.Subdomain("App.Example.COM:443", lookup)
+		id, err := derive(newRequest("acme.app.example.com", "/"))
+		require.NoError(t, err)
+		assert.Equal(t, "t_01acme", id)
+	})
+
+	t.Run("lookup receives the normalized label", func(t *testing.T) {
+		t.Parallel()
+		var got string
+		derive := tenant.Subdomain("app.example.com", subdomainLookupFunc(func(_ context.Context, subdomain string) (string, error) {
+			got = subdomain
+			return "t_1", nil
+		}))
+		_, err := derive(newRequest("ACME.app.example.com:8443", "/"))
+		require.NoError(t, err)
+		assert.Equal(t, "acme", got)
+	})
+
+	t.Run("lookup skipped when no label matches", func(t *testing.T) {
+		t.Parallel()
+		derive := tenant.Subdomain("app.example.com", subdomainLookupFunc(func(context.Context, string) (string, error) {
+			t.Fatal("lookup must not run without a matched label")
+			return "", nil
+		}))
+		id, err := derive(newRequest("app.example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("infrastructure error stops chain", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("db down")
+		derive := tenant.Subdomain("app.example.com", subdomainLookupFunc(func(context.Context, string) (string, error) {
+			return "", boom
+		}))
+		_, err := derive(newRequest("acme.app.example.com", "/"))
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("empty base panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrEmptyName, func() { tenant.Subdomain("", lookup) })
+	})
+
+	t.Run("nil lookup panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrNilLookup, func() { tenant.Subdomain("app.example.com", nil) })
+	})
+}
+
+func TestStaticSubdomains(t *testing.T) {
+	t.Parallel()
+
+	lookup := tenant.StaticSubdomains(map[string]string{
+		"Acme":  "t_01acme",
+		"":      "dropped",
+		"empty": "",
+	})
+
+	t.Run("keys lowercased at construction", func(t *testing.T) {
+		t.Parallel()
+		id, err := lookup.TenantBySubdomain(context.Background(), "acme")
+		require.NoError(t, err)
+		assert.Equal(t, "t_01acme", id)
+	})
+
+	t.Run("unknown label", func(t *testing.T) {
+		t.Parallel()
+		_, err := lookup.TenantBySubdomain(context.Background(), "other")
+		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
+	})
+
+	t.Run("empty-key and empty-ID entries dropped", func(t *testing.T) {
+		t.Parallel()
+		_, err := lookup.TenantBySubdomain(context.Background(), "")
+		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
+		_, err = lookup.TenantBySubdomain(context.Background(), "empty")
+		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
+	})
+}
+
+func TestMap(t *testing.T) {
+	t.Parallel()
+
+	slugToID := func(_ context.Context, slug string) (string, error) {
+		if slug == "acme" {
+			return "t_01acme", nil
+		}
+		return "", tenant.ErrTenantNotFound
+	}
+
+	t.Run("translates derived value", func(t *testing.T) {
+		t.Parallel()
+		derive := tenant.Map(tenant.PathPrefix("/t"), slugToID)
+		id, err := derive(newRequest("example.com", "/t/acme/dashboard"))
+		require.NoError(t, err)
+		assert.Equal(t, "t_01acme", id)
+	})
+
+	t.Run("ErrTenantNotFound continues chain", func(t *testing.T) {
+		t.Parallel()
+		derive := tenant.Map(tenant.PathPrefix("/t"), slugToID)
+		id, err := derive(newRequest("example.com", "/t/other/dashboard"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("fn skipped when inner source misses", func(t *testing.T) {
+		t.Parallel()
+		derive := tenant.Map(tenant.PathPrefix("/t"), func(context.Context, string) (string, error) {
+			t.Fatal("fn must not run for an underived value")
+			return "", nil
+		})
+		id, err := derive(newRequest("example.com", "/orders"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("inner source error propagates without fn", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("inner failed")
+		derive := tenant.Map(func(*http.Request) (string, error) { return "", boom }, slugToID)
+		_, err := derive(newRequest("example.com", "/"))
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("fn error stops chain", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("db down")
+		derive := tenant.Map(tenant.PathPrefix("/t"), func(context.Context, string) (string, error) {
+			return "", boom
+		})
+		_, err := derive(newRequest("example.com", "/t/acme"))
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("nil arguments panic", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrNilSource, func() { tenant.Map(nil, slugToID) })
+		assert.PanicsWithValue(t, tenant.ErrNilLookup, func() { tenant.Map(tenant.Context(), nil) })
+	})
+}
+
+type lookupFunc func(ctx context.Context, domain string) (string, error)
+
+func (f lookupFunc) TenantByDomain(ctx context.Context, domain string) (string, error) {
+	return f(ctx, domain)
+}
+
+func TestDomain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("found", func(t *testing.T) {
+		t.Parallel()
+		derive := tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "acme"}))
+		id, err := derive(newRequest("shop.acme.com", "/"))
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("not found continues chain", func(t *testing.T) {
+		t.Parallel()
+		derive := tenant.Domain(tenant.StaticDomains(nil))
+		id, err := derive(newRequest("unknown.example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("empty and malformed hosts skip the lookup", func(t *testing.T) {
+		t.Parallel()
+		derive := tenant.Domain(lookupFunc(func(context.Context, string) (string, error) {
+			t.Fatal("lookup must not run without a normalized host")
+			return "", nil
+		}))
+		for _, host := range []string{"", "[::1"} {
+			id, err := derive(newRequest(host, "/"))
+			require.NoError(t, err)
+			assert.Empty(t, id)
+		}
+	})
+
+	t.Run("lookup receives normalized host", func(t *testing.T) {
+		t.Parallel()
+		var got string
+		derive := tenant.Domain(lookupFunc(func(_ context.Context, domain string) (string, error) {
+			got = domain
+			return "acme", nil
+		}))
+		_, err := derive(newRequest("Shop.Acme.COM:8443", "/"))
+		require.NoError(t, err)
+		assert.Equal(t, "shop.acme.com", got)
+	})
+
+	t.Run("infrastructure error stops chain", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("db down")
+		derive := tenant.Domain(lookupFunc(func(context.Context, string) (string, error) {
+			return "", boom
+		}))
+		_, err := derive(newRequest("shop.acme.com", "/"))
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("nil lookup panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrNilLookup, func() { tenant.Domain(nil) })
+	})
+}
+
+func TestStaticDomains(t *testing.T) {
+	t.Parallel()
+
+	lookup := tenant.StaticDomains(map[string]string{
+		"Shop.Acme.com:443": "acme",
+		"":                  "dropped",
+		"empty.example.com": "",
+	})
+
+	t.Run("keys normalized at construction", func(t *testing.T) {
+		t.Parallel()
+		id, err := lookup.TenantByDomain(context.Background(), "shop.acme.com")
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("lookup input normalized", func(t *testing.T) {
+		t.Parallel()
+		id, err := lookup.TenantByDomain(context.Background(), "SHOP.acme.com.")
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("unknown domain", func(t *testing.T) {
+		t.Parallel()
+		_, err := lookup.TenantByDomain(context.Background(), "other.example.com")
+		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
+	})
+
+	t.Run("empty-ID entries dropped", func(t *testing.T) {
+		t.Parallel()
+		_, err := lookup.TenantByDomain(context.Background(), "empty.example.com")
+		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
+	})
+}
+
+func TestHeader(t *testing.T) {
+	t.Parallel()
+
+	derive := tenant.Header("X-Tenant-ID")
+
+	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+		r := newRequest("example.com", "/")
+		r.Header.Set("X-Tenant-ID", "acme")
+		id, err := derive(r)
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		id, err := derive(newRequest("example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("empty name panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrEmptyName, func() { tenant.Header("") })
+	})
+}
+
+func TestCookie(t *testing.T) {
+	t.Parallel()
+
+	derive := tenant.Cookie("tenant")
+
+	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+		r := newRequest("example.com", "/")
+		r.AddCookie(&http.Cookie{Name: "tenant", Value: "acme"})
+		id, err := derive(r)
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		id, err := derive(newRequest("example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("empty value reads as not resolved", func(t *testing.T) {
+		t.Parallel()
+		r := newRequest("example.com", "/")
+		r.Header.Set("Cookie", "tenant=")
+		id, err := derive(r)
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("empty name panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrEmptyName, func() { tenant.Cookie("") })
+	})
+}
+
+func TestQuery(t *testing.T) {
+	t.Parallel()
+
+	derive := tenant.Query("tenant")
+
+	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+		id, err := derive(newRequest("example.com", "/orders?tenant=acme"))
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		id, err := derive(newRequest("example.com", "/orders"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("empty value reads as not resolved", func(t *testing.T) {
+		t.Parallel()
+		id, err := derive(newRequest("example.com", "/orders?tenant="))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("empty name panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrEmptyName, func() { tenant.Query("") })
+	})
+}
+
+func TestPathPrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with prefix", func(t *testing.T) {
+		t.Parallel()
+		derive := tenant.PathPrefix("/t")
+		tests := []struct{ name, path, want string }{
+			{"segment after prefix", "/t/acme/dashboard", "acme"},
+			{"segment only", "/t/acme", "acme"},
+			{"trailing slash", "/t/acme/", "acme"},
+			{"prefix only", "/t", ""},
+			{"prefix with bare slash", "/t/", ""},
+			{"prefix not a segment boundary", "/team/acme", ""},
+			{"other path", "/orders", ""},
+			{"root", "/", ""},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				id, err := derive(newRequest("example.com", tt.path))
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, id)
+			})
+		}
+	})
+
+	t.Run("empty prefix takes first segment", func(t *testing.T) {
+		t.Parallel()
+		derive := tenant.PathPrefix("")
+		id, err := derive(newRequest("example.com", "/acme/dashboard"))
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+
+		id, err = derive(newRequest("example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+
+	t.Run("invalid prefix panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithValue(t, tenant.ErrInvalidPrefix, func() { tenant.PathPrefix("t") })
+		assert.PanicsWithValue(t, tenant.ErrInvalidPrefix, func() { tenant.PathPrefix("/t/") })
+	})
+}
+
+func TestContextSource(t *testing.T) {
+	t.Parallel()
+
+	derive := tenant.Context()
+
+	t.Run("stamped upstream", func(t *testing.T) {
+		t.Parallel()
+		r := newRequest("example.com", "/")
+		r = r.WithContext(tenant.NewContext(r.Context(), "acme"))
+		id, err := derive(r)
+		require.NoError(t, err)
+		assert.Equal(t, "acme", id)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		id, err := derive(newRequest("example.com", "/"))
+		require.NoError(t, err)
+		assert.Empty(t, id)
+	})
+}

--- a/web/tenant/source_test.go
+++ b/web/tenant/source_test.go
@@ -1,14 +1,11 @@
 package tenant_test
 
 import (
-	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/dmitrymomot/forge/web/tenant"
 )
@@ -19,28 +16,20 @@ func newRequest(host, path string) *http.Request {
 	return r
 }
 
-type subdomainLookupFunc func(ctx context.Context, subdomain string) (string, error)
-
-func (f subdomainLookupFunc) TenantBySubdomain(ctx context.Context, subdomain string) (string, error) {
-	return f(ctx, subdomain)
-}
-
 func TestSubdomain(t *testing.T) {
 	t.Parallel()
 
-	lookup := tenant.StaticSubdomains(map[string]string{"acme": "t_01acme"})
-	derive := tenant.Subdomain("app.example.com", lookup)
+	extract := tenant.Subdomain("app.example.com")
 	tests := []struct{ name, host, want string }{
-		{"single label", "acme.app.example.com", "t_01acme"},
-		{"unknown label continues chain", "other.app.example.com", ""},
+		{"single label", "acme.app.example.com", "acme"},
 		{"bare base", "app.example.com", ""},
 		{"nested labels", "a.b.app.example.com", ""},
 		{"unrelated host", "other.example.org", ""},
 		{"suffix but not label boundary", "notapp.example.com", ""},
 		{"embedded base not suffix", "app.example.com.evil.io", ""},
-		{"with port", "acme.app.example.com:8443", "t_01acme"},
-		{"uppercase", "ACME.App.Example.COM", "t_01acme"},
-		{"trailing FQDN dot", "acme.app.example.com.", "t_01acme"},
+		{"with port", "acme.app.example.com:8443", "acme"},
+		{"uppercase", "ACME.App.Example.COM", "acme"},
+		{"trailing FQDN dot", "acme.app.example.com.", "acme"},
 		{"empty host", "", ""},
 		{"dot only prefix", ".app.example.com", ""},
 		{"ipv6 literal", "[::1]:8080", ""},
@@ -48,278 +37,71 @@ func TestSubdomain(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			id, err := derive(newRequest(tt.host, "/"))
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, id)
+			ident, ok := extract(newRequest(tt.host, "/"))
+			if tt.want == "" {
+				assert.False(t, ok)
+				assert.Zero(t, ident)
+				return
+			}
+			assert.True(t, ok)
+			assert.Equal(t, tenant.Identifier{Kind: tenant.KindSubdomain, Value: tt.want}, ident)
 		})
 	}
 
 	t.Run("base is normalized at construction", func(t *testing.T) {
 		t.Parallel()
-		derive := tenant.Subdomain("App.Example.COM:443", lookup)
-		id, err := derive(newRequest("acme.app.example.com", "/"))
-		require.NoError(t, err)
-		assert.Equal(t, "t_01acme", id)
-	})
-
-	t.Run("lookup receives the normalized label", func(t *testing.T) {
-		t.Parallel()
-		var got string
-		derive := tenant.Subdomain("app.example.com", subdomainLookupFunc(func(_ context.Context, subdomain string) (string, error) {
-			got = subdomain
-			return "t_1", nil
-		}))
-		_, err := derive(newRequest("ACME.app.example.com:8443", "/"))
-		require.NoError(t, err)
-		assert.Equal(t, "acme", got)
-	})
-
-	t.Run("lookup skipped when no label matches", func(t *testing.T) {
-		t.Parallel()
-		derive := tenant.Subdomain("app.example.com", subdomainLookupFunc(func(context.Context, string) (string, error) {
-			t.Fatal("lookup must not run without a matched label")
-			return "", nil
-		}))
-		id, err := derive(newRequest("app.example.com", "/"))
-		require.NoError(t, err)
-		assert.Empty(t, id)
-	})
-
-	t.Run("infrastructure error stops chain", func(t *testing.T) {
-		t.Parallel()
-		boom := errors.New("db down")
-		derive := tenant.Subdomain("app.example.com", subdomainLookupFunc(func(context.Context, string) (string, error) {
-			return "", boom
-		}))
-		_, err := derive(newRequest("acme.app.example.com", "/"))
-		require.ErrorIs(t, err, boom)
+		extract := tenant.Subdomain("App.Example.COM:443")
+		ident, ok := extract(newRequest("acme.app.example.com", "/"))
+		assert.True(t, ok)
+		assert.Equal(t, "acme", ident.Value)
 	})
 
 	t.Run("empty base panics", func(t *testing.T) {
 		t.Parallel()
-		assert.PanicsWithValue(t, tenant.ErrEmptyName, func() { tenant.Subdomain("", lookup) })
+		assert.PanicsWithValue(t, tenant.ErrEmptyName, func() { tenant.Subdomain("") })
 	})
-
-	t.Run("nil lookup panics", func(t *testing.T) {
-		t.Parallel()
-		assert.PanicsWithValue(t, tenant.ErrNilLookup, func() { tenant.Subdomain("app.example.com", nil) })
-	})
-}
-
-func TestStaticSubdomains(t *testing.T) {
-	t.Parallel()
-
-	lookup := tenant.StaticSubdomains(map[string]string{
-		"Acme":  "t_01acme",
-		"":      "dropped",
-		"empty": "",
-	})
-
-	t.Run("keys lowercased at construction", func(t *testing.T) {
-		t.Parallel()
-		id, err := lookup.TenantBySubdomain(context.Background(), "acme")
-		require.NoError(t, err)
-		assert.Equal(t, "t_01acme", id)
-	})
-
-	t.Run("unknown label", func(t *testing.T) {
-		t.Parallel()
-		_, err := lookup.TenantBySubdomain(context.Background(), "other")
-		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
-	})
-
-	t.Run("empty-key and empty-ID entries dropped", func(t *testing.T) {
-		t.Parallel()
-		_, err := lookup.TenantBySubdomain(context.Background(), "")
-		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
-		_, err = lookup.TenantBySubdomain(context.Background(), "empty")
-		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
-	})
-}
-
-func TestMap(t *testing.T) {
-	t.Parallel()
-
-	slugToID := func(_ context.Context, slug string) (string, error) {
-		if slug == "acme" {
-			return "t_01acme", nil
-		}
-		return "", tenant.ErrTenantNotFound
-	}
-
-	t.Run("translates derived value", func(t *testing.T) {
-		t.Parallel()
-		derive := tenant.Map(tenant.PathPrefix("/t"), slugToID)
-		id, err := derive(newRequest("example.com", "/t/acme/dashboard"))
-		require.NoError(t, err)
-		assert.Equal(t, "t_01acme", id)
-	})
-
-	t.Run("ErrTenantNotFound continues chain", func(t *testing.T) {
-		t.Parallel()
-		derive := tenant.Map(tenant.PathPrefix("/t"), slugToID)
-		id, err := derive(newRequest("example.com", "/t/other/dashboard"))
-		require.NoError(t, err)
-		assert.Empty(t, id)
-	})
-
-	t.Run("fn skipped when inner source misses", func(t *testing.T) {
-		t.Parallel()
-		derive := tenant.Map(tenant.PathPrefix("/t"), func(context.Context, string) (string, error) {
-			t.Fatal("fn must not run for an underived value")
-			return "", nil
-		})
-		id, err := derive(newRequest("example.com", "/orders"))
-		require.NoError(t, err)
-		assert.Empty(t, id)
-	})
-
-	t.Run("inner source error propagates without fn", func(t *testing.T) {
-		t.Parallel()
-		boom := errors.New("inner failed")
-		derive := tenant.Map(func(*http.Request) (string, error) { return "", boom }, slugToID)
-		_, err := derive(newRequest("example.com", "/"))
-		require.ErrorIs(t, err, boom)
-	})
-
-	t.Run("fn error stops chain", func(t *testing.T) {
-		t.Parallel()
-		boom := errors.New("db down")
-		derive := tenant.Map(tenant.PathPrefix("/t"), func(context.Context, string) (string, error) {
-			return "", boom
-		})
-		_, err := derive(newRequest("example.com", "/t/acme"))
-		require.ErrorIs(t, err, boom)
-	})
-
-	t.Run("nil arguments panic", func(t *testing.T) {
-		t.Parallel()
-		assert.PanicsWithValue(t, tenant.ErrNilSource, func() { tenant.Map(nil, slugToID) })
-		assert.PanicsWithValue(t, tenant.ErrNilLookup, func() { tenant.Map(tenant.Context(), nil) })
-	})
-}
-
-type lookupFunc func(ctx context.Context, domain string) (string, error)
-
-func (f lookupFunc) TenantByDomain(ctx context.Context, domain string) (string, error) {
-	return f(ctx, domain)
 }
 
 func TestDomain(t *testing.T) {
 	t.Parallel()
 
-	t.Run("found", func(t *testing.T) {
+	extract := tenant.Domain()
+
+	t.Run("extracts normalized host", func(t *testing.T) {
 		t.Parallel()
-		derive := tenant.Domain(tenant.StaticDomains(map[string]string{"shop.acme.com": "acme"}))
-		id, err := derive(newRequest("shop.acme.com", "/"))
-		require.NoError(t, err)
-		assert.Equal(t, "acme", id)
+		ident, ok := extract(newRequest("Shop.Acme.COM:8443", "/"))
+		assert.True(t, ok)
+		assert.Equal(t, tenant.Identifier{Kind: tenant.KindDomain, Value: "shop.acme.com"}, ident)
 	})
 
-	t.Run("not found continues chain", func(t *testing.T) {
+	t.Run("empty and malformed hosts do not extract", func(t *testing.T) {
 		t.Parallel()
-		derive := tenant.Domain(tenant.StaticDomains(nil))
-		id, err := derive(newRequest("unknown.example.com", "/"))
-		require.NoError(t, err)
-		assert.Empty(t, id)
-	})
-
-	t.Run("empty and malformed hosts skip the lookup", func(t *testing.T) {
-		t.Parallel()
-		derive := tenant.Domain(lookupFunc(func(context.Context, string) (string, error) {
-			t.Fatal("lookup must not run without a normalized host")
-			return "", nil
-		}))
 		for _, host := range []string{"", "[::1"} {
-			id, err := derive(newRequest(host, "/"))
-			require.NoError(t, err)
-			assert.Empty(t, id)
+			ident, ok := extract(newRequest(host, "/"))
+			assert.False(t, ok)
+			assert.Zero(t, ident)
 		}
-	})
-
-	t.Run("lookup receives normalized host", func(t *testing.T) {
-		t.Parallel()
-		var got string
-		derive := tenant.Domain(lookupFunc(func(_ context.Context, domain string) (string, error) {
-			got = domain
-			return "acme", nil
-		}))
-		_, err := derive(newRequest("Shop.Acme.COM:8443", "/"))
-		require.NoError(t, err)
-		assert.Equal(t, "shop.acme.com", got)
-	})
-
-	t.Run("infrastructure error stops chain", func(t *testing.T) {
-		t.Parallel()
-		boom := errors.New("db down")
-		derive := tenant.Domain(lookupFunc(func(context.Context, string) (string, error) {
-			return "", boom
-		}))
-		_, err := derive(newRequest("shop.acme.com", "/"))
-		require.ErrorIs(t, err, boom)
-	})
-
-	t.Run("nil lookup panics", func(t *testing.T) {
-		t.Parallel()
-		assert.PanicsWithValue(t, tenant.ErrNilLookup, func() { tenant.Domain(nil) })
-	})
-}
-
-func TestStaticDomains(t *testing.T) {
-	t.Parallel()
-
-	lookup := tenant.StaticDomains(map[string]string{
-		"Shop.Acme.com:443": "acme",
-		"":                  "dropped",
-		"empty.example.com": "",
-	})
-
-	t.Run("keys normalized at construction", func(t *testing.T) {
-		t.Parallel()
-		id, err := lookup.TenantByDomain(context.Background(), "shop.acme.com")
-		require.NoError(t, err)
-		assert.Equal(t, "acme", id)
-	})
-
-	t.Run("lookup input normalized", func(t *testing.T) {
-		t.Parallel()
-		id, err := lookup.TenantByDomain(context.Background(), "SHOP.acme.com.")
-		require.NoError(t, err)
-		assert.Equal(t, "acme", id)
-	})
-
-	t.Run("unknown domain", func(t *testing.T) {
-		t.Parallel()
-		_, err := lookup.TenantByDomain(context.Background(), "other.example.com")
-		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
-	})
-
-	t.Run("empty-ID entries dropped", func(t *testing.T) {
-		t.Parallel()
-		_, err := lookup.TenantByDomain(context.Background(), "empty.example.com")
-		require.ErrorIs(t, err, tenant.ErrTenantNotFound)
 	})
 }
 
 func TestHeader(t *testing.T) {
 	t.Parallel()
 
-	derive := tenant.Header("X-Tenant-ID")
+	extract := tenant.Header("X-Tenant-ID")
 
 	t.Run("present", func(t *testing.T) {
 		t.Parallel()
 		r := newRequest("example.com", "/")
-		r.Header.Set("X-Tenant-ID", "acme")
-		id, err := derive(r)
-		require.NoError(t, err)
-		assert.Equal(t, "acme", id)
+		r.Header.Set("X-Tenant-ID", "t_123")
+		ident, ok := extract(r)
+		assert.True(t, ok)
+		assert.Equal(t, tenant.Identifier{Kind: tenant.KindID, Value: "t_123"}, ident)
 	})
 
 	t.Run("absent", func(t *testing.T) {
 		t.Parallel()
-		id, err := derive(newRequest("example.com", "/"))
-		require.NoError(t, err)
-		assert.Empty(t, id)
+		_, ok := extract(newRequest("example.com", "/"))
+		assert.False(t, ok)
 	})
 
 	t.Run("empty name panics", func(t *testing.T) {
@@ -331,31 +113,29 @@ func TestHeader(t *testing.T) {
 func TestCookie(t *testing.T) {
 	t.Parallel()
 
-	derive := tenant.Cookie("tenant")
+	extract := tenant.Cookie("tenant")
 
 	t.Run("present", func(t *testing.T) {
 		t.Parallel()
 		r := newRequest("example.com", "/")
-		r.AddCookie(&http.Cookie{Name: "tenant", Value: "acme"})
-		id, err := derive(r)
-		require.NoError(t, err)
-		assert.Equal(t, "acme", id)
+		r.AddCookie(&http.Cookie{Name: "tenant", Value: "t_123"})
+		ident, ok := extract(r)
+		assert.True(t, ok)
+		assert.Equal(t, tenant.Identifier{Kind: tenant.KindID, Value: "t_123"}, ident)
 	})
 
 	t.Run("absent", func(t *testing.T) {
 		t.Parallel()
-		id, err := derive(newRequest("example.com", "/"))
-		require.NoError(t, err)
-		assert.Empty(t, id)
+		_, ok := extract(newRequest("example.com", "/"))
+		assert.False(t, ok)
 	})
 
-	t.Run("empty value reads as not resolved", func(t *testing.T) {
+	t.Run("empty value reads as not present", func(t *testing.T) {
 		t.Parallel()
 		r := newRequest("example.com", "/")
 		r.Header.Set("Cookie", "tenant=")
-		id, err := derive(r)
-		require.NoError(t, err)
-		assert.Empty(t, id)
+		_, ok := extract(r)
+		assert.False(t, ok)
 	})
 
 	t.Run("empty name panics", func(t *testing.T) {
@@ -367,28 +147,33 @@ func TestCookie(t *testing.T) {
 func TestQuery(t *testing.T) {
 	t.Parallel()
 
-	derive := tenant.Query("tenant")
+	extract := tenant.Query("tenant")
 
-	t.Run("present", func(t *testing.T) {
-		t.Parallel()
-		id, err := derive(newRequest("example.com", "/orders?tenant=acme"))
-		require.NoError(t, err)
-		assert.Equal(t, "acme", id)
-	})
-
-	t.Run("absent", func(t *testing.T) {
-		t.Parallel()
-		id, err := derive(newRequest("example.com", "/orders"))
-		require.NoError(t, err)
-		assert.Empty(t, id)
-	})
-
-	t.Run("empty value reads as not resolved", func(t *testing.T) {
-		t.Parallel()
-		id, err := derive(newRequest("example.com", "/orders?tenant="))
-		require.NoError(t, err)
-		assert.Empty(t, id)
-	})
+	tests := []struct{ name, query, want string }{
+		{"present", "tenant=t_123", "t_123"},
+		{"absent", "other=x", ""},
+		{"empty value", "tenant=", ""},
+		{"empty query", "", ""},
+		{"later pair", "a=1&tenant=t_123", "t_123"},
+		{"percent-decoded value", "tenant=t%5F123", "t_123"},
+		{"percent-decoded key", "%74enant=t_123", "t_123"},
+		{"plus decodes to space", "tenant=+t_123", " t_123"},
+		{"bad escape in value skipped", "tenant=%zz", ""},
+		{"bad escape in key skips pair only", "%zz=1&tenant=t_123", "t_123"},
+		{"semicolon pair skipped", "tenant=evil;tenant=alt", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ident, ok := extract(newRequest("example.com", "/orders?"+tt.query))
+			if tt.want == "" {
+				assert.False(t, ok)
+				return
+			}
+			assert.True(t, ok)
+			assert.Equal(t, tenant.Identifier{Kind: tenant.KindID, Value: tt.want}, ident)
+		})
+	}
 
 	t.Run("empty name panics", func(t *testing.T) {
 		t.Parallel()
@@ -401,7 +186,7 @@ func TestPathPrefix(t *testing.T) {
 
 	t.Run("with prefix", func(t *testing.T) {
 		t.Parallel()
-		derive := tenant.PathPrefix("/t")
+		extract := tenant.PathPrefix("/t")
 		tests := []struct{ name, path, want string }{
 			{"segment after prefix", "/t/acme/dashboard", "acme"},
 			{"segment only", "/t/acme", "acme"},
@@ -415,23 +200,26 @@ func TestPathPrefix(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
-				id, err := derive(newRequest("example.com", tt.path))
-				require.NoError(t, err)
-				assert.Equal(t, tt.want, id)
+				ident, ok := extract(newRequest("example.com", tt.path))
+				if tt.want == "" {
+					assert.False(t, ok)
+					return
+				}
+				assert.True(t, ok)
+				assert.Equal(t, tenant.Identifier{Kind: tenant.KindPath, Value: tt.want}, ident)
 			})
 		}
 	})
 
 	t.Run("empty prefix takes first segment", func(t *testing.T) {
 		t.Parallel()
-		derive := tenant.PathPrefix("")
-		id, err := derive(newRequest("example.com", "/acme/dashboard"))
-		require.NoError(t, err)
-		assert.Equal(t, "acme", id)
+		extract := tenant.PathPrefix("")
+		ident, ok := extract(newRequest("example.com", "/acme/dashboard"))
+		assert.True(t, ok)
+		assert.Equal(t, "acme", ident.Value)
 
-		id, err = derive(newRequest("example.com", "/"))
-		require.NoError(t, err)
-		assert.Empty(t, id)
+		_, ok = extract(newRequest("example.com", "/"))
+		assert.False(t, ok)
 	})
 
 	t.Run("invalid prefix panics", func(t *testing.T) {
@@ -444,21 +232,20 @@ func TestPathPrefix(t *testing.T) {
 func TestContextSource(t *testing.T) {
 	t.Parallel()
 
-	derive := tenant.Context()
+	extract := tenant.Context()
 
 	t.Run("stamped upstream", func(t *testing.T) {
 		t.Parallel()
 		r := newRequest("example.com", "/")
-		r = r.WithContext(tenant.NewContext(r.Context(), "acme"))
-		id, err := derive(r)
-		require.NoError(t, err)
-		assert.Equal(t, "acme", id)
+		r = r.WithContext(tenant.NewContext(r.Context(), "t_123"))
+		ident, ok := extract(r)
+		assert.True(t, ok)
+		assert.Equal(t, tenant.Identifier{Kind: tenant.KindID, Value: "t_123"}, ident)
 	})
 
 	t.Run("absent", func(t *testing.T) {
 		t.Parallel()
-		id, err := derive(newRequest("example.com", "/"))
-		require.NoError(t, err)
-		assert.Empty(t, id)
+		_, ok := extract(newRequest("example.com", "/"))
+		assert.False(t, ok)
 	})
 }


### PR DESCRIPTION
## Summary

Rebuild of the removed `data/tenant` as a **pure transport-layer** package at `web/tenant` — it derives the tenant from the request, validates it through consumer-owned seams, and returns the canonical tenant ID. No SQL query builders: how the ID scopes storage is each consumer package's concern (wire `tenant.Scope` into their `WithScope` options).

### Shape

- **Sources** (`Source func(*http.Request) (string, error)`): `Header`, `Cookie`, `Query`, `PathPrefix`, `Subdomain(base, lookup)`, `Domain(lookup)`, `Context()` passthrough, and `Map` for alias→ID translation on any other source. Subdomain labels / custom domains / slugs are aliases, never IDs — they translate through the storage-agnostic `SubdomainLookup`/`DomainLookup` seams (`StaticDomains`/`StaticSubdomains` in-memory impls for tests/dev).
- **Constructor**: `New(...Option) *Resolver` — `WithSources` (precedence chain, first non-empty wins), `WithValidator` (the soft-deleted/disabled/suspended status seam: `ErrTenantNotFound`/`ErrTenantInactive`, always fail-closed), `WithErrorHandler` (replaceable response, default 404 for rejections / 500 for infrastructure), `WithLogger` (default no-op).
- **Middleware**: stamps the resolved ID on the context; unresolved requests pass through untenanted (add `Require` where tenancy is mandatory); resolved-but-invalid tenants are rejected, never passed through. "Nothing resolved" is distinguished from errors **structurally**, so a consumer source/validator returning `ErrNoTenant` cannot forge the untenanted passthrough — it fails closed as 500.
- **Carrier**: `NewContext`/`FromContext`/`Scope` over `core/ctxkey`; `Scope` is the fail-closed hook matching every forge package's `WithScope(func(ctx) (string, error))`.

The source funcs and `normalizeHost` are a near-verbatim port of the reviewed data/tenant resolvers (PR #67); new code is the engine (`Resolver`/`New`/`Resolve`/`Middleware`), options, validator seam, and the `Query` source.

### Benchmarks (Apple M3 Max)

| bench | ns/op | allocs/op |
|---|---|---|
| Subdomain (hit) | 34.6 | 0 |
| Subdomain (miss) | 22.5 | 0 |
| Header | 19.5 | 0 |
| PathPrefix | 2.7 | 0 |
| Domain (static) | 39.6 | 0 |
| Resolve (2-source chain + validator) | 100 | 0 |
| Middleware end-to-end | 166 | 3 (ctx stamp + request clone, intrinsic) |

Numbers match the pre-removal package (e.g. old BenchmarkMiddleware was the same 3-alloc shape); no post-bench optimization was warranted — every parse/derive path is already zero-alloc.

### Testing

- 100% statement coverage, black-box (`tenant_test`), `-race` clean.
- Fuzz: `FuzzSubdomain` (label extraction properties, echo lookup) and `FuzzPathPrefix` — 10s sessions clean.
- Local agent review applied: structural fail-closed passthrough (above), security note on client-controlled sources overriding upstream identity (order `Context()` first), client-controlled caveat on `PathPrefix`, Debug-vs-Error log-level tests, `WithLogger(nil)` test.
- `just lint` (vet, golangci-lint, nilaway, betteralign, modernize, integration-tag tier) clean.