### PR TITLE
feat(async/queue): add MongoDB broker driver

### DIFF
--- a/async/queue/mongo/bench_test.go
+++ b/async/queue/mongo/bench_test.go
@@ -61,15 +61,21 @@ func BenchmarkMongoClaimBatch(b *testing.B) {
 	broker := newBroker(b)
 	ctx := context.Background()
 
-	// Seed enough backlog that Claim never runs dry inside the measured loop.
+	// seed keeps a backlog ahead of the measured loop; when it runs dry
+	// (long -benchtime or -count), it is refilled outside the timer so any
+	// iteration count measures pure claim/ack work.
 	const seed = 20000
-	jobs := make([]queue.Job, seed)
-	for i := range jobs {
-		jobs[i] = benchJob("default")
+	refill := func() {
+		b.Helper()
+		jobs := make([]queue.Job, seed)
+		for i := range jobs {
+			jobs[i] = benchJob("default")
+		}
+		if err := broker.Push(ctx, jobs...); err != nil {
+			b.Fatal(err)
+		}
 	}
-	if err := broker.Push(ctx, jobs...); err != nil {
-		b.Fatal(err)
-	}
+	refill()
 
 	b.ReportAllocs()
 	for b.Loop() {
@@ -78,7 +84,10 @@ func BenchmarkMongoClaimBatch(b *testing.B) {
 			b.Fatal(err)
 		}
 		if len(got) == 0 {
-			b.Fatal("backlog ran dry mid-benchmark")
+			b.StopTimer()
+			refill()
+			b.StartTimer()
+			continue
 		}
 		for _, j := range got {
 			if err := broker.Ack(ctx, j.ID, j.Token); err != nil {

--- a/async/queue/mongo/bench_test.go
+++ b/async/queue/mongo/bench_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+package mongoqueue_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Past-biased RunAt throughout so every pushed job is immediately claimable.
+func benchJob(q string) queue.Job {
+	return queue.Job{
+		ID: id.NewUUID().String(), Queue: q, Type: "bench.mongo", Payload: []byte(`{"n":1}`),
+		RunAt: time.Now().UTC().Add(-2 * time.Second), CreatedAt: time.Now().UTC(),
+	}
+}
+
+func BenchmarkMongoPushClaimAck(b *testing.B) {
+	broker := newBroker(b)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := broker.Push(ctx, benchJob("default")); err != nil {
+			b.Fatal(err)
+		}
+		jobs, err := broker.Claim(ctx, "default", 1, time.Minute)
+		if err != nil || len(jobs) != 1 {
+			b.Fatalf("claim: %v (%d jobs)", err, len(jobs))
+		}
+		if err := broker.Ack(ctx, jobs[0].ID, jobs[0].Token); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkMongoPushBatch measures the transactional multi-document push (the
+// all-or-nothing path every batch > 1 takes).
+func BenchmarkMongoPushBatch(b *testing.B) {
+	broker := newBroker(b)
+	ctx := context.Background()
+	const batch = 100
+	b.ReportAllocs()
+	for b.Loop() {
+		jobs := make([]queue.Job, batch)
+		for i := range jobs {
+			jobs[i] = benchJob("bulk")
+		}
+		if err := broker.Push(ctx, jobs...); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkMongoClaimBatch measures a full claim round (candidate scan,
+// guarded update, fetch) at a worker-sized batch, against a deep backlog.
+func BenchmarkMongoClaimBatch(b *testing.B) {
+	broker := newBroker(b)
+	ctx := context.Background()
+
+	// Seed enough backlog that Claim never runs dry inside the measured loop.
+	const seed = 20000
+	jobs := make([]queue.Job, seed)
+	for i := range jobs {
+		jobs[i] = benchJob("default")
+	}
+	if err := broker.Push(ctx, jobs...); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		got, err := broker.Claim(ctx, "default", 20, time.Minute)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(got) == 0 {
+			b.Fatal("backlog ran dry mid-benchmark")
+		}
+		for _, j := range got {
+			if err := broker.Ack(ctx, j.ID, j.Token); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+func BenchmarkMongoListDead(b *testing.B) {
+	broker := newBroker(b)
+	ctx := context.Background()
+
+	// Seed once, before b.Loop(): push 5000 jobs in one batch, claim in
+	// batches of 100 and Kill each with its token to build up the dead set
+	// that ListDead scans. Seeding cost must stay out of the measured loop.
+	const total = 5000
+	const batch = 100
+	jobs := make([]queue.Job, total)
+	for i := range jobs {
+		jobs[i] = benchJob("default")
+	}
+	if err := broker.Push(ctx, jobs...); err != nil {
+		b.Fatal(err)
+	}
+	for claimed := 0; claimed < total; claimed += batch {
+		got, err := broker.Claim(ctx, "default", batch, time.Minute)
+		if err != nil || len(got) != batch {
+			b.Fatalf("claim: %v (%d jobs)", err, len(got))
+		}
+		for _, j := range got {
+			if err := broker.Kill(ctx, j.ID, j.Token, "bench"); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := broker.ListDead(ctx, "default", 50); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/async/queue/mongo/doc.go
+++ b/async/queue/mongo/doc.go
@@ -1,0 +1,45 @@
+// Package mongoqueue is the MongoDB queue.Broker: guarded update-many
+// claiming with fencing tokens over a single jobs collection, atomic
+// single-document lifecycle transitions, bounded stats, and transactional
+// enqueue via the queue.TxPusher capability (pass a *mongo.Session to
+// queue.PushTx). Call EnsureIndexes once at boot, after data/mongo.Open.
+// There is no change stream tailing: the engine's poll ticker drives
+// claiming.
+//
+// Requires a replica set (or mongos) for multi-job Push and PushTx, which run
+// inside a multi-document transaction to honor the all-or-nothing contract;
+// every other operation — including single-job Push, the entire claim/ack
+// lifecycle, and the dead-letter ops — is a single atomic command and works
+// on a standalone server too. Tested against MongoDB 7.
+//
+// # Single-collection layout
+//
+// Live and dead jobs share one collection (queue_jobs by default; WithCollection
+// overrides) discriminated by a state field, so Kill and Requeue are single
+// atomic updates — no cross-collection move that could lose a job between a
+// delete and an insert. Partial indexes keep the hot claim index free of
+// dead-letter entries and vice versa, so the shared collection costs the hot
+// path nothing.
+//
+// A claim is three round trips: an index-ordered candidate scan in
+// (run_at, _id) order, one guarded updateMany that stamps the lease, fencing token, and
+// attempt increment only on documents that are still claimable, and one fetch
+// of the won documents by _id and token. Documents lost to a concurrent
+// claimer simply drop out of the batch.
+//
+// Due-ness, lease expiry, and purge cutoffs are compared against the worker
+// process clock (like queue.MemoryBroker), not the server clock: filters stay
+// plain and fully indexable. Clock skew between workers can only shift when a
+// lease is considered expired; the fencing token keeps a stale worker's
+// Extend/Ack/Nack/Kill from disturbing the new claim, so delivery stays
+// at-least-once regardless of skew.
+//
+// Stats counts are exact up to 10,000 documents per queue; beyond that the
+// count stops at the cap and QueueStats reports the cap with its Capped flag
+// set, keeping Stats O(cap) instead of O(collection).
+//
+// Push also composes with a caller-owned transaction without the TxPusher
+// capability: run it with the session-bound context data/mongo.WithTransaction
+// passes to its callback and the insert joins that transaction instead of
+// starting its own.
+package mongoqueue

--- a/async/queue/mongo/doc.go
+++ b/async/queue/mongo/doc.go
@@ -1,10 +1,10 @@
 // Package mongoqueue is the MongoDB queue.Broker: guarded update-many
 // claiming with fencing tokens over a single jobs collection, atomic
 // single-document lifecycle transitions, bounded stats, and transactional
-// enqueue via the queue.TxPusher capability (pass a *mongo.Session to
-// queue.PushTx). Call EnsureIndexes once at boot, after data/mongo.Open.
-// There is no change stream tailing: the engine's poll ticker drives
-// claiming.
+// enqueue via the queue.TxPusher capability (pass a *mongo.Session with a
+// running transaction to queue.PushTx). Call EnsureIndexes once at boot,
+// after data/mongo.Open. There is no change stream tailing: the engine's
+// poll ticker drives claiming.
 //
 // Requires a replica set (or mongos) for multi-job Push and PushTx, which run
 // inside a multi-document transaction to honor the all-or-nothing contract;
@@ -21,18 +21,27 @@
 // dead-letter entries and vice versa, so the shared collection costs the hot
 // path nothing.
 //
-// A claim is three round trips: an index-ordered candidate scan in
-// (run_at, _id) order, one guarded updateMany that stamps the lease, fencing token, and
-// attempt increment only on documents that are still claimable, and one fetch
-// of the won documents by _id and token. Documents lost to a concurrent
-// claimer simply drop out of the batch.
+// Visibility is one always-set indexed watermark, visible_at: run_at on
+// push, the lease deadline while claimed, the retry time after a nack. The
+// claim scan is a single tight index range over {queue, visible_at, _id} —
+// in-flight jobs sit beyond the watermark instead of being fetched and
+// filtered out on every poll.
+//
+// A batch claim is a shortlist of candidate ids in visibility order, one
+// guarded updateMany that stamps the lease, fencing token, and attempt
+// increment only on documents that are still claimable, and one fetch of the
+// won documents. Candidates lost to a concurrent claimer are refilled from
+// the next shortlist (bounded rounds), so contention thins a batch rather
+// than emptying it. A single-job claim is one atomic findAndModify.
 //
 // Due-ness, lease expiry, and purge cutoffs are compared against the worker
 // process clock (like queue.MemoryBroker), not the server clock: filters stay
 // plain and fully indexable. Clock skew between workers can only shift when a
 // lease is considered expired; the fencing token keeps a stale worker's
 // Extend/Ack/Nack/Kill from disturbing the new claim, so delivery stays
-// at-least-once regardless of skew.
+// at-least-once regardless of skew. The broker reads from the primary
+// regardless of the client's read preference — a queue must read its own
+// acknowledged writes.
 //
 // Stats counts are exact up to 10,000 documents per queue; beyond that the
 // count stops at the cap and QueueStats reports the cap with its Capped flag
@@ -41,5 +50,9 @@
 // Push also composes with a caller-owned transaction without the TxPusher
 // capability: run it with the session-bound context data/mongo.WithTransaction
 // passes to its callback and the insert joins that transaction instead of
-// starting its own.
+// starting its own. (Inside that callback the session for queue.PushTx is
+// recoverable via mongo.SessionFromContext, but plain Push is the simpler
+// path.) A session bound for causal consistency only — no running
+// transaction — is not mistaken for one: Push falls back to its own
+// transaction and PushTx rejects the session.
 package mongoqueue

--- a/async/queue/mongo/doc.go
+++ b/async/queue/mongo/doc.go
@@ -10,7 +10,10 @@
 // inside a multi-document transaction to honor the all-or-nothing contract;
 // every other operation — including single-job Push, the entire claim/ack
 // lifecycle, and the dead-letter ops — is a single atomic command and works
-// on a standalone server too. Tested against MongoDB 7.
+// on a standalone server too. Tested against MongoDB 8.3; this is a
+// tested-floor statement, not a feature dependency — every command this
+// driver uses (partial indexes, findAndModify, multi-document transactions)
+// has existed since MongoDB 4.2.
 //
 // # Single-collection layout
 //

--- a/async/queue/mongo/mongoqueue.go
+++ b/async/queue/mongo/mongoqueue.go
@@ -1,0 +1,558 @@
+package mongoqueue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	mongodriver "go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// state discriminates live jobs (pending or claimed) from dead-lettered ones
+// inside the shared collection; partial indexes are filtered on it so each
+// side pays only for its own entries.
+const (
+	stateLive = "live"
+	stateDead = "dead"
+)
+
+var collectionNameRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// statsCap bounds per-queue stats counting: counts are exact up to the cap;
+// beyond it QueueStats reports the cap with the Capped flag set. Keeps Stats
+// O(cap) via server-side count limits instead of O(collection).
+const statsCap = 10000
+
+// purgeBatch bounds one PurgeDeadBefore round (an _id find plus a deleteMany
+// over those ids): a huge backlog costs many short commands instead of one
+// long deleteMany that a context deadline or socket timeout would interrupt
+// with an unknown partial count. 5000 UUID ids is ~200KB of $in filter, far
+// inside the 16MB command ceiling.
+const purgeBatch = 5000
+
+// jobDoc is the BSON shape of a queue job. claimed_until, claim_token, and
+// died_at exist only while relevant (set/unset by the lifecycle updates) and
+// are never decoded back into a Job, so they carry no struct fields. Payload
+// is stored as a raw JSON string, never re-encoded as BSON, so bytes round-trip
+// exactly.
+type jobDoc struct {
+	RunAt       time.Time `bson:"run_at"`
+	CreatedAt   time.Time `bson:"created_at"`
+	ID          string    `bson:"_id"`
+	Queue       string    `bson:"queue"`
+	Type        string    `bson:"type"`
+	Scope       string    `bson:"scope"`
+	State       string    `bson:"state"`
+	Payload     string    `bson:"payload"`
+	LastError   string    `bson:"last_error,omitempty"`
+	Attempt     int32     `bson:"attempt"`
+	MaxAttempts int32     `bson:"max_attempts"`
+}
+
+func newDoc(j queue.Job) jobDoc {
+	return jobDoc{
+		ID:          j.ID,
+		Queue:       j.Queue,
+		Type:        j.Type,
+		Payload:     string(j.Payload),
+		Scope:       j.Scope,
+		State:       stateLive,
+		LastError:   j.LastError,
+		Attempt:     int32(j.Attempt),
+		MaxAttempts: int32(j.MaxAttempts),
+		RunAt:       j.RunAt.UTC(),
+		CreatedAt:   j.CreatedAt.UTC(),
+	}
+}
+
+func (d jobDoc) job() queue.Job {
+	return queue.Job{
+		ID:          d.ID,
+		Queue:       d.Queue,
+		Type:        d.Type,
+		Payload:     []byte(d.Payload),
+		Scope:       d.Scope,
+		LastError:   d.LastError,
+		Attempt:     int(d.Attempt),
+		MaxAttempts: int(d.MaxAttempts),
+		RunAt:       d.RunAt,
+		CreatedAt:   d.CreatedAt,
+	}
+}
+
+// Broker is the MongoDB queue.Broker and queue.TxPusher.
+type Broker struct {
+	coll *mongodriver.Collection
+}
+
+// config carries construction-time settings.
+type config struct {
+	collection string
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithCollection overrides the collection name (default "queue_jobs").
+func WithCollection(name string) Option {
+	return func(c *config) { c.collection = name }
+}
+
+// New builds a Broker over db. It performs no I/O; call EnsureIndexes once at
+// boot to create the indexes the hot paths depend on.
+func New(db *mongodriver.Database, opts ...Option) (*Broker, error) {
+	cfg := config{collection: "queue_jobs"}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if db == nil {
+		return nil, errors.New("mongoqueue: nil database")
+	}
+	if !collectionNameRe.MatchString(cfg.collection) {
+		return nil, fmt.Errorf("mongoqueue: invalid collection name %q", cfg.collection)
+	}
+	return &Broker{coll: db.Collection(cfg.collection)}, nil
+}
+
+// EnsureIndexes idempotently creates the partial indexes the broker relies
+// on: the claim scan index over live jobs, the dead-letter listing index, and
+// the retention-sweep index. Run once at boot; re-running is a server-side
+// no-op.
+func (b *Broker) EnsureIndexes(ctx context.Context) error {
+	models := []mongodriver.IndexModel{
+		{
+			Keys: bson.D{{Key: "queue", Value: 1}, {Key: "run_at", Value: 1}, {Key: "_id", Value: 1}},
+			Options: options.Index().SetName("queue_claim").
+				SetPartialFilterExpression(bson.D{{Key: "state", Value: stateLive}}),
+		},
+		{
+			Keys: bson.D{{Key: "queue", Value: 1}, {Key: "died_at", Value: 1}, {Key: "_id", Value: 1}},
+			Options: options.Index().SetName("queue_dead").
+				SetPartialFilterExpression(bson.D{{Key: "state", Value: stateDead}}),
+		},
+		{
+			Keys: bson.D{{Key: "died_at", Value: 1}},
+			Options: options.Index().SetName("queue_dead_sweep").
+				SetPartialFilterExpression(bson.D{{Key: "state", Value: stateDead}}),
+		},
+	}
+	if _, err := b.coll.Indexes().CreateMany(ctx, models); err != nil {
+		return fmt.Errorf("mongoqueue: ensure indexes: %w", err)
+	}
+	return nil
+}
+
+func docsOf(jobs []queue.Job) []jobDoc {
+	docs := make([]jobDoc, len(jobs))
+	for i, j := range jobs {
+		docs[i] = newDoc(j)
+	}
+	return docs
+}
+
+func (b *Broker) Push(ctx context.Context, jobs ...queue.Job) error {
+	switch len(jobs) {
+	case 0:
+		return nil
+	case 1:
+		if _, err := b.coll.InsertOne(ctx, newDoc(jobs[0])); err != nil {
+			return fmt.Errorf("mongoqueue: push: %w", err)
+		}
+		return nil
+	}
+	docs := docsOf(jobs)
+	// Inside a caller-owned session (e.g. data/mongo.WithTransaction) the
+	// insert joins that transaction; all-or-nothing is the caller's commit.
+	if mongodriver.SessionFromContext(ctx) != nil {
+		if _, err := b.coll.InsertMany(ctx, docs); err != nil {
+			return fmt.Errorf("mongoqueue: push: %w", err)
+		}
+		return nil
+	}
+	// InsertMany alone is not all-or-nothing (an ordered insert stops at the
+	// first error but keeps what preceded it), so a standalone batch gets its
+	// own transaction. Requires a replica set; see the package doc.
+	sess, err := b.coll.Database().Client().StartSession()
+	if err != nil {
+		return fmt.Errorf("mongoqueue: push: %w", err)
+	}
+	defer sess.EndSession(ctx)
+	if _, err := sess.WithTransaction(ctx, func(ctx context.Context) (any, error) {
+		return b.coll.InsertMany(ctx, docs)
+	}); err != nil {
+		return fmt.Errorf("mongoqueue: push: %w", err)
+	}
+	return nil
+}
+
+// PushTx implements queue.TxPusher: the batch insert inside a caller-owned
+// *mongo.Session whose transaction the caller has already started (typically
+// via Session.WithTransaction), so the jobs commit or abort with the business
+// transaction.
+func (b *Broker) PushTx(ctx context.Context, tx any, jobs ...queue.Job) error {
+	sess, ok := tx.(*mongodriver.Session)
+	if !ok || sess == nil {
+		return fmt.Errorf("mongoqueue: push tx: expected *mongo.Session, got %T", tx)
+	}
+	if len(jobs) == 0 {
+		return nil
+	}
+	if _, err := b.coll.InsertMany(mongodriver.NewSessionContext(ctx, sess), docsOf(jobs)); err != nil {
+		return fmt.Errorf("mongoqueue: push tx: %w", err)
+	}
+	return nil
+}
+
+// claimable matches live jobs in queueName that are due and not under an
+// active lease as of now. claimed_until is unset (never null) on unclaimed
+// documents, so $exists:false is the "no lease" arm.
+func claimable(queueName string, now time.Time) bson.D {
+	return bson.D{
+		{Key: "state", Value: stateLive},
+		{Key: "queue", Value: queueName},
+		{Key: "run_at", Value: bson.D{{Key: "$lte", Value: now}}},
+		{Key: "$or", Value: bson.A{
+			bson.D{{Key: "claimed_until", Value: bson.D{{Key: "$exists", Value: false}}}},
+			bson.D{{Key: "claimed_until", Value: bson.D{{Key: "$lt", Value: now}}}},
+		}},
+	}
+}
+
+var claimSort = bson.D{{Key: "run_at", Value: 1}, {Key: "_id", Value: 1}}
+
+// claimUpdate stamps the lease, the fencing token, and the attempt increment.
+func claimUpdate(token string, until time.Time) bson.D {
+	return bson.D{
+		{Key: "$set", Value: bson.D{
+			{Key: "claimed_until", Value: until},
+			{Key: "claim_token", Value: token},
+		}},
+		{Key: "$inc", Value: bson.D{{Key: "attempt", Value: 1}}},
+	}
+}
+
+func (b *Broker) Claim(ctx context.Context, queueName string, n int, lease time.Duration) ([]queue.ClaimedJob, error) {
+	if n <= 0 {
+		return nil, nil
+	}
+	now := time.Now().UTC()
+	token := id.NewUUID().String()
+
+	// Single-job fast path: findAndModify claims, stamps, and returns the
+	// post-update document atomically in one round trip instead of the
+	// three-step batch below. Measured ~19% faster on the push/claim/ack
+	// cycle (1.61ms -> 1.31ms per op) with 41% fewer allocations; see
+	// bench_test.go.
+	if n == 1 {
+		var d jobDoc
+		err := b.coll.FindOneAndUpdate(ctx, claimable(queueName, now), claimUpdate(token, now.Add(lease)),
+			options.FindOneAndUpdate().SetSort(claimSort).SetReturnDocument(options.After)).Decode(&d)
+		switch {
+		case errors.Is(err, mongodriver.ErrNoDocuments):
+			return nil, nil
+		case err != nil:
+			return nil, fmt.Errorf("mongoqueue: claim: %w", err)
+		}
+		return []queue.ClaimedJob{{Job: d.job(), Token: token}}, nil
+	}
+
+	// Round trip 1: candidate ids in (run_at, _id) order off the partial
+	// claim index. Not yet a claim — just the shortlist.
+	cur, err := b.coll.Find(ctx, claimable(queueName, now), options.Find().
+		SetSort(claimSort).
+		SetLimit(int64(n)).
+		SetProjection(bson.D{{Key: "_id", Value: 1}}))
+	if err != nil {
+		return nil, fmt.Errorf("mongoqueue: claim find: %w", err)
+	}
+	var candidates []struct {
+		ID string `bson:"_id"`
+	}
+	if err := cur.All(ctx, &candidates); err != nil {
+		return nil, fmt.Errorf("mongoqueue: claim decode: %w", err)
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	ids := make([]string, len(candidates))
+	for i, c := range candidates {
+		ids[i] = c.ID
+	}
+
+	// Round trip 2: claim atomically per document. The guard repeats the
+	// claimable predicate so a candidate won by a concurrent claimer since
+	// round trip 1 is skipped, not stolen; each matched document gets the
+	// lease, the batch token, and its attempt increment in one atomic update.
+	guard := append(bson.D{{Key: "_id", Value: bson.D{{Key: "$in", Value: ids}}}}, claimable(queueName, now)...)
+	res, err := b.coll.UpdateMany(ctx, guard, claimUpdate(token, now.Add(lease)))
+	if err != nil {
+		return nil, fmt.Errorf("mongoqueue: claim update: %w", err)
+	}
+	if res.ModifiedCount == 0 {
+		return nil, nil
+	}
+
+	// Round trip 3: fetch the documents this token actually won, post-update
+	// (attempt already incremented), via the _id index.
+	cur, err = b.coll.Find(ctx, bson.D{
+		{Key: "_id", Value: bson.D{{Key: "$in", Value: ids}}},
+		{Key: "claim_token", Value: token},
+	}, options.Find().SetSort(claimSort))
+	if err != nil {
+		return nil, fmt.Errorf("mongoqueue: claim fetch: %w", err)
+	}
+	var docs []jobDoc
+	if err := cur.All(ctx, &docs); err != nil {
+		return nil, fmt.Errorf("mongoqueue: claim fetch decode: %w", err)
+	}
+	claimed := make([]queue.ClaimedJob, len(docs))
+	for i, d := range docs {
+		claimed[i] = queue.ClaimedJob{Job: d.job(), Token: token}
+	}
+	return claimed, nil
+}
+
+// fenced is the ownership filter for Extend/Ack/Nack/Kill: the update or
+// delete applies only while token still holds the claim.
+func fenced(jobID, token string) bson.D {
+	return bson.D{
+		{Key: "_id", Value: jobID},
+		{Key: "state", Value: stateLive},
+		{Key: "claim_token", Value: token},
+	}
+}
+
+func (b *Broker) Extend(ctx context.Context, jobID, token string, lease time.Duration) error {
+	res, err := b.coll.UpdateOne(ctx, fenced(jobID, token), bson.D{
+		{Key: "$set", Value: bson.D{{Key: "claimed_until", Value: time.Now().UTC().Add(lease)}}},
+	})
+	if err != nil {
+		return fmt.Errorf("mongoqueue: extend: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return queue.ErrLeaseLost
+	}
+	return nil
+}
+
+func (b *Broker) Ack(ctx context.Context, jobID, token string) error {
+	res, err := b.coll.DeleteOne(ctx, fenced(jobID, token))
+	if err != nil {
+		return fmt.Errorf("mongoqueue: ack: %w", err)
+	}
+	if res.DeletedCount == 0 {
+		return queue.ErrLeaseLost
+	}
+	return nil
+}
+
+func (b *Broker) Nack(ctx context.Context, jobID, token string, retryAt time.Time, reason string) error {
+	res, err := b.coll.UpdateOne(ctx, fenced(jobID, token), bson.D{
+		{Key: "$set", Value: bson.D{
+			{Key: "run_at", Value: retryAt.UTC()},
+			{Key: "last_error", Value: reason},
+		}},
+		{Key: "$unset", Value: bson.D{
+			{Key: "claimed_until", Value: ""},
+			{Key: "claim_token", Value: ""},
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("mongoqueue: nack: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return queue.ErrLeaseLost
+	}
+	return nil
+}
+
+func (b *Broker) Kill(ctx context.Context, jobID, token string, reason string) error {
+	res, err := b.coll.UpdateOne(ctx, fenced(jobID, token), bson.D{
+		{Key: "$set", Value: bson.D{
+			{Key: "state", Value: stateDead},
+			{Key: "died_at", Value: time.Now().UTC()},
+			{Key: "last_error", Value: reason},
+		}},
+		{Key: "$unset", Value: bson.D{
+			{Key: "claimed_until", Value: ""},
+			{Key: "claim_token", Value: ""},
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("mongoqueue: kill: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return queue.ErrLeaseLost
+	}
+	return nil
+}
+
+func (b *Broker) ListDead(ctx context.Context, queueName string, limit int) ([]queue.Job, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	cur, err := b.coll.Find(ctx, bson.D{
+		{Key: "state", Value: stateDead},
+		{Key: "queue", Value: queueName},
+	}, options.Find().
+		SetSort(bson.D{{Key: "died_at", Value: 1}, {Key: "_id", Value: 1}}).
+		SetLimit(int64(limit)))
+	if err != nil {
+		return nil, fmt.Errorf("mongoqueue: list dead: %w", err)
+	}
+	var docs []jobDoc
+	if err := cur.All(ctx, &docs); err != nil {
+		return nil, fmt.Errorf("mongoqueue: list dead decode: %w", err)
+	}
+	jobs := make([]queue.Job, len(docs))
+	for i, d := range docs {
+		jobs[i] = d.job()
+	}
+	return jobs, nil
+}
+
+func (b *Broker) Requeue(ctx context.Context, jobID string) error {
+	res, err := b.coll.UpdateOne(ctx, bson.D{
+		{Key: "_id", Value: jobID},
+		{Key: "state", Value: stateDead},
+	}, bson.D{
+		{Key: "$set", Value: bson.D{
+			{Key: "state", Value: stateLive},
+			{Key: "attempt", Value: int32(0)},
+			{Key: "run_at", Value: time.Now().UTC()},
+		}},
+		{Key: "$unset", Value: bson.D{{Key: "died_at", Value: ""}}},
+	})
+	if err != nil {
+		return fmt.Errorf("mongoqueue: requeue: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return b.notDeadOrMissing(ctx, jobID)
+	}
+	return nil
+}
+
+func (b *Broker) Purge(ctx context.Context, jobID string) error {
+	res, err := b.coll.DeleteOne(ctx, bson.D{
+		{Key: "_id", Value: jobID},
+		{Key: "state", Value: stateDead},
+	})
+	if err != nil {
+		return fmt.Errorf("mongoqueue: purge: %w", err)
+	}
+	if res.DeletedCount == 0 {
+		return b.notDeadOrMissing(ctx, jobID)
+	}
+	return nil
+}
+
+func (b *Broker) PurgeDeadBefore(ctx context.Context, cutoff time.Time) (int, error) {
+	total := 0
+	// Drain in bounded rounds so a large backlog costs many short commands
+	// instead of one long delete; a backlog too large for one tick simply
+	// continues on the next.
+	for {
+		cur, err := b.coll.Find(ctx, bson.D{
+			{Key: "state", Value: stateDead},
+			{Key: "died_at", Value: bson.D{{Key: "$lt", Value: cutoff.UTC()}}},
+		}, options.Find().
+			SetLimit(purgeBatch).
+			SetProjection(bson.D{{Key: "_id", Value: 1}}))
+		if err != nil {
+			return total, fmt.Errorf("mongoqueue: purge dead before: %w", err)
+		}
+		var docs []struct {
+			ID string `bson:"_id"`
+		}
+		if err := cur.All(ctx, &docs); err != nil {
+			return total, fmt.Errorf("mongoqueue: purge dead before decode: %w", err)
+		}
+		if len(docs) == 0 {
+			return total, nil
+		}
+		ids := make([]string, len(docs))
+		for i, d := range docs {
+			ids[i] = d.ID
+		}
+		// state repeated in the delete filter: a concurrent Requeue between
+		// the find and the delete makes the job live again, and a live job
+		// must never be swept.
+		res, err := b.coll.DeleteMany(ctx, bson.D{
+			{Key: "_id", Value: bson.D{{Key: "$in", Value: ids}}},
+			{Key: "state", Value: stateDead},
+		})
+		if err != nil {
+			return total, fmt.Errorf("mongoqueue: purge dead before: %w", err)
+		}
+		total += int(res.DeletedCount)
+		if len(docs) < purgeBatch {
+			// Short round: nothing left under the cutoff beyond this batch.
+			// A concurrent sweeper may have won some of these ids; total stays
+			// honest about what we removed, and whoever won keeps draining.
+			return total, nil
+		}
+		if ctx.Err() != nil {
+			return total, ctx.Err()
+		}
+	}
+}
+
+func (b *Broker) notDeadOrMissing(ctx context.Context, jobID string) error {
+	n, err := b.coll.CountDocuments(ctx, bson.D{{Key: "_id", Value: jobID}}, options.Count().SetLimit(1))
+	if err != nil {
+		return fmt.Errorf("mongoqueue: exists: %w", err)
+	}
+	if n > 0 {
+		return queue.ErrNotDead
+	}
+	return queue.ErrJobNotFound
+}
+
+func (b *Broker) Stats(ctx context.Context) (queue.Stats, error) {
+	st := make(queue.Stats)
+	if err := b.statsInto(ctx, st, stateLive); err != nil {
+		return nil, err
+	}
+	if err := b.statsInto(ctx, st, stateDead); err != nil {
+		return nil, err
+	}
+	return st, nil
+}
+
+// statsInto merges one state's per-queue counts into st. Counts run with a
+// server-side limit of statsCap+1: a full statsCap+1 result means "more than
+// the cap", reported as the cap with the Capped flag set.
+func (b *Broker) statsInto(ctx context.Context, st queue.Stats, state string) error {
+	var queues []string
+	if err := b.coll.Distinct(ctx, "queue", bson.D{{Key: "state", Value: state}}).Decode(&queues); err != nil {
+		return fmt.Errorf("mongoqueue: stats distinct: %w", err)
+	}
+	for _, q := range queues {
+		n, err := b.coll.CountDocuments(ctx, bson.D{
+			{Key: "state", Value: state},
+			{Key: "queue", Value: q},
+		}, options.Count().SetLimit(statsCap+1))
+		if err != nil {
+			return fmt.Errorf("mongoqueue: stats count: %w", err)
+		}
+		capped := n > statsCap
+		if capped {
+			n = statsCap
+		}
+		qs := st[q]
+		if state == stateDead {
+			qs.Dead, qs.DeadCapped = int(n), capped
+		} else {
+			qs.Pending, qs.PendingCapped = int(n), capped
+		}
+		st[q] = qs
+	}
+	return nil
+}

--- a/async/queue/mongo/mongoqueue.go
+++ b/async/queue/mongo/mongoqueue.go
@@ -5,11 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	mongodriver "go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
 
 	"github.com/dmitrymomot/forge/async/queue"
 	"github.com/dmitrymomot/forge/core/id"
@@ -37,13 +40,31 @@ const statsCap = 10000
 // inside the 16MB command ceiling.
 const purgeBatch = 5000
 
-// jobDoc is the BSON shape of a queue job. claimed_until, claim_token, and
-// died_at exist only while relevant (set/unset by the lifecycle updates) and
-// are never decoded back into a Job, so they carry no struct fields. Payload
-// is stored as a raw JSON string, never re-encoded as BSON, so bytes round-trip
-// exactly.
+// claimRounds bounds the batch-claim refill loop: under claimer contention a
+// round can lose its whole shortlist to a faster worker, and without a cap
+// two pathological claimers could ping-pong indefinitely. Four rounds cover
+// realistic contention; a short batch is legal, the engine just polls again.
+const claimRounds = 4
+
+// Constant filter/update fragments hoisted off the hot paths, like claimSort.
+var (
+	claimSort    = bson.D{{Key: "visible_at", Value: 1}, {Key: "_id", Value: 1}}
+	deadSort     = bson.D{{Key: "died_at", Value: 1}, {Key: "_id", Value: 1}}
+	idProjection = bson.D{{Key: "_id", Value: 1}}
+	unsetClaim   = bson.D{{Key: "claim_token", Value: ""}}
+)
+
+// jobDoc is the BSON shape of a queue job. visible_at is the single indexed
+// visibility watermark: run_at on push, the lease deadline while claimed, the
+// retry time after a nack — so "claimable" is one range predicate with tight
+// index bounds instead of an $or over an optional lease field. claim_token
+// exists only while claimed and died_at only once dead (set/unset by the
+// lifecycle updates); neither is decoded back into a Job, so they carry no
+// struct fields. Payload is stored as a raw JSON string, never re-encoded as
+// BSON, so bytes round-trip exactly.
 type jobDoc struct {
 	RunAt       time.Time `bson:"run_at"`
+	VisibleAt   time.Time `bson:"visible_at"`
 	CreatedAt   time.Time `bson:"created_at"`
 	ID          string    `bson:"_id"`
 	Queue       string    `bson:"queue"`
@@ -54,6 +75,19 @@ type jobDoc struct {
 	LastError   string    `bson:"last_error,omitempty"`
 	Attempt     int32     `bson:"attempt"`
 	MaxAttempts int32     `bson:"max_attempts"`
+}
+
+// ceilMillis rounds t up to the next BSON-representable instant. BSON
+// datetimes carry millisecond precision and marshalling floors, which would
+// make a nacked job claimable up to 1ms before its retryAt and every lease
+// expire up to 1ms early; visibility watermarks are therefore ceiled so
+// "no earlier than" holds literally.
+func ceilMillis(t time.Time) time.Time {
+	f := t.Truncate(time.Millisecond)
+	if f.Equal(t) {
+		return t
+	}
+	return f.Add(time.Millisecond)
 }
 
 func newDoc(j queue.Job) jobDoc {
@@ -68,6 +102,7 @@ func newDoc(j queue.Job) jobDoc {
 		Attempt:     int32(j.Attempt),
 		MaxAttempts: int32(j.MaxAttempts),
 		RunAt:       j.RunAt.UTC(),
+		VisibleAt:   ceilMillis(j.RunAt.UTC()),
 		CreatedAt:   j.CreatedAt.UTC(),
 	}
 }
@@ -106,7 +141,11 @@ func WithCollection(name string) Option {
 }
 
 // New builds a Broker over db. It performs no I/O; call EnsureIndexes once at
-// boot to create the indexes the hot paths depend on.
+// boot to create the indexes the hot paths depend on. The broker's collection
+// handle is pinned to primary reads regardless of the client's read
+// preference: a queue must read its own acknowledged writes, and a
+// secondary-lagging read after a claim would hand out leases on jobs it then
+// fails to return.
 func New(db *mongodriver.Database, opts ...Option) (*Broker, error) {
 	cfg := config{collection: "queue_jobs"}
 	for _, opt := range opts {
@@ -118,7 +157,8 @@ func New(db *mongodriver.Database, opts ...Option) (*Broker, error) {
 	if !collectionNameRe.MatchString(cfg.collection) {
 		return nil, fmt.Errorf("mongoqueue: invalid collection name %q", cfg.collection)
 	}
-	return &Broker{coll: db.Collection(cfg.collection)}, nil
+	coll := db.Collection(cfg.collection, options.Collection().SetReadPreference(readpref.Primary()))
+	return &Broker{coll: coll}, nil
 }
 
 // EnsureIndexes idempotently creates the partial indexes the broker relies
@@ -128,7 +168,7 @@ func New(db *mongodriver.Database, opts ...Option) (*Broker, error) {
 func (b *Broker) EnsureIndexes(ctx context.Context) error {
 	models := []mongodriver.IndexModel{
 		{
-			Keys: bson.D{{Key: "queue", Value: 1}, {Key: "run_at", Value: 1}, {Key: "_id", Value: 1}},
+			Keys: bson.D{{Key: "queue", Value: 1}, {Key: "visible_at", Value: 1}, {Key: "_id", Value: 1}},
 			Options: options.Index().SetName("queue_claim").
 				SetPartialFilterExpression(bson.D{{Key: "state", Value: stateLive}}),
 		},
@@ -168,9 +208,13 @@ func (b *Broker) Push(ctx context.Context, jobs ...queue.Job) error {
 		return nil
 	}
 	docs := docsOf(jobs)
-	// Inside a caller-owned session (e.g. data/mongo.WithTransaction) the
-	// insert joins that transaction; all-or-nothing is the caller's commit.
-	if mongodriver.SessionFromContext(ctx) != nil {
+	// Inside a caller-owned transaction (e.g. data/mongo.WithTransaction) the
+	// insert joins it; all-or-nothing is the caller's commit. A session
+	// without a running transaction (causal consistency only) gives no
+	// atomicity, so it falls through to the broker's own transaction below —
+	// WithTransaction binds its session into the callback context, replacing
+	// the ambient one for the insert only.
+	if sess := mongodriver.SessionFromContext(ctx); sess != nil && sess.TransactionRunning() {
 		if _, err := b.coll.InsertMany(ctx, docs); err != nil {
 			return fmt.Errorf("mongoqueue: push: %w", err)
 		}
@@ -193,13 +237,20 @@ func (b *Broker) Push(ctx context.Context, jobs ...queue.Job) error {
 }
 
 // PushTx implements queue.TxPusher: the batch insert inside a caller-owned
-// *mongo.Session whose transaction the caller has already started (typically
-// via Session.WithTransaction), so the jobs commit or abort with the business
-// transaction.
+// *mongo.Session with a running transaction (started via StartTransaction or
+// inside Session.WithTransaction), so the jobs commit or abort with the
+// business transaction. A session whose transaction is not running is
+// rejected rather than silently degrading to a non-transactional insert.
+// Callers inside data/mongo.WithTransaction can recover the session with
+// mongo.SessionFromContext(ctx), or simply call Push with the callback
+// context — it joins the transaction on its own.
 func (b *Broker) PushTx(ctx context.Context, tx any, jobs ...queue.Job) error {
 	sess, ok := tx.(*mongodriver.Session)
 	if !ok || sess == nil {
 		return fmt.Errorf("mongoqueue: push tx: expected *mongo.Session, got %T", tx)
+	}
+	if !sess.TransactionRunning() {
+		return errors.New("mongoqueue: push tx: session has no running transaction")
 	}
 	if len(jobs) == 0 {
 		return nil
@@ -210,28 +261,22 @@ func (b *Broker) PushTx(ctx context.Context, tx any, jobs ...queue.Job) error {
 	return nil
 }
 
-// claimable matches live jobs in queueName that are due and not under an
-// active lease as of now. claimed_until is unset (never null) on unclaimed
-// documents, so $exists:false is the "no lease" arm.
+// claimable matches live jobs in queueName whose visibility watermark has
+// passed: due and not under an active lease.
 func claimable(queueName string, now time.Time) bson.D {
 	return bson.D{
 		{Key: "state", Value: stateLive},
 		{Key: "queue", Value: queueName},
-		{Key: "run_at", Value: bson.D{{Key: "$lte", Value: now}}},
-		{Key: "$or", Value: bson.A{
-			bson.D{{Key: "claimed_until", Value: bson.D{{Key: "$exists", Value: false}}}},
-			bson.D{{Key: "claimed_until", Value: bson.D{{Key: "$lt", Value: now}}}},
-		}},
+		{Key: "visible_at", Value: bson.D{{Key: "$lte", Value: now}}},
 	}
 }
 
-var claimSort = bson.D{{Key: "run_at", Value: 1}, {Key: "_id", Value: 1}}
-
-// claimUpdate stamps the lease, the fencing token, and the attempt increment.
+// claimUpdate stamps the lease (as the visibility watermark), the fencing
+// token, and the attempt increment.
 func claimUpdate(token string, until time.Time) bson.D {
 	return bson.D{
 		{Key: "$set", Value: bson.D{
-			{Key: "claimed_until", Value: until},
+			{Key: "visible_at", Value: until},
 			{Key: "claim_token", Value: token},
 		}},
 		{Key: "$inc", Value: bson.D{{Key: "attempt", Value: 1}}},
@@ -242,17 +287,19 @@ func (b *Broker) Claim(ctx context.Context, queueName string, n int, lease time.
 	if n <= 0 {
 		return nil, nil
 	}
-	now := time.Now().UTC()
 	token := id.NewUUID().String()
 
 	// Single-job fast path: findAndModify claims, stamps, and returns the
-	// post-update document atomically in one round trip instead of the
-	// three-step batch below. Measured ~19% faster on the push/claim/ack
-	// cycle (1.61ms -> 1.31ms per op) with 41% fewer allocations; see
-	// bench_test.go.
+	// post-update document atomically in one server command instead of the
+	// find/update/fetch rounds below. Wall latency ties the batch path on a
+	// local server (A/B via bench_test.go PushClaimAck: ~1.8ms/op both ways,
+	// within container noise), but it measures 44% fewer allocations
+	// (352 vs 625, 32KB vs 57KB), issues a third of the commands, and closes
+	// the batch path's claimed-but-unfetched crash window entirely.
 	if n == 1 {
+		now := time.Now().UTC()
 		var d jobDoc
-		err := b.coll.FindOneAndUpdate(ctx, claimable(queueName, now), claimUpdate(token, now.Add(lease)),
+		err := b.coll.FindOneAndUpdate(ctx, claimable(queueName, now), claimUpdate(token, ceilMillis(now.Add(lease))),
 			options.FindOneAndUpdate().SetSort(claimSort).SetReturnDocument(options.After)).Decode(&d)
 		switch {
 		case errors.Is(err, mongodriver.ErrNoDocuments):
@@ -263,48 +310,66 @@ func (b *Broker) Claim(ctx context.Context, queueName string, n int, lease time.
 		return []queue.ClaimedJob{{Job: d.job(), Token: token}}, nil
 	}
 
-	// Round trip 1: candidate ids in (run_at, _id) order off the partial
-	// claim index. Not yet a claim — just the shortlist.
-	cur, err := b.coll.Find(ctx, claimable(queueName, now), options.Find().
-		SetSort(claimSort).
-		SetLimit(int64(n)).
-		SetProjection(bson.D{{Key: "_id", Value: 1}}))
-	if err != nil {
-		return nil, fmt.Errorf("mongoqueue: claim find: %w", err)
+	// Batch path: shortlist candidate ids in visibility order, then claim
+	// them with a guarded updateMany — each matched document gets the lease,
+	// the batch token, and its attempt increment in one atomic update, and a
+	// candidate won by a concurrent claimer since the shortlist is skipped,
+	// not stolen. Lost candidates are refilled from the next shortlist (their
+	// winner's lease bump hides them) so contention thins a batch instead of
+	// emptying it: the engine reads a short return as "queue drained".
+	remaining := n
+	var ids []string
+	for round := 0; remaining > 0 && round < claimRounds; round++ {
+		limit := remaining
+		now := time.Now().UTC()
+		cur, err := b.coll.Find(ctx, claimable(queueName, now), options.Find().
+			SetSort(claimSort).
+			SetLimit(int64(limit)).
+			SetBatchSize(int32(limit)).
+			SetProjection(idProjection))
+		if err != nil {
+			return nil, fmt.Errorf("mongoqueue: claim find: %w", err)
+		}
+		var candidates []struct {
+			ID string `bson:"_id"`
+		}
+		if err := cur.All(ctx, &candidates); err != nil {
+			return nil, fmt.Errorf("mongoqueue: claim decode: %w", err)
+		}
+		if len(candidates) == 0 {
+			break
+		}
+		batch := make([]string, len(candidates))
+		for i, c := range candidates {
+			batch[i] = c.ID
+		}
+		ids = append(ids, batch...)
+		// The guard repeats the claimable predicate with a fresh clock so the
+		// lease is measured from the moment it is stamped, not from before
+		// the shortlist round trip.
+		now = time.Now().UTC()
+		guard := append(bson.D{{Key: "_id", Value: bson.D{{Key: "$in", Value: batch}}}}, claimable(queueName, now)...)
+		res, err := b.coll.UpdateMany(ctx, guard, claimUpdate(token, ceilMillis(now.Add(lease))))
+		if err != nil {
+			return nil, fmt.Errorf("mongoqueue: claim update: %w", err)
+		}
+		remaining -= int(res.MatchedCount)
+		if len(candidates) < limit {
+			// Short shortlist: nothing more was due when it was taken.
+			break
+		}
 	}
-	var candidates []struct {
-		ID string `bson:"_id"`
-	}
-	if err := cur.All(ctx, &candidates); err != nil {
-		return nil, fmt.Errorf("mongoqueue: claim decode: %w", err)
-	}
-	if len(candidates) == 0 {
+	if remaining == n {
 		return nil, nil
 	}
-	ids := make([]string, len(candidates))
-	for i, c := range candidates {
-		ids[i] = c.ID
-	}
 
-	// Round trip 2: claim atomically per document. The guard repeats the
-	// claimable predicate so a candidate won by a concurrent claimer since
-	// round trip 1 is skipped, not stolen; each matched document gets the
-	// lease, the batch token, and its attempt increment in one atomic update.
-	guard := append(bson.D{{Key: "_id", Value: bson.D{{Key: "$in", Value: ids}}}}, claimable(queueName, now)...)
-	res, err := b.coll.UpdateMany(ctx, guard, claimUpdate(token, now.Add(lease)))
-	if err != nil {
-		return nil, fmt.Errorf("mongoqueue: claim update: %w", err)
-	}
-	if res.ModifiedCount == 0 {
-		return nil, nil
-	}
-
-	// Round trip 3: fetch the documents this token actually won, post-update
-	// (attempt already incremented), via the _id index.
-	cur, err = b.coll.Find(ctx, bson.D{
+	// Fetch the documents this token actually won, post-update (attempt
+	// already incremented), via the _id index; ordering is restored
+	// client-side, sparing the server a blocking sort stage no index covers.
+	cur, err := b.coll.Find(ctx, bson.D{
 		{Key: "_id", Value: bson.D{{Key: "$in", Value: ids}}},
 		{Key: "claim_token", Value: token},
-	}, options.Find().SetSort(claimSort))
+	}, options.Find().SetBatchSize(int32(len(ids))))
 	if err != nil {
 		return nil, fmt.Errorf("mongoqueue: claim fetch: %w", err)
 	}
@@ -312,6 +377,12 @@ func (b *Broker) Claim(ctx context.Context, queueName string, n int, lease time.
 	if err := cur.All(ctx, &docs); err != nil {
 		return nil, fmt.Errorf("mongoqueue: claim fetch decode: %w", err)
 	}
+	slices.SortFunc(docs, func(a, b jobDoc) int {
+		if c := a.RunAt.Compare(b.RunAt); c != 0 {
+			return c
+		}
+		return strings.Compare(a.ID, b.ID)
+	})
 	claimed := make([]queue.ClaimedJob, len(docs))
 	for i, d := range docs {
 		claimed[i] = queue.ClaimedJob{Job: d.job(), Token: token}
@@ -329,17 +400,24 @@ func fenced(jobID, token string) bson.D {
 	}
 }
 
-func (b *Broker) Extend(ctx context.Context, jobID, token string, lease time.Duration) error {
-	res, err := b.coll.UpdateOne(ctx, fenced(jobID, token), bson.D{
-		{Key: "$set", Value: bson.D{{Key: "claimed_until", Value: time.Now().UTC().Add(lease)}}},
-	})
+// fencedUpdate runs a token-guarded update; zero matched documents means the
+// token no longer owns the job. Matched, not modified: a no-op rewrite (e.g.
+// an Extend landing on the same millisecond) still proves ownership.
+func (b *Broker) fencedUpdate(ctx context.Context, op, jobID, token string, update bson.D) error {
+	res, err := b.coll.UpdateOne(ctx, fenced(jobID, token), update)
 	if err != nil {
-		return fmt.Errorf("mongoqueue: extend: %w", err)
+		return fmt.Errorf("mongoqueue: %s: %w", op, err)
 	}
 	if res.MatchedCount == 0 {
 		return queue.ErrLeaseLost
 	}
 	return nil
+}
+
+func (b *Broker) Extend(ctx context.Context, jobID, token string, lease time.Duration) error {
+	return b.fencedUpdate(ctx, "extend", jobID, token, bson.D{
+		{Key: "$set", Value: bson.D{{Key: "visible_at", Value: ceilMillis(time.Now().UTC().Add(lease))}}},
+	})
 }
 
 func (b *Broker) Ack(ctx context.Context, jobID, token string) error {
@@ -354,44 +432,26 @@ func (b *Broker) Ack(ctx context.Context, jobID, token string) error {
 }
 
 func (b *Broker) Nack(ctx context.Context, jobID, token string, retryAt time.Time, reason string) error {
-	res, err := b.coll.UpdateOne(ctx, fenced(jobID, token), bson.D{
+	visibleAt := ceilMillis(retryAt.UTC())
+	return b.fencedUpdate(ctx, "nack", jobID, token, bson.D{
 		{Key: "$set", Value: bson.D{
 			{Key: "run_at", Value: retryAt.UTC()},
+			{Key: "visible_at", Value: visibleAt},
 			{Key: "last_error", Value: reason},
 		}},
-		{Key: "$unset", Value: bson.D{
-			{Key: "claimed_until", Value: ""},
-			{Key: "claim_token", Value: ""},
-		}},
+		{Key: "$unset", Value: unsetClaim},
 	})
-	if err != nil {
-		return fmt.Errorf("mongoqueue: nack: %w", err)
-	}
-	if res.MatchedCount == 0 {
-		return queue.ErrLeaseLost
-	}
-	return nil
 }
 
 func (b *Broker) Kill(ctx context.Context, jobID, token string, reason string) error {
-	res, err := b.coll.UpdateOne(ctx, fenced(jobID, token), bson.D{
+	return b.fencedUpdate(ctx, "kill", jobID, token, bson.D{
 		{Key: "$set", Value: bson.D{
 			{Key: "state", Value: stateDead},
 			{Key: "died_at", Value: time.Now().UTC()},
 			{Key: "last_error", Value: reason},
 		}},
-		{Key: "$unset", Value: bson.D{
-			{Key: "claimed_until", Value: ""},
-			{Key: "claim_token", Value: ""},
-		}},
+		{Key: "$unset", Value: unsetClaim},
 	})
-	if err != nil {
-		return fmt.Errorf("mongoqueue: kill: %w", err)
-	}
-	if res.MatchedCount == 0 {
-		return queue.ErrLeaseLost
-	}
-	return nil
 }
 
 func (b *Broker) ListDead(ctx context.Context, queueName string, limit int) ([]queue.Job, error) {
@@ -402,8 +462,9 @@ func (b *Broker) ListDead(ctx context.Context, queueName string, limit int) ([]q
 		{Key: "state", Value: stateDead},
 		{Key: "queue", Value: queueName},
 	}, options.Find().
-		SetSort(bson.D{{Key: "died_at", Value: 1}, {Key: "_id", Value: 1}}).
-		SetLimit(int64(limit)))
+		SetSort(deadSort).
+		SetLimit(int64(limit)).
+		SetBatchSize(int32(limit)))
 	if err != nil {
 		return nil, fmt.Errorf("mongoqueue: list dead: %w", err)
 	}
@@ -419,6 +480,7 @@ func (b *Broker) ListDead(ctx context.Context, queueName string, limit int) ([]q
 }
 
 func (b *Broker) Requeue(ctx context.Context, jobID string) error {
+	now := time.Now().UTC()
 	res, err := b.coll.UpdateOne(ctx, bson.D{
 		{Key: "_id", Value: jobID},
 		{Key: "state", Value: stateDead},
@@ -426,7 +488,8 @@ func (b *Broker) Requeue(ctx context.Context, jobID string) error {
 		{Key: "$set", Value: bson.D{
 			{Key: "state", Value: stateLive},
 			{Key: "attempt", Value: int32(0)},
-			{Key: "run_at", Value: time.Now().UTC()},
+			{Key: "run_at", Value: now},
+			{Key: "visible_at", Value: now},
 		}},
 		{Key: "$unset", Value: bson.D{{Key: "died_at", Value: ""}}},
 	})
@@ -464,7 +527,8 @@ func (b *Broker) PurgeDeadBefore(ctx context.Context, cutoff time.Time) (int, er
 			{Key: "died_at", Value: bson.D{{Key: "$lt", Value: cutoff.UTC()}}},
 		}, options.Find().
 			SetLimit(purgeBatch).
-			SetProjection(bson.D{{Key: "_id", Value: 1}}))
+			SetBatchSize(purgeBatch).
+			SetProjection(idProjection))
 		if err != nil {
 			return total, fmt.Errorf("mongoqueue: purge dead before: %w", err)
 		}
@@ -541,6 +605,11 @@ func (b *Broker) statsInto(ctx context.Context, st queue.Stats, state string) er
 		}, options.Count().SetLimit(statsCap+1))
 		if err != nil {
 			return fmt.Errorf("mongoqueue: stats count: %w", err)
+		}
+		if n == 0 {
+			// The queue drained between the distinct and the count; skip it
+			// rather than report a {0, 0} entry no other broker would emit.
+			continue
 		}
 		capped := n > statsCap
 		if capped {

--- a/async/queue/mongo/mongoqueue_test.go
+++ b/async/queue/mongo/mongoqueue_test.go
@@ -1,0 +1,289 @@
+//go:build integration
+
+package mongoqueue_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	mongodriver "go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/async/queue/brokertest"
+	mongoqueue "github.com/dmitrymomot/forge/async/queue/mongo"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/testkit/mongotest"
+)
+
+var (
+	_ queue.Broker   = (*mongoqueue.Broker)(nil)
+	_ queue.TxPusher = (*mongoqueue.Broker)(nil)
+)
+
+// runID makes every collection name unique per test process so re-runs
+// against a persistent server (FORGE_TEST_MONGO_URI) never collide with prior
+// state.
+var runID = id.NewULID().String()
+
+// dial connects to the mongo under test: mongotest.URI honors
+// FORGE_TEST_MONGO_URI if set, else starts a throwaway single-node
+// replica-set container shared across the test process.
+func dial(tb testing.TB) *mongodriver.Database {
+	tb.Helper()
+	client, err := mongodriver.Connect(options.Client().ApplyURI(mongotest.URI(tb)))
+	require.NoError(tb, err)
+	tb.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = client.Disconnect(ctx)
+	})
+	return client.Database("forge_queue_test")
+}
+
+var collSeq int
+
+// newBroker namespaces each subtest in its own collection; collections leak
+// into the ephemeral test server (the mongotest container or a shared real
+// mongo), which is acceptable — runID keeps re-runs collision-free.
+func newBroker(tb testing.TB) *mongoqueue.Broker {
+	tb.Helper()
+	collSeq++
+	b, err := mongoqueue.New(dial(tb), mongoqueue.WithCollection(fmt.Sprintf("qt_%s_%d", runID, collSeq)))
+	require.NoError(tb, err)
+	require.NoError(tb, b.EnsureIndexes(context.Background()))
+	return b
+}
+
+func TestMongoQueue_Conformance(t *testing.T) {
+	brokertest.Run(t, func(t *testing.T) queue.Broker { return newBroker(t) })
+}
+
+// claimOne polls Claim until the queue yields a job or a deadline passes,
+// tolerating slow containers.
+func claimOne(t *testing.T, b queue.Broker, q string) queue.ClaimedJob {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		got, err := b.Claim(ctx, q, 10, time.Minute)
+		require.NoError(t, err)
+		if len(got) >= 1 {
+			return got[0]
+		}
+		if time.Now().After(deadline) {
+			require.Len(t, got, 1, "expected 1 claimable job within deadline")
+			return queue.ClaimedJob{}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func TestMongoQueue_PushTx(t *testing.T) {
+	db := dial(t)
+	collSeq++
+	b, err := mongoqueue.New(db, mongoqueue.WithCollection(fmt.Sprintf("qt_%s_tx_%d", runID, collSeq)))
+	require.NoError(t, err)
+	require.NoError(t, b.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+	c := queue.NewClient(b)
+	kind := queue.NewKind[struct {
+		N int `json:"n"`
+	}]("tx.kind")
+
+	t.Run("commit makes the job claimable", func(t *testing.T) {
+		sess, err := db.Client().StartSession()
+		require.NoError(t, err)
+		defer sess.EndSession(ctx)
+		require.NoError(t, sess.StartTransaction())
+		sc := mongodriver.NewSessionContext(ctx, sess)
+		require.NoError(t, queue.PushTx(sc, c, sess, kind, struct {
+			N int `json:"n"`
+		}{N: 1}))
+
+		got, err := b.Claim(ctx, "default", 10, time.Minute)
+		require.NoError(t, err)
+		assert.Empty(t, got, "job must be invisible before commit")
+
+		require.NoError(t, sess.CommitTransaction(sc))
+		job := claimOne(t, b, "default")
+		require.NoError(t, b.Ack(ctx, job.ID, job.Token))
+	})
+
+	t.Run("abort discards the job", func(t *testing.T) {
+		sess, err := db.Client().StartSession()
+		require.NoError(t, err)
+		defer sess.EndSession(ctx)
+		require.NoError(t, sess.StartTransaction())
+		sc := mongodriver.NewSessionContext(ctx, sess)
+		require.NoError(t, queue.PushTx(sc, c, sess, kind, struct {
+			N int `json:"n"`
+		}{N: 2}))
+		require.NoError(t, sess.AbortTransaction(sc))
+
+		got, err := b.Claim(ctx, "default", 10, time.Minute)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("wrong tx type errors", func(t *testing.T) {
+		err := queue.PushTx(ctx, c, "not a session", kind, struct {
+			N int `json:"n"`
+		}{N: 3})
+		require.Error(t, err)
+	})
+}
+
+// TestMongoQueue_PushJoinsAmbientSession pins the session-riding idiom the
+// package doc promises: a multi-job Push under a caller-owned session-bound
+// context must join that transaction instead of starting its own, so an abort
+// discards the whole batch.
+func TestMongoQueue_PushJoinsAmbientSession(t *testing.T) {
+	db := dial(t)
+	collSeq++
+	// The session below is bound to db's client, so the broker must live on
+	// the same client — newBroker would dial a separate one.
+	b, err := mongoqueue.New(db, mongoqueue.WithCollection(fmt.Sprintf("qt_%s_ambient_%d", runID, collSeq)))
+	require.NoError(t, err)
+	require.NoError(t, b.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+
+	sess, err := db.Client().StartSession()
+	require.NoError(t, err)
+	defer sess.EndSession(ctx)
+	require.NoError(t, sess.StartTransaction())
+	sc := mongodriver.NewSessionContext(ctx, sess)
+
+	jobs := []queue.Job{makeJob("ambient"), makeJob("ambient")}
+	require.NoError(t, b.Push(sc, jobs...))
+	require.NoError(t, sess.AbortTransaction(sc))
+
+	got, err := b.Claim(ctx, "ambient", 10, time.Minute)
+	require.NoError(t, err)
+	assert.Empty(t, got, "aborted ambient transaction must discard the batch")
+}
+
+func TestMongoQueue_WithCollectionValidation(t *testing.T) {
+	db := dial(t)
+	_, err := mongoqueue.New(db, mongoqueue.WithCollection("bad$name"))
+	require.Error(t, err, "unsafe collection name rejected")
+	_, err = mongoqueue.New(db, mongoqueue.WithCollection(""))
+	require.Error(t, err, "empty collection name rejected")
+}
+
+func TestMongoQueue_PayloadRoundTripsJSON(t *testing.T) {
+	b := newBroker(t)
+	ctx := context.Background()
+	c := queue.NewClient(b)
+	require.NoError(t, c.PushRaw(ctx, "raw.kind", json.RawMessage(`{"deep":{"x":[1,2,3]}}`)))
+	job := claimOne(t, b, "default")
+	assert.JSONEq(t, `{"deep":{"x":[1,2,3]}}`, string(job.Payload))
+}
+
+func makeJob(q string) queue.Job {
+	return queue.Job{
+		ID:          id.NewUUID().String(),
+		Queue:       q,
+		Type:        "test.kind",
+		Payload:     []byte(`{"n":1}`),
+		MaxAttempts: 25,
+		RunAt:       time.Now().UTC().Add(-2 * time.Second),
+		CreatedAt:   time.Now().UTC(),
+	}
+}
+
+func TestMongoQueue_StatsCapped(t *testing.T) {
+	b := newBroker(t)
+	ctx := context.Background()
+
+	jobs := make([]queue.Job, 10001)
+	for i := range jobs {
+		jobs[i] = queue.Job{
+			ID: id.NewUUID().String(), Queue: "bulk", Type: "cap.kind",
+			Payload: []byte(`{}`), RunAt: time.Now().UTC(), CreatedAt: time.Now().UTC(),
+		}
+	}
+	require.NoError(t, b.Push(ctx, jobs...))
+
+	st, err := b.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 10000, st["bulk"].Pending, "count reports the cap, not the true size")
+	assert.True(t, st["bulk"].PendingCapped)
+	assert.False(t, st["bulk"].DeadCapped)
+}
+
+// TestMongoQueue_PurgeDeadBeforeSpansManyBatches covers the batched drain
+// loop that brokertest's PurgeDeadBefore subtest cannot reach: it purges a
+// single dead job, so one round always suffices and an off-by-one in the loop
+// — a batch silently left behind, or a miscounted total — would go unnoticed.
+// 12001 dead documents span two full purgeBatch(5000) rounds plus a short
+// one, and the odd document proves the loop's exit does not depend on an
+// exact multiple.
+//
+// The documents are inserted straight into the collection as already-dead
+// fixtures rather than pushed, claimed and killed one by one: the sweep reads
+// nothing but state and died_at, and 12001 round-trip Kill calls would
+// dominate the runtime without testing anything this test is about.
+func TestMongoQueue_PurgeDeadBeforeSpansManyBatches(t *testing.T) {
+	db := dial(t)
+	collSeq++
+	collName := fmt.Sprintf("qt_%s_purge_%d", runID, collSeq)
+	b, err := mongoqueue.New(db, mongoqueue.WithCollection(collName))
+	require.NoError(t, err)
+	require.NoError(t, b.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+	coll := db.Collection(collName)
+
+	const dead = 12001 // > 2x the 5000 batch, deliberately not a multiple of it
+	diedAt := time.Now().UTC().Add(-40 * 24 * time.Hour)
+	docs := make([]any, dead)
+	for i := range docs {
+		docs[i] = bson.D{
+			{Key: "_id", Value: id.NewUUID().String()},
+			{Key: "queue", Value: "purgebatch"},
+			{Key: "type", Value: "purge.kind"},
+			{Key: "payload", Value: "{}"},
+			{Key: "scope", Value: ""},
+			{Key: "state", Value: "dead"},
+			{Key: "attempt", Value: int32(1)},
+			{Key: "max_attempts", Value: int32(5)},
+			{Key: "run_at", Value: diedAt},
+			{Key: "created_at", Value: diedAt},
+			{Key: "died_at", Value: diedAt},
+			{Key: "last_error", Value: "retention fixture"},
+		}
+	}
+	_, err = coll.InsertMany(ctx, docs)
+	require.NoError(t, err)
+
+	countDead := func() int {
+		n, err := coll.CountDocuments(ctx, bson.D{{Key: "state", Value: "dead"}})
+		require.NoError(t, err)
+		return int(n)
+	}
+	// Premise guard: without this, an assertion of "everything is gone" could
+	// pass on a collection that was never populated.
+	require.Equal(t, dead, countDead(), "fixture must fill the dead set")
+
+	// A cutoff before every died_at removes nothing: the loop must exit on
+	// the first empty round rather than spin.
+	n, err := b.PurgeDeadBefore(ctx, time.Now().Add(-365*24*time.Hour))
+	require.NoError(t, err)
+	assert.Zero(t, n)
+	require.Equal(t, dead, countDead(), "a cutoff older than every document must purge nothing")
+
+	n, err = b.PurgeDeadBefore(ctx, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, dead, n, "the batched loop must report every purged document exactly once across all rounds")
+	assert.Zero(t, countDead(), "no dead document may survive the sweep")
+
+	left, err := b.ListDead(ctx, "purgebatch", 10)
+	require.NoError(t, err)
+	assert.Empty(t, left)
+}

--- a/async/queue/mongo/mongoqueue_test.go
+++ b/async/queue/mongo/mongoqueue_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -47,17 +48,25 @@ func dial(tb testing.TB) *mongodriver.Database {
 	return client.Database("forge_queue_test")
 }
 
-var collSeq int
+var collSeq atomic.Int64
 
-// newBroker namespaces each subtest in its own collection; collections leak
-// into the ephemeral test server (the mongotest container or a shared real
-// mongo), which is acceptable — runID keeps re-runs collision-free.
-func newBroker(tb testing.TB) *mongoqueue.Broker {
+// brokerOn builds a broker over db in its own uniquely named collection and
+// creates its indexes; it returns the collection name for tests that need the
+// raw collection. Collections leak into the ephemeral test server (the
+// mongotest container or a shared real mongo), which is acceptable — runID
+// keeps re-runs collision-free.
+func brokerOn(tb testing.TB, db *mongodriver.Database) (*mongoqueue.Broker, string) {
 	tb.Helper()
-	collSeq++
-	b, err := mongoqueue.New(dial(tb), mongoqueue.WithCollection(fmt.Sprintf("qt_%s_%d", runID, collSeq)))
+	name := fmt.Sprintf("qt_%s_%d", runID, collSeq.Add(1))
+	b, err := mongoqueue.New(db, mongoqueue.WithCollection(name))
 	require.NoError(tb, err)
 	require.NoError(tb, b.EnsureIndexes(context.Background()))
+	return b, name
+}
+
+func newBroker(tb testing.TB) *mongoqueue.Broker {
+	tb.Helper()
+	b, _ := brokerOn(tb, dial(tb))
 	return b
 }
 
@@ -85,12 +94,21 @@ func claimOne(t *testing.T, b queue.Broker, q string) queue.ClaimedJob {
 	}
 }
 
+func makeJob(q string) queue.Job {
+	return queue.Job{
+		ID:          id.NewUUID().String(),
+		Queue:       q,
+		Type:        "test.kind",
+		Payload:     []byte(`{"n":1}`),
+		MaxAttempts: 25,
+		RunAt:       time.Now().UTC().Add(-2 * time.Second),
+		CreatedAt:   time.Now().UTC(),
+	}
+}
+
 func TestMongoQueue_PushTx(t *testing.T) {
 	db := dial(t)
-	collSeq++
-	b, err := mongoqueue.New(db, mongoqueue.WithCollection(fmt.Sprintf("qt_%s_tx_%d", runID, collSeq)))
-	require.NoError(t, err)
-	require.NoError(t, b.EnsureIndexes(context.Background()))
+	b, _ := brokerOn(t, db)
 	ctx := context.Background()
 	c := queue.NewClient(b)
 	kind := queue.NewKind[struct {
@@ -132,26 +150,35 @@ func TestMongoQueue_PushTx(t *testing.T) {
 		assert.Empty(t, got)
 	})
 
+	t.Run("session without a running transaction is rejected", func(t *testing.T) {
+		sess, err := db.Client().StartSession()
+		require.NoError(t, err)
+		defer sess.EndSession(ctx)
+		err = queue.PushTx(ctx, c, sess, kind, struct {
+			N int `json:"n"`
+		}{N: 3})
+		require.Error(t, err, "a session with no transaction must not degrade to a plain insert")
+
+		got, err := b.Claim(ctx, "default", 10, time.Minute)
+		require.NoError(t, err)
+		assert.Empty(t, got, "nothing may be enqueued by the rejected push")
+	})
+
 	t.Run("wrong tx type errors", func(t *testing.T) {
 		err := queue.PushTx(ctx, c, "not a session", kind, struct {
 			N int `json:"n"`
-		}{N: 3})
+		}{N: 4})
 		require.Error(t, err)
 	})
 }
 
 // TestMongoQueue_PushJoinsAmbientSession pins the session-riding idiom the
 // package doc promises: a multi-job Push under a caller-owned session-bound
-// context must join that transaction instead of starting its own, so an abort
-// discards the whole batch.
+// context with a RUNNING transaction must join that transaction instead of
+// starting its own, so an abort discards the whole batch.
 func TestMongoQueue_PushJoinsAmbientSession(t *testing.T) {
 	db := dial(t)
-	collSeq++
-	// The session below is bound to db's client, so the broker must live on
-	// the same client — newBroker would dial a separate one.
-	b, err := mongoqueue.New(db, mongoqueue.WithCollection(fmt.Sprintf("qt_%s_ambient_%d", runID, collSeq)))
-	require.NoError(t, err)
-	require.NoError(t, b.EnsureIndexes(context.Background()))
+	b, _ := brokerOn(t, db)
 	ctx := context.Background()
 
 	sess, err := db.Client().StartSession()
@@ -169,12 +196,29 @@ func TestMongoQueue_PushJoinsAmbientSession(t *testing.T) {
 	assert.Empty(t, got, "aborted ambient transaction must discard the batch")
 }
 
-func TestMongoQueue_WithCollectionValidation(t *testing.T) {
+// TestMongoQueue_PushAmbientSessionWithoutTransaction pins the other side of
+// the idiom: a session bound for causal consistency only (no transaction
+// running) must NOT be mistaken for a caller-owned transaction — Push wraps
+// the batch in its own transaction, so a mid-batch failure (duplicate _id
+// here) leaves nothing behind instead of the pre-failure prefix.
+func TestMongoQueue_PushAmbientSessionWithoutTransaction(t *testing.T) {
 	db := dial(t)
-	_, err := mongoqueue.New(db, mongoqueue.WithCollection("bad$name"))
-	require.Error(t, err, "unsafe collection name rejected")
-	_, err = mongoqueue.New(db, mongoqueue.WithCollection(""))
-	require.Error(t, err, "empty collection name rejected")
+	b, _ := brokerOn(t, db)
+	ctx := context.Background()
+
+	sess, err := db.Client().StartSession()
+	require.NoError(t, err)
+	defer sess.EndSession(ctx)
+	sc := mongodriver.NewSessionContext(ctx, sess)
+
+	j1, j3 := makeJob("noamb"), makeJob("noamb")
+	dup := makeJob("noamb")
+	dup.ID = j1.ID // ordered insert fails here, after j1 landed
+	require.Error(t, b.Push(sc, j1, dup, j3), "duplicate id must fail the batch")
+
+	got, err := b.Claim(ctx, "noamb", 10, time.Minute)
+	require.NoError(t, err)
+	assert.Empty(t, got, "failed batch must be all-or-nothing even under a non-transactional ambient session")
 }
 
 func TestMongoQueue_PayloadRoundTripsJSON(t *testing.T) {
@@ -184,18 +228,6 @@ func TestMongoQueue_PayloadRoundTripsJSON(t *testing.T) {
 	require.NoError(t, c.PushRaw(ctx, "raw.kind", json.RawMessage(`{"deep":{"x":[1,2,3]}}`)))
 	job := claimOne(t, b, "default")
 	assert.JSONEq(t, `{"deep":{"x":[1,2,3]}}`, string(job.Payload))
-}
-
-func makeJob(q string) queue.Job {
-	return queue.Job{
-		ID:          id.NewUUID().String(),
-		Queue:       q,
-		Type:        "test.kind",
-		Payload:     []byte(`{"n":1}`),
-		MaxAttempts: 25,
-		RunAt:       time.Now().UTC().Add(-2 * time.Second),
-		CreatedAt:   time.Now().UTC(),
-	}
 }
 
 func TestMongoQueue_StatsCapped(t *testing.T) {
@@ -232,11 +264,7 @@ func TestMongoQueue_StatsCapped(t *testing.T) {
 // dominate the runtime without testing anything this test is about.
 func TestMongoQueue_PurgeDeadBeforeSpansManyBatches(t *testing.T) {
 	db := dial(t)
-	collSeq++
-	collName := fmt.Sprintf("qt_%s_purge_%d", runID, collSeq)
-	b, err := mongoqueue.New(db, mongoqueue.WithCollection(collName))
-	require.NoError(t, err)
-	require.NoError(t, b.EnsureIndexes(context.Background()))
+	b, collName := brokerOn(t, db)
 	ctx := context.Background()
 	coll := db.Collection(collName)
 
@@ -254,12 +282,13 @@ func TestMongoQueue_PurgeDeadBeforeSpansManyBatches(t *testing.T) {
 			{Key: "attempt", Value: int32(1)},
 			{Key: "max_attempts", Value: int32(5)},
 			{Key: "run_at", Value: diedAt},
+			{Key: "visible_at", Value: diedAt},
 			{Key: "created_at", Value: diedAt},
 			{Key: "died_at", Value: diedAt},
 			{Key: "last_error", Value: "retention fixture"},
 		}
 	}
-	_, err = coll.InsertMany(ctx, docs)
+	_, err := coll.InsertMany(ctx, docs)
 	require.NoError(t, err)
 
 	countDead := func() int {
@@ -286,4 +315,33 @@ func TestMongoQueue_PurgeDeadBeforeSpansManyBatches(t *testing.T) {
 	left, err := b.ListDead(ctx, "purgebatch", 10)
 	require.NoError(t, err)
 	assert.Empty(t, left)
+}
+
+// TestMongoQueue_ClaimFillsPastRivalClaims pins that another worker's
+// in-flight claims never occupy shortlist slots: after a rival broker claims
+// half the queue, a full batch must still come back from the unclaimed
+// remainder. (The mid-claim interleaving the refill loop exists for — a
+// candidate stolen between the shortlist read and the guarded update — has
+// no deterministic external trigger; this covers the observable contract
+// that contention must not shrink a batch while due work remains.)
+func TestMongoQueue_ClaimFillsPastRivalClaims(t *testing.T) {
+	db := dial(t)
+	b, collName := brokerOn(t, db)
+	rival, err := mongoqueue.New(db, mongoqueue.WithCollection(collName))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	jobs := make([]queue.Job, 6)
+	for i := range jobs {
+		jobs[i] = makeJob("contended")
+	}
+	require.NoError(t, b.Push(ctx, jobs...))
+
+	stolen, err := rival.Claim(ctx, "contended", 3, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, stolen, 3)
+
+	got, err := b.Claim(ctx, "contended", 3, time.Minute)
+	require.NoError(t, err)
+	assert.Len(t, got, 3, "claim must fill its batch from the unclaimed remainder")
 }

--- a/async/queue/mongo/validate_test.go
+++ b/async/queue/mongo/validate_test.go
@@ -1,0 +1,15 @@
+package mongoqueue_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mongoqueue "github.com/dmitrymomot/forge/async/queue/mongo"
+)
+
+func TestMongoQueue_ValidatesConstruction(t *testing.T) {
+	t.Parallel()
+	_, err := mongoqueue.New(nil)
+	require.Error(t, err, "nil database rejected")
+}

--- a/async/queue/mongo/validate_test.go
+++ b/async/queue/mongo/validate_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	mongodriver "go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	mongoqueue "github.com/dmitrymomot/forge/async/queue/mongo"
 )
@@ -12,4 +14,18 @@ func TestMongoQueue_ValidatesConstruction(t *testing.T) {
 	t.Parallel()
 	_, err := mongoqueue.New(nil)
 	require.Error(t, err, "nil database rejected")
+
+	// Connect performs no I/O in driver v2, so name validation — a pure
+	// regexp check inside New — stays in the Docker-free unit tier.
+	client, err := mongodriver.Connect(options.Client().ApplyURI("mongodb://127.0.0.1:1"))
+	require.NoError(t, err)
+	db := client.Database("unit")
+
+	_, err = mongoqueue.New(db, mongoqueue.WithCollection("bad$name"))
+	require.Error(t, err, "unsafe collection name rejected")
+	_, err = mongoqueue.New(db, mongoqueue.WithCollection(""))
+	require.Error(t, err, "empty collection name rejected")
+
+	_, err = mongoqueue.New(db)
+	require.NoError(t, err, "default collection name accepted")
 }

--- a/async/queue/redis/doc.go
+++ b/async/queue/redis/doc.go
@@ -2,8 +2,8 @@
 // per queue for claim-with-lease (XAUTOCLAIM redelivers entries idle longer
 // than the lease), a sorted set staging delayed and retried jobs (promoted
 // atomically by a Lua script during Claim), and a hash holding dead-letter
-// payloads. No transactional enqueue — use async/queue/postgres or, once it
-// lands, async/outbox.
+// payloads. No transactional enqueue — use async/queue/postgres,
+// async/queue/mongo, or, once it lands, async/outbox.
 //
 // Claim ownership is tracked in-process, not in redis: Broker keeps a
 // job-id-keyed map of live claims in memory, so a fencing token from Claim is

--- a/docs/design.md
+++ b/docs/design.md
@@ -154,8 +154,9 @@ and the driver leaves stays stdlib.
   delayed jobs, max-attempts → dead-letter, idempotency inbox — so app
   behavior is identical across postgres/sqlite/redis/mongo/nats/kafka; the engine
   uses a driver's native capability when declared. Transactional publish
-  (`PushTx`) is native on SQL drivers; non-SQL drivers get it via
-  `async/outbox`.
+  (`PushTx`) is native on drivers whose store has real multi-document ACID
+  transactions (postgres, sqlite, mongo); drivers without them (redis, nats,
+  kafka) get it via `async/outbox`.
 - **Authorization decision seam** — `rbac`, `acl`, and `abac` are composable
   bricks feeding one shared Allow/Deny decision interface consumed by
   `guard` / `RequirePermission` middleware (401-vs-403 split). External

--- a/docs/design.md
+++ b/docs/design.md
@@ -99,7 +99,7 @@ go-sdk (`mcpserver`), `x/image` (`imageproc`), prometheus client
 test-only), `nats.go` (`queue/nats`), a Kafka client (`queue/kafka`),
 a cgo-free SQLite driver (`queue/sqlite`). **Postgres is the primary
 database**; the async engine is storage-agnostic with first-class drivers
-(postgres, sqlite, redis, nats, kafka); everything else outside `data/*`
+(postgres, sqlite, redis, mongo, nats, kafka); everything else outside `data/*`
 and the driver leaves stays stdlib.
 
 ## Repository layout rules
@@ -152,7 +152,7 @@ and the driver leaves stays stdlib.
   seam; `scheduler`, `eventbus`, and `outbox` ride it unchanged. The
   **engine, not the driver, owns the hard semantics** — retry/backoff,
   delayed jobs, max-attempts → dead-letter, idempotency inbox — so app
-  behavior is identical across postgres/sqlite/redis/nats/kafka; the engine
+  behavior is identical across postgres/sqlite/redis/mongo/nats/kafka; the engine
   uses a driver's native capability when declared. Transactional publish
   (`PushTx`) is native on SQL drivers; non-SQL drivers get it via
   `async/outbox`.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -340,8 +340,10 @@ Additional `queue.Broker` drivers for the shipped `async/queue` engine
 dev/test), `queue/nats`, `queue/kafka`. The engine — not the driver —
 owns retry/backoff, delay, and max-attempts → dead-letter, so behavior is
 identical across backends; each driver only moves bytes behind the
-strictly-pull `Broker` seam. Non-SQL brokers get transactional enqueue
-via `async/outbox` (SQL drivers implement `TxPusher` natively).
+strictly-pull `Broker` seam. Brokers without real multi-document ACID
+transactions (redis, nats, kafka) get transactional enqueue via
+`async/outbox`; stores that have them implement `TxPusher` natively
+(`queue/postgres`, `queue/mongo`, `queue/sqlite`).
 
 Deps: `async/queue`; drivers: `data/sqlite` (planned), `data/nats`
 (planned), `data/kafka` (planned).

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -335,8 +335,8 @@ Deps: `core/money`; `core/fsm`.
 **async/queue/sqlite · async/queue/nats · async/queue/kafka**
 
 Additional `queue.Broker` drivers for the shipped `async/queue` engine
-(engine, in-memory broker, `queue/postgres`, and `queue/redis` already
-ship — see their godoc): `queue/sqlite` (zero-infra single-node and
+(engine, in-memory broker, `queue/postgres`, `queue/redis`, and
+`queue/mongo` already ship — see their godoc): `queue/sqlite` (zero-infra single-node and
 dev/test), `queue/nats`, `queue/kafka`. The engine — not the driver —
 owns retry/backoff, delay, and max-attempts → dead-letter, so behavior is
 identical across backends; each driver only moves bytes behind the

--- a/testkit/mongotest/mongotest.go
+++ b/testkit/mongotest/mongotest.go
@@ -25,7 +25,7 @@ var (
 // URI returns a MongoDB connection string to test against.
 //
 // If FORGE_TEST_MONGO_URI is set it is returned verbatim, pointing the suite at
-// an existing server. Otherwise a throwaway mongo:7 container is started once
+// an existing server. Otherwise a throwaway mongo:8.3 container is started once
 // per test process as a single-node replica set — so multi-document
 // transactions work — shared across every test in the package and removed by
 // the testcontainers Ryuk reaper when the process exits.
@@ -46,7 +46,7 @@ func URI(tb testing.TB) string {
 // sharedURI empty and make every later caller dial "".
 func startShared() {
 	ctx := context.Background()
-	c, err := mongodb.Run(ctx, "mongo:7", mongodb.WithReplicaSet("rs0"))
+	c, err := mongodb.Run(ctx, "mongo:8.3", mongodb.WithReplicaSet("rs0"))
 	if err != nil {
 		panic(fmt.Sprintf("mongotest: start container: %v", err))
 	}


### PR DESCRIPTION
## Description

Adds `async/queue/mongo` (package `mongoqueue`): a MongoDB `queue.Broker` + `queue.TxPusher` driver for the shipped async/queue engine, passing the full `brokertest` conformance suite under `-race` (85% coverage). Also bumps the shared `testkit/mongotest` container from the stale `mongo:7` pin to the current stable `mongo:8.3` (both mongo-backed integration suites pass against it).

### Design

- **Single collection, `state` discriminator (live/dead).** Kill, Requeue, and Purge are single atomic document updates — no cross-collection move can lose a job mid-crash, and everything except multi-job Push works on a standalone server.
- **One always-set indexed `visible_at` watermark** (run_at on push → lease deadline while claimed → retry time after nack). The claim scan is a single tight `{queue, visible_at, _id}` partial-index range; in-flight jobs never get fetched-and-filtered per poll, unlike the naive `$or` over an optional lease field. Watermarks are ceiled to the next millisecond so BSON's ms floor can't make a nacked job claimable before `retryAt` or expire a lease early.
- **Claiming.** Batch path: shortlist of candidate ids in visibility order → guarded `updateMany` stamping lease + fencing token + attempt atomically per document → fetch of the won documents, with bounded refill rounds when a concurrent claimer steals candidates (the engine reads a short `Claim` return as "queue drained"). Single-job claims are one atomic `findAndModify` — wall-time ties the batch path but 44% fewer allocations, a third of the server commands, and no claimed-but-unfetched crash window.
- **Transactional enqueue.** Multi-job Push wraps in its own session transaction to honor the all-or-nothing contract (replica set required); `PushTx` takes a caller-owned `*mongo.Session`, and Push joins an ambient transaction-bound context (`data/mongo.WithTransaction`) automatically. Both guard with `Session.TransactionRunning()` so a session bound for causal consistency only can never silently degrade a batch to a non-atomic ordered insert.
- **Primary-pinned reads.** The collection handle overrides the client's read preference: a queue must read its own acknowledged writes, and a `secondaryPreferred` client would otherwise lose claimed jobs between the guarded update and the fetch (leases burned with zero executions).
- Stats counts are bounded at 10k per queue with `Capped` flags (pgqueue semantics); retention sweeps drain in bounded 5000-doc rounds so a huge backlog costs many short commands instead of one unkillable delete.

### Review

An 8-angle adversarial review ran before pushing; all 10 verified findings are fixed in the second commit — the most notable: session-without-running-transaction silently dropping all-or-nothing, `secondaryPreferred` losing claimed jobs on the post-update fetch, BSON ms-floor breaching the `retryAt` contract, lease stamped from a pre-round-trip clock, and `ModifiedCount` used where `MatchedCount` is the ownership signal.

### Benchmarks (Apple M3 Max, mongo container, `-benchtime=2s`)

| benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| PushClaimAck | ~1.85ms | 31,690 | 352 |
| PushBatch (100 jobs, txn) | ~2.5ms | 731,259 | 4,046 |
| ClaimBatch (claim 20 + acks, 20k backlog) | ~10.7ms | 387,610 | 3,251 |
| ListDead (50 of 5k) | ~0.4ms | 326,218 | 2,938 |

Post-benchmark optimization pass: the `findAndModify` n==1 fast path (kept on measured allocation/command wins after an honest same-environment A/B showed wall-time parity — the initial cross-container comparison had claimed 19%), hoisted constant BSON fragments, `SetBatchSize` on multi-doc finds to kill a `getMore` round trip past 101 docs, and client-side batch ordering to spare the server an uncovered sort stage.

### Notes for review

- `docs/design.md` driver enumerations and `docs/packages.md`'s shipped-driver parenthetical now include mongo.
- Collection name validation runs in the Docker-free unit tier (driver v2 `Connect` does no I/O); everything else is `//go:build integration` via `testkit/mongotest` (single-node replica set, so multi-document transactions work).
- Client-clock visibility semantics (like `queue.MemoryBroker`) are documented in `doc.go`: fencing keeps delivery at-least-once regardless of worker clock skew.

## Checklist

- [x] `just lint` passes
- [x] `just test` passes
- [x] New code has tests
- [x] Commit messages follow conventional commits
