### PR TITLE
docs(web/smartlink): add flow.svg architecture diagram

### DIFF
--- a/web/smartlink/flow.svg
+++ b/web/smartlink/flow.svg
@@ -1,0 +1,121 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1290 750" font-family="'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1e1e1e"/>
+    </marker>
+    <marker id="arrG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#22c55e"/>
+    </marker>
+    <style>
+      .lbl { font-size:16px; fill:#1e1e1e; text-anchor:middle; }
+      .albl { font-size:14px; fill:#1e1e1e; text-anchor:middle; paint-order:stroke; stroke:#ffffff; stroke-width:4px; }
+    </style>
+  </defs>
+
+  <rect x="0" y="0" width="1290" height="750" fill="#ffffff"/>
+
+  <text x="645" y="28" font-size="26" font-weight="600" fill="#1e1e1e" text-anchor="middle">web/smartlink: click → decision → redirect</text>
+
+  <!-- management -->
+  <rect x="640" y="44" width="400" height="60" rx="8" fill="#ffd8a8" stroke="#f59e0b" stroke-width="2"/>
+  <text class="lbl" x="840" y="68" font-size="15">Management: Create / Activate / Deactivate / Delete</text>
+  <text class="lbl" x="840" y="88" font-size="15">— WithScope tenancy (management only)</text>
+  <line x1="840" y1="104" x2="754" y2="176" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+  <text class="albl" x="812" y="142">writes Links</text>
+
+  <!-- handler zone -->
+  <rect x="20" y="170" width="320" height="560" rx="8" fill="#dbe4ff" fill-opacity="0.3" stroke="#4a9eed" stroke-width="1"/>
+  <text x="40" y="195" font-size="16" fill="#2563eb">Manager.Handler()</text>
+
+  <!-- visitor -->
+  <rect x="40" y="80" width="220" height="56" rx="8" fill="#a5d8ff" stroke="#4a9eed" stroke-width="2"/>
+  <text class="lbl" x="150" y="103">Visitor clicks</text>
+  <text class="lbl" x="150" y="123">/{code}?src=fb</text>
+  <line x1="150" y1="136" x2="150" y2="206" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- step 1 -->
+  <rect x="60" y="210" width="240" height="54" rx="8" fill="#d0bfff" stroke="#8b5cf6" stroke-width="2"/>
+  <text class="lbl" x="180" y="242">1. Resolve(code)</text>
+
+  <!-- cache + store -->
+  <rect x="420" y="180" width="170" height="60" rx="8" fill="#c3fae8" stroke="#06b6d4" stroke-width="2"/>
+  <text class="lbl" x="505" y="215">Cache (optional)</text>
+  <line x1="300" y1="237" x2="416" y2="214" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+  <text class="albl" x="356" y="215">read-through</text>
+  <rect x="650" y="180" width="200" height="60" rx="8" fill="#c3fae8" stroke="#06b6d4" stroke-width="2"/>
+  <text class="lbl" x="750" y="204">Store:</text>
+  <text class="lbl" x="750" y="224">pgstore / memory</text>
+  <line x1="590" y1="210" x2="646" y2="210" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+  <text class="albl" x="618" y="200">miss</text>
+  <rect x="420" y="270" width="430" height="44" rx="8" fill="#fff3bf" fill-opacity="0.6" stroke="#f59e0b" stroke-width="1"/>
+  <text class="albl" x="635" y="288">dead / unknown code → fallback URL or 404,</text>
+  <text class="albl" x="635" y="306">Store outage → 500</text>
+
+  <!-- step 2 -->
+  <rect x="60" y="310" width="240" height="70" rx="8" fill="#d0bfff" stroke="#8b5cf6" stroke-width="2"/>
+  <text class="lbl" x="180" y="340">2. Build Visit: query +</text>
+  <text class="lbl" x="180" y="360">VisitFunc, Metadata wins</text>
+  <line x1="180" y1="264" x2="180" y2="306" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- step 3 -->
+  <rect x="60" y="430" width="240" height="54" rx="8" fill="#d0bfff" stroke="#8b5cf6" stroke-width="2"/>
+  <text class="lbl" x="180" y="462">3. Decide(Visit)</text>
+  <line x1="180" y1="380" x2="180" y2="426" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- decorators + branch -->
+  <rect x="360" y="330" width="280" height="44" rx="8" fill="#eebefa" stroke="#8b5cf6" stroke-width="2"/>
+  <text class="albl" x="500" y="357">Decorators wrap Decide (fraud, A/B)</text>
+  <polygon points="470,400 560,455 470,510 380,455" fill="#fff3bf" stroke="#f59e0b" stroke-width="2"/>
+  <text class="lbl" x="470" y="460">Target or Ref?</text>
+  <line x1="300" y1="457" x2="376" y2="455" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+
+  <rect x="640" y="380" width="230" height="56" rx="8" fill="#ffd8a8" stroke="#f59e0b" stroke-width="2"/>
+  <text class="lbl" x="755" y="403">Target link:</text>
+  <text class="lbl" x="755" y="423">compile single template</text>
+  <line x1="560" y1="440" x2="636" y2="413" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+  <text class="albl" x="596" y="418">Target</text>
+
+  <rect x="640" y="470" width="230" height="80" rx="8" fill="#ffd8a8" stroke="#f59e0b" stroke-width="2"/>
+  <text class="lbl" x="755" y="494">Ref link: Resolver /</text>
+  <text class="lbl" x="755" y="513">Cache — load Spec,</text>
+  <text class="lbl" x="755" y="532">compile, TTL + Invalidate</text>
+  <line x1="560" y1="470" x2="636" y2="502" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+  <text class="albl" x="592" y="493">Ref</text>
+
+  <!-- engine zone -->
+  <rect x="940" y="330" width="330" height="360" rx="8" fill="#d3f9d8" fill-opacity="0.3" stroke="#22c55e" stroke-width="1"/>
+  <text x="955" y="355" font-size="16" fill="#15803d">Engine: Compiled.Decide</text>
+  <rect x="960" y="375" width="290" height="50" rx="8" fill="#b2f2bb" stroke="#22c55e" stroke-width="2"/>
+  <text class="lbl" x="1105" y="396">Ordered rules — first match</text>
+  <text class="lbl" x="1105" y="415">wins, else Default</text>
+  <rect x="960" y="445" width="290" height="64" rx="8" fill="#b2f2bb" stroke="#22c55e" stroke-width="2"/>
+  <text class="lbl" x="1105" y="471">Match: Geo, Device, Locale,</text>
+  <text class="lbl" x="1105" y="491">ParamEquals, TimeWindow, Percent</text>
+  <rect x="960" y="529" width="290" height="64" rx="8" fill="#b2f2bb" stroke="#22c55e" stroke-width="2"/>
+  <text class="lbl" x="1105" y="555">Split: FNV-1a(salt, rule,</text>
+  <text class="lbl" x="1105" y="575">StickyKey) — sticky, no RNG</text>
+  <rect x="960" y="613" width="290" height="60" rx="8" fill="#b2f2bb" stroke="#22c55e" stroke-width="2"/>
+  <text class="lbl" x="1105" y="637">Render macros {country}</text>
+  <text class="lbl" x="1105" y="657">{device} {param.X} — escaped</text>
+  <line x1="870" y1="408" x2="936" y2="466" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="870" y1="510" x2="936" y2="528" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- step 4 -->
+  <rect x="60" y="530" width="240" height="60" rx="8" fill="#b2f2bb" stroke="#22c55e" stroke-width="2"/>
+  <text class="lbl" x="180" y="554">4. Redirect 302/307 +</text>
+  <text class="lbl" x="180" y="574">Cache-Control: no-store</text>
+  <line x1="180" y1="484" x2="180" y2="526" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="960" y1="643" x2="306" y2="562" stroke="#22c55e" stroke-width="2" marker-end="url(#arrG)"/>
+  <text class="albl" x="633" y="596" fill="#15803d">Decision{URL, rule}</text>
+
+  <!-- step 5 -->
+  <rect x="60" y="640" width="240" height="60" rx="8" fill="#eebefa" stroke="#8b5cf6" stroke-width="2"/>
+  <text class="lbl" x="180" y="664">5. OnHit(Hit) — after</text>
+  <text class="lbl" x="180" y="684">redirect, ctx detached</text>
+  <line x1="180" y1="590" x2="180" y2="636" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+
+  <rect x="420" y="640" width="250" height="64" rx="8" fill="#eebefa" stroke="#8b5cf6" stroke-width="2"/>
+  <text class="lbl" x="545" y="666">Your sink: bounded queue</text>
+  <text class="lbl" x="545" y="686">→ analytics / postbacks</text>
+  <line x1="300" y1="670" x2="416" y2="671" stroke="#1e1e1e" stroke-width="2" marker-end="url(#arr)"/>
+</svg>


### PR DESCRIPTION
## Description

Adds `web/smartlink/flow.svg` — a rendered architecture diagram of the package's click→decision→redirect pipeline: `Manager.Handler()` steps (Resolve with cache read-through and dead-link/outage handling, Visit building with Metadata-wins merge, Target/Ref decide branch, 302/307 no-store redirect, detached-ctx OnHit), the `Compiled.Decide` engine internals (ordered rules, typed matchers, FNV-1a sticky splits, positional macro escaping), and the tenant-scoped management surface writing Links to the Store.

Docs-only asset — no Go code touched.

## Checklist

- [x] `just lint` passes (no Go changes; unaffected by this PR)
- [x] `just test` passes (no Go changes; unaffected by this PR)
- [ ] New code has tests — N/A, no code
- [x] Commit messages follow conventional commits