### PR TITLE
feat(comms/postback): tracker-style S2S postback sender

### DIFF
--- a/comms/postback/bench_test.go
+++ b/comms/postback/bench_test.go
@@ -49,6 +49,23 @@ func BenchmarkRender(b *testing.B) {
 	}
 }
 
+func BenchmarkRenderPathMacro(b *testing.B) {
+	vocab := benchVocab(b)
+	dest, err := postback.NewDestination("https://tracker.example.com/pb/{click_id}/{status}?s1={sub1}", vocab)
+	if err != nil {
+		b.Fatal(err)
+	}
+	values := map[string]string{
+		"click_id": "8f14e45fceea167a",
+		"status":   "approved",
+		"sub1":     "campaign-7",
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = dest.Render(values)
+	}
+}
+
 func BenchmarkSend(b *testing.B) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/comms/postback/bench_test.go
+++ b/comms/postback/bench_test.go
@@ -1,0 +1,70 @@
+package postback_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/comms/postback"
+)
+
+func benchVocab(b *testing.B) postback.Vocabulary {
+	b.Helper()
+	v, err := postback.NewVocabulary("click_id", "payout", "status", "sub1", "sub2")
+	if err != nil {
+		b.Fatal(err)
+	}
+	return v
+}
+
+func BenchmarkNewDestination(b *testing.B) {
+	vocab := benchVocab(b)
+	raw := "https://tracker.example.com/pb?cid={click_id}&sum={payout}&st={status}&s1={sub1}&s2={sub2}"
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := postback.NewDestination(raw, vocab); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRender(b *testing.B) {
+	vocab := benchVocab(b)
+	dest, err := postback.NewDestination(
+		"https://tracker.example.com/pb?cid={click_id}&sum={payout}&st={status}&s1={sub1}&s2={sub2}",
+		vocab,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	values := map[string]string{
+		"click_id": "8f14e45fceea167a",
+		"payout":   "12.50",
+		"status":   "approved",
+		"sub1":     "campaign-7",
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = dest.Render(values)
+	}
+}
+
+func BenchmarkSend(b *testing.B) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	b.Cleanup(srv.Close)
+	sender := postback.New(postback.WithHTTPClient(srv.Client()))
+	vocab := benchVocab(b)
+	dest, err := postback.NewDestination(srv.URL+"/pb?cid={click_id}&sum={payout}", vocab)
+	if err != nil {
+		b.Fatal(err)
+	}
+	values := map[string]string{"click_id": "8f14e45fceea167a", "payout": "12.50"}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := sender.Send(b.Context(), dest, values); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/comms/postback/destination.go
+++ b/comms/postback/destination.go
@@ -171,8 +171,9 @@ func (d Destination) Render(values map[string]string) string {
 			case "..":
 				b.WriteString("%2E%2E")
 			default:
-				// ':' additionally encoded: in the first path segment it would
-				// otherwise reparse as a scheme delimiter.
+				// ':' additionally encoded everywhere in path position: in the
+				// first segment it would otherwise reparse as a scheme delimiter,
+				// and over-encoding it elsewhere is harmless.
 				b.WriteString(strings.ReplaceAll(url.PathEscape(val), ":", "%3A"))
 			}
 		case escAuthority:

--- a/comms/postback/destination.go
+++ b/comms/postback/destination.go
@@ -1,0 +1,183 @@
+package postback
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// escMode selects the positional escaping for a macro, decided at parse from
+// the literal text preceding it: query escapes with url.QueryEscape; path
+// escapes with url.PathEscape plus ':' (so a value can't smuggle a scheme
+// into the first path segment). Macros in the scheme or authority are
+// rejected at NewDestination — a click ID can't pick the host it reports to.
+type escMode uint8
+
+const (
+	escPath escMode = iota
+	escQuery
+	escAuthority
+)
+
+// segment is one parsed piece of a URL template: a literal followed by an
+// optional macro.
+type segment struct {
+	literal string
+	macro   string // "" for the literal-only tail
+	esc     escMode
+}
+
+// Destination is a validated postback target: a URL template parsed against a
+// Vocabulary plus the HTTP method to fire with. Construct via NewDestination;
+// the zero value fails closed in Send.
+type Destination struct {
+	raw    string
+	method string
+	segs   []segment
+}
+
+// DestinationOption configures a Destination at parse time.
+type DestinationOption func(*Destination)
+
+// WithMethod sets the HTTP method Send fires with (default GET). Only GET and
+// POST are accepted — macros ride the URL either way, the body stays empty.
+func WithMethod(method string) DestinationOption {
+	return func(d *Destination) { d.method = strings.ToUpper(method) }
+}
+
+// NewDestination parses and validates a postback URL template. Every {macro}
+// must be registered in vocab (ErrUnknownMacro), the macro-elided template
+// must parse as an absolute http(s) URL with no fragment, and no macro may
+// sit in the authority (ErrInvalidTemplate) — all construction errors, never
+// an empty substitution at fire time.
+func NewDestination(raw string, vocab Vocabulary, opts ...DestinationOption) (Destination, error) {
+	d := Destination{raw: raw, method: http.MethodGet}
+	for _, opt := range opts {
+		opt(&d)
+	}
+	if d.method != http.MethodGet && d.method != http.MethodPost {
+		return Destination{}, fmt.Errorf("%w: %q", ErrInvalidMethod, d.method)
+	}
+
+	var elided strings.Builder
+	rest := raw
+	for {
+		open := strings.IndexByte(rest, '{')
+		if open < 0 {
+			break
+		}
+		end := strings.IndexByte(rest[open:], '}')
+		if end < 0 {
+			return Destination{}, fmt.Errorf("%w: unclosed '{' in %q", ErrInvalidTemplate, raw)
+		}
+		end += open
+		literal := rest[:open]
+		if strings.ContainsRune(literal, '}') {
+			return Destination{}, fmt.Errorf("%w: unmatched '}' in %q", ErrInvalidTemplate, raw)
+		}
+		name := rest[open+1 : end]
+		if !vocab.contains(name) {
+			return Destination{}, fmt.Errorf("%w: {%s}", ErrUnknownMacro, name)
+		}
+		elided.WriteString(literal)
+		esc := escapeModeFor(elided.String())
+		if esc == escAuthority {
+			return Destination{}, fmt.Errorf("%w: macro {%s} in scheme or authority of %q", ErrInvalidTemplate, name, raw)
+		}
+		d.segs = append(d.segs, segment{literal: literal, macro: name, esc: esc})
+		rest = rest[end+1:]
+	}
+	if strings.ContainsRune(rest, '}') {
+		return Destination{}, fmt.Errorf("%w: unmatched '}' in %q", ErrInvalidTemplate, raw)
+	}
+	if rest != "" {
+		if d.segs != nil {
+			d.segs = append(d.segs, segment{literal: rest})
+		}
+		elided.WriteString(rest)
+	}
+
+	u, err := url.Parse(elided.String())
+	if err != nil {
+		return Destination{}, fmt.Errorf("%w: %v", ErrInvalidTemplate, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return Destination{}, fmt.Errorf("%w: scheme must be http or https in %q", ErrInvalidTemplate, raw)
+	}
+	if u.Host == "" {
+		return Destination{}, fmt.Errorf("%w: missing host in %q", ErrInvalidTemplate, raw)
+	}
+	if u.Fragment != "" || strings.HasSuffix(elided.String(), "#") {
+		return Destination{}, fmt.Errorf("%w: fragment never reaches the tracker in %q", ErrInvalidTemplate, raw)
+	}
+	return d, nil
+}
+
+// escapeModeFor derives a macro's escaping from the macro-elided literal
+// prefix before it (macro values never create structure, so the prefix alone
+// fixes the position). escAuthority covers everything before the first '/'
+// after "://" — including a prefix with no "://" at all, i.e. a macro in or
+// before the scheme: every legitimate path macro of an absolute http(s)
+// template has "://" upstream, so its absence means the macro shapes the
+// scheme or host and must be rejected.
+func escapeModeFor(prefix string) escMode {
+	if strings.ContainsRune(prefix, '?') {
+		return escQuery
+	}
+	_, after, found := strings.Cut(prefix, "://")
+	if !found || !strings.ContainsAny(after, "/?#") {
+		return escAuthority
+	}
+	return escPath
+}
+
+// Raw returns the template as given to NewDestination.
+func (d Destination) Raw() string { return d.raw }
+
+// Method returns the HTTP method Send fires with.
+func (d Destination) Method() string { return d.method }
+
+// Render substitutes event values into the template, escaping each for its
+// position. A registered macro absent from values (or empty) renders as an
+// empty string — sub-IDs are genuinely sparse and trackers accept empty
+// parameters.
+func (d Destination) Render(values map[string]string) string {
+	if d.segs == nil {
+		return d.raw
+	}
+	var b strings.Builder
+	b.Grow(len(d.raw) + 16)
+	for _, s := range d.segs {
+		b.WriteString(s.literal)
+		if s.macro == "" {
+			continue
+		}
+		val := values[s.macro]
+		if val == "" {
+			continue
+		}
+		switch s.esc {
+		case escQuery:
+			b.WriteString(url.QueryEscape(val))
+		case escPath:
+			switch val {
+			// PathEscape leaves dots alone, so a bare dot value would render a
+			// dot-segment ("/pb/../done") that path-normalizing servers collapse,
+			// dropping a segment the template author fixed. Percent-encoded dots
+			// are not dot-segments (RFC 3986 §3.3), so encode them.
+			case ".":
+				b.WriteString("%2E")
+			case "..":
+				b.WriteString("%2E%2E")
+			default:
+				// ':' additionally encoded: in the first path segment it would
+				// otherwise reparse as a scheme delimiter.
+				b.WriteString(strings.ReplaceAll(url.PathEscape(val), ":", "%3A"))
+			}
+		case escAuthority:
+			// unreachable: rejected at NewDestination
+		}
+	}
+	return b.String()
+}

--- a/comms/postback/destination_test.go
+++ b/comms/postback/destination_test.go
@@ -1,0 +1,210 @@
+package postback_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/dmitrymomot/forge/comms/postback"
+)
+
+func mustVocab(t *testing.T, names ...string) postback.Vocabulary {
+	t.Helper()
+	v, err := postback.NewVocabulary(names...)
+	if err != nil {
+		t.Fatalf("NewVocabulary(%q): %v", names, err)
+	}
+	return v
+}
+
+func TestNewVocabulary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid names", func(t *testing.T) {
+		t.Parallel()
+		if _, err := postback.NewVocabulary("click_id", "payout", "sub-1", "goal.id", "S2"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty vocabulary is legal", func(t *testing.T) {
+		t.Parallel()
+		if _, err := postback.NewVocabulary(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid names fail closed", func(t *testing.T) {
+		t.Parallel()
+		for _, name := range []string{"", "click id", "a{b", "a}b", "päy", "a/b"} {
+			if _, err := postback.NewVocabulary(name); !errors.Is(err, postback.ErrInvalidMacro) {
+				t.Errorf("NewVocabulary(%q) = %v, want ErrInvalidMacro", name, err)
+			}
+		}
+	})
+}
+
+func TestNewDestination(t *testing.T) {
+	t.Parallel()
+	vocab := mustVocab(t, "click_id", "payout", "sub1")
+
+	t.Run("valid template", func(t *testing.T) {
+		t.Parallel()
+		d, err := postback.NewDestination("https://t.example.com/pb?cid={click_id}&sum={payout}", vocab)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if d.Raw() != "https://t.example.com/pb?cid={click_id}&sum={payout}" {
+			t.Errorf("Raw() = %q", d.Raw())
+		}
+		if d.Method() != http.MethodGet {
+			t.Errorf("Method() = %q, want GET", d.Method())
+		}
+	})
+
+	t.Run("literal template without macros", func(t *testing.T) {
+		t.Parallel()
+		d, err := postback.NewDestination("https://t.example.com/ping", postback.Vocabulary{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := d.Render(nil); got != "https://t.example.com/ping" {
+			t.Errorf("Render() = %q", got)
+		}
+	})
+
+	t.Run("unknown macro", func(t *testing.T) {
+		t.Parallel()
+		if _, err := postback.NewDestination("https://t.example.com/pb?cid={clickid}", vocab); !errors.Is(err, postback.ErrUnknownMacro) {
+			t.Errorf("err = %v, want ErrUnknownMacro", err)
+		}
+	})
+
+	t.Run("zero vocabulary rejects any macro", func(t *testing.T) {
+		t.Parallel()
+		if _, err := postback.NewDestination("https://t.example.com/pb?cid={click_id}", postback.Vocabulary{}); !errors.Is(err, postback.ErrUnknownMacro) {
+			t.Errorf("err = %v, want ErrUnknownMacro", err)
+		}
+	})
+
+	t.Run("malformed templates", func(t *testing.T) {
+		t.Parallel()
+		cases := map[string]string{
+			"unclosed brace":      "https://t.example.com/pb?cid={click_id",
+			"unmatched close":     "https://t.example.com/pb?cid=click_id}",
+			"close before open":   "https://t.example.com/pb?a=}{click_id}",
+			"trailing close":      "https://t.example.com/pb?cid={click_id}}",
+			"relative URL":        "/pb?cid={click_id}",
+			"missing host":        "https:///pb?cid={click_id}",
+			"ftp scheme":          "ftp://t.example.com/pb?cid={click_id}",
+			"fragment":            "https://t.example.com/pb#frag?cid={click_id}",
+			"bare fragment":       "https://t.example.com/pb?cid={click_id}#",
+			"macro in host":       "https://{click_id}.example.com/pb",
+			"macro in port":       "https://t.example.com:{click_id}/pb",
+			"macro before scheme": "{click_id}https://t.example.com/pb",
+			"macro in scheme":     "http{click_id}://t.example.com/pb",
+			"invalid elided URL":  "https://t.example .com/pb?cid={click_id}",
+			"empty template":      "",
+			"scheme-only":         "https://",
+		}
+		for name, raw := range cases {
+			if _, err := postback.NewDestination(raw, vocab); !errors.Is(err, postback.ErrInvalidTemplate) {
+				t.Errorf("%s: NewDestination(%q) = %v, want ErrInvalidTemplate", name, raw, err)
+			}
+		}
+	})
+
+	t.Run("method option", func(t *testing.T) {
+		t.Parallel()
+		d, err := postback.NewDestination("https://t.example.com/pb?cid={click_id}", vocab, postback.WithMethod("post"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if d.Method() != http.MethodPost {
+			t.Errorf("Method() = %q, want POST", d.Method())
+		}
+	})
+
+	t.Run("invalid method", func(t *testing.T) {
+		t.Parallel()
+		for _, m := range []string{"DELETE", "PATCH", "PUT", ""} {
+			if _, err := postback.NewDestination("https://t.example.com/pb", vocab, postback.WithMethod(m)); !errors.Is(err, postback.ErrInvalidMethod) {
+				t.Errorf("WithMethod(%q) = %v, want ErrInvalidMethod", m, err)
+			}
+		}
+	})
+}
+
+func TestDestinationRender(t *testing.T) {
+	t.Parallel()
+	vocab := mustVocab(t, "click_id", "payout", "sub1", "goal")
+
+	tests := map[string]struct {
+		raw    string
+		values map[string]string
+		want   string
+	}{
+		"query escaping": {
+			raw:    "https://t.example.com/pb?cid={click_id}&sum={payout}",
+			values: map[string]string{"click_id": "a b&c=d", "payout": "12.50"},
+			want:   "https://t.example.com/pb?cid=a+b%26c%3Dd&sum=12.50",
+		},
+		"path escaping": {
+			raw:    "https://t.example.com/pb/{click_id}/done",
+			values: map[string]string{"click_id": "a/b:c?x"},
+			want:   "https://t.example.com/pb/a%2Fb%3Ac%3Fx/done",
+		},
+		"absent macro renders empty": {
+			raw:    "https://t.example.com/pb?cid={click_id}&s1={sub1}",
+			values: map[string]string{"click_id": "abc"},
+			want:   "https://t.example.com/pb?cid=abc&s1=",
+		},
+		"nil values render all empty": {
+			raw:    "https://t.example.com/pb?cid={click_id}",
+			values: nil,
+			want:   "https://t.example.com/pb?cid=",
+		},
+		"duplicate macro renders twice": {
+			raw:    "https://t.example.com/pb?cid={click_id}&again={click_id}",
+			values: map[string]string{"click_id": "abc"},
+			want:   "https://t.example.com/pb?cid=abc&again=abc",
+		},
+		"extra values are ignored": {
+			raw:    "https://t.example.com/pb?cid={click_id}",
+			values: map[string]string{"click_id": "abc", "goal": "reg"},
+			want:   "https://t.example.com/pb?cid=abc",
+		},
+		"value cannot alter structure": {
+			raw:    "https://t.example.com/pb?cid={click_id}",
+			values: map[string]string{"click_id": "x#frag"},
+			want:   "https://t.example.com/pb?cid=x%23frag",
+		},
+		"path dot-segment values are encoded": {
+			raw:    "https://t.example.com/pb/{click_id}/done",
+			values: map[string]string{"click_id": ".."},
+			want:   "https://t.example.com/pb/%2E%2E/done",
+		},
+		"path dot value is encoded": {
+			raw:    "https://t.example.com/pb/{click_id}/done",
+			values: map[string]string{"click_id": "."},
+			want:   "https://t.example.com/pb/%2E/done",
+		},
+		"multi-segment traversal cannot form": {
+			raw:    "https://t.example.com/pb/{click_id}/done",
+			values: map[string]string{"click_id": "../.."},
+			want:   "https://t.example.com/pb/..%2F../done",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			d, err := postback.NewDestination(tc.raw, vocab)
+			if err != nil {
+				t.Fatalf("NewDestination(%q): %v", tc.raw, err)
+			}
+			if got := d.Render(tc.values); got != tc.want {
+				t.Errorf("Render() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/comms/postback/doc.go
+++ b/comms/postback/doc.go
@@ -1,0 +1,54 @@
+// Package postback fires tracker-style server-to-server postbacks — the
+// affiliate/ad-network conversion ping: an unsigned GET (or POST) to a
+// partner-configured URL template whose {macro} placeholders carry the click
+// ID, payout, status, and sub-IDs.
+//
+// The macro vocabulary is consumer data: register the names your platform
+// exposes with NewVocabulary, then parse each partner URL with
+// NewDestination. Validation is fail-closed at registration — an unknown
+// macro, unbalanced braces, a non-http(s) or relative URL, a fragment, or a
+// macro in the authority are construction errors, never an empty
+// substitution at fire time. A registered macro absent from the per-event
+// value map renders as an empty string: sub-IDs are genuinely sparse and
+// trackers accept empty parameters. Values are URL-escaped for their
+// position (query vs path), so a hostile value can't alter the URL structure
+// validated at registration.
+//
+// Send renders, fires through one reused *http.Client, and reports the
+// outcome by status class: nil for 2xx, ErrServerStatus for 5xx (transient —
+// worth retrying), ErrClientStatus for everything else (permanent — the
+// destination or event is wrong). That split maps directly onto a queue's
+// retry-vs-dead-letter decision.
+//
+// # Non-goals
+//
+//   - No signatures: trackers correlate by click ID, not HMAC — signed
+//     deliveries are comms/webhook.
+//   - No dedup: stable event IDs ride as macros; receivers dedup.
+//   - No durable delivery or per-destination fan-out: ride async/queue /
+//     async/eventrouter, where Send slots in as a deliverer.
+//   - No per-tracker format tables: which macros exist and which template
+//     each partner registered is consumer data.
+//   - No tenant seam: a Destination is a passed value; scope destinations in
+//     the consumer store that holds them.
+//
+// # Usage
+//
+//	vocab, _ := postback.NewVocabulary("click_id", "payout", "status", "sub1")
+//	dest, err := postback.NewDestination(
+//		"https://tracker.example.com/pb?cid={click_id}&sum={payout}&st={status}",
+//		vocab,
+//	)
+//	if err != nil {
+//		// reject the partner's URL at registration time
+//	}
+//
+//	sender := postback.New()
+//	res, err := sender.Send(ctx, dest, map[string]string{
+//		"click_id": "abc123",
+//		"payout":   "12.50",
+//		"status":   "approved",
+//	})
+//	// res.URL and res.StatusCode feed the audit log;
+//	// errors.Is(err, postback.ErrServerStatus) → requeue.
+package postback

--- a/comms/postback/errors.go
+++ b/comms/postback/errors.go
@@ -1,0 +1,30 @@
+package postback
+
+import "errors"
+
+var (
+	// ErrInvalidMacro means a vocabulary name is empty or carries characters
+	// outside letters, digits, '_', '.', and '-'.
+	ErrInvalidMacro = errors.New("postback: invalid macro name")
+
+	// ErrUnknownMacro means a template references a macro the vocabulary does
+	// not register — caught at NewDestination, never an empty substitution at
+	// fire time.
+	ErrUnknownMacro = errors.New("postback: unknown macro")
+
+	// ErrInvalidTemplate means the destination URL template is malformed:
+	// unbalanced braces, not an absolute http(s) URL, a fragment (never sent
+	// to the server), or a macro in the authority.
+	ErrInvalidTemplate = errors.New("postback: invalid template")
+
+	// ErrInvalidMethod means the destination method is neither GET nor POST.
+	ErrInvalidMethod = errors.New("postback: invalid method")
+
+	// ErrClientStatus means the tracker answered with a non-2xx, non-5xx
+	// status — the destination or event is wrong; retrying won't help.
+	ErrClientStatus = errors.New("postback: client-error status")
+
+	// ErrServerStatus means the tracker answered 5xx — transient, worth
+	// retrying.
+	ErrServerStatus = errors.New("postback: server-error status")
+)

--- a/comms/postback/example_test.go
+++ b/comms/postback/example_test.go
@@ -1,0 +1,30 @@
+package postback_test
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/comms/postback"
+)
+
+func ExampleNewDestination() {
+	vocab, _ := postback.NewVocabulary("click_id", "payout", "status")
+
+	dest, _ := postback.NewDestination(
+		"https://tracker.example.com/pb?cid={click_id}&sum={payout}&st={status}",
+		vocab,
+	)
+	fmt.Println(dest.Render(map[string]string{
+		"click_id": "abc123",
+		"payout":   "12.50",
+		"status":   "approved",
+	}))
+
+	// A typo'd macro fails at registration, never at fire time.
+	_, err := postback.NewDestination("https://tracker.example.com/pb?cid={clickid}", vocab)
+	fmt.Println(errors.Is(err, postback.ErrUnknownMacro))
+
+	// Output:
+	// https://tracker.example.com/pb?cid=abc123&sum=12.50&st=approved
+	// true
+}

--- a/comms/postback/options.go
+++ b/comms/postback/options.go
@@ -1,0 +1,37 @@
+package postback
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/dmitrymomot/forge/web/httpclient"
+)
+
+type config struct {
+	client *http.Client
+}
+
+func newConfig(opts ...Option) config {
+	var c config
+	for _, o := range opts {
+		o(&c)
+	}
+	if c.client == nil {
+		c.client = httpclient.New(httpclient.WithTimeout(10 * time.Second))
+	}
+	return c
+}
+
+// Option configures the Sender.
+type Option func(*config)
+
+// WithHTTPClient replaces the default client — the seam for custom retry
+// policy (e.g. retrying POST destinations), per-attempt timeouts, breakers,
+// or a test server's client. Nil is ignored.
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *config) {
+		if client != nil {
+			c.client = client
+		}
+	}
+}

--- a/comms/postback/postback.go
+++ b/comms/postback/postback.go
@@ -1,0 +1,67 @@
+package postback
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Sender fires rendered postbacks through one reused *http.Client.
+type Sender struct {
+	client *http.Client
+}
+
+// New returns a Sender. Without WithHTTPClient it builds a default
+// httpclient.New client with a 10s overall timeout — which retries transient
+// failures on GET but not POST (non-idempotent); bring your own client to
+// change either.
+func New(opts ...Option) *Sender {
+	c := newConfig(opts...)
+	return &Sender{client: c.client}
+}
+
+// Result reports a fired postback for audit logging: the fully rendered URL
+// and the tracker's status code (0 when no response arrived).
+type Result struct {
+	URL        string
+	StatusCode int
+}
+
+// Send renders dest against the per-event values map and fires it. The
+// outcome is reported by status class: nil error for 2xx, ErrServerStatus for
+// 5xx (transient — worth retrying), ErrClientStatus for any other status
+// (permanent — the destination or event is wrong). Transport failures return
+// the underlying error with a zero StatusCode.
+func (s *Sender) Send(ctx context.Context, dest Destination, values map[string]string) (Result, error) {
+	if s == nil || s.client == nil { // zero Sender bypassed New
+		return Result{}, errors.New("postback: sender not constructed with New")
+	}
+	if dest.method == "" { // zero Destination bypassed NewDestination
+		return Result{}, fmt.Errorf("%w: zero destination", ErrInvalidTemplate)
+	}
+	rendered := dest.Render(values)
+	req, err := http.NewRequestWithContext(ctx, dest.method, rendered, nil)
+	if err != nil {
+		return Result{URL: rendered}, fmt.Errorf("postback: build request: %w", err)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return Result{URL: rendered}, fmt.Errorf("postback: send: %w", err)
+	}
+	// Bounded drain so the connection is reusable; trackers answer tiny bodies.
+	//nolint:nilaway // resp is non-nil whenever err is nil, per http.Client.Do's contract
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+	_ = resp.Body.Close()
+
+	res := Result{URL: rendered, StatusCode: resp.StatusCode}
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return res, nil
+	case resp.StatusCode >= 500:
+		return res, fmt.Errorf("%w: %d", ErrServerStatus, resp.StatusCode)
+	default:
+		return res, fmt.Errorf("%w: %d", ErrClientStatus, resp.StatusCode)
+	}
+}

--- a/comms/postback/postback_test.go
+++ b/comms/postback/postback_test.go
@@ -1,0 +1,147 @@
+package postback_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dmitrymomot/forge/comms/postback"
+)
+
+// newServer returns an httptest server plus a Sender wired to its plain
+// client (no retries), so status-class tests stay single-attempt and fast.
+func newServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *postback.Sender) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv, postback.New(postback.WithHTTPClient(srv.Client()))
+}
+
+func destFor(t *testing.T, raw string, opts ...postback.DestinationOption) postback.Destination {
+	t.Helper()
+	vocab := mustVocab(t, "click_id", "payout", "sub1")
+	d, err := postback.NewDestination(raw, vocab, opts...)
+	if err != nil {
+		t.Fatalf("NewDestination(%q): %v", raw, err)
+	}
+	return d
+}
+
+func TestSenderSend(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success reports rendered URL and status", func(t *testing.T) {
+		t.Parallel()
+		var gotQuery atomic.Value
+		srv, sender := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+			gotQuery.Store(r.URL.RawQuery)
+			w.WriteHeader(http.StatusOK)
+		})
+		dest := destFor(t, srv.URL+"/pb?cid={click_id}&sum={payout}")
+		res, err := sender.Send(t.Context(), dest, map[string]string{"click_id": "a b", "payout": "12.50"})
+		if err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		if res.StatusCode != http.StatusOK {
+			t.Errorf("StatusCode = %d, want 200", res.StatusCode)
+		}
+		if want := srv.URL + "/pb?cid=a+b&sum=12.50"; res.URL != want {
+			t.Errorf("URL = %q, want %q", res.URL, want)
+		}
+		if q := gotQuery.Load(); q != "cid=a+b&sum=12.50" {
+			t.Errorf("server saw query %q", q)
+		}
+	})
+
+	t.Run("4xx is ErrClientStatus", func(t *testing.T) {
+		t.Parallel()
+		srv, sender := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+		res, err := sender.Send(t.Context(), destFor(t, srv.URL+"/pb?cid={click_id}"), nil)
+		if !errors.Is(err, postback.ErrClientStatus) {
+			t.Fatalf("err = %v, want ErrClientStatus", err)
+		}
+		if res.StatusCode != http.StatusNotFound {
+			t.Errorf("StatusCode = %d, want 404", res.StatusCode)
+		}
+	})
+
+	t.Run("5xx is ErrServerStatus", func(t *testing.T) {
+		t.Parallel()
+		srv, sender := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		})
+		res, err := sender.Send(t.Context(), destFor(t, srv.URL+"/pb?cid={click_id}"), nil)
+		if !errors.Is(err, postback.ErrServerStatus) {
+			t.Fatalf("err = %v, want ErrServerStatus", err)
+		}
+		if res.StatusCode != http.StatusBadGateway {
+			t.Errorf("StatusCode = %d, want 502", res.StatusCode)
+		}
+	})
+
+	t.Run("POST destination fires POST", func(t *testing.T) {
+		t.Parallel()
+		var gotMethod atomic.Value
+		srv, sender := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+			gotMethod.Store(r.Method)
+			w.WriteHeader(http.StatusOK)
+		})
+		dest := destFor(t, srv.URL+"/pb?cid={click_id}", postback.WithMethod(http.MethodPost))
+		if _, err := sender.Send(t.Context(), dest, map[string]string{"click_id": "abc"}); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		if m := gotMethod.Load(); m != http.MethodPost {
+			t.Errorf("server saw method %v, want POST", m)
+		}
+	})
+
+	t.Run("transport failure returns error with zero status", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.NotFoundHandler())
+		srv.Close() // dead server: connection refused
+		sender := postback.New()
+		res, err := sender.Send(t.Context(), destFor(t, srv.URL+"/pb?cid={click_id}"), nil)
+		if err == nil {
+			t.Fatal("want transport error")
+		}
+		if errors.Is(err, postback.ErrClientStatus) || errors.Is(err, postback.ErrServerStatus) {
+			t.Errorf("transport error must not match a status class: %v", err)
+		}
+		if res.StatusCode != 0 {
+			t.Errorf("StatusCode = %d, want 0", res.StatusCode)
+		}
+	})
+
+	t.Run("canceled context aborts", func(t *testing.T) {
+		t.Parallel()
+		srv, sender := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		if _, err := sender.Send(ctx, destFor(t, srv.URL+"/pb?cid={click_id}"), nil); !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("zero sender fails closed", func(t *testing.T) {
+		t.Parallel()
+		var sender postback.Sender
+		if _, err := sender.Send(t.Context(), destFor(t, "https://t.example.com/pb?cid={click_id}"), nil); err == nil {
+			t.Fatal("want error from zero Sender, got nil")
+		}
+	})
+
+	t.Run("zero destination fails closed", func(t *testing.T) {
+		t.Parallel()
+		sender := postback.New()
+		if _, err := sender.Send(t.Context(), postback.Destination{}, nil); !errors.Is(err, postback.ErrInvalidTemplate) {
+			t.Fatalf("err = %v, want ErrInvalidTemplate", err)
+		}
+	})
+}

--- a/comms/postback/postback_test.go
+++ b/comms/postback/postback_test.go
@@ -129,6 +129,18 @@ func TestSenderSend(t *testing.T) {
 		}
 	})
 
+	t.Run("nil WithHTTPClient falls back to the default client", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+		sender := postback.New(postback.WithHTTPClient(nil))
+		if _, err := sender.Send(t.Context(), destFor(t, srv.URL+"/pb?cid={click_id}"), nil); err != nil {
+			t.Fatalf("Send with defaulted client: %v", err)
+		}
+	})
+
 	t.Run("zero sender fails closed", func(t *testing.T) {
 		t.Parallel()
 		var sender postback.Sender

--- a/comms/postback/vocabulary.go
+++ b/comms/postback/vocabulary.go
@@ -1,0 +1,44 @@
+package postback
+
+import "fmt"
+
+// Vocabulary is the set of macro names a platform exposes to its postback
+// templates. It is consumer data — forge ships no names. The zero value is an
+// empty vocabulary: every macro is unknown, so templates with placeholders
+// fail closed at NewDestination.
+type Vocabulary struct {
+	names map[string]struct{}
+}
+
+// NewVocabulary registers the macro names templates may reference. Names are
+// validated fail-closed: empty names or characters outside letters, digits,
+// '_', '.', and '-' are ErrInvalidMacro. Duplicates collapse silently.
+func NewVocabulary(names ...string) (Vocabulary, error) {
+	set := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if !validMacroName(name) {
+			return Vocabulary{}, fmt.Errorf("%w: %q", ErrInvalidMacro, name)
+		}
+		set[name] = struct{}{}
+	}
+	return Vocabulary{names: set}, nil
+}
+
+func (v Vocabulary) contains(name string) bool {
+	_, ok := v.names[name]
+	return ok
+}
+
+func validMacroName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := range len(name) {
+		c := name[i]
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_' || c == '.' || c == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -388,8 +388,8 @@ delivery (`Idempotency-Key` header / payload field) and receivers dedup
 — the Stripe contract (in-router suppression would trade duplicates for
 silent loss).
 
-Deps: `web/httpclient`; `async/eventbus`, `comms/webhook`,
-`comms/postback` (all planned).
+Deps: `web/httpclient`, `comms/postback`; `async/eventbus`,
+`comms/webhook` (both planned).
 
 ---
 
@@ -606,27 +606,6 @@ pluggable `Scheme` seam, so bespoke partner schemes register without
 forking the package.
 
 Deps: `web/httpclient`, `crypto/sign`; `async/queue`.
-
----
-
-**comms/postback**
-
-Tracker-style server-to-server postbacks — the affiliate/ad-network
-conversion ping: a destination is a URL template over a caller-registered
-macro vocabulary (`{click_id}`, `{payout}`, `{status}`, sub-IDs — the
-vocabulary is consumer data), parsed and validated at registration — an
-unknown macro is a construction error, never an empty substitution at
-fire time. `Send` renders the template against a per-event macro map
-(values URL-escaped), fires GET (or a configured method) via httpclient
-with timeout and bounded retry, and reports outcome by status class.
-Unsigned by design — trackers correlate by click ID, not signatures
-(HMAC-signed deliveries are `comms/webhook`); no dedup — stable event IDs
-ride as macros and receivers dedup. Per-tracker format tables are
-consumer data; durable delivery and per-destination fan-out come from
-`async/queue` / `async/eventrouter`, where this package slots in as a
-`Deliverer`.
-
-Deps: `web/httpclient`.
 
 ---
 


### PR DESCRIPTION
## Summary

New `comms/postback` package — the affiliate/ad-network conversion ping: unsigned GET (or POST) to a partner-configured URL template whose `{macro}` placeholders carry click ID, payout, status, and sub-IDs.

- **`Vocabulary`** — caller-registered macro names (consumer data; forge ships none). Names validated fail-closed (`ErrInvalidMacro`); the zero value rejects every macro.
- **`Destination`** — URL template parsed against a vocabulary at registration, fail-closed: unknown macro (`ErrUnknownMacro`), unbalanced braces, non-http(s)/relative URL, fragment, or a macro in the scheme/authority (`ErrInvalidTemplate`) are construction errors — never an empty substitution at fire time. Method GET default, POST via `WithMethod` (`ErrInvalidMethod` otherwise).
- **`Sender.Send`** — renders the per-event value map with positional URL escaping (query `QueryEscape`, path `PathEscape` + `:` + dot-segment values `%2E`-encoded so a hostile value can never alter the URL structure validated at registration), fires through one reused `*http.Client`, and reports outcome by status class: **nil for 2xx, `ErrServerStatus` for 5xx (transient — requeue), `ErrClientStatus` otherwise (permanent — dead-letter)**. `Result{URL, StatusCode}` feeds the audit log.
- Registered-but-absent values render empty by design — sub-IDs are genuinely sparse and trackers accept empty parameters.
- Default client is `httpclient.New` with a 10s timeout (retries transient failures on GET, not POST); `WithHTTPClient` is the seam for custom retry/breaker policy.

Per the catalog design: unsigned (trackers correlate by click ID; HMAC deliveries are `comms/webhook`), no dedup (stable event IDs ride as macros; receivers dedup), no durability (rides `async/queue`/`async/eventrouter` as a deliverer), no tenant seam (a `Destination` is a passed value). The macro vocabulary stays consumer data, so per-tracker format tables (pending from Alisa) don't block this package.

Catalog entry deleted from `docs/packages.md` per the shipped-package rule; `async/eventrouter` deps line updated.

## Review pass

An adversarial pre-PR review caught three real issues, all fixed with regression tests:
1. Zero-value `Sender` panicked on nil client — now fails closed with an error.
2. A macro in or before the scheme (`{click_id}https://…`, `http{click_id}://…`) passed registration fail-open — `escapeModeFor` now treats a prefix without `://` as scheme/authority position and rejects it.
3. A path-position value of `.`/`..` rendered a dot-segment that path-normalizing servers collapse — bare dot values are now `%2E`-encoded (percent-encoded dots are not dot-segments, RFC 3986 §3.3).

## Benchmarks (Apple M3 Max)

```
BenchmarkNewDestination-14   2560393    455.1 ns/op    960 B/op    8 allocs/op   (cold path, registration)
BenchmarkRender-14          10883851    112.0 ns/op    112 B/op    1 allocs/op   (hot path — the 1 alloc is the result string)
BenchmarkSend-14               32976   35317 ns/op    4922 B/op   57 allocs/op   (dominated by net/http over httptest)
```

No post-benchmark optimization applied: `Render` is already at the 1-alloc floor (`strings.Builder` grown once; `QueryEscape` returns its input unchanged for clean values), and `Send`'s allocations are all `net/http` internals.

## Testing

- `go test -race ./comms/postback/` — black-box tests: template parse/validation matrix, positional escaping (incl. structure-injection and traversal attempts), status-class mapping, POST method, transport failure, context cancellation, zero-value `Sender`/`Destination` fail-closed.
- `just lint` — clean (vet, golangci-lint, betteralign, nilaway).