### PR TITLE
feat(comms/webhook): signed webhook deliveries + verification middleware

### DIFF
--- a/comms/webhook/bench_test.go
+++ b/comms/webhook/bench_test.go
@@ -1,0 +1,77 @@
+package webhook_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/comms/webhook"
+)
+
+var benchPayload = []byte(`{"type":"invoice.paid","id":"evt_1","data":{"object":{"id":"in_1","amount_due":1250,"currency":"usd","customer":"cus_9","status":"paid"}}}`)
+
+func BenchmarkSchemeSign(b *testing.B) {
+	now := time.Now()
+	for name, scheme := range map[string]webhook.Scheme{
+		"stripe": webhook.Stripe(),
+		"github": webhook.GitHub(),
+		"slack":  webhook.Slack(),
+	} {
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := scheme.Sign(testSecret, benchPayload, now); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkSchemeVerify(b *testing.B) {
+	now := time.Now()
+	for name, scheme := range map[string]webhook.Scheme{
+		"stripe": webhook.Stripe(),
+		"github": webhook.GitHub(),
+		"slack":  webhook.Slack(),
+	} {
+		b.Run(name, func(b *testing.B) {
+			h, err := scheme.Sign(testSecret, benchPayload, now)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := scheme.Verify(testSecret, benchPayload, h, now, 5*time.Minute); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkVerifyMiddleware(b *testing.B) {
+	scheme := webhook.Stripe()
+	handler := webhook.Verify(scheme, webhook.StaticSecrets(testSecret))(
+		http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			_, _ = io.Copy(io.Discard, r.Body)
+		}),
+	)
+	sig, err := scheme.Sign(testSecret, benchPayload, time.Now())
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		req := httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader(benchPayload))
+		req.Header = sig.Clone()
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			b.Fatalf("status %d", rec.Code)
+		}
+	}
+}

--- a/comms/webhook/doc.go
+++ b/comms/webhook/doc.go
@@ -1,0 +1,68 @@
+// Package webhook is the complete webhooks package, both directions: outbound
+// HMAC-signed deliveries with durable retry over async/queue, and inbound
+// signature-verification middleware. One pluggable Scheme seam carries both —
+// Stripe (t=,v1=), GitHub (X-Hub-Signature-256), and Slack (v0:) ship
+// built-in, and a bespoke partner scheme is one interface away.
+//
+// # Outbound
+//
+// A Sender POSTs a payload to an Endpoint (URL + signing secret), signed by
+// its Scheme (default: Stripe-style under a neutral "Webhook-Signature"
+// header) with an idempotency key in "Webhook-Id" so receivers dedup across
+// retries. Send fires exactly one attempt and reports the outcome by class —
+// nil for 2xx, ErrTransientStatus for 408/429/5xx, ErrPermanentStatus for
+// any other status, transport failures as-is — the split a queue needs for
+// its retry-vs-dead-letter decision.
+//
+// Durable delivery rides async/queue: Enqueue pushes a Delivery naming a
+// stored endpoint by ID, and RegisterDeliverer binds the worker-side handler
+// that resolves the endpoint through a consumer Resolver at fire time (URL
+// and secret come from the consumer's store on every attempt — secrets never
+// sit in job rows), sends, and maps outcomes to queue verdicts: transient
+// failures retry on the queue's backoff, permanent ones dead-letter without
+// burning attempts, and a deleted endpoint (ErrEndpointNotFound) cancels the
+// job as moot.
+//
+// # Inbound
+//
+// Verify wraps a handler with fail-closed signature verification: the body is
+// read capped (default 1 MiB) and restored so the handler reads it normally,
+// the scheme authenticates it in constant time within a timestamp tolerance
+// (default 5m), and any secret from the Secrets source may match — hand out
+// several during rotation. Rejections answer problem+json built from a bare
+// sentinel; scheme and lookup internals never reach the caller.
+//
+// # Non-goals
+//
+//   - No endpoint store or registry: endpoints, their secrets, and their
+//     event subscriptions are consumer data behind the Resolver.
+//   - No fan-out: which endpoints receive which event is a consumer query
+//     that ends in one Enqueue per endpoint.
+//   - No delivery-attempt log: persist Result consumer-side.
+//   - No unsigned deliveries: an endpoint without a secret is rejected —
+//     tracker-style unsigned pings are comms/postback.
+//   - No tenant seam of its own: outbound scoping lives in the Resolver
+//     (the queue's scope context is on ctx), inbound in the per-request
+//     Secrets source.
+//
+// # Usage
+//
+// Outbound, durable:
+//
+//	sender := webhook.New()
+//	webhook.RegisterDeliverer(svc, sender, func(ctx context.Context, id string) (webhook.Endpoint, error) {
+//		return store.Endpoint(ctx, id) // -> webhook.ErrEndpointNotFound when deleted
+//	})
+//
+//	err := webhook.Enqueue(ctx, client, webhook.Delivery{
+//		Endpoint: "ep_123",
+//		Payload:  json.RawMessage(`{"type":"invoice.paid","id":"evt_1"}`),
+//	})
+//
+// Inbound:
+//
+//	mux.Handle("POST /hooks/github", webhook.Verify(
+//		webhook.GitHub(),
+//		webhook.StaticSecrets([]byte(os.Getenv("GITHUB_WEBHOOK_SECRET"))),
+//	)(handler))
+package webhook

--- a/comms/webhook/errors.go
+++ b/comms/webhook/errors.go
@@ -1,0 +1,49 @@
+package webhook
+
+import "errors"
+
+var (
+	// ErrInvalidEndpoint means Send got an endpoint it must not deliver to: an
+	// empty secret (unsigned webhooks are never sent) or a URL that is not
+	// absolute http(s).
+	ErrInvalidEndpoint = errors.New("webhook: invalid endpoint")
+
+	// ErrTransientStatus means the receiver answered 408, 429, or 5xx —
+	// worth retrying.
+	ErrTransientStatus = errors.New("webhook: transient delivery status")
+
+	// ErrPermanentStatus means the receiver answered a non-2xx status outside
+	// the transient set (including redirects, which deliveries never follow) —
+	// the endpoint or event is wrong; retrying won't help.
+	ErrPermanentStatus = errors.New("webhook: permanent delivery status")
+
+	// ErrEndpointNotFound is the Resolver contract: the stored endpoint no
+	// longer exists (deleted or disabled), so the queued delivery is moot and
+	// is cancelled rather than retried or dead-lettered.
+	ErrEndpointNotFound = errors.New("webhook: endpoint not found")
+
+	// ErrInvalidDelivery is returned by Enqueue on an empty endpoint ID or a
+	// payload that is not valid JSON.
+	ErrInvalidDelivery = errors.New("webhook: invalid delivery")
+
+	// ErrMissingSignature means the request carries no signature (or, for
+	// timestamped schemes, no timestamp) header.
+	ErrMissingSignature = errors.New("webhook: missing signature")
+
+	// ErrInvalidSignature means the signature does not authenticate the
+	// payload under any accepted secret. The Verify middleware also collapses
+	// secret-lookup failures to this sentinel — fail closed, no detail leaks.
+	ErrInvalidSignature = errors.New("webhook: invalid signature")
+
+	// ErrInvalidTimestamp means a timestamped scheme got an unparseable
+	// timestamp or one outside the verification tolerance window.
+	ErrInvalidTimestamp = errors.New("webhook: invalid or expired timestamp")
+
+	// ErrBodyTooLarge means the inbound request body exceeds the Verify
+	// middleware's cap (default 1 MiB, WithMaxBody).
+	ErrBodyTooLarge = errors.New("webhook: request body exceeds limit")
+
+	// ErrUnreadableBody means the inbound request body could not be read
+	// (client hung up mid-request).
+	ErrUnreadableBody = errors.New("webhook: unreadable request body")
+)

--- a/comms/webhook/example_test.go
+++ b/comms/webhook/example_test.go
@@ -1,0 +1,63 @@
+package webhook_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/dmitrymomot/forge/comms/webhook"
+)
+
+func ExampleScheme() {
+	// One Scheme serves both directions: sign an outbound payload, verify it
+	// back on the inbound side.
+	scheme := webhook.GitHub()
+	secret := []byte("It's a Secret to Everybody")
+	payload := []byte("Hello, World!")
+
+	header, _ := scheme.Sign(secret, payload, time.Now())
+	fmt.Println(header.Get("X-Hub-Signature-256"))
+
+	err := scheme.Verify(secret, payload, header, time.Now(), 0)
+	fmt.Println(err)
+
+	err = scheme.Verify(secret, []byte("tampered"), header, time.Now(), 0)
+	fmt.Println(errors.Is(err, webhook.ErrInvalidSignature))
+
+	// Output:
+	// sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17
+	// <nil>
+	// true
+}
+
+func ExampleVerify() {
+	// Inbound: wrap the handler; the body arrives verified and intact.
+	scheme := webhook.Stripe()
+	secret := []byte("whsec_partner_secret")
+	handler := webhook.Verify(scheme, webhook.StaticSecrets(secret))(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprint(w, "received")
+		}),
+	)
+
+	payload := `{"type":"invoice.paid"}`
+	sig, _ := scheme.Sign(secret, []byte(payload), time.Now())
+	req := httptest.NewRequest(http.MethodPost, "/hooks/stripe", strings.NewReader(payload))
+	req.Header = sig
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	fmt.Println(rec.Code, rec.Body.String())
+
+	// An unsigned request never reaches the handler.
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hooks/stripe", strings.NewReader(payload)))
+	fmt.Println(rec.Code)
+
+	// Output:
+	// 200 received
+	// 401
+}

--- a/comms/webhook/options.go
+++ b/comms/webhook/options.go
@@ -1,0 +1,75 @@
+package webhook
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/dmitrymomot/forge/web/httpclient"
+)
+
+type config struct {
+	client      *http.Client
+	scheme      Scheme
+	keyHeader   string
+	contentType string
+}
+
+func newConfig(opts ...Option) config {
+	c := config{keyHeader: "Webhook-Id", contentType: "application/json"}
+	for _, o := range opts {
+		o(&c)
+	}
+	if c.scheme == nil {
+		c.scheme = Stripe(WithSignatureHeader("Webhook-Signature"))
+	}
+	if c.client == nil {
+		client := httpclient.New(httpclient.WithTimeout(10 * time.Second))
+		client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+		c.client = client
+	}
+	return c
+}
+
+// Option configures the Sender.
+type Option func(*config)
+
+// WithHTTPClient replaces the default client — the seam for custom timeouts,
+// breakers, static headers, or a test server's client. A custom client keeps
+// its own redirect policy (the default client never follows). Nil is ignored.
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *config) {
+		if client != nil {
+			c.client = client
+		}
+	}
+}
+
+// WithScheme replaces the default outbound scheme (Stripe-style under
+// "Webhook-Signature"). Nil is ignored.
+func WithScheme(s Scheme) Option {
+	return func(c *config) {
+		if s != nil {
+			c.scheme = s
+		}
+	}
+}
+
+// WithIdempotencyHeader renames the header carrying the delivery's
+// idempotency key (default "Webhook-Id"). An empty name is ignored.
+func WithIdempotencyHeader(name string) Option {
+	return func(c *config) {
+		if name != "" {
+			c.keyHeader = name
+		}
+	}
+}
+
+// WithContentType overrides the outbound Content-Type (default
+// "application/json"). An empty value is ignored.
+func WithContentType(ct string) Option {
+	return func(c *config) {
+		if ct != "" {
+			c.contentType = ct
+		}
+	}
+}

--- a/comms/webhook/queue.go
+++ b/comms/webhook/queue.go
@@ -1,0 +1,96 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Kind is the queue job kind for durable webhook deliveries: Enqueue pushes
+// it, RegisterDeliverer handles it.
+var Kind = queue.NewKind[Delivery]("webhook.deliver")
+
+// Delivery is the queued job payload: which stored endpoint to deliver to
+// (resolved to URL+secret at fire time, so secrets never sit in job rows),
+// the event body, and the idempotency key reused across retries. The body
+// survives the queue's JSON round trip semantically intact but not
+// byte-for-byte (stdlib re-encoding compacts and HTML-escapes <, >, &);
+// the signature is computed over the delivered bytes, so it always matches.
+type Delivery struct {
+	Endpoint string          `json:"endpoint"`
+	Key      string          `json:"key,omitempty"`
+	Payload  json.RawMessage `json:"payload"`
+}
+
+// Enqueue pushes a delivery for durable dispatch. An empty Key gets a
+// generated UUID so every retry of the job carries the same idempotency key.
+// Returns ErrInvalidDelivery on an empty endpoint ID, a non-JSON payload, or
+// a Key that cannot ride in an HTTP header (it would fail every attempt).
+func Enqueue(ctx context.Context, c *queue.Client, d Delivery, opts ...queue.PushOption) error {
+	if d.Endpoint == "" {
+		return fmt.Errorf("%w: empty endpoint id", ErrInvalidDelivery)
+	}
+	if !json.Valid(d.Payload) {
+		return fmt.Errorf("%w: payload is not valid JSON", ErrInvalidDelivery)
+	}
+	if !validKey(d.Key) {
+		return fmt.Errorf("%w: key contains non-printable-ASCII bytes", ErrInvalidDelivery)
+	}
+	if d.Key == "" {
+		d.Key = id.NewUUID().String()
+	}
+	return queue.Push(ctx, c, Kind, d, opts...)
+}
+
+// validKey reports whether key is printable ASCII (no spaces) — the subset
+// that is always a valid HTTP header value. Idempotency keys are IDs, so the
+// strictness costs nothing and catches a poisoned job before it burns its
+// whole attempt budget on "invalid header field value" transport errors.
+func validKey(key string) bool {
+	for i := range len(key) {
+		if key[i] <= ' ' || key[i] > '~' {
+			return false
+		}
+	}
+	return true
+}
+
+// Resolver maps a stored endpoint ID to its current URL and secret at fire
+// time. Return ErrEndpointNotFound when the endpoint was deleted or disabled
+// — the queued delivery is cancelled as moot. Any other error is treated as
+// transient and the delivery retries. In multi-tenant apps the queue's scope
+// context (queue.WithScopeContext) is already on ctx — scope the lookup there.
+type Resolver func(ctx context.Context, endpointID string) (Endpoint, error)
+
+// RegisterDeliverer binds the delivery handler on a queue worker: resolve the
+// endpoint, send, and map the outcome to a queue verdict — nil or transient
+// errors retry on the queue's backoff, ErrPermanentStatus and
+// ErrInvalidEndpoint dead-letter without burning attempts, and
+// ErrEndpointNotFound cancels the job. Panics on nil sender or resolver —
+// wiring bugs, same contract as queue.Register.
+func RegisterDeliverer(s *queue.Service, sender *Sender, resolve Resolver, opts ...queue.HandlerOption) {
+	if sender == nil {
+		panic("webhook: RegisterDeliverer with nil sender")
+	}
+	if resolve == nil {
+		panic("webhook: RegisterDeliverer with nil resolver")
+	}
+	queue.Register(s, Kind, func(ctx context.Context, d Delivery) error {
+		ep, err := resolve(ctx, d.Endpoint)
+		switch {
+		case errors.Is(err, ErrEndpointNotFound):
+			return queue.Cancel
+		case err != nil:
+			return fmt.Errorf("webhook: resolve endpoint %q: %w", d.Endpoint, err)
+		}
+		_, err = sender.Send(ctx, ep, d.Payload, d.Key)
+		if errors.Is(err, ErrPermanentStatus) || errors.Is(err, ErrInvalidEndpoint) {
+			return queue.SkipRetry(err)
+		}
+		return err
+	}, opts...)
+}

--- a/comms/webhook/queue_test.go
+++ b/comms/webhook/queue_test.go
@@ -1,0 +1,262 @@
+package webhook_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/comms/webhook"
+	"github.com/dmitrymomot/forge/resilience/backoff"
+)
+
+// startWorker runs a fast-polling queue worker with the delivery handler
+// registered; it stops when the test ends.
+func startWorker(t *testing.T, broker queue.Broker, sender *webhook.Sender, resolve webhook.Resolver) {
+	t.Helper()
+	svc, err := queue.NewService(broker,
+		queue.WithConfig(queue.Config{Concurrency: 2, PollInterval: 10 * time.Millisecond, Lease: 30 * time.Second, MaxAttempts: 25, HandlerTimeout: time.Minute}),
+		queue.WithBackoff(backoff.Constant(time.Millisecond)),
+	)
+	require.NoError(t, err)
+	webhook.RegisterDeliverer(svc, sender, resolve)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = svc.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+}
+
+func staticResolver(ep webhook.Endpoint) webhook.Resolver {
+	return func(context.Context, string) (webhook.Endpoint, error) { return ep, nil }
+}
+
+func drained(t *testing.T, c *queue.Client) func() bool {
+	t.Helper()
+	return func() bool {
+		stats, err := c.Stats(t.Context())
+		require.NoError(t, err)
+		return stats["default"].Pending == 0
+	}
+}
+
+func TestEnqueueValidation(t *testing.T) {
+	t.Parallel()
+	c := queue.NewClient(queue.NewMemoryBroker())
+
+	err := webhook.Enqueue(t.Context(), c, webhook.Delivery{Payload: testPayload})
+	assert.ErrorIs(t, err, webhook.ErrInvalidDelivery)
+
+	err = webhook.Enqueue(t.Context(), c, webhook.Delivery{Endpoint: "ep_1", Payload: json.RawMessage(`{broken`)})
+	assert.ErrorIs(t, err, webhook.ErrInvalidDelivery)
+
+	err = webhook.Enqueue(t.Context(), c, webhook.Delivery{Endpoint: "ep_1", Payload: testPayload, Key: "evt\r\n1"})
+	assert.ErrorIs(t, err, webhook.ErrInvalidDelivery, "a header-illegal key would fail every attempt")
+}
+
+func TestDeliveryPayloadSurvivesQueueEncoding(t *testing.T) {
+	t.Parallel()
+	bodies := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies <- body
+	}))
+	defer srv.Close()
+
+	broker := queue.NewMemoryBroker()
+	c := queue.NewClient(broker)
+	sender := webhook.New(webhook.WithHTTPClient(srv.Client()))
+	startWorker(t, broker, sender, staticResolver(webhook.Endpoint{URL: srv.URL, Secret: testSecret}))
+
+	payload := json.RawMessage(`{"html": "<b>tags & ampersands</b>"}`)
+	require.NoError(t, webhook.Enqueue(t.Context(), c, webhook.Delivery{Endpoint: "ep_1", Payload: payload}))
+
+	select {
+	case body := <-bodies:
+		// The queue's JSON round trip may compact and HTML-escape the body;
+		// what arrives is semantically the same document.
+		assert.JSONEq(t, string(payload), string(body))
+	case <-time.After(5 * time.Second):
+		t.Fatal("delivery never arrived")
+	}
+}
+
+func TestRegisterDelivererNilWiringPanics(t *testing.T) {
+	t.Parallel()
+	svc, err := queue.NewService(queue.NewMemoryBroker())
+	require.NoError(t, err)
+	resolve := staticResolver(webhook.Endpoint{})
+	assert.Panics(t, func() { webhook.RegisterDeliverer(svc, nil, resolve) })
+	assert.Panics(t, func() { webhook.RegisterDeliverer(svc, webhook.New(), nil) })
+}
+
+func TestDurableDeliverySuccess(t *testing.T) {
+	t.Parallel()
+	type hit struct {
+		key  string
+		body []byte
+	}
+	hits := make(chan hit, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		hits <- hit{key: r.Header.Get("Webhook-Id"), body: body}
+	}))
+	defer srv.Close()
+
+	broker := queue.NewMemoryBroker()
+	c := queue.NewClient(broker)
+	sender := webhook.New(webhook.WithHTTPClient(srv.Client()))
+	startWorker(t, broker, sender, staticResolver(webhook.Endpoint{URL: srv.URL, Secret: testSecret}))
+
+	require.NoError(t, webhook.Enqueue(t.Context(), c, webhook.Delivery{Endpoint: "ep_1", Payload: testPayload}))
+
+	select {
+	case h := <-hits:
+		assert.NotEmpty(t, h.key, "Enqueue generated an idempotency key")
+		assert.Equal(t, testPayload, h.body, "an escape-free payload survives byte-for-byte")
+	case <-time.After(5 * time.Second):
+		t.Fatal("delivery never arrived")
+	}
+	require.Eventually(t, drained(t, c), 5*time.Second, 10*time.Millisecond)
+}
+
+func TestEnqueuePreservesKey(t *testing.T) {
+	t.Parallel()
+	keys := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		keys <- r.Header.Get("Webhook-Id")
+	}))
+	defer srv.Close()
+
+	broker := queue.NewMemoryBroker()
+	c := queue.NewClient(broker)
+	sender := webhook.New(webhook.WithHTTPClient(srv.Client()))
+	startWorker(t, broker, sender, staticResolver(webhook.Endpoint{URL: srv.URL, Secret: testSecret}))
+
+	require.NoError(t, webhook.Enqueue(t.Context(), c, webhook.Delivery{Endpoint: "ep_1", Payload: testPayload, Key: "evt_42"}))
+
+	select {
+	case key := <-keys:
+		assert.Equal(t, "evt_42", key)
+	case <-time.After(5 * time.Second):
+		t.Fatal("delivery never arrived")
+	}
+}
+
+func TestTransientStatusRetries(t *testing.T) {
+	t.Parallel()
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if hits.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	}))
+	defer srv.Close()
+
+	broker := queue.NewMemoryBroker()
+	c := queue.NewClient(broker)
+	sender := webhook.New(webhook.WithHTTPClient(srv.Client()))
+	startWorker(t, broker, sender, staticResolver(webhook.Endpoint{URL: srv.URL, Secret: testSecret}))
+
+	require.NoError(t, webhook.Enqueue(t.Context(), c, webhook.Delivery{Endpoint: "ep_1", Payload: testPayload}))
+
+	require.Eventually(t, func() bool { return hits.Load() >= 3 }, 10*time.Second, 10*time.Millisecond, "two 503s then success")
+	require.Eventually(t, drained(t, c), 5*time.Second, 10*time.Millisecond)
+
+	dead, err := c.ListDead(t.Context(), "default", 10)
+	require.NoError(t, err)
+	assert.Empty(t, dead, "the delivery succeeded on the third attempt")
+}
+
+func TestPermanentStatusDeadLetters(t *testing.T) {
+	t.Parallel()
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	broker := queue.NewMemoryBroker()
+	c := queue.NewClient(broker)
+	sender := webhook.New(webhook.WithHTTPClient(srv.Client()))
+	startWorker(t, broker, sender, staticResolver(webhook.Endpoint{URL: srv.URL, Secret: testSecret}))
+
+	require.NoError(t, webhook.Enqueue(t.Context(), c, webhook.Delivery{Endpoint: "ep_1", Payload: testPayload}))
+
+	require.Eventually(t, func() bool {
+		dead, err := c.ListDead(t.Context(), "default", 10)
+		require.NoError(t, err)
+		return len(dead) == 1
+	}, 5*time.Second, 10*time.Millisecond, "a 404 dead-letters without burning attempts")
+	assert.Equal(t, int32(1), hits.Load(), "no retries on a permanent status")
+}
+
+func TestEndpointNotFoundCancels(t *testing.T) {
+	t.Parallel()
+	var resolved atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("a cancelled delivery must never reach the endpoint")
+	}))
+	defer srv.Close()
+
+	broker := queue.NewMemoryBroker()
+	c := queue.NewClient(broker)
+	sender := webhook.New(webhook.WithHTTPClient(srv.Client()))
+	startWorker(t, broker, sender, func(context.Context, string) (webhook.Endpoint, error) {
+		resolved.Add(1)
+		return webhook.Endpoint{}, webhook.ErrEndpointNotFound
+	})
+
+	require.NoError(t, webhook.Enqueue(t.Context(), c, webhook.Delivery{Endpoint: "ep_gone", Payload: testPayload}))
+
+	require.Eventually(t, func() bool { return resolved.Load() == 1 }, 5*time.Second, 10*time.Millisecond)
+	require.Eventually(t, drained(t, c), 5*time.Second, 10*time.Millisecond)
+
+	dead, err := c.ListDead(t.Context(), "default", 10)
+	require.NoError(t, err)
+	assert.Empty(t, dead, "cancelled, not dead-lettered")
+}
+
+func TestResolverErrorRetries(t *testing.T) {
+	t.Parallel()
+	hits := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		hits <- struct{}{}
+	}))
+	defer srv.Close()
+
+	var calls atomic.Int32
+	broker := queue.NewMemoryBroker()
+	c := queue.NewClient(broker)
+	sender := webhook.New(webhook.WithHTTPClient(srv.Client()))
+	startWorker(t, broker, sender, func(context.Context, string) (webhook.Endpoint, error) {
+		if calls.Add(1) == 1 {
+			return webhook.Endpoint{}, assert.AnError // transient store hiccup
+		}
+		return webhook.Endpoint{URL: srv.URL, Secret: testSecret}, nil
+	})
+
+	require.NoError(t, webhook.Enqueue(t.Context(), c, webhook.Delivery{Endpoint: "ep_1", Payload: testPayload}))
+
+	select {
+	case <-hits:
+		assert.GreaterOrEqual(t, calls.Load(), int32(2), "first resolve failed, retry delivered")
+	case <-time.After(10 * time.Second):
+		t.Fatal("delivery never arrived after resolver retry")
+	}
+}

--- a/comms/webhook/scheme.go
+++ b/comms/webhook/scheme.go
@@ -1,0 +1,302 @@
+package webhook
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dmitrymomot/forge/crypto/consttime"
+	"github.com/dmitrymomot/forge/crypto/sign"
+)
+
+// maxSignatureCandidates bounds how many v1 elements Stripe's Verify will
+// consider; legitimate rotation never produces more than two.
+const maxSignatureCandidates = 8
+
+// Scheme is one HMAC signature wire format, shared by both directions: Sign
+// produces the headers the Sender attaches to an outbound delivery, Verify
+// authenticates an inbound request's payload against its headers in constant
+// time. Register a bespoke partner scheme by implementing this interface —
+// nothing else in the package needs forking. Implementations must be safe for
+// concurrent use.
+type Scheme interface {
+	// Sign returns the signature headers for payload at time now.
+	Sign(secret, payload []byte, now time.Time) (http.Header, error)
+
+	// Verify authenticates payload against the request headers. Timestamped
+	// schemes reject timestamps outside now±tolerance; tolerance <= 0
+	// disables that check, and schemes without timestamps ignore both
+	// arguments. Failures are ErrMissingSignature, ErrInvalidTimestamp, or
+	// ErrInvalidSignature; an empty secret is reported as a wrapped
+	// crypto/sign error.
+	Verify(secret, payload []byte, header http.Header, now time.Time, tolerance time.Duration) error
+}
+
+// schemeConfig holds the header names a built-in scheme reads and writes.
+type schemeConfig struct {
+	sigHeader string
+	tsHeader  string
+}
+
+// SchemeOption customizes a built-in scheme's header names.
+type SchemeOption func(*schemeConfig)
+
+// WithSignatureHeader overrides the signature header name. An empty name is
+// ignored.
+func WithSignatureHeader(name string) SchemeOption {
+	return func(c *schemeConfig) {
+		if name != "" {
+			c.sigHeader = name
+		}
+	}
+}
+
+// WithTimestampHeader overrides the timestamp header name on schemes that
+// carry the timestamp separately (Slack). An empty name is ignored; schemes
+// with an embedded timestamp (Stripe) or none (GitHub) ignore it.
+func WithTimestampHeader(name string) SchemeOption {
+	return func(c *schemeConfig) {
+		if name != "" {
+			c.tsHeader = name
+		}
+	}
+}
+
+func newSchemeConfig(sigHeader, tsHeader string, opts []SchemeOption) schemeConfig {
+	c := schemeConfig{sigHeader: sigHeader, tsHeader: tsHeader}
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// newSigner wraps sign.New so an empty secret surfaces as a package-prefixed
+// error instead of a bare crypto/sign sentinel.
+func newSigner(secret []byte) (*sign.Signer, error) {
+	s, err := sign.New(secret)
+	if err != nil {
+		return nil, fmt.Errorf("webhook: %w", err)
+	}
+	return s, nil
+}
+
+// checkTolerance rejects unix timestamps outside now±tolerance; tolerance <= 0
+// disables the check.
+func checkTolerance(ts int64, now time.Time, tolerance time.Duration) error {
+	if tolerance <= 0 {
+		return nil
+	}
+	d := now.Sub(time.Unix(ts, 0)).Abs()
+	if d > tolerance {
+		return fmt.Errorf("%w: timestamp %d outside tolerance %s", ErrInvalidTimestamp, ts, tolerance)
+	}
+	return nil
+}
+
+// Stripe returns the Stripe-style scheme: one header (default
+// "Stripe-Signature") carrying "t=<unix>,v1=<hex>" where v1 is the HMAC-SHA256
+// of "<t>.<payload>". Verify accepts multiple v1 elements (secret rotation on
+// the sender's side) and ignores unknown elements. This is the Sender's
+// default outbound scheme, renamed to "Webhook-Signature".
+func Stripe(opts ...SchemeOption) Scheme {
+	return stripeScheme{header: newSchemeConfig("Stripe-Signature", "", opts).sigHeader}
+}
+
+type stripeScheme struct {
+	header string
+}
+
+// stripeMsg builds the signed payload "<ts>.<payload>". ts stays the exact
+// string off the wire — re-formatting a parsed value would silently change
+// the signed message for unusual-but-valid encodings (leading zeros).
+func stripeMsg(ts string, payload []byte) []byte {
+	msg := make([]byte, 0, len(ts)+1+len(payload))
+	msg = append(msg, ts...)
+	msg = append(msg, '.')
+	msg = append(msg, payload...)
+	return msg
+}
+
+func (s stripeScheme) Sign(secret, payload []byte, now time.Time) (http.Header, error) {
+	signer, err := newSigner(secret)
+	if err != nil {
+		return nil, err
+	}
+	ts := strconv.FormatInt(now.Unix(), 10)
+	mac := signer.Sign(stripeMsg(ts, payload))
+	h := make(http.Header, 1)
+	h.Set(s.header, "t="+ts+",v1="+hex.EncodeToString(mac))
+	return h, nil
+}
+
+func (s stripeScheme) Verify(secret, payload []byte, header http.Header, now time.Time, tolerance time.Duration) error {
+	val := header.Get(s.header)
+	if val == "" {
+		return fmt.Errorf("%w: %s", ErrMissingSignature, s.header)
+	}
+	signer, err := newSigner(secret)
+	if err != nil {
+		return err
+	}
+	var ts int64
+	rawTS := ""
+	tsSeen := false
+	var macs [][]byte
+	for elem := range strings.SplitSeq(val, ",") {
+		k, v, ok := strings.Cut(strings.TrimSpace(elem), "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "t":
+			n, err := strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				return fmt.Errorf("%w: unparseable t element", ErrInvalidTimestamp)
+			}
+			ts, rawTS, tsSeen = n, v, true
+		case "v1":
+			// Cap candidates: rotation never yields more than two live
+			// signatures, and the header is attacker-controlled.
+			if len(macs) < maxSignatureCandidates {
+				if mac, err := hex.DecodeString(v); err == nil {
+					macs = append(macs, mac)
+				}
+			}
+		}
+	}
+	if !tsSeen {
+		return fmt.Errorf("%w: missing t element", ErrInvalidTimestamp)
+	}
+	if err := checkTolerance(ts, now, tolerance); err != nil {
+		return err
+	}
+	// One full-message HMAC, however many v1 candidates arrived — recomputing
+	// it per element would hand an unauthenticated caller a CPU amplifier.
+	expected := signer.Sign(stripeMsg(rawTS, payload))
+	for _, mac := range macs {
+		if consttime.BytesEqual(expected, mac) {
+			return nil
+		}
+	}
+	return ErrInvalidSignature
+}
+
+// GitHub returns the GitHub-style scheme: one header (default
+// "X-Hub-Signature-256") carrying "sha256=<hex>" — the HMAC-SHA256 of the raw
+// payload. The format carries no timestamp, so Verify ignores tolerance;
+// replay protection must come from the consumer (e.g. tracking GitHub's
+// X-GitHub-Delivery header).
+func GitHub(opts ...SchemeOption) Scheme {
+	return githubScheme{header: newSchemeConfig("X-Hub-Signature-256", "", opts).sigHeader}
+}
+
+type githubScheme struct {
+	header string
+}
+
+func (s githubScheme) Sign(secret, payload []byte, _ time.Time) (http.Header, error) {
+	signer, err := newSigner(secret)
+	if err != nil {
+		return nil, err
+	}
+	h := make(http.Header, 1)
+	h.Set(s.header, "sha256="+hex.EncodeToString(signer.Sign(payload)))
+	return h, nil
+}
+
+func (s githubScheme) Verify(secret, payload []byte, header http.Header, _ time.Time, _ time.Duration) error {
+	val := header.Get(s.header)
+	if val == "" {
+		return fmt.Errorf("%w: %s", ErrMissingSignature, s.header)
+	}
+	hexMac, ok := strings.CutPrefix(val, "sha256=")
+	if !ok {
+		return fmt.Errorf("%w: missing sha256= prefix", ErrInvalidSignature)
+	}
+	mac, err := hex.DecodeString(hexMac)
+	if err != nil {
+		return fmt.Errorf("%w: signature is not hex", ErrInvalidSignature)
+	}
+	signer, err := newSigner(secret)
+	if err != nil {
+		return err
+	}
+	if !signer.Verify(payload, mac) {
+		return ErrInvalidSignature
+	}
+	return nil
+}
+
+// Slack returns the Slack-style scheme: a signature header (default
+// "X-Slack-Signature") carrying "v0=<hex>" — the HMAC-SHA256 of
+// "v0:<timestamp>:<payload>" — plus a separate timestamp header (default
+// "X-Slack-Request-Timestamp").
+func Slack(opts ...SchemeOption) Scheme {
+	c := newSchemeConfig("X-Slack-Signature", "X-Slack-Request-Timestamp", opts)
+	return slackScheme(c)
+}
+
+type slackScheme struct {
+	sigHeader string
+	tsHeader  string
+}
+
+// slackMsg builds the base string "v0:<ts>:<payload>".
+func slackMsg(ts string, payload []byte) []byte {
+	msg := make([]byte, 0, 3+len(ts)+1+len(payload))
+	msg = append(msg, "v0:"...)
+	msg = append(msg, ts...)
+	msg = append(msg, ':')
+	msg = append(msg, payload...)
+	return msg
+}
+
+func (s slackScheme) Sign(secret, payload []byte, now time.Time) (http.Header, error) {
+	signer, err := newSigner(secret)
+	if err != nil {
+		return nil, err
+	}
+	ts := strconv.FormatInt(now.Unix(), 10)
+	mac := signer.Sign(slackMsg(ts, payload))
+	h := make(http.Header, 2)
+	h.Set(s.sigHeader, "v0="+hex.EncodeToString(mac))
+	h.Set(s.tsHeader, ts)
+	return h, nil
+}
+
+func (s slackScheme) Verify(secret, payload []byte, header http.Header, now time.Time, tolerance time.Duration) error {
+	val := header.Get(s.sigHeader)
+	if val == "" {
+		return fmt.Errorf("%w: %s", ErrMissingSignature, s.sigHeader)
+	}
+	tsStr := header.Get(s.tsHeader)
+	if tsStr == "" {
+		return fmt.Errorf("%w: %s", ErrMissingSignature, s.tsHeader)
+	}
+	ts, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("%w: unparseable %s", ErrInvalidTimestamp, s.tsHeader)
+	}
+	if err := checkTolerance(ts, now, tolerance); err != nil {
+		return err
+	}
+	hexMac, ok := strings.CutPrefix(val, "v0=")
+	if !ok {
+		return fmt.Errorf("%w: missing v0= prefix", ErrInvalidSignature)
+	}
+	mac, err := hex.DecodeString(hexMac)
+	if err != nil {
+		return fmt.Errorf("%w: signature is not hex", ErrInvalidSignature)
+	}
+	signer, err := newSigner(secret)
+	if err != nil {
+		return err
+	}
+	if !signer.Verify(slackMsg(tsStr, payload), mac) {
+		return ErrInvalidSignature
+	}
+	return nil
+}

--- a/comms/webhook/scheme_test.go
+++ b/comms/webhook/scheme_test.go
@@ -1,0 +1,216 @@
+package webhook_test
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/comms/webhook"
+)
+
+var (
+	testSecret  = []byte("s3cr3t-signing-key")
+	testPayload = []byte(`{"type":"invoice.paid","id":"evt_1"}`)
+)
+
+func schemes() map[string]webhook.Scheme {
+	return map[string]webhook.Scheme{
+		"stripe": webhook.Stripe(),
+		"github": webhook.GitHub(),
+		"slack":  webhook.Slack(),
+	}
+}
+
+func TestSchemeRoundTrip(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	for name, s := range schemes() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			h, err := s.Sign(testSecret, testPayload, now)
+			require.NoError(t, err)
+			require.NoError(t, s.Verify(testSecret, testPayload, h, now, 5*time.Minute))
+
+			assert.ErrorIs(t, s.Verify(testSecret, []byte(`{"tampered":true}`), h, now, 5*time.Minute), webhook.ErrInvalidSignature)
+			assert.ErrorIs(t, s.Verify([]byte("wrong-secret"), testPayload, h, now, 5*time.Minute), webhook.ErrInvalidSignature)
+			assert.ErrorIs(t, s.Verify(testSecret, testPayload, http.Header{}, now, 5*time.Minute), webhook.ErrMissingSignature)
+		})
+	}
+}
+
+func TestSchemeEmptySecret(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	for name, s := range schemes() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := s.Sign(nil, testPayload, now)
+			require.Error(t, err)
+
+			h, err := s.Sign(testSecret, testPayload, now)
+			require.NoError(t, err)
+			require.Error(t, s.Verify(nil, testPayload, h, now, 0))
+		})
+	}
+}
+
+func TestStripeTolerance(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	s := webhook.Stripe()
+	h, err := s.Sign(testSecret, testPayload, now.Add(-10*time.Minute))
+	require.NoError(t, err)
+
+	assert.ErrorIs(t, s.Verify(testSecret, testPayload, h, now, 5*time.Minute), webhook.ErrInvalidTimestamp)
+	assert.NoError(t, s.Verify(testSecret, testPayload, h, now, 15*time.Minute), "within a wider window")
+	assert.NoError(t, s.Verify(testSecret, testPayload, h, now, 0), "zero tolerance disables the check")
+
+	// A signature from the future is just as rejected as a stale one.
+	h, err = s.Sign(testSecret, testPayload, now.Add(10*time.Minute))
+	require.NoError(t, err)
+	assert.ErrorIs(t, s.Verify(testSecret, testPayload, h, now, 5*time.Minute), webhook.ErrInvalidTimestamp)
+}
+
+func TestStripeHeaderParsing(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	s := webhook.Stripe()
+	signed, err := s.Sign(testSecret, testPayload, now)
+	require.NoError(t, err)
+	good := signed.Get("Stripe-Signature")
+
+	set := func(v string) http.Header {
+		h := http.Header{}
+		h.Set("Stripe-Signature", v)
+		return h
+	}
+
+	// Extra v1 elements (sender-side rotation) and unknown elements are tolerated.
+	assert.NoError(t, s.Verify(testSecret, testPayload, set(good+",v1=deadbeef,v0=ignored"), now, time.Minute))
+	assert.NoError(t, s.Verify(testSecret, testPayload, set("v1=deadbeef, "+good), now, time.Minute), "whitespace and a bad v1 first")
+
+	assert.ErrorIs(t, s.Verify(testSecret, testPayload, set("v1=deadbeef"), now, time.Minute), webhook.ErrInvalidTimestamp, "missing t")
+	assert.ErrorIs(t, s.Verify(testSecret, testPayload, set("t=notanumber,v1=deadbeef"), now, time.Minute), webhook.ErrInvalidTimestamp)
+	assert.ErrorIs(t, s.Verify(testSecret, testPayload, set("t="+strconv.FormatInt(now.Unix(), 10)), now, time.Minute), webhook.ErrInvalidSignature, "no v1 at all")
+}
+
+func TestStripeCandidateCap(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	s := webhook.Stripe()
+	signed, err := s.Sign(testSecret, testPayload, now)
+	require.NoError(t, err)
+	// Sign produces "t=<ts>,v1=<good>"; ts element first, good sig second.
+	good := signed.Get("Stripe-Signature")
+
+	set := func(v string) http.Header {
+		h := http.Header{}
+		h.Set("Stripe-Signature", v)
+		return h
+	}
+	junk := strings.Repeat("v1="+strings.Repeat("ab", 32)+",", 8)
+
+	assert.ErrorIs(t, s.Verify(testSecret, testPayload, set(junk+good), now, time.Minute), webhook.ErrInvalidSignature,
+		"the genuine signature past the candidate cap is not considered")
+	assert.NoError(t, s.Verify(testSecret, testPayload, set(good+","+junk), now, time.Minute),
+		"the genuine signature within the cap verifies")
+}
+
+func TestGitHubKnownVector(t *testing.T) {
+	t.Parallel()
+	// The exact example from GitHub's webhook docs.
+	secret := []byte("It's a Secret to Everybody")
+	payload := []byte("Hello, World!")
+	const want = "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17"
+
+	s := webhook.GitHub()
+	h, err := s.Sign(secret, payload, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, want, h.Get("X-Hub-Signature-256"))
+
+	require.NoError(t, s.Verify(secret, payload, h, time.Now(), 0))
+}
+
+func TestGitHubIgnoresTolerance(t *testing.T) {
+	t.Parallel()
+	s := webhook.GitHub()
+	h, err := s.Sign(testSecret, testPayload, time.Now().Add(-24*time.Hour))
+	require.NoError(t, err)
+	assert.NoError(t, s.Verify(testSecret, testPayload, h, time.Now(), time.Minute), "no timestamp in the format")
+}
+
+func TestGitHubMalformedSignature(t *testing.T) {
+	t.Parallel()
+	s := webhook.GitHub()
+	set := func(v string) http.Header {
+		h := http.Header{}
+		h.Set("X-Hub-Signature-256", v)
+		return h
+	}
+	assert.ErrorIs(t, s.Verify(testSecret, testPayload, set("sha1=deadbeef"), time.Now(), 0), webhook.ErrInvalidSignature)
+	assert.ErrorIs(t, s.Verify(testSecret, testPayload, set("sha256=nothex"), time.Now(), 0), webhook.ErrInvalidSignature)
+}
+
+func TestSlackKnownVector(t *testing.T) {
+	t.Parallel()
+	// The exact example from Slack's request-verification docs.
+	secret := []byte("8f742231b10e8888abcd99yyyzzz85a5")
+	payload := []byte("token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c")
+	at := time.Unix(1531420618, 0)
+
+	s := webhook.Slack()
+	h, err := s.Sign(secret, payload, at)
+	require.NoError(t, err)
+	assert.Equal(t, "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503", h.Get("X-Slack-Signature"))
+	assert.Equal(t, "1531420618", h.Get("X-Slack-Request-Timestamp"))
+
+	require.NoError(t, s.Verify(secret, payload, h, at, 5*time.Minute))
+}
+
+func TestSlackToleranceAndMalformed(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	s := webhook.Slack()
+	h, err := s.Sign(testSecret, testPayload, now.Add(-10*time.Minute))
+	require.NoError(t, err)
+	assert.ErrorIs(t, s.Verify(testSecret, testPayload, h, now, 5*time.Minute), webhook.ErrInvalidTimestamp)
+
+	h, err = s.Sign(testSecret, testPayload, now)
+	require.NoError(t, err)
+
+	noTS := h.Clone()
+	noTS.Del("X-Slack-Request-Timestamp")
+	assert.ErrorIs(t, s.Verify(testSecret, testPayload, noTS, now, time.Minute), webhook.ErrMissingSignature)
+
+	badTS := h.Clone()
+	badTS.Set("X-Slack-Request-Timestamp", "notanumber")
+	assert.ErrorIs(t, s.Verify(testSecret, testPayload, badTS, now, time.Minute), webhook.ErrInvalidTimestamp)
+
+	badPrefix := h.Clone()
+	badPrefix.Set("X-Slack-Signature", "v1="+h.Get("X-Slack-Signature")[3:])
+	assert.ErrorIs(t, s.Verify(testSecret, testPayload, badPrefix, now, time.Minute), webhook.ErrInvalidSignature)
+}
+
+func TestSchemeCustomHeaders(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	s := webhook.Stripe(webhook.WithSignatureHeader("Webhook-Signature"))
+	h, err := s.Sign(testSecret, testPayload, now)
+	require.NoError(t, err)
+	assert.NotEmpty(t, h.Get("Webhook-Signature"))
+	assert.Empty(t, h.Get("Stripe-Signature"))
+	require.NoError(t, s.Verify(testSecret, testPayload, h, now, time.Minute))
+
+	sl := webhook.Slack(webhook.WithSignatureHeader("X-Partner-Sig"), webhook.WithTimestampHeader("X-Partner-Ts"))
+	h, err = sl.Sign(testSecret, testPayload, now)
+	require.NoError(t, err)
+	assert.NotEmpty(t, h.Get("X-Partner-Sig"))
+	assert.NotEmpty(t, h.Get("X-Partner-Ts"))
+	require.NoError(t, sl.Verify(testSecret, testPayload, h, now, time.Minute))
+}

--- a/comms/webhook/sender.go
+++ b/comms/webhook/sender.go
@@ -1,0 +1,103 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Endpoint is one partner-registered delivery target: where to POST and which
+// secret signs the payload. Endpoints (with their event subscriptions and
+// state) are consumer data — a Resolver fetches them at fire time.
+type Endpoint struct {
+	URL    string
+	Secret []byte
+}
+
+func (ep Endpoint) validate() error {
+	if len(ep.Secret) == 0 {
+		return fmt.Errorf("%w: empty secret", ErrInvalidEndpoint)
+	}
+	u, err := url.Parse(ep.URL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return fmt.Errorf("%w: %q is not an absolute http(s) URL", ErrInvalidEndpoint, ep.URL)
+	}
+	return nil
+}
+
+// Result reports a fired delivery for audit logging: the receiver's status
+// code (0 when no response arrived).
+type Result struct {
+	StatusCode int
+}
+
+// Sender fires signed webhook deliveries through one reused *http.Client.
+type Sender struct {
+	client      *http.Client
+	scheme      Scheme
+	keyHeader   string
+	contentType string
+}
+
+// New returns a Sender. Defaults: the Stripe-style scheme under a neutral
+// "Webhook-Signature" header, idempotency keys in "Webhook-Id",
+// "application/json" bodies, and an httpclient with a 10s overall timeout
+// that does not follow redirects (a redirect is a permanent delivery
+// failure, never a re-send elsewhere).
+func New(opts ...Option) *Sender {
+	c := newConfig(opts...)
+	return &Sender{client: c.client, scheme: c.scheme, keyHeader: c.keyHeader, contentType: c.contentType}
+}
+
+// Send signs payload for ep and POSTs it once. key, when non-empty, rides in
+// the idempotency header so receivers can dedup across retries — pass the
+// same key on every attempt (Enqueue does). The outcome maps onto a queue's
+// retry decision: nil for 2xx, ErrTransientStatus for 408/429/5xx (retry),
+// ErrPermanentStatus for any other status (the endpoint or event is wrong).
+// Transport failures return the underlying error with a zero StatusCode.
+func (s *Sender) Send(ctx context.Context, ep Endpoint, payload []byte, key string) (Result, error) {
+	if s == nil || s.client == nil { // zero Sender bypassed New
+		return Result{}, errors.New("webhook: sender not constructed with New")
+	}
+	if err := ep.validate(); err != nil {
+		return Result{}, err
+	}
+	sig, err := s.scheme.Sign(ep.Secret, payload, time.Now())
+	if err != nil {
+		return Result{}, fmt.Errorf("webhook: sign: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ep.URL, bytes.NewReader(payload))
+	if err != nil {
+		return Result{}, fmt.Errorf("webhook: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", s.contentType)
+	if key != "" {
+		req.Header.Set(s.keyHeader, key)
+	}
+	maps.Copy(req.Header, sig)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return Result{}, fmt.Errorf("webhook: send: %w", err)
+	}
+	// Bounded drain so the connection is reusable; receivers answer tiny bodies.
+	//nolint:nilaway // resp is non-nil whenever err is nil, per http.Client.Do's contract
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+	_ = resp.Body.Close()
+
+	res := Result{StatusCode: resp.StatusCode}
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return res, nil
+	case resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
+		return res, fmt.Errorf("%w: %d", ErrTransientStatus, resp.StatusCode)
+	default:
+		return res, fmt.Errorf("%w: %d", ErrPermanentStatus, resp.StatusCode)
+	}
+}

--- a/comms/webhook/sender_test.go
+++ b/comms/webhook/sender_test.go
@@ -1,0 +1,179 @@
+package webhook_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/comms/webhook"
+)
+
+func TestSendSignedDelivery(t *testing.T) {
+	t.Parallel()
+	type received struct {
+		header http.Header
+		body   []byte
+	}
+	got := make(chan received, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		got <- received{header: r.Header.Clone(), body: body}
+	}))
+	defer srv.Close()
+
+	sender := webhook.New(webhook.WithHTTPClient(srv.Client()))
+	res, err := sender.Send(t.Context(), webhook.Endpoint{URL: srv.URL, Secret: testSecret}, testPayload, "evt_1")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	rec := <-got
+	assert.Equal(t, "application/json", rec.header.Get("Content-Type"))
+	assert.Equal(t, "evt_1", rec.header.Get("Webhook-Id"))
+	assert.Equal(t, testPayload, rec.body)
+
+	// What arrived over the wire verifies under the Sender's default scheme.
+	scheme := webhook.Stripe(webhook.WithSignatureHeader("Webhook-Signature"))
+	require.NoError(t, scheme.Verify(testSecret, rec.body, rec.header, time.Now(), 5*time.Minute))
+}
+
+func TestSendStatusClasses(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		status int
+		want   error
+	}{
+		{"created", http.StatusCreated, nil},
+		{"server error", http.StatusInternalServerError, webhook.ErrTransientStatus},
+		{"bad gateway", http.StatusBadGateway, webhook.ErrTransientStatus},
+		{"too many requests", http.StatusTooManyRequests, webhook.ErrTransientStatus},
+		{"request timeout", http.StatusRequestTimeout, webhook.ErrTransientStatus},
+		{"not found", http.StatusNotFound, webhook.ErrPermanentStatus},
+		{"bad request", http.StatusBadRequest, webhook.ErrPermanentStatus},
+		{"gone", http.StatusGone, webhook.ErrPermanentStatus},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			sender := webhook.New(webhook.WithHTTPClient(srv.Client()))
+			res, err := sender.Send(t.Context(), webhook.Endpoint{URL: srv.URL, Secret: testSecret}, testPayload, "")
+			assert.Equal(t, tc.status, res.StatusCode)
+			if tc.want == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestSendDoesNotFollowRedirects(t *testing.T) {
+	t.Parallel()
+	followed := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/moved" {
+			followed = true
+			return
+		}
+		http.Redirect(w, r, "/moved", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+
+	// Default client (not srv.Client()) so the no-follow redirect policy is exercised;
+	// httptest URLs are plain http so no TLS config is needed.
+	sender := webhook.New()
+	res, err := sender.Send(t.Context(), webhook.Endpoint{URL: srv.URL, Secret: testSecret}, testPayload, "")
+	assert.ErrorIs(t, err, webhook.ErrPermanentStatus)
+	assert.Equal(t, http.StatusTemporaryRedirect, res.StatusCode)
+	assert.False(t, followed, "a signed POST must land on the registered URL only")
+}
+
+func TestSendInvalidEndpoint(t *testing.T) {
+	t.Parallel()
+	sender := webhook.New()
+	for name, ep := range map[string]webhook.Endpoint{
+		"empty secret": {URL: "https://example.com/hook"},
+		"empty url":    {Secret: testSecret},
+		"relative url": {URL: "/hook", Secret: testSecret},
+		"non-http url": {URL: "ftp://example.com/hook", Secret: testSecret},
+		"schemeless":   {URL: "example.com/hook", Secret: testSecret},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := sender.Send(t.Context(), ep, testPayload, "")
+			assert.ErrorIs(t, err, webhook.ErrInvalidEndpoint)
+		})
+	}
+}
+
+func TestSendTransportError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // guaranteed connection refused
+
+	sender := webhook.New()
+	res, err := sender.Send(t.Context(), webhook.Endpoint{URL: url, Secret: testSecret}, testPayload, "")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, webhook.ErrTransientStatus)
+	assert.NotErrorIs(t, err, webhook.ErrPermanentStatus)
+	assert.Zero(t, res.StatusCode)
+}
+
+func TestSendZeroSender(t *testing.T) {
+	t.Parallel()
+	var zero webhook.Sender
+	_, err := zero.Send(t.Context(), webhook.Endpoint{URL: "https://example.com", Secret: testSecret}, testPayload, "")
+	require.Error(t, err)
+}
+
+func TestSendOptions(t *testing.T) {
+	t.Parallel()
+	got := make(chan http.Header, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got <- r.Header.Clone()
+	}))
+	defer srv.Close()
+
+	sender := webhook.New(
+		webhook.WithHTTPClient(srv.Client()),
+		webhook.WithScheme(webhook.GitHub()),
+		webhook.WithIdempotencyHeader("Idempotency-Key"),
+		webhook.WithContentType("application/cloudevents+json"),
+	)
+	_, err := sender.Send(t.Context(), webhook.Endpoint{URL: srv.URL, Secret: testSecret}, testPayload, "evt_9")
+	require.NoError(t, err)
+
+	h := <-got
+	assert.Equal(t, "application/cloudevents+json", h.Get("Content-Type"))
+	assert.Equal(t, "evt_9", h.Get("Idempotency-Key"))
+	assert.NotEmpty(t, h.Get("X-Hub-Signature-256"))
+	assert.Empty(t, h.Get("Webhook-Signature"))
+}
+
+func TestSendOmitsEmptyKey(t *testing.T) {
+	t.Parallel()
+	got := make(chan http.Header, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got <- r.Header.Clone()
+	}))
+	defer srv.Close()
+
+	sender := webhook.New(webhook.WithHTTPClient(srv.Client()))
+	_, err := sender.Send(t.Context(), webhook.Endpoint{URL: srv.URL, Secret: testSecret}, testPayload, "")
+	require.NoError(t, err)
+
+	h := <-got
+	_, present := h["Webhook-Id"]
+	assert.False(t, present)
+}

--- a/comms/webhook/verify.go
+++ b/comms/webhook/verify.go
@@ -1,0 +1,158 @@
+package webhook
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/dmitrymomot/forge/web/middleware"
+	"github.com/dmitrymomot/forge/web/problem"
+)
+
+// Secrets yields the signing secrets accepted for a request — several during
+// rotation, resolved per request in multi-tenant apps (tenant from host or
+// path). An error or an empty list rejects the request: fail closed.
+type Secrets func(r *http.Request) ([][]byte, error)
+
+// StaticSecrets adapts fixed secrets for the single-tenant case. The secrets
+// are cloned at construction; empty ones are dropped, and dropping them all
+// yields a middleware that rejects every request.
+func StaticSecrets(secrets ...[]byte) Secrets {
+	cp := make([][]byte, 0, len(secrets))
+	for _, s := range secrets {
+		if len(s) > 0 {
+			cp = append(cp, slices.Clone(s))
+		}
+	}
+	return func(*http.Request) ([][]byte, error) { return cp, nil }
+}
+
+type verifyConfig struct {
+	responder func(http.ResponseWriter, *http.Request, error)
+	tolerance time.Duration
+	maxBody   int64
+}
+
+// VerifyOption configures the Verify middleware.
+type VerifyOption func(*verifyConfig)
+
+// WithTolerance sets the timestamp tolerance window (default 5m). Zero
+// disables the timestamp check; negative values are ignored.
+func WithTolerance(d time.Duration) VerifyOption {
+	return func(c *verifyConfig) {
+		if d >= 0 {
+			c.tolerance = d
+		}
+	}
+}
+
+// WithMaxBody caps the inbound body size in bytes (default 1 MiB). Larger
+// requests are rejected with 413 before verification. Non-positive values
+// are ignored.
+func WithMaxBody(n int64) VerifyOption {
+	return func(c *verifyConfig) {
+		if n > 0 {
+			c.maxBody = n
+		}
+	}
+}
+
+// WithResponder replaces the rejection writer (default: problem+json with the
+// status from the sentinel — 401, 413 for ErrBodyTooLarge, 400 for
+// ErrUnreadableBody). Unlike the default, a custom responder receives the
+// full wrapped error chain (match with errors.Is) — keep lookup detail out
+// of the response body yourself. Nil is ignored.
+func WithResponder(fn func(w http.ResponseWriter, r *http.Request, err error)) VerifyOption {
+	return func(c *verifyConfig) {
+		if fn != nil {
+			c.responder = fn
+		}
+	}
+}
+
+// Verify returns middleware that authenticates every request's body against
+// its signature headers through scheme, fail closed. The body is read capped
+// (WithMaxBody) and restored, so downstream handlers read it normally.
+// Verification passes when any secret from secrets authenticates the payload
+// — hand out several during rotation. Rejections answer problem+json (401 by
+// default) built from a bare sentinel, so scheme and lookup internals never
+// reach the caller. Panics on nil scheme or secrets — wiring bugs.
+func Verify(scheme Scheme, secrets Secrets, opts ...VerifyOption) middleware.Middleware {
+	if scheme == nil {
+		panic("webhook: Verify with nil scheme")
+	}
+	if secrets == nil {
+		panic("webhook: Verify with nil secrets")
+	}
+	jsonResponder := problem.JSON(problem.WithStatusOf(statusOf))
+	cfg := verifyConfig{
+		tolerance: 5 * time.Minute,
+		maxBody:   1 << 20,
+		// The default responder collapses the chain to its bare sentinel
+		// before handing off to problem.JSON, which otherwise puts
+		// err.Error() straight into the response body for any 4xx status.
+		responder: func(w http.ResponseWriter, r *http.Request, err error) {
+			jsonResponder(w, r, collapse(err))
+		},
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, cfg.maxBody))
+			if err != nil {
+				if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+					cfg.responder(w, r, fmt.Errorf("%w: cap %d bytes", ErrBodyTooLarge, cfg.maxBody))
+				} else {
+					cfg.responder(w, r, fmt.Errorf("%w: %w", ErrUnreadableBody, err))
+				}
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewReader(body))
+
+			keys, err := secrets(r)
+			if err != nil {
+				cfg.responder(w, r, fmt.Errorf("%w: secret lookup: %w", ErrInvalidSignature, err))
+				return
+			}
+			now := time.Now()
+			verr := fmt.Errorf("%w: no secrets configured", ErrInvalidSignature)
+			for _, key := range keys {
+				err := scheme.Verify(key, body, r.Header, now, cfg.tolerance)
+				if err == nil {
+					next.ServeHTTP(w, r)
+					return
+				}
+				verr = err
+			}
+			cfg.responder(w, r, verr)
+		})
+	}
+}
+
+func statusOf(err error) int {
+	switch {
+	case errors.Is(err, ErrBodyTooLarge):
+		return http.StatusRequestEntityTooLarge
+	case errors.Is(err, ErrUnreadableBody):
+		return http.StatusBadRequest
+	default:
+		return http.StatusUnauthorized
+	}
+}
+
+// collapse strips a rejection down to its bare sentinel so no wrapped detail
+// (lookup errors, header names, caps) reaches the client.
+func collapse(err error) error {
+	for _, sentinel := range []error{ErrBodyTooLarge, ErrUnreadableBody, ErrMissingSignature, ErrInvalidTimestamp} {
+		if errors.Is(err, sentinel) {
+			return sentinel
+		}
+	}
+	return ErrInvalidSignature
+}

--- a/comms/webhook/verify_test.go
+++ b/comms/webhook/verify_test.go
@@ -1,0 +1,230 @@
+package webhook_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/comms/webhook"
+)
+
+// signedRequest builds a POST with payload signed by scheme at time at.
+func signedRequest(t *testing.T, scheme webhook.Scheme, secret, payload []byte, at time.Time) *http.Request {
+	t.Helper()
+	h, err := scheme.Sign(secret, payload, at)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader(payload))
+	maps.Copy(req.Header, h)
+	return req
+}
+
+// echoBody records that it ran and echoes the request body it could read.
+func echoBody(t *testing.T, called *bool) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*called = true
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		_, _ = w.Write(body)
+	})
+}
+
+func TestVerifyPassesAndRestoresBody(t *testing.T) {
+	t.Parallel()
+	for name, scheme := range schemes() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			called := false
+			h := webhook.Verify(scheme, webhook.StaticSecrets(testSecret))(echoBody(t, &called))
+
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, signedRequest(t, scheme, testSecret, testPayload, time.Now()))
+
+			require.True(t, called)
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, testPayload, rec.Body.Bytes(), "handler saw the exact original body")
+		})
+	}
+}
+
+func TestVerifyRejects(t *testing.T) {
+	t.Parallel()
+	scheme := webhook.Stripe()
+	cases := []struct {
+		name       string
+		req        func(t *testing.T) *http.Request
+		wantStatus int
+		wantDetail string
+	}{
+		{
+			name: "wrong secret",
+			req: func(t *testing.T) *http.Request {
+				return signedRequest(t, scheme, []byte("wrong"), testPayload, time.Now())
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantDetail: webhook.ErrInvalidSignature.Error(),
+		},
+		{
+			name: "no signature header",
+			req: func(*testing.T) *http.Request {
+				return httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader(testPayload))
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantDetail: webhook.ErrMissingSignature.Error(),
+		},
+		{
+			name: "stale timestamp",
+			req: func(t *testing.T) *http.Request {
+				return signedRequest(t, scheme, testSecret, testPayload, time.Now().Add(-time.Hour))
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantDetail: webhook.ErrInvalidTimestamp.Error(),
+		},
+		{
+			name: "tampered payload",
+			req: func(t *testing.T) *http.Request {
+				r := signedRequest(t, scheme, testSecret, testPayload, time.Now())
+				r.Body = io.NopCloser(strings.NewReader(`{"tampered":true}`))
+				return r
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantDetail: webhook.ErrInvalidSignature.Error(),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			called := false
+			h := webhook.Verify(scheme, webhook.StaticSecrets(testSecret))(echoBody(t, &called))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, tc.req(t))
+
+			assert.False(t, called)
+			assert.Equal(t, tc.wantStatus, rec.Code)
+			assert.Equal(t, "application/problem+json", rec.Header().Get("Content-Type"))
+
+			var p struct {
+				Detail string `json:"detail"`
+			}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &p))
+			assert.Equal(t, tc.wantDetail, p.Detail, "bare sentinel only, no internals")
+		})
+	}
+}
+
+func TestVerifyBodyTooLarge(t *testing.T) {
+	t.Parallel()
+	called := false
+	h := webhook.Verify(webhook.GitHub(), webhook.StaticSecrets(testSecret), webhook.WithMaxBody(8))(echoBody(t, &called))
+
+	req := httptest.NewRequest(http.MethodPost, "/hook", strings.NewReader("way more than eight bytes"))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.False(t, called)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	assert.Contains(t, rec.Body.String(), webhook.ErrBodyTooLarge.Error())
+	assert.NotContains(t, rec.Body.String(), "cap 8", "cap detail stays server-side")
+}
+
+func TestVerifySecretsFailClosed(t *testing.T) {
+	t.Parallel()
+	scheme := webhook.GitHub()
+	cases := map[string]webhook.Secrets{
+		"lookup error": func(*http.Request) ([][]byte, error) { return nil, errors.New("tenant db down") },
+		"no secrets":   webhook.StaticSecrets(),
+		"only empties": webhook.StaticSecrets(nil, []byte{}),
+	}
+	for name, secrets := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			called := false
+			h := webhook.Verify(scheme, secrets)(echoBody(t, &called))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, signedRequest(t, scheme, testSecret, testPayload, time.Now()))
+
+			assert.False(t, called)
+			assert.Equal(t, http.StatusUnauthorized, rec.Code)
+			assert.NotContains(t, rec.Body.String(), "tenant db down", "lookup detail never leaks")
+		})
+	}
+}
+
+func TestVerifySecretRotation(t *testing.T) {
+	t.Parallel()
+	scheme := webhook.Stripe()
+	old, current := []byte("old-secret"), []byte("new-secret")
+	called := false
+	h := webhook.Verify(scheme, webhook.StaticSecrets(current, old))(echoBody(t, &called))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedRequest(t, scheme, old, testPayload, time.Now()))
+	assert.True(t, called, "a signature under the retired secret still verifies")
+}
+
+func TestVerifyToleranceOptions(t *testing.T) {
+	t.Parallel()
+	scheme := webhook.Stripe()
+	stale := func(t *testing.T) *http.Request {
+		return signedRequest(t, scheme, testSecret, testPayload, time.Now().Add(-time.Hour))
+	}
+
+	called := false
+	h := webhook.Verify(scheme, webhook.StaticSecrets(testSecret), webhook.WithTolerance(0))(echoBody(t, &called))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, stale(t))
+	assert.True(t, called, "zero tolerance disables the timestamp check")
+
+	called = false
+	h = webhook.Verify(scheme, webhook.StaticSecrets(testSecret), webhook.WithTolerance(2*time.Hour))(echoBody(t, &called))
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, stale(t))
+	assert.True(t, called, "stale but within a widened window")
+}
+
+func TestVerifyCustomResponder(t *testing.T) {
+	t.Parallel()
+	scheme := webhook.GitHub()
+	var got error
+	h := webhook.Verify(scheme, webhook.StaticSecrets(testSecret), webhook.WithResponder(func(w http.ResponseWriter, _ *http.Request, err error) {
+		got = err
+		w.WriteHeader(http.StatusForbidden)
+	}))(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader(testPayload)))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	require.ErrorIs(t, got, webhook.ErrMissingSignature, "custom responder sees the full chain")
+	assert.ErrorContains(t, got, "X-Hub-Signature-256")
+}
+
+func TestVerifyNilWiringPanics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { webhook.Verify(nil, webhook.StaticSecrets(testSecret)) })
+	assert.Panics(t, func() { webhook.Verify(webhook.GitHub(), nil) })
+}
+
+func TestStaticSecretsClones(t *testing.T) {
+	t.Parallel()
+	scheme := webhook.GitHub()
+	secret := []byte("rotate-me")
+	secrets := webhook.StaticSecrets(secret)
+	copy(secret, []byte("MUTATED!!"))
+
+	called := false
+	h := webhook.Verify(scheme, secrets)(echoBody(t, &called))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedRequest(t, scheme, []byte("rotate-me"), testPayload, time.Now()))
+	assert.True(t, called, "the middleware holds its own copy of the secret")
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -388,8 +388,8 @@ delivery (`Idempotency-Key` header / payload field) and receivers dedup
 — the Stripe contract (in-router suppression would trade duplicates for
 silent loss).
 
-Deps: `web/httpclient`, `comms/postback`; `async/eventbus`,
-`comms/webhook` (both planned).
+Deps: `web/httpclient`, `comms/postback`, `comms/webhook`;
+`async/eventbus` (planned).
 
 ---
 
@@ -591,21 +591,6 @@ transactional format; goldmark confined there. Provider adapters
 (SES/Postmark/…) are consumer-side or isolated subpackages.
 
 Deps: none forge-internal (goldmark external, isolated).
-
----
-
-**comms/webhook**
-
-The complete webhooks/postbacks package, both directions: outbound
-HMAC-signed deliveries (Stripe-style `t=,v1=`) with timeout, bounded
-retry, and idempotency keys — durable delivery rides `async/queue` —
-and inbound signature-verification middleware (Stripe/GitHub/Slack HMAC
-schemes, constant-time, timestamp tolerance, reads and restores
-`r.Body`). Signing and verifying share one scheme implementation behind a
-pluggable `Scheme` seam, so bespoke partner schemes register without
-forking the package.
-
-Deps: `web/httpclient`, `crypto/sign`; `async/queue`.
 
 ---
 


### PR DESCRIPTION
## What

\`comms/webhook\` — the complete webhooks package, both directions, per the catalog entry (now removed per the shipped-package rule):

- **\`Scheme\` seam** shared by signing and verifying — one wire format per implementation, so bespoke partner schemes register without forking the package. Built-in: **Stripe** (\`t=,v1=\` over \`HMAC-SHA256("<t>.<payload>")\`, multiple \`v1\` accepted), **GitHub** (\`X-Hub-Signature-256: sha256=<hex>\`), **Slack** (\`v0:<ts>:<body>\` + separate timestamp header). GitHub and Slack are pinned to the providers' published known-answer vectors.
- **Outbound \`Sender\`** over \`web/httpclient\`: one signed POST per call (10s timeout, never follows redirects), idempotency key in \`Webhook-Id\`, outcome by class — nil for 2xx, \`ErrTransientStatus\` for 408/429/5xx, \`ErrPermanentStatus\` for the rest — exactly the split a queue needs. Default outbound scheme is Stripe-style under a neutral \`Webhook-Signature\` header.
- **Durable delivery rides \`async/queue\`**: \`Enqueue\` (auto-generated idempotency key, stable across retries) + \`RegisterDeliverer\` with a consumer \`Resolver\` that maps endpoint ID → URL+secret at fire time, so secrets never sit in job rows. Verdict mapping: transient → retry on the queue's backoff, permanent → \`SkipRetry\` (DLQ without burning attempts), \`ErrEndpointNotFound\` → \`queue.Cancel\` (moot).
- **Inbound \`Verify\` middleware**: capped (\`WithMaxBody\`, 1 MiB) body read + restore, constant-time verification within a timestamp tolerance (\`WithTolerance\`, 5m), any secret from the \`Secrets\` source may match (rotation), fail closed on lookup error/empty set. Rejections are problem+json built from a bare sentinel — lookup and scheme internals never leak (guard-precedent responder).

Tenancy: outbound scoping lives in the \`Resolver\` (the queue's scope context is on ctx), inbound in the per-request \`Secrets\` func; single-tenant is \`StaticSecrets\` — zero ceremony.

## Pre-PR adversarial review (2 independent agents)

- **Important (fixed):** Stripe \`Verify\` recomputed the full-message HMAC once per attacker-supplied \`v1\` element — an unauthenticated CPU-amplification vector (packed header × 1 MiB body ≈ thousands of full-body HMACs). Now one HMAC per secret regardless of candidate count, candidates capped at 8, compared via \`consttime.BytesEqual\`. Regression test included.
- **Fixed:** Stripe verification now MACs the raw wire timestamp string (a re-formatted parsed value would break on leading-zero encodings — the Slack path already did this correctly).
- **Fixed:** \`Enqueue\` rejects header-illegal idempotency keys (\`ErrInvalidDelivery\`) — a \`\n\` in a key would otherwise fail every attempt as "transient" and burn the whole budget before dead-lettering.
- **Doc fixes:** queued payload documented as semantically-intact-not-byte-exact (stdlib JSON re-encoding compacts/HTML-escapes; signature is over delivered bytes so it always matches — test added), \`Scheme.Verify\` error contract now mentions the empty-secret case, GitHub replay note points at \`X-GitHub-Delivery\` (a header, not payload).

## Benchmarks (M3 Max, required post-bench pass)

| benchmark | before | after |
|---|---|---|
| SchemeSign/stripe | 620.5 ns/op, 1408 B, 17 allocs | 593.0 ns/op, 1392 B, 16 allocs |
| SchemeSign/github | 530.7 ns/op, 1216 B, 14 allocs | 526.2 ns/op, 1216 B, 14 allocs |
| SchemeSign/slack | 627.9 ns/op, 1408 B, 17 allocs | 632.6 ns/op, 1408 B, 17 allocs |
| SchemeVerify/stripe | 1319 ns/op, 1880 B, 25 allocs | 1267 ns/op, 1864 B, 24 allocs |
| SchemeVerify/github | 1205 ns/op, 1680 B, 22 allocs | 1175 ns/op, 1680 B, 22 allocs |
| SchemeVerify/slack | 1319 ns/op, 1840 B, 23 allocs | 1271 ns/op, 1840 B, 23 allocs |
| VerifyMiddleware | 2739 ns/op, 8371 B, 48 allocs | 2631 ns/op, 8355 B, 47 allocs |

The wins came from signing over the raw timestamp string (drops a \`FormatInt\` on both paths) and the hoisted verify MAC. Remaining cost is inherent per-call \`crypto/hmac\` state allocation; caching keyed HMACs would need per-secret pooling — unjustified complexity for paths that end in a network POST or sit inside an HTTP handler.

## Testing

- Black-box only (\`package webhook_test\`); \`go test -race\` clean, \`just lint\` clean (vet, golangci-lint, betteralign, nilaway).
- Provider known-answer vectors (GitHub/Slack docs examples, independently recomputed via openssl), tamper/stale/malformed/missing-header rejection per scheme, tolerance semantics incl. future timestamps and the candidate cap.
- Sender: wire-level signature round-trip through a real HTTP server, full status-class table, redirect no-follow, invalid endpoints, transport errors, zero-value Sender.
- Middleware: byte-exact body restore, 401/413/400 mapping, detail-leak suppression ("tenant db down", cap size), rotation, fail-closed lookup, custom responder contract, \`StaticSecrets\` cloning.
- Queue: end-to-end through a real worker over the memory broker — success, key stability, transient retry (503×2→200), permanent dead-letter without retries, endpoint-gone cancel, resolver-error retry, payload JSON-escaping round trip.