### PR TITLE
feat(data/dataloader): generic per-request batch-and-cache loader

### DIFF
--- a/data/dataloader/bench_test.go
+++ b/data/dataloader/bench_test.go
@@ -1,0 +1,110 @@
+package dataloader_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/data/dataloader"
+)
+
+func newBenchLoader(opts ...dataloader.Option) *dataloader.Loader[string, string] {
+	return dataloader.New(func(_ context.Context, keys []string) (map[string]string, error) {
+		out := make(map[string]string, len(keys))
+		for _, k := range keys {
+			out[k] = k
+		}
+		return out, nil
+	}, opts...)
+}
+
+// BenchmarkLoadCached is the request hot path: every key already resolved.
+func BenchmarkLoadCached(b *testing.B) {
+	l := newBenchLoader(dataloader.WithMaxBatchSize(1))
+	ctx := b.Context()
+	if _, err := l.Load(ctx, "k"); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := l.Load(ctx, "k"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkLoadCachedParallel(b *testing.B) {
+	l := newBenchLoader(dataloader.WithMaxBatchSize(1))
+	if _, err := l.Load(b.Context(), "k"); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		ctx := context.Background()
+		for pb.Next() {
+			if _, err := l.Load(ctx, "k"); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkLoadManyCold measures batching 100 fresh keys into one fetch.
+func BenchmarkLoadManyCold(b *testing.B) {
+	keys := make([]string, 100)
+	for i := range keys {
+		keys[i] = strconv.Itoa(i)
+	}
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		l := newBenchLoader(dataloader.WithWait(time.Hour), dataloader.WithMaxBatchSize(100))
+		if _, err := l.LoadMany(ctx, keys); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLoadManyWarm measures the all-cached bulk path.
+func BenchmarkLoadManyWarm(b *testing.B) {
+	keys := make([]string, 100)
+	for i := range keys {
+		keys[i] = strconv.Itoa(i)
+	}
+	ctx := b.Context()
+	l := newBenchLoader(dataloader.WithWait(time.Hour), dataloader.WithMaxBatchSize(100))
+	if _, err := l.LoadMany(ctx, keys); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := l.LoadMany(ctx, keys); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLoadColdSolo measures a full miss->batch-of-one->resolve cycle.
+func BenchmarkLoadColdSolo(b *testing.B) {
+	ctx := b.Context()
+	l := newBenchLoader(dataloader.WithMaxBatchSize(1))
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		if _, err := l.Load(ctx, strconv.Itoa(i)); err != nil {
+			b.Fatal(err)
+		}
+		i++
+	}
+}
+
+func BenchmarkPrime(b *testing.B) {
+	l := newBenchLoader()
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		l.Prime(strconv.Itoa(i), "v")
+		i++
+	}
+}

--- a/data/dataloader/dataloader.go
+++ b/data/dataloader/dataloader.go
@@ -1,0 +1,290 @@
+package dataloader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+)
+
+// BatchFunc loads values for a set of deduplicated keys in one round trip.
+// A key absent from the returned map resolves to ErrNotFound for its caller;
+// a non-nil error fails every key in the batch with that error.
+type BatchFunc[K comparable, V any] func(ctx context.Context, keys []K) (map[K]V, error)
+
+// thunk is one key's pending or completed result. done is the owning batch's
+// channel (shared by every thunk of that batch, since they complete together);
+// it is closed exactly once after all the batch's val/err fields are set, so
+// waiters read them without a lock.
+type thunk[V any] struct {
+	done chan struct{}
+	val  V
+	err  error
+}
+
+func (t *thunk[V]) wait(ctx context.Context) (V, error) {
+	// Prefer a ready result over a simultaneously-done context.
+	select {
+	case <-t.done:
+		return t.val, t.err
+	default:
+	}
+	select {
+	case <-t.done:
+		return t.val, t.err
+	case <-ctx.Done():
+		var zero V
+		return zero, ctx.Err()
+	}
+}
+
+// closedDone is shared by every pre-resolved thunk (Prime) so priming never
+// allocates a channel.
+var closedDone = func() chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
+}()
+
+// batch accumulates keys until the wait window elapses or maxBatch is hit.
+// keys and thunks are parallel slices; both are mutated only under the
+// loader's mutex and only while the batch is current (fired == false).
+type batch[K comparable, V any] struct {
+	ctx    context.Context
+	timer  *time.Timer
+	done   chan struct{}
+	keys   []K
+	thunks []*thunk[V]
+	fired  bool
+	// cleared records that Clear/ClearAll dropped cache entries while this
+	// batch was open, so a re-Load must rejoin the pending thunk instead of
+	// appending its key a second time.
+	cleared bool
+}
+
+// Loader collapses N+1 lookups: concurrent and batched Load calls within the
+// wait window are deduplicated and fetched in one BatchFunc call, and every
+// resolved key (including its error) is memoized for the loader's lifetime.
+// A Loader is safe for concurrent use, but it is a per-request object: create
+// one per request (or per tenant scope) so the memoized results never leak
+// across requests or tenants.
+type Loader[K comparable, V any] struct {
+	fetch    BatchFunc[K, V]
+	cache    map[K]*thunk[V]
+	current  *batch[K, V]
+	wait     time.Duration
+	maxBatch int
+	mu       sync.Mutex
+}
+
+// New returns a Loader over fetch. It panics on a nil fetch — a Loader
+// without a BatchFunc is a programming error, not a runtime condition.
+func New[K comparable, V any](fetch BatchFunc[K, V], opts ...Option) *Loader[K, V] {
+	if fetch == nil {
+		panic("dataloader: nil BatchFunc")
+	}
+	c := newConfig(opts...)
+	return &Loader[K, V]{
+		fetch:    fetch,
+		cache:    make(map[K]*thunk[V]),
+		wait:     c.wait,
+		maxBatch: c.maxBatch,
+	}
+}
+
+// Load returns the value for key, joining the current batch (or opening one)
+// on a cache miss. It blocks until the batch resolves or ctx ends; a caller
+// abandoning the wait does not abort the batch, and the result is still
+// cached for later calls.
+func (l *Loader[K, V]) Load(ctx context.Context, key K) (V, error) {
+	if l == nil || l.fetch == nil {
+		var zero V
+		return zero, errNotConstructed
+	}
+	l.mu.Lock()
+	t := l.scheduleLocked(ctx, key)
+	l.mu.Unlock()
+	return t.wait(ctx)
+}
+
+// LoadMany resolves all keys (duplicates collapse) and returns the values
+// found. Keys the BatchFunc did not return are simply absent from the result
+// map — absence is the not-found signal. Any other per-batch errors are
+// deduplicated and joined into the returned error alongside the partial
+// results. All keys are scheduled before waiting, so a sequential loop's
+// lookups still land in shared batches.
+func (l *Loader[K, V]) LoadMany(ctx context.Context, keys []K) (map[K]V, error) {
+	if l == nil || l.fetch == nil {
+		return nil, errNotConstructed
+	}
+	thunks := make(map[K]*thunk[V], len(keys))
+	l.mu.Lock()
+	for _, key := range keys {
+		if _, ok := thunks[key]; ok {
+			continue
+		}
+		thunks[key] = l.scheduleLocked(ctx, key)
+	}
+	l.mu.Unlock()
+
+	out := make(map[K]V, len(thunks))
+	var errs []error
+	for key, t := range thunks {
+		v, err := t.wait(ctx)
+		if err == nil {
+			out[key] = v
+			continue
+		}
+		// Loader-generated absence (exact type, set only by run): the missing
+		// map entry is the signal. A caller batch error that merely wraps
+		// ErrNotFound does not match and still joins the returned error.
+		if _, absent := err.(*notFoundError); absent {
+			continue
+		}
+		// A whole-batch failure repeats the same error instance across its
+		// keys; errors.Is-based dedup keeps the join readable and is safe
+		// even for uncomparable error types.
+		if !slices.ContainsFunc(errs, func(e error) bool { return errors.Is(e, err) }) {
+			errs = append(errs, err)
+		}
+	}
+	return out, errors.Join(errs...)
+}
+
+// Prime seeds key with value so later Loads skip the BatchFunc. It reports
+// whether the value was stored: an already cached or in-flight key is left
+// untouched (Clear first to overwrite).
+func (l *Loader[K, V]) Prime(key K, value V) bool {
+	if l == nil || l.fetch == nil {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, ok := l.cache[key]; ok {
+		return false
+	}
+	l.cache[key] = &thunk[V]{done: closedDone, val: value}
+	return true
+}
+
+// Clear drops key from the cache so the next Load refetches it. A key whose
+// fetch has not started yet (still in the open batch) rejoins that pending
+// fetch instead of being fetched twice; a fetch already in flight completes
+// and delivers to its current waiters.
+func (l *Loader[K, V]) Clear(key K) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	delete(l.cache, key)
+	if l.current != nil {
+		l.current.cleared = true
+	}
+	l.mu.Unlock()
+}
+
+// ClearAll drops every cached and pending entry; in-flight fetches still
+// deliver to their current waiters.
+func (l *Loader[K, V]) ClearAll() {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	l.cache = make(map[K]*thunk[V])
+	if l.current != nil {
+		l.current.cleared = true
+	}
+	l.mu.Unlock()
+}
+
+// scheduleLocked returns the thunk for key, creating it and appending the key
+// to the current batch on a miss. The caller holds l.mu.
+func (l *Loader[K, V]) scheduleLocked(ctx context.Context, key K) *thunk[V] {
+	if t, ok := l.cache[key]; ok {
+		return t
+	}
+	b := l.current
+	if b != nil && b.cleared {
+		// Clear dropped the cache entry but the key may still sit in the open
+		// batch; rejoin its pending thunk so the BatchFunc never sees the same
+		// key twice.
+		if i := slices.Index(b.keys, key); i >= 0 {
+			t := b.thunks[i]
+			l.cache[key] = t
+			return t
+		}
+	}
+	created := b == nil
+	if created {
+		// The batch runs under the opening caller's context values but
+		// detached from its cancellation (singleflight precedent): one caller
+		// abandoning must not fail the shared fetch. The BatchFunc owns its
+		// own timeout.
+		b = &batch[K, V]{ctx: context.WithoutCancel(ctx), done: make(chan struct{})}
+		l.current = b
+	}
+	t := &thunk[V]{done: b.done}
+	l.cache[key] = t
+	b.keys = append(b.keys, key)
+	b.thunks = append(b.thunks, t)
+	switch {
+	case l.maxBatch > 0 && len(b.keys) >= l.maxBatch:
+		b.fired = true
+		if b.timer != nil {
+			b.timer.Stop()
+		}
+		l.current = nil
+		go l.run(b)
+	case created:
+		// Armed after the size check so a batch that fills instantly
+		// (maxBatch 1) never allocates a timer.
+		b.timer = time.AfterFunc(l.wait, func() { l.fire(b) })
+	}
+	return t
+}
+
+// fire is the timer path: detach the batch under the lock, then fetch. The
+// fired flag makes timer expiry and the full-batch path race-safe.
+func (l *Loader[K, V]) fire(b *batch[K, V]) {
+	l.mu.Lock()
+	if b.fired {
+		l.mu.Unlock()
+		return
+	}
+	b.fired = true
+	if l.current == b {
+		l.current = nil
+	}
+	l.mu.Unlock()
+	l.run(b)
+}
+
+// run executes the fetch for a detached batch and resolves its thunks. b is
+// no longer reachable from the loader, so its slices are read without a lock.
+func (l *Loader[K, V]) run(b *batch[K, V]) {
+	results, err := l.safeFetch(b.ctx, b.keys)
+	for i, key := range b.keys {
+		t := b.thunks[i]
+		if err != nil {
+			t.err = err
+		} else if v, ok := results[key]; ok {
+			t.val = v
+		} else {
+			t.err = &notFoundError{err: fmt.Errorf("%w: key %v", ErrNotFound, key)}
+		}
+	}
+	close(b.done) // after every thunk is resolved — waiters read without a lock
+}
+
+// safeFetch converts a BatchFunc panic into an error so waiters are released
+// instead of deadlocking.
+func (l *Loader[K, V]) safeFetch(ctx context.Context, keys []K) (results map[K]V, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%w: %v", ErrFetchPanic, r)
+		}
+	}()
+	return l.fetch(ctx, keys)
+}

--- a/data/dataloader/dataloader.go
+++ b/data/dataloader/dataloader.go
@@ -179,7 +179,9 @@ func (l *Loader[K, V]) Clear(key K) {
 	}
 	l.mu.Lock()
 	delete(l.cache, key)
-	if l.current != nil {
+	// Flag the open batch only when this key is actually pending in it, so
+	// unrelated Clears never tax later scheduling with rejoin scans.
+	if l.current != nil && slices.Contains(l.current.keys, key) {
 		l.current.cleared = true
 	}
 	l.mu.Unlock()

--- a/data/dataloader/dataloader_test.go
+++ b/data/dataloader/dataloader_test.go
@@ -535,6 +535,46 @@ func TestClearDuringOpenBatchNeverDuplicatesKeys(t *testing.T) {
 	}
 }
 
+func TestClearUnrelatedKeyLeavesOpenBatchAlone(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetch{}
+	l := dataloader.New(cf.fetch, dataloader.WithWait(time.Hour), dataloader.WithMaxBatchSize(2))
+	l.Prime("a", "cached")
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		if _, err := l.Load(t.Context(), "b"); err != nil {
+			t.Errorf("Load b: %v", err)
+		}
+	})
+	time.Sleep(5 * time.Millisecond) // let b land in the open batch
+	l.Clear("a")                     // evicts the cached key; "a" is not in the batch
+	wg.Go(func() {
+		if _, err := l.Load(t.Context(), "c"); err != nil {
+			t.Errorf("Load c: %v", err)
+		}
+	})
+	wg.Wait()
+
+	// The open batch fetched only its own keys, exactly once each.
+	cf.mu.Lock()
+	batches := len(cf.batches)
+	cf.mu.Unlock()
+	if batches != 1 {
+		t.Fatalf("fetch calls = %d, want 1", batches)
+	}
+
+	// And the Clear still evicted "a": the next lookup refetches it ("d"
+	// rides along so the two-key cap fires the batch under the hour window).
+	got, err := l.LoadMany(t.Context(), []string{"a", "d"})
+	if err != nil {
+		t.Fatalf("LoadMany after Clear: %v", err)
+	}
+	if got["a"] != "v:a" {
+		t.Fatalf(`LoadMany["a"] = %q, want refetched %q`, got["a"], "v:a")
+	}
+}
+
 func TestLoadManySurfacesBatchErrorWrappingNotFound(t *testing.T) {
 	t.Parallel()
 	batchErr := fmt.Errorf("upstream 404: %w", dataloader.ErrNotFound)

--- a/data/dataloader/dataloader_test.go
+++ b/data/dataloader/dataloader_test.go
@@ -1,0 +1,696 @@
+package dataloader_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/data/dataloader"
+)
+
+// countingFetch records every batch it receives and resolves keys via fn.
+type countingFetch struct {
+	mu      sync.Mutex
+	batches [][]string
+	fn      func(ctx context.Context, keys []string) (map[string]string, error)
+}
+
+func (c *countingFetch) fetch(ctx context.Context, keys []string) (map[string]string, error) {
+	c.mu.Lock()
+	c.batches = append(c.batches, append([]string(nil), keys...))
+	c.mu.Unlock()
+	if c.fn != nil {
+		return c.fn(ctx, keys)
+	}
+	out := make(map[string]string, len(keys))
+	for _, k := range keys {
+		out[k] = "v:" + k
+	}
+	return out, nil
+}
+
+func (c *countingFetch) calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.batches)
+}
+
+func (c *countingFetch) batchSizes() []int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	sizes := make([]int, len(c.batches))
+	for i, b := range c.batches {
+		sizes[i] = len(b)
+	}
+	return sizes
+}
+
+func TestLoadSingle(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetch{}
+	l := dataloader.New(cf.fetch, dataloader.WithMaxBatchSize(1))
+
+	v, err := l.Load(t.Context(), "a")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if v != "v:a" {
+		t.Fatalf("Load = %q, want %q", v, "v:a")
+	}
+	if got := cf.calls(); got != 1 {
+		t.Fatalf("fetch calls = %d, want 1", got)
+	}
+}
+
+func TestLoadNotFound(t *testing.T) {
+	t.Parallel()
+	l := dataloader.New(func(_ context.Context, _ []string) (map[string]string, error) {
+		return nil, nil
+	}, dataloader.WithMaxBatchSize(1))
+
+	_, err := l.Load(t.Context(), "missing")
+	if !errors.Is(err, dataloader.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("err %q does not name the key", err)
+	}
+}
+
+func TestLoadCoalescesConcurrent(t *testing.T) {
+	t.Parallel()
+	const n = 10
+	cf := &countingFetch{}
+	// Window effectively infinite; the size cap is the only trigger, so the
+	// test is deterministic: fetch fires exactly when all n keys are in. The
+	// deadline turns a coalescing regression into a fast failure instead of a
+	// suite-timeout hang.
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	l := dataloader.New(cf.fetch, dataloader.WithWait(time.Hour), dataloader.WithMaxBatchSize(n))
+
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	vals := make([]string, n)
+	for i := range n {
+		wg.Go(func() {
+			vals[i], errs[i] = l.Load(ctx, string(rune('a'+i)))
+		})
+	}
+	wg.Wait()
+
+	for i := range n {
+		if errs[i] != nil {
+			t.Fatalf("Load %d: %v", i, errs[i])
+		}
+		if want := "v:" + string(rune('a'+i)); vals[i] != want {
+			t.Fatalf("Load %d = %q, want %q", i, vals[i], want)
+		}
+	}
+	if got := cf.calls(); got != 1 {
+		t.Fatalf("fetch calls = %d, want 1", got)
+	}
+}
+
+func TestLoadDedupsInFlightKey(t *testing.T) {
+	t.Parallel()
+	release := make(chan struct{})
+	var calls atomic.Int32
+	l := dataloader.New(func(_ context.Context, keys []string) (map[string]string, error) {
+		calls.Add(1)
+		<-release
+		return map[string]string{keys[0]: "shared"}, nil
+	}, dataloader.WithMaxBatchSize(1))
+
+	results := make(chan string, 2)
+	for range 2 {
+		go func() {
+			v, err := l.Load(t.Context(), "k")
+			if err != nil {
+				t.Errorf("Load: %v", err)
+			}
+			results <- v
+		}()
+	}
+	// Both goroutines target the same key; the second joins the first's
+	// in-flight thunk. Let the fetch finish once both are waiting.
+	time.Sleep(10 * time.Millisecond)
+	close(release)
+	for range 2 {
+		if v := <-results; v != "shared" {
+			t.Fatalf("Load = %q, want %q", v, "shared")
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("fetch calls = %d, want 1", got)
+	}
+}
+
+func TestLoadCachedSkipsFetch(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetch{}
+	l := dataloader.New(cf.fetch, dataloader.WithMaxBatchSize(1))
+
+	for range 3 {
+		if _, err := l.Load(t.Context(), "a"); err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+	}
+	if got := cf.calls(); got != 1 {
+		t.Fatalf("fetch calls = %d, want 1", got)
+	}
+}
+
+func TestLoadManySingleBatch(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetch{}
+	keys := []string{"a", "b", "c", "a", "b"} // duplicates collapse
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	l := dataloader.New(cf.fetch, dataloader.WithWait(time.Hour), dataloader.WithMaxBatchSize(3))
+
+	got, err := l.LoadMany(ctx, keys)
+	if err != nil {
+		t.Fatalf("LoadMany: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("LoadMany returned %d entries, want 3", len(got))
+	}
+	for _, k := range []string{"a", "b", "c"} {
+		if got[k] != "v:"+k {
+			t.Fatalf("LoadMany[%q] = %q, want %q", k, got[k], "v:"+k)
+		}
+	}
+	if got := cf.calls(); got != 1 {
+		t.Fatalf("fetch calls = %d, want 1", got)
+	}
+}
+
+func TestLoadManyMissingKeysAbsent(t *testing.T) {
+	t.Parallel()
+	l := dataloader.New(func(_ context.Context, keys []string) (map[string]string, error) {
+		out := make(map[string]string)
+		for _, k := range keys {
+			if k != "gone" {
+				out[k] = "v:" + k
+			}
+		}
+		return out, nil
+	}, dataloader.WithMaxBatchSize(3))
+
+	got, err := l.LoadMany(t.Context(), []string{"a", "gone", "b"})
+	if err != nil {
+		t.Fatalf("LoadMany: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("LoadMany returned %d entries, want 2", len(got))
+	}
+	if _, ok := got["gone"]; ok {
+		t.Fatal("missing key present in result map")
+	}
+}
+
+func TestLoadManyBatchErrorDeduplicated(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("db down")
+	l := dataloader.New(func(_ context.Context, _ []string) (map[string]string, error) {
+		return nil, boom
+	}, dataloader.WithMaxBatchSize(5))
+
+	got, err := l.LoadMany(t.Context(), []string{"a", "b", "c", "d", "e"})
+	if len(got) != 0 {
+		t.Fatalf("LoadMany returned %d entries, want 0", len(got))
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want wrapped %v", err, boom)
+	}
+	// One batch failed once; the joined error must not repeat it per key.
+	if n := strings.Count(err.Error(), "db down"); n != 1 {
+		t.Fatalf("error mentions batch failure %d times, want 1: %v", n, err)
+	}
+}
+
+func TestMaxBatchSplits(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetch{}
+	l := dataloader.New(cf.fetch, dataloader.WithWait(5*time.Millisecond), dataloader.WithMaxBatchSize(10))
+
+	keys := make([]string, 25)
+	for i := range keys {
+		keys[i] = string(rune('a' + i))
+	}
+	got, err := l.LoadMany(t.Context(), keys)
+	if err != nil {
+		t.Fatalf("LoadMany: %v", err)
+	}
+	if len(got) != 25 {
+		t.Fatalf("LoadMany returned %d entries, want 25", len(got))
+	}
+	// LoadMany schedules all keys under one lock hold, so the split is
+	// deterministic: two full batches plus a 5-key remainder on the timer.
+	sizes := cf.batchSizes()
+	if len(sizes) != 3 || sizes[0] != 10 || sizes[1] != 10 || sizes[2] != 5 {
+		t.Fatalf("batch sizes = %v, want [10 10 5]", sizes)
+	}
+}
+
+func TestErrorCachedUntilClear(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("transient")
+	var calls atomic.Int32
+	l := dataloader.New(func(_ context.Context, keys []string) (map[string]string, error) {
+		if calls.Add(1) == 1 {
+			return nil, boom
+		}
+		return map[string]string{keys[0]: "recovered"}, nil
+	}, dataloader.WithMaxBatchSize(1))
+
+	if _, err := l.Load(t.Context(), "k"); !errors.Is(err, boom) {
+		t.Fatalf("first Load err = %v, want %v", err, boom)
+	}
+	// The failure is memoized: no refetch without Clear.
+	if _, err := l.Load(t.Context(), "k"); !errors.Is(err, boom) {
+		t.Fatalf("second Load err = %v, want cached %v", err, boom)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("fetch calls = %d, want 1", got)
+	}
+
+	l.Clear("k")
+	v, err := l.Load(t.Context(), "k")
+	if err != nil {
+		t.Fatalf("Load after Clear: %v", err)
+	}
+	if v != "recovered" {
+		t.Fatalf("Load after Clear = %q, want %q", v, "recovered")
+	}
+}
+
+func TestFetchPanicRecovered(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	l := dataloader.New(func(_ context.Context, keys []string) (map[string]string, error) {
+		if calls.Add(1) == 1 {
+			panic("kaboom")
+		}
+		return map[string]string{keys[0]: "ok"}, nil
+	}, dataloader.WithMaxBatchSize(1))
+
+	_, err := l.Load(t.Context(), "a")
+	if !errors.Is(err, dataloader.ErrFetchPanic) {
+		t.Fatalf("err = %v, want ErrFetchPanic", err)
+	}
+	if !strings.Contains(err.Error(), "kaboom") {
+		t.Fatalf("err %q does not carry the panic value", err)
+	}
+
+	// The loader stays usable after a fetch panic.
+	v, err := l.Load(t.Context(), "b")
+	if err != nil {
+		t.Fatalf("Load after panic: %v", err)
+	}
+	if v != "ok" {
+		t.Fatalf("Load after panic = %q, want %q", v, "ok")
+	}
+}
+
+func TestPrime(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetch{}
+	l := dataloader.New(cf.fetch, dataloader.WithMaxBatchSize(1))
+
+	if !l.Prime("a", "seeded") {
+		t.Fatal("Prime new key = false, want true")
+	}
+	if l.Prime("a", "overwritten") {
+		t.Fatal("Prime existing key = true, want false")
+	}
+
+	v, err := l.Load(t.Context(), "a")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if v != "seeded" {
+		t.Fatalf("Load = %q, want primed %q", v, "seeded")
+	}
+	if got := cf.calls(); got != 0 {
+		t.Fatalf("fetch calls = %d, want 0", got)
+	}
+}
+
+func TestClearAll(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetch{}
+	l := dataloader.New(cf.fetch, dataloader.WithMaxBatchSize(2))
+
+	if _, err := l.LoadMany(t.Context(), []string{"a", "b"}); err != nil {
+		t.Fatalf("LoadMany: %v", err)
+	}
+	l.ClearAll()
+	if _, err := l.LoadMany(t.Context(), []string{"a", "b"}); err != nil {
+		t.Fatalf("LoadMany after ClearAll: %v", err)
+	}
+	if got := cf.calls(); got != 2 {
+		t.Fatalf("fetch calls = %d, want 2", got)
+	}
+}
+
+func TestCanceledWaitDoesNotAbortBatch(t *testing.T) {
+	t.Parallel()
+	release := make(chan struct{})
+	l := dataloader.New(func(_ context.Context, keys []string) (map[string]string, error) {
+		<-release
+		return map[string]string{keys[0]: "late"}, nil
+	}, dataloader.WithMaxBatchSize(1))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+	if _, err := l.Load(ctx, "k"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+
+	// The batch keeps running and its result lands in the cache.
+	close(release)
+	v, err := l.Load(t.Context(), "k")
+	if err != nil {
+		t.Fatalf("Load after cancel: %v", err)
+	}
+	if v != "late" {
+		t.Fatalf("Load after cancel = %q, want %q", v, "late")
+	}
+}
+
+func TestFetchContextDetachedButCarriesValues(t *testing.T) {
+	t.Parallel()
+	type ctxKey struct{}
+	release := make(chan struct{})
+	fetchErr := make(chan error, 1)
+	fetchVal := make(chan any, 1)
+	l := dataloader.New(func(ctx context.Context, keys []string) (map[string]string, error) {
+		<-release
+		fetchErr <- ctx.Err()
+		fetchVal <- ctx.Value(ctxKey{})
+		return map[string]string{keys[0]: "ok"}, nil
+	}, dataloader.WithMaxBatchSize(1))
+
+	ctx, cancel := context.WithCancel(context.WithValue(t.Context(), ctxKey{}, "tenant-1"))
+	done := make(chan struct{})
+	go func() {
+		_, _ = l.Load(ctx, "k")
+		close(done)
+	}()
+	time.Sleep(5 * time.Millisecond)
+	cancel()
+	close(release)
+	<-done
+
+	if err := <-fetchErr; err != nil {
+		t.Fatalf("fetch ctx canceled: %v (must be detached from caller cancellation)", err)
+	}
+	if v := <-fetchVal; v != "tenant-1" {
+		t.Fatalf("fetch ctx value = %v, want %q", v, "tenant-1")
+	}
+}
+
+func TestZeroValueLoaderErrors(t *testing.T) {
+	t.Parallel()
+	var l dataloader.Loader[string, string]
+	if _, err := l.Load(t.Context(), "k"); err == nil {
+		t.Fatal("zero-value Load = nil error, want error")
+	}
+	if _, err := l.LoadMany(t.Context(), []string{"k"}); err == nil {
+		t.Fatal("zero-value LoadMany = nil error, want error")
+	}
+	if l.Prime("k", "v") {
+		t.Fatal("zero-value Prime = true, want false")
+	}
+	l.Clear("k") // must not panic
+	l.ClearAll() // must not panic
+
+	var nilLoader *dataloader.Loader[string, string]
+	if _, err := nilLoader.Load(t.Context(), "k"); err == nil {
+		t.Fatal("nil-loader Load = nil error, want error")
+	}
+	if _, err := nilLoader.LoadMany(t.Context(), []string{"k"}); err == nil {
+		t.Fatal("nil-loader LoadMany = nil error, want error")
+	}
+	if nilLoader.Prime("k", "v") {
+		t.Fatal("nil-loader Prime = true, want false")
+	}
+	nilLoader.Clear("k") // must not panic
+	nilLoader.ClearAll() // must not panic
+}
+
+func TestNewNilFetchPanics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("New(nil) did not panic")
+		}
+	}()
+	dataloader.New[string, string](nil)
+}
+
+func TestWaitWindowCoalescesAcrossGoroutines(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetch{}
+	// A generous window: the assertion only needs both goroutines to start
+	// within 1s of each other, so scheduler jitter on slow CI cannot flake it.
+	l := dataloader.New(cf.fetch, dataloader.WithWait(time.Second))
+
+	var wg sync.WaitGroup
+	for _, k := range []string{"a", "b"} {
+		wg.Go(func() {
+			if _, err := l.Load(t.Context(), k); err != nil {
+				t.Errorf("Load(%q): %v", k, err)
+			}
+		})
+	}
+	wg.Wait()
+	if got := cf.calls(); got != 1 {
+		t.Fatalf("fetch calls = %d, want 1 (both keys inside one window)", got)
+	}
+}
+
+func TestClearDuringOpenBatchNeverDuplicatesKeys(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetch{}
+	l := dataloader.New(cf.fetch, dataloader.WithWait(20*time.Millisecond), dataloader.WithMaxBatchSize(2))
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		if _, err := l.Load(t.Context(), "k"); err != nil {
+			t.Errorf("Load k#1: %v", err)
+		}
+	})
+	time.Sleep(5 * time.Millisecond) // let k land in the open batch
+	l.Clear("k")
+	for _, key := range []string{"k", "x"} {
+		wg.Go(func() {
+			if _, err := l.Load(t.Context(), key); err != nil {
+				t.Errorf("Load %s: %v", key, err)
+			}
+		})
+	}
+	wg.Wait()
+
+	// Same interleaving through ClearAll.
+	wg.Go(func() {
+		if _, err := l.Load(t.Context(), "m"); err != nil {
+			t.Errorf("Load m#1: %v", err)
+		}
+	})
+	time.Sleep(5 * time.Millisecond)
+	l.ClearAll()
+	for _, key := range []string{"m", "n"} {
+		wg.Go(func() {
+			if _, err := l.Load(t.Context(), key); err != nil {
+				t.Errorf("Load %s: %v", key, err)
+			}
+		})
+	}
+	wg.Wait()
+
+	// The contract under test: no single fetch may ever see the same key
+	// twice, regardless of how Clear interleaved with the open batch.
+	cf.mu.Lock()
+	defer cf.mu.Unlock()
+	for _, batch := range cf.batches {
+		seen := make(map[string]bool, len(batch))
+		for _, k := range batch {
+			if seen[k] {
+				t.Fatalf("fetch received duplicate key %q in batch %v", k, batch)
+			}
+			seen[k] = true
+		}
+	}
+}
+
+func TestLoadManySurfacesBatchErrorWrappingNotFound(t *testing.T) {
+	t.Parallel()
+	batchErr := fmt.Errorf("upstream 404: %w", dataloader.ErrNotFound)
+	l := dataloader.New(func(_ context.Context, _ []string) (map[string]string, error) {
+		return nil, batchErr
+	}, dataloader.WithMaxBatchSize(2))
+
+	got, err := l.LoadMany(t.Context(), []string{"a", "b"})
+	if len(got) != 0 {
+		t.Fatalf("LoadMany returned %d entries, want 0", len(got))
+	}
+	// A whole-batch failure must never be reinterpreted as per-key absence,
+	// even when the caller's error wraps ErrNotFound.
+	if !errors.Is(err, batchErr) {
+		t.Fatalf("err = %v, want wrapped %v", err, batchErr)
+	}
+}
+
+func TestCachedHitWinsOverCanceledContext(t *testing.T) {
+	t.Parallel()
+	l := dataloader.New((&countingFetch{}).fetch, dataloader.WithMaxBatchSize(1))
+	if _, err := l.Load(t.Context(), "k"); err != nil {
+		t.Fatalf("warm Load: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	v, err := l.Load(ctx, "k")
+	if err != nil {
+		t.Fatalf("cached Load under canceled ctx = %v, want value", err)
+	}
+	if v != "v:k" {
+		t.Fatalf("cached Load = %q, want %q", v, "v:k")
+	}
+}
+
+func TestUnboundedBatchFiresOnTimer(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetch{}
+	l := dataloader.New(cf.fetch, dataloader.WithWait(10*time.Millisecond), dataloader.WithMaxBatchSize(0))
+
+	keys := make([]string, 500)
+	for i := range keys {
+		keys[i] = strconv.Itoa(i)
+	}
+	got, err := l.LoadMany(t.Context(), keys)
+	if err != nil {
+		t.Fatalf("LoadMany: %v", err)
+	}
+	if len(got) != 500 {
+		t.Fatalf("LoadMany returned %d entries, want 500", len(got))
+	}
+	if calls := cf.calls(); calls != 1 {
+		t.Fatalf("fetch calls = %d, want 1 (uncapped single batch)", calls)
+	}
+}
+
+func TestLoadManyEmptyKeys(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetch{}
+	l := dataloader.New(cf.fetch)
+
+	got, err := l.LoadMany(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("LoadMany(nil): %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("LoadMany(nil) returned %d entries, want 0", len(got))
+	}
+	if calls := cf.calls(); calls != 0 {
+		t.Fatalf("fetch calls = %d, want 0", calls)
+	}
+}
+
+func TestExtraUnrequestedKeysIgnored(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	l := dataloader.New(func(_ context.Context, keys []string) (map[string]string, error) {
+		calls.Add(1)
+		out := map[string]string{"extra": "smuggled"}
+		for _, k := range keys {
+			out[k] = "v:" + k
+		}
+		return out, nil
+	}, dataloader.WithMaxBatchSize(1))
+
+	if _, err := l.Load(t.Context(), "a"); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// The unrequested "extra" key must not have been cached.
+	v, err := l.Load(t.Context(), "extra")
+	if err != nil {
+		t.Fatalf("Load extra: %v", err)
+	}
+	if v != "v:extra" {
+		t.Fatalf("Load extra = %q, want freshly fetched %q", v, "v:extra")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("fetch calls = %d, want 2 (extra key not cached)", got)
+	}
+}
+
+func TestNonStringInstantiation(t *testing.T) {
+	t.Parallel()
+	type row struct {
+		Name string
+		Tags []string
+	}
+	l := dataloader.New(func(_ context.Context, ids []int) (map[int]*row, error) {
+		out := make(map[int]*row, len(ids))
+		for _, id := range ids {
+			out[id] = &row{Name: strconv.Itoa(id), Tags: []string{"t"}}
+		}
+		return out, nil
+	}, dataloader.WithMaxBatchSize(2))
+
+	got, err := l.LoadMany(t.Context(), []int{7, 42})
+	if err != nil {
+		t.Fatalf("LoadMany: %v", err)
+	}
+	if got[7] == nil || got[7].Name != "7" || got[42] == nil || got[42].Name != "42" {
+		t.Fatalf("LoadMany = %+v, want rows for 7 and 42", got)
+	}
+}
+
+func TestConcurrentStress(t *testing.T) {
+	t.Parallel()
+	l := dataloader.New(func(_ context.Context, keys []string) (map[string]string, error) {
+		out := make(map[string]string, len(keys))
+		for _, k := range keys {
+			out[k] = "v:" + k
+		}
+		return out, nil
+	}, dataloader.WithWait(time.Microsecond), dataloader.WithMaxBatchSize(8))
+
+	var wg sync.WaitGroup
+	for w := range 8 {
+		wg.Go(func() {
+			for i := range 50 {
+				key := string(rune('a' + (w+i)%16))
+				switch i % 4 {
+				case 0:
+					if v, err := l.Load(t.Context(), key); err != nil || v != "v:"+key {
+						t.Errorf("Load(%q) = %q, %v", key, v, err)
+					}
+				case 1:
+					if _, err := l.LoadMany(t.Context(), []string{key, "x", "y"}); err != nil {
+						t.Errorf("LoadMany: %v", err)
+					}
+				case 2:
+					l.Prime(key, "v:"+key)
+				default:
+					l.Clear(key)
+				}
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/data/dataloader/doc.go
+++ b/data/dataloader/doc.go
@@ -1,0 +1,31 @@
+// Package dataloader collapses N+1 lookups with a generic per-request
+// batch-and-cache loader. Keys requested concurrently or in bulk within a
+// short window are deduplicated and handed to one caller-owned BatchFunc
+// call; every resolved key — value, not-found, or error — is memoized for
+// the loader's lifetime. Pure generics, no storage imports: the BatchFunc
+// owns the actual lookup (SQL IN-list, cache MGET, RPC).
+//
+// A Loader is a per-request object. Construct one per request so memoized
+// results never outlive the request or leak across tenants; in multi-tenant
+// apps the BatchFunc closure carries the tenant scope (it receives the
+// context values of the caller that opened each batch, detached from that
+// caller's cancellation). Because the batch context carries no deadline, the
+// BatchFunc must bound its own work — set a query timeout inside it.
+//
+// Batching has two triggers: the wait window (default 1ms) and the batch
+// size cap (default 100), whichever comes first. Sequential per-item Loads
+// each pay the window; collapse loops with LoadMany, which schedules all its
+// keys into shared batches before waiting.
+//
+// # Usage
+//
+//	loader := dataloader.New(func(ctx context.Context, ids []string) (map[string]User, error) {
+//		return repo.UsersByIDs(ctx, ids) // one SELECT ... WHERE id = ANY($1)
+//	})
+//
+//	// Concurrent resolvers coalesce into one query per window.
+//	u, err := loader.Load(ctx, comment.AuthorID)
+//
+//	// A loop's lookups become one query.
+//	authors, err := loader.LoadMany(ctx, authorIDs)
+package dataloader

--- a/data/dataloader/errors.go
+++ b/data/dataloader/errors.go
@@ -1,0 +1,24 @@
+package dataloader
+
+import "errors"
+
+var (
+	// ErrNotFound resolves a key the BatchFunc did not return. Load wraps it
+	// with the key; match with errors.Is.
+	ErrNotFound = errors.New("dataloader: not found")
+
+	// ErrFetchPanic wraps a panic recovered from the BatchFunc so waiters are
+	// released with an error instead of deadlocking.
+	ErrFetchPanic = errors.New("dataloader: fetch panicked")
+)
+
+// errNotConstructed reports use of a zero-value Loader that bypassed New.
+var errNotConstructed = errors.New("dataloader: loader not constructed with New")
+
+// notFoundError marks loader-generated per-key absence (it wraps ErrNotFound
+// for consumers) so LoadMany can tell it apart from a caller batch error that
+// happens to wrap ErrNotFound too.
+type notFoundError struct{ err error }
+
+func (e *notFoundError) Error() string { return e.err.Error() }
+func (e *notFoundError) Unwrap() error { return e.err }

--- a/data/dataloader/example_test.go
+++ b/data/dataloader/example_test.go
@@ -1,0 +1,46 @@
+package dataloader_test
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/dmitrymomot/forge/data/dataloader"
+)
+
+func ExampleLoader() {
+	// The BatchFunc owns the lookup — one round trip for the whole batch.
+	users := map[string]string{"u1": "Ada", "u2": "Grace", "u3": "Edsger"}
+	loader := dataloader.New(func(_ context.Context, ids []string) (map[string]string, error) {
+		fmt.Printf("one fetch for %d ids\n", len(ids))
+		out := make(map[string]string, len(ids))
+		for _, id := range ids {
+			if name, ok := users[id]; ok {
+				out[id] = name
+			}
+		}
+		return out, nil
+	}, dataloader.WithMaxBatchSize(3))
+
+	// A loop's N lookups collapse into one BatchFunc call.
+	names, err := loader.LoadMany(context.Background(), []string{"u1", "u2", "u3"})
+	if err != nil {
+		fmt.Println("load:", err)
+		return
+	}
+	for _, id := range slices.Sorted(maps.Keys(names)) {
+		fmt.Println(id, "->", names[id])
+	}
+
+	// Resolved keys are memoized: no second fetch.
+	name, _ := loader.Load(context.Background(), "u2")
+	fmt.Println("cached:", name)
+
+	// Output:
+	// one fetch for 3 ids
+	// u1 -> Ada
+	// u2 -> Grace
+	// u3 -> Edsger
+	// cached: Grace
+}

--- a/data/dataloader/options.go
+++ b/data/dataloader/options.go
@@ -1,0 +1,34 @@
+package dataloader
+
+import "time"
+
+type config struct {
+	wait     time.Duration
+	maxBatch int
+}
+
+// Option configures a Loader at construction time.
+type Option func(*config)
+
+func newConfig(opts ...Option) config {
+	c := config{wait: time.Millisecond, maxBatch: 100}
+	for _, o := range opts {
+		o(&c)
+	}
+	c.wait = max(c.wait, 0)
+	c.maxBatch = max(c.maxBatch, 0)
+	return c
+}
+
+// WithWait sets the batching window: how long an open batch collects keys
+// before fetching. Default 1ms. Zero (or negative) fires each batch as soon
+// as its opener releases the loader — callers scheduling under one lock hold
+// (LoadMany) still coalesce, but the cross-goroutine window is gone. The
+// window is also the latency bound on an abandoned batch: a request that dies
+// right after scheduling still fires its BatchFunc up to this much later.
+func WithWait(d time.Duration) Option { return func(c *config) { c.wait = d } }
+
+// WithMaxBatchSize caps keys per BatchFunc call; a full batch fetches
+// immediately without waiting out the window. Default 100. Zero or negative
+// removes the cap.
+func WithMaxBatchSize(n int) Option { return func(c *config) { c.maxBatch = n } }

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -101,15 +101,6 @@ Deps: `core/structfields`, `core/validate`, `core/i18n`.
 
 ---
 
-**data/dataloader**
-
-Generic per-request batch-and-cache loader collapsing N+1 lookups; pure
-generics, no DB imports; the batch fn is caller-owned.
-
-Deps: none (stdlib only).
-
----
-
 **data/objectstore**
 
 Blob `Store` seam with a path-traversal-safe disk adapter;


### PR DESCRIPTION
## Summary

New `data/dataloader` package: a generic per-request batch-and-cache loader collapsing N+1 lookups. Pure generics, stdlib-only, no DB imports — the batch fn is caller-owned, exactly per the catalog contract (entry removed per the shipped-package rule).

## Design

- `Load`/`LoadMany` dedupe keys into an open batch fired by a wait window (default 1ms) or a size cap (default 100), whichever comes first; `LoadMany` schedules all its keys under one lock hold so a sequential loop's lookups land in shared batches.
- `BatchFunc[K, V]` returns `map[K]V`: an absent key resolves to `ErrNotFound` (wrapped with the key), one error fails the whole batch. The map contract eliminates the aligned-slice misalignment bug class of classic dataloaders; per-key errors, when truly needed, belong in `V`.
- Every resolved key — value, not-found, or error — is memoized for the loader's lifetime; `Prime` seeds, `Clear`/`ClearAll` evict.
- Batch ctx is `context.WithoutCancel` of the batch opener's ctx (singleflight precedent): one caller abandoning its wait never fails the shared fetch, and context values (tenant scope) propagate into the BatchFunc. Tenancy: the loader is a per-request object and the BatchFunc closure carries the scope — zero single-tenant ceremony, no cross-tenant cache leaks by construction.
- Thunks of one batch share a single done channel closed after all results are set; a BatchFunc panic is recovered into `ErrFetchPanic` so waiters are released instead of deadlocking.

## Pre-PR adversarial review (3 independent agents)

Concurrency, design-rules, and test-adequacy reviewers all ran against the package; `-race` stress (timer-vs-cap contention, cancel racing, Clear/Prime churn) found **no races, deadlocks, or lost/double-fired batches**. Confirmed findings, all fixed:

- **Important (found by all 3):** `Clear` on a key still pending in the open batch let a re-`Load` append the same key to that batch twice, violating the documented "deduplicated keys" BatchFunc contract. Fixed: a cleared open batch rejoins the pending thunk (regression test asserts no fetch ever sees a duplicate key, for both `Clear` and `ClearAll`).
- **Minor:** `LoadMany` classified a caller batch error that *wraps* `ErrNotFound` as per-key absence and silently returned nil error. Fixed with an internal `notFoundError` type marking loader-generated absence; caller errors now always surface.
- Test hardening: the cross-goroutine window test got a 1s window (was 100ms, schedulable-flake risk on slow CI); hour-window tests got 10s deadlines so a coalescing regression fails fast instead of hanging the suite; added edge tests for unbounded cap firing via timer, empty `LoadMany`, unrequested extra keys not cached, cached-hit-beats-canceled-ctx, typed-nil/zero-value misuse, and a non-string instantiation.

## Benchmarks (Apple M3 Max, `-benchmem`)

Post-benchmark optimization pass, measured wins only:

| Benchmark | Before | After | Change |
|---|---|---|---|
| LoadManyCold (100 keys) | 19.9µs / 245 allocs | 17.0µs / 146 allocs | shared per-batch done channel instead of per-thunk channels |
| LoadColdSolo | 1347ns / 12 allocs | 1176ns / 10 allocs | timer armed only when the batch survives the size check |
| LoadCached | 13.5ns / 0 allocs | 13.5ns / 0 allocs | already optimal |
| LoadCachedParallel | 127ns / 0 allocs | 122ns / 0 allocs | — |
| LoadManyWarm (100 keys) | 5.0µs / 7 allocs | 5.0µs / 7 allocs | — |
| Prime | 270ns / 2 allocs | 244ns / 2 allocs | shared closed channel, no per-Prime chan alloc |

## Testing

- `just test ./data/dataloader/...` — race-clean, 97.6% coverage, black-box only
- `just lint` — clean (vet, golangci-lint, nilaway, betteralign, modernize, integration-tag tier)