### PR TITLE
feat(async/eventbus): typed pub/sub over the queue engine with idempotency inbox

### DIFF
--- a/async/eventbus/bench_test.go
+++ b/async/eventbus/bench_test.go
@@ -1,0 +1,75 @@
+package eventbus_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+	"github.com/dmitrymomot/forge/async/queue"
+)
+
+type benchPayload struct {
+	UserID string `json:"user_id"`
+	Email  string `json:"email"`
+}
+
+var benchEvent = eventbus.NewEvent[benchPayload]("bench.user_created")
+
+func noopHandler(context.Context, eventbus.Delivery[benchPayload]) error { return nil }
+
+func syncBus(subs int) *eventbus.Bus {
+	bus := eventbus.NewSync()
+	for i := range subs {
+		eventbus.Subscribe(bus, benchEvent, fmt.Sprintf("sub_%d", i), noopHandler)
+	}
+	return bus
+}
+
+func BenchmarkSyncPublish(b *testing.B) {
+	for _, subs := range []int{1, 4} {
+		b.Run(fmt.Sprintf("subs_%d", subs), func(b *testing.B) {
+			bus := syncBus(subs)
+			ctx := context.Background()
+			payload := benchPayload{UserID: "u_1", Email: "a@b.c"}
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := eventbus.Publish(ctx, bus, benchEvent, payload); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkDurablePublish(b *testing.B) {
+	for _, subs := range []int{1, 4} {
+		b.Run(fmt.Sprintf("subs_%d", subs), func(b *testing.B) {
+			bus := eventbus.New(queue.NewMemoryBroker())
+			for i := range subs {
+				eventbus.Subscribe(bus, benchEvent, fmt.Sprintf("sub_%d", i), noopHandler)
+			}
+			ctx := context.Background()
+			payload := benchPayload{UserID: "u_1", Email: "a@b.c"}
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := eventbus.Publish(ctx, bus, benchEvent, payload); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMemoryInboxSeen(b *testing.B) {
+	inbox := eventbus.NewMemoryInbox()
+	ctx := context.Background()
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		i++
+		if _, err := inbox.Seen(ctx, nil, fmt.Sprintf("evt-%d", i)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/async/eventbus/bus.go
+++ b/async/eventbus/bus.go
@@ -1,0 +1,292 @@
+package eventbus
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Bus is the event registry and publisher. Wire it once at startup: declare
+// every subscription with Subscribe, then share the Bus app-wide — it is
+// cheap and safe for concurrent publishing. Subscribe is not safe to call
+// concurrently with Publish or a running Service.
+//
+// A durable Bus (New) fans every published event out as one queue.Job per
+// subscription; a sync Bus (NewSync) invokes handlers in-process during
+// Publish. Publisher-only processes construct the same wiring but simply do
+// not run the Service.
+type Bus struct {
+	broker queue.Broker // nil on a sync bus
+	scope  func(ctx context.Context) (string, error)
+	clk    clock.Clock
+	subs   map[string][]*subscription // event name → subscriptions, in Subscribe order
+	names  map[string]struct{}        // subscription names, duplicate guard
+	types  map[string]any             // event name → (*T)(nil) marker, payload-type-drift guard
+}
+
+// subscription is one named binding of an event to a handler. Its name is
+// both the queue and the job type of the fanned-out jobs.
+type subscription struct {
+	name   string
+	handle func(ctx context.Context, env envelope) error
+	hopts  []queue.HandlerOption
+}
+
+// New builds a durable Bus over broker: Publish fans out one job per
+// subscription and handlers run in a worker Service with the queue engine's
+// retry, backoff, and dead-letter semantics. Panics on a nil broker — the
+// bus is startup wiring, not runtime data.
+func New(broker queue.Broker, opts ...Option) *Bus {
+	if broker == nil {
+		panic("eventbus: New requires a broker (use NewSync for the in-process bus)")
+	}
+	return newBus(broker, opts)
+}
+
+// NewSync builds a sync in-process Bus: Publish invokes every subscription
+// handler synchronously on the caller's goroutine and joins their errors. No
+// durability, no retries — a crash between handlers loses the event. Use it
+// for tests, dev, and single-process apps that can afford loss.
+func NewSync(opts ...Option) *Bus {
+	return newBus(nil, opts)
+}
+
+func newBus(broker queue.Broker, opts []Option) *Bus {
+	b := &Bus{
+		broker: broker,
+		clk:    clock.System(),
+		subs:   make(map[string][]*subscription),
+		names:  make(map[string]struct{}),
+		types:  make(map[string]any),
+	}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
+}
+
+// Subscribe declares a named subscription of evt: fn runs once per published
+// event. The full subscription name — "<event>.<name>" — is the durable
+// queue (and job type) the event fans out to, so it must be unique across
+// the app; competing worker instances drain it together. Panics on an empty
+// name, a nil fn, or a duplicate (event, name) pair: subscriptions are
+// startup wiring, and failing fast beats silently double-routing.
+//
+// HANDLERS MUST BE IDEMPOTENT: durable delivery is at-least-once, and a
+// lease lost mid-handler redelivers the event. Dedup side effects with the
+// Inbox keyed by Delivery.ID.
+func Subscribe[T any](bus *Bus, evt Event[T], name string, fn func(ctx context.Context, d Delivery[T]) error, opts ...SubscribeOption) {
+	if name == "" {
+		panic(fmt.Sprintf("eventbus: Subscribe(%q) requires a non-empty subscription name", evt.Name()))
+	}
+	if fn == nil {
+		panic(fmt.Sprintf("eventbus: Subscribe(%q, %q) with nil handler", evt.Name(), name))
+	}
+	full := evt.Name() + "." + name
+	if _, dup := bus.names[full]; dup {
+		panic(fmt.Sprintf("eventbus: duplicate subscription %q", full))
+	}
+	// Two independent NewEvent declarations sharing a name but not a payload
+	// type would otherwise cross-deliver: lenient JSON decoding silently zeroes
+	// the mismatched fields instead of failing.
+	if tok, ok := bus.types[evt.Name()]; ok {
+		if _, same := tok.(*T); !same {
+			panic(fmt.Sprintf("eventbus: event %q subscribed with conflicting payload types (%T vs *%T)", evt.Name(), tok, *new(T)))
+		}
+	} else {
+		bus.types[evt.Name()] = (*T)(nil)
+	}
+	sub := &subscription{
+		name: full,
+		handle: func(ctx context.Context, env envelope) error {
+			if env.V != wireVersion {
+				return queue.SkipRetry(fmt.Errorf("eventbus: subscription %q: unsupported envelope version %d", full, env.V))
+			}
+			// A foreign producer omitting the event id would poison every
+			// inbox-using handler; that is malformed input, not a transient
+			// failure, so dead-letter instead of burning the retry budget.
+			if env.ID == "" {
+				return queue.SkipRetry(fmt.Errorf("eventbus: subscription %q: envelope without event id", full))
+			}
+			var p T
+			if len(env.Payload) > 0 {
+				if err := json.Unmarshal(env.Payload, &p); err != nil {
+					return queue.SkipRetry(fmt.Errorf("eventbus: unmarshal payload for %q: %w", full, err))
+				}
+			}
+			return fn(ctx, Delivery[T]{
+				OccurredAt: time.UnixMilli(env.AtMS).UTC(),
+				ID:         env.ID,
+				Name:       env.Name,
+				Payload:    p,
+			})
+		},
+	}
+	for _, opt := range opts {
+		opt(sub)
+	}
+	bus.names[full] = struct{}{}
+	bus.subs[evt.Name()] = append(bus.subs[evt.Name()], sub)
+}
+
+// Publish emits an event to every subscription of evt. On a durable bus this
+// pushes one job per subscription in a single all-or-nothing broker batch; on
+// a sync bus it runs every handler in-process and returns their joined errors
+// (a failing handler does not stop the others; queue.Cancel counts as
+// success). An event with no subscriptions delivers nothing — publishers
+// never couple to subscriber existence — though a configured scope hook still
+// fails closed and an unmarshalable payload still errors.
+func Publish[T any](ctx context.Context, bus *Bus, evt Event[T], payload T) error {
+	if err := checkType[T](bus, evt.Name()); err != nil {
+		return err
+	}
+	env, scope, err := bus.prepare(ctx, evt.Name(), payload)
+	if err != nil {
+		return err
+	}
+	subs := bus.subs[evt.Name()]
+	if len(subs) == 0 {
+		return nil
+	}
+	if bus.broker == nil {
+		return bus.dispatchSync(ctx, env, subs)
+	}
+	jobs, err := bus.fanout(env, subs, scope)
+	if err != nil {
+		return err
+	}
+	return bus.broker.Push(ctx, jobs...)
+}
+
+// PublishTx emits an event inside a caller-owned database transaction: the
+// fan-out commits or rolls back with the caller's writes. tx is
+// driver-specific, exactly as in queue.PushTx (pgqueue asserts pgx.Tx).
+// Requires a durable bus whose broker implements queue.TxPusher; otherwise
+// ErrTxUnsupported.
+func PublishTx[T any](ctx context.Context, bus *Bus, tx any, evt Event[T], payload T) error {
+	if bus.broker == nil {
+		return fmt.Errorf("%w: sync bus", ErrTxUnsupported)
+	}
+	tp, ok := bus.broker.(queue.TxPusher)
+	if !ok {
+		return fmt.Errorf("%w: broker does not implement queue.TxPusher", ErrTxUnsupported)
+	}
+	if err := checkType[T](bus, evt.Name()); err != nil {
+		return err
+	}
+	env, scope, err := bus.prepare(ctx, evt.Name(), payload)
+	if err != nil {
+		return err
+	}
+	subs := bus.subs[evt.Name()]
+	if len(subs) == 0 {
+		return nil
+	}
+	jobs, err := bus.fanout(env, subs, scope)
+	if err != nil {
+		return err
+	}
+	return tp.PushTx(ctx, tx, jobs...)
+}
+
+// checkType rejects a publish whose payload type differs from the one the
+// event's subscribers declared — reachable only through duplicate NewEvent
+// declarations sharing a name, where lenient JSON decoding would otherwise
+// deliver silently zeroed fields.
+func checkType[T any](bus *Bus, name string) error {
+	if tok, ok := bus.types[name]; ok {
+		if _, same := tok.(*T); !same {
+			return fmt.Errorf("eventbus: publish %q: payload type *%T conflicts with subscribed type %T", name, *new(T), tok)
+		}
+	}
+	return nil
+}
+
+// prepare marshals the payload, resolves the tenancy scope (fail-closed on
+// both bus modes, so a sync dev setup catches missing tenant context exactly
+// like the durable production one), and stamps the envelope.
+func (b *Bus) prepare(ctx context.Context, name string, payload any) (envelope, string, error) {
+	scope := ""
+	if b.scope != nil {
+		s, err := b.scope(ctx)
+		if err != nil {
+			return envelope{}, "", fmt.Errorf("%w: %w", ErrScopeMissing, err)
+		}
+		if s == "" {
+			return envelope{}, "", ErrScopeMissing
+		}
+		scope = s
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return envelope{}, "", fmt.Errorf("eventbus: marshal payload for %q: %w", name, err)
+	}
+	return envelope{
+		V:       wireVersion,
+		ID:      id.NewUUID().String(),
+		Name:    name,
+		AtMS:    b.clk.Now().UnixMilli(),
+		Payload: raw,
+	}, scope, nil
+}
+
+// fanout builds one job per subscription, all carrying the same encoded
+// envelope: same event id everywhere, distinct job ids per queue.
+func (b *Bus) fanout(env envelope, subs []*subscription, scope string) ([]queue.Job, error) {
+	raw, err := json.Marshal(env)
+	if err != nil {
+		return nil, fmt.Errorf("eventbus: encode envelope for %q: %w", env.Name, err)
+	}
+	now := time.UnixMilli(env.AtMS).UTC()
+	jobs := make([]queue.Job, 0, len(subs))
+	for _, s := range subs {
+		jobs = append(jobs, queue.Job{
+			ID:        id.NewUUID().String(),
+			Queue:     s.name,
+			Type:      s.name,
+			Payload:   raw,
+			Scope:     scope,
+			RunAt:     now,
+			CreatedAt: now,
+		})
+	}
+	return jobs, nil
+}
+
+// dispatchSync runs every handler on the caller's goroutine, joining their
+// errors so one failing observer never starves the rest. A cancelled context
+// stops the walk: remaining handlers are skipped and ctx.Err() joins the
+// result. queue.Cancel keeps its durable-mode meaning — the handler discarded
+// a moot event, which is success — so mode-agnostic handlers behave
+// identically on both buses.
+func (b *Bus) dispatchSync(ctx context.Context, env envelope, subs []*subscription) error {
+	var errs []error
+	for _, s := range subs {
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, err)
+			break
+		}
+		if err := invokeSync(ctx, s, env); err != nil && !errors.Is(err, queue.Cancel) {
+			errs = append(errs, fmt.Errorf("eventbus: subscription %q: %w", s.name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// invokeSync runs one handler with panic recovery: a panicking observer is a
+// failed observer, not a crashed publisher — parity with the queue engine's
+// handler recovery in durable mode.
+func invokeSync(ctx context.Context, s *subscription, env envelope) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("handler panic: %v", r)
+		}
+	}()
+	return s.handle(ctx, env)
+}

--- a/async/eventbus/bus_test.go
+++ b/async/eventbus/bus_test.go
@@ -1,0 +1,397 @@
+package eventbus_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type userCreated struct {
+	Email string `json:"email"`
+}
+
+func TestNewEvent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("name", func(t *testing.T) {
+		t.Parallel()
+		evt := eventbus.NewEvent[userCreated]("user.created")
+		assert.Equal(t, "user.created", evt.Name())
+	})
+
+	t.Run("panics on empty name", func(t *testing.T) {
+		t.Parallel()
+		assert.Panics(t, func() { eventbus.NewEvent[userCreated]("") })
+	})
+}
+
+func TestNew_PanicsOnNilBroker(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { eventbus.New(nil) })
+}
+
+func TestSubscribe_WiringPanics(t *testing.T) {
+	t.Parallel()
+	evt := eventbus.NewEvent[userCreated]("user.created")
+	handler := func(context.Context, eventbus.Delivery[userCreated]) error { return nil }
+
+	t.Run("empty name", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.NewSync()
+		assert.Panics(t, func() { eventbus.Subscribe(bus, evt, "", handler) })
+	})
+
+	t.Run("nil handler", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.NewSync()
+		assert.Panics(t, func() { eventbus.Subscribe(bus, evt, "send_welcome", nil) })
+	})
+
+	t.Run("duplicate subscription", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.NewSync()
+		eventbus.Subscribe(bus, evt, "send_welcome", handler)
+		assert.Panics(t, func() { eventbus.Subscribe(bus, evt, "send_welcome", handler) })
+	})
+
+	t.Run("same name on different events is fine", func(t *testing.T) {
+		t.Parallel()
+		other := eventbus.NewEvent[userCreated]("user.deleted")
+		bus := eventbus.NewSync()
+		eventbus.Subscribe(bus, evt, "cleanup", handler)
+		assert.NotPanics(t, func() { eventbus.Subscribe(bus, other, "cleanup", handler) })
+	})
+
+	t.Run("conflicting payload types for one event name", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.NewSync()
+		eventbus.Subscribe(bus, evt, "typed", handler)
+		clash := eventbus.NewEvent[struct {
+			Other int `json:"other"`
+		}]("user.created")
+		assert.Panics(t, func() {
+			eventbus.Subscribe(bus, clash, "clashing", func(context.Context, eventbus.Delivery[struct {
+				Other int `json:"other"`
+			}]) error {
+				return nil
+			})
+		})
+	})
+}
+
+func TestPublish_PayloadTypeConflict(t *testing.T) {
+	t.Parallel()
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[userCreated]("user.created")
+	eventbus.Subscribe(bus, evt, "typed", func(context.Context, eventbus.Delivery[userCreated]) error { return nil })
+
+	clash := eventbus.NewEvent[struct {
+		Other int `json:"other"`
+	}]("user.created")
+	err := eventbus.Publish(context.Background(), bus, clash, struct {
+		Other int `json:"other"`
+	}{Other: 1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "payload type")
+}
+
+func TestSyncPublish(t *testing.T) {
+	t.Parallel()
+	evt := eventbus.NewEvent[userCreated]("user.created")
+
+	t.Run("delivers to every subscription with shared metadata", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+		bus := eventbus.NewSync(eventbus.WithClock(clock.NewMock(now)))
+		var first, second eventbus.Delivery[userCreated]
+		eventbus.Subscribe(bus, evt, "first", func(_ context.Context, d eventbus.Delivery[userCreated]) error {
+			first = d
+			return nil
+		})
+		eventbus.Subscribe(bus, evt, "second", func(_ context.Context, d eventbus.Delivery[userCreated]) error {
+			second = d
+			return nil
+		})
+
+		require.NoError(t, eventbus.Publish(context.Background(), bus, evt, userCreated{Email: "a@b.c"}))
+
+		assert.Equal(t, "a@b.c", first.Payload.Email)
+		assert.Equal(t, "a@b.c", second.Payload.Email)
+		assert.Equal(t, "user.created", first.Name)
+		assert.NotEmpty(t, first.ID)
+		assert.Equal(t, first.ID, second.ID, "one publish = one event id across subscriptions")
+		assert.Equal(t, now, first.OccurredAt)
+	})
+
+	t.Run("no subscriptions is a no-op", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.NewSync()
+		assert.NoError(t, eventbus.Publish(context.Background(), bus, evt, userCreated{}))
+	})
+
+	t.Run("unmarshalable payload errors", func(t *testing.T) {
+		t.Parallel()
+		poison := eventbus.NewEvent[chan int]("bad.payload")
+		bus := eventbus.NewSync()
+		err := eventbus.Publish(context.Background(), bus, poison, make(chan int))
+		assert.Error(t, err)
+	})
+
+	t.Run("joins handler errors and keeps going", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.NewSync()
+		sentinel := errors.New("boom")
+		ran := 0
+		eventbus.Subscribe(bus, evt, "failing", func(context.Context, eventbus.Delivery[userCreated]) error {
+			ran++
+			return sentinel
+		})
+		eventbus.Subscribe(bus, evt, "healthy", func(context.Context, eventbus.Delivery[userCreated]) error {
+			ran++
+			return nil
+		})
+
+		err := eventbus.Publish(context.Background(), bus, evt, userCreated{})
+		require.ErrorIs(t, err, sentinel)
+		assert.Contains(t, err.Error(), `"user.created.failing"`)
+		assert.Equal(t, 2, ran, "a failing observer must not starve the rest")
+	})
+
+	t.Run("queue.Cancel counts as success", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.NewSync()
+		eventbus.Subscribe(bus, evt, "moot", func(context.Context, eventbus.Delivery[userCreated]) error {
+			return queue.Cancel
+		})
+		assert.NoError(t, eventbus.Publish(context.Background(), bus, evt, userCreated{}))
+	})
+
+	t.Run("recovers handler panic", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.NewSync()
+		eventbus.Subscribe(bus, evt, "panicky", func(context.Context, eventbus.Delivery[userCreated]) error {
+			panic("kaboom")
+		})
+		err := eventbus.Publish(context.Background(), bus, evt, userCreated{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "handler panic")
+	})
+
+	t.Run("cancelled context stops the walk", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.NewSync()
+		ran := false
+		eventbus.Subscribe(bus, evt, "never", func(context.Context, eventbus.Delivery[userCreated]) error {
+			ran = true
+			return nil
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := eventbus.Publish(ctx, bus, evt, userCreated{})
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, ran)
+	})
+}
+
+// decodeEnvelope pulls the shared event metadata out of a fanned-out job's
+// payload without depending on the unexported wire type.
+func decodeEnvelope(t *testing.T, payload []byte) (id string, name string, raw json.RawMessage) {
+	t.Helper()
+	var env struct {
+		ID      string          `json:"id"`
+		Name    string          `json:"n"`
+		Payload json.RawMessage `json:"p"`
+		V       int             `json:"v"`
+	}
+	require.NoError(t, json.Unmarshal(payload, &env))
+	require.Equal(t, 1, env.V)
+	return env.ID, env.Name, env.Payload
+}
+
+func claimAll(t *testing.T, broker queue.Broker, q string) []queue.ClaimedJob {
+	t.Helper()
+	jobs, err := broker.Claim(context.Background(), q, 10, time.Minute)
+	require.NoError(t, err)
+	return jobs
+}
+
+func TestDurablePublish(t *testing.T) {
+	t.Parallel()
+	evt := eventbus.NewEvent[userCreated]("user.created")
+
+	t.Run("fans out one job per subscription", func(t *testing.T) {
+		t.Parallel()
+		broker := queue.NewMemoryBroker()
+		bus := eventbus.New(broker)
+		handler := func(context.Context, eventbus.Delivery[userCreated]) error { return nil }
+		eventbus.Subscribe(bus, evt, "send_welcome", handler)
+		eventbus.Subscribe(bus, evt, "provision", handler)
+
+		require.NoError(t, eventbus.Publish(context.Background(), bus, evt, userCreated{Email: "a@b.c"}))
+
+		welcome := claimAll(t, broker, "user.created.send_welcome")
+		provision := claimAll(t, broker, "user.created.provision")
+		require.Len(t, welcome, 1)
+		require.Len(t, provision, 1)
+
+		assert.Equal(t, "user.created.send_welcome", welcome[0].Type)
+		assert.Equal(t, "user.created.provision", provision[0].Type)
+		assert.NotEqual(t, welcome[0].ID, provision[0].ID, "distinct job ids per subscription")
+
+		wID, wName, wRaw := decodeEnvelope(t, welcome[0].Payload)
+		pID, _, _ := decodeEnvelope(t, provision[0].Payload)
+		assert.Equal(t, wID, pID, "same event id across subscriptions")
+		assert.Equal(t, "user.created", wName)
+		var p userCreated
+		require.NoError(t, json.Unmarshal(wRaw, &p))
+		assert.Equal(t, "a@b.c", p.Email)
+	})
+
+	t.Run("no subscriptions pushes nothing", func(t *testing.T) {
+		t.Parallel()
+		broker := queue.NewMemoryBroker()
+		bus := eventbus.New(broker)
+		require.NoError(t, eventbus.Publish(context.Background(), bus, evt, userCreated{}))
+		st, err := broker.Stats(context.Background())
+		require.NoError(t, err)
+		assert.Empty(t, st)
+	})
+
+	t.Run("other events' subscriptions are not fanned out", func(t *testing.T) {
+		t.Parallel()
+		broker := queue.NewMemoryBroker()
+		bus := eventbus.New(broker)
+		other := eventbus.NewEvent[userCreated]("user.deleted")
+		handler := func(context.Context, eventbus.Delivery[userCreated]) error { return nil }
+		eventbus.Subscribe(bus, evt, "send_welcome", handler)
+		eventbus.Subscribe(bus, other, "cleanup", handler)
+
+		require.NoError(t, eventbus.Publish(context.Background(), bus, evt, userCreated{}))
+
+		assert.Len(t, claimAll(t, broker, "user.created.send_welcome"), 1)
+		assert.Empty(t, claimAll(t, broker, "user.deleted.cleanup"))
+	})
+}
+
+func TestScope(t *testing.T) {
+	t.Parallel()
+	evt := eventbus.NewEvent[userCreated]("user.created")
+	handler := func(context.Context, eventbus.Delivery[userCreated]) error { return nil }
+
+	t.Run("captured into fanned-out jobs", func(t *testing.T) {
+		t.Parallel()
+		broker := queue.NewMemoryBroker()
+		bus := eventbus.New(broker, eventbus.WithScope(func(context.Context) (string, error) {
+			return "tenant-1", nil
+		}))
+		eventbus.Subscribe(bus, evt, "send_welcome", handler)
+
+		require.NoError(t, eventbus.Publish(context.Background(), bus, evt, userCreated{}))
+		jobs := claimAll(t, broker, "user.created.send_welcome")
+		require.Len(t, jobs, 1)
+		assert.Equal(t, "tenant-1", jobs[0].Scope)
+	})
+
+	t.Run("fail closed on empty scope", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.New(queue.NewMemoryBroker(), eventbus.WithScope(func(context.Context) (string, error) {
+			return "", nil
+		}))
+		eventbus.Subscribe(bus, evt, "send_welcome", handler)
+		err := eventbus.Publish(context.Background(), bus, evt, userCreated{})
+		assert.ErrorIs(t, err, eventbus.ErrScopeMissing)
+	})
+
+	t.Run("fail closed on hook error", func(t *testing.T) {
+		t.Parallel()
+		cause := errors.New("no tenant in ctx")
+		bus := eventbus.New(queue.NewMemoryBroker(), eventbus.WithScope(func(context.Context) (string, error) {
+			return "", cause
+		}))
+		eventbus.Subscribe(bus, evt, "send_welcome", handler)
+		err := eventbus.Publish(context.Background(), bus, evt, userCreated{})
+		assert.ErrorIs(t, err, eventbus.ErrScopeMissing)
+		assert.ErrorIs(t, err, cause)
+	})
+
+	t.Run("sync bus enforces the hook too", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.NewSync(eventbus.WithScope(func(context.Context) (string, error) {
+			return "", nil
+		}))
+		ran := false
+		eventbus.Subscribe(bus, evt, "send_welcome", func(context.Context, eventbus.Delivery[userCreated]) error {
+			ran = true
+			return nil
+		})
+		err := eventbus.Publish(context.Background(), bus, evt, userCreated{})
+		assert.ErrorIs(t, err, eventbus.ErrScopeMissing)
+		assert.False(t, ran, "fail-closed publish must not deliver")
+	})
+}
+
+// txRecorder wraps the memory broker with a queue.TxPusher that records the
+// tx it was handed and the jobs pushed through it.
+type txRecorder struct {
+	*queue.MemoryBroker
+	tx   any
+	jobs []queue.Job
+}
+
+func (r *txRecorder) PushTx(_ context.Context, tx any, jobs ...queue.Job) error {
+	r.tx = tx
+	r.jobs = append(r.jobs, jobs...)
+	return nil
+}
+
+func TestPublishTx(t *testing.T) {
+	t.Parallel()
+	evt := eventbus.NewEvent[userCreated]("user.created")
+	handler := func(context.Context, eventbus.Delivery[userCreated]) error { return nil }
+
+	t.Run("routes through TxPusher with the caller's tx", func(t *testing.T) {
+		t.Parallel()
+		rec := &txRecorder{MemoryBroker: queue.NewMemoryBroker()}
+		bus := eventbus.New(rec)
+		eventbus.Subscribe(bus, evt, "send_welcome", handler)
+		eventbus.Subscribe(bus, evt, "provision", handler)
+
+		tx := struct{ name string }{"fake-tx"}
+		require.NoError(t, eventbus.PublishTx(context.Background(), bus, tx, evt, userCreated{Email: "a@b.c"}))
+		assert.Equal(t, tx, rec.tx)
+		assert.Len(t, rec.jobs, 2)
+	})
+
+	t.Run("no subscriptions is a no-op", func(t *testing.T) {
+		t.Parallel()
+		rec := &txRecorder{MemoryBroker: queue.NewMemoryBroker()}
+		bus := eventbus.New(rec)
+		require.NoError(t, eventbus.PublishTx(context.Background(), bus, "tx", evt, userCreated{}))
+		assert.Empty(t, rec.jobs)
+	})
+
+	t.Run("broker without TxPusher", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.New(queue.NewMemoryBroker())
+		eventbus.Subscribe(bus, evt, "send_welcome", handler)
+		err := eventbus.PublishTx(context.Background(), bus, "tx", evt, userCreated{})
+		assert.ErrorIs(t, err, eventbus.ErrTxUnsupported)
+	})
+
+	t.Run("sync bus", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.NewSync()
+		eventbus.Subscribe(bus, evt, "send_welcome", handler)
+		err := eventbus.PublishTx(context.Background(), bus, "tx", evt, userCreated{})
+		assert.ErrorIs(t, err, eventbus.ErrTxUnsupported)
+	})
+}

--- a/async/eventbus/doc.go
+++ b/async/eventbus/doc.go
@@ -1,0 +1,52 @@
+// Package eventbus is typed publish/subscribe over the queue engine: an
+// event is a fact that already happened, and every named subscription
+// reacts to it independently.
+//
+// Two modes share one wiring API. The durable bus (New, over any
+// queue.Broker) fans each published event out as one job per subscription —
+// each subscription is its own queue, so competing worker instances share a
+// subscription's load and a slow subscription only delays itself — with the
+// queue engine's at-least-once delivery, retry, backoff, and per-subscription
+// dead-lettering. The sync bus (NewSync) invokes handlers in-process during
+// Publish with no durability: tests, dev, and apps that can afford loss.
+// Swapping modes changes one constructor call.
+//
+// # Usage
+//
+//	var UserCreated = eventbus.NewEvent[UserCreatedPayload]("user.created")
+//
+//	bus := eventbus.New(broker)
+//	eventbus.Subscribe(bus, UserCreated, "send_welcome", func(ctx context.Context, d eventbus.Delivery[UserCreatedPayload]) error {
+//		return mailer.SendWelcome(ctx, d.Payload.Email)
+//	})
+//	eventbus.Subscribe(bus, UserCreated, "provision", provisionHandler, eventbus.WithMaxAttempts(5))
+//
+//	svc, _ := eventbus.NewService(bus)   // run under ops/supervisor
+//	err := eventbus.Publish(ctx, bus, UserCreated, UserCreatedPayload{...})
+//
+// Publishing an event with no subscriptions delivers nothing: publishers
+// never couple to subscriber existence. Subscription handlers return the same
+// verdicts as queue handlers — nil completes, queue.SkipRetry dead-letters
+// poison input, queue.Cancel discards a moot event, any other error retries.
+// The sync bus honors queue.Cancel as success too, but has no retry or
+// dead-letter: every other handler error joins Publish's returned error.
+//
+// # Transactional publish and the idempotency inbox
+//
+// On brokers with real multi-document transactions (queue.TxPusher — pgqueue,
+// mongoqueue), PublishTx fans out inside the caller's own transaction: the
+// event is published if and only if the business writes commit. Brokers
+// without it (redis) get transactional publish via async/outbox instead.
+//
+// Delivery is at-least-once, so HANDLERS MUST BE IDEMPOTENT. Every delivery
+// of one published event — across retries and across subscriptions — carries
+// the same Delivery.ID; the Inbox seam turns that into exactly-once side
+// effects: Seen(ctx, tx, d.ID) inside the handler's transaction claims the id
+// or reports it already processed. MemoryInbox is the test double;
+// async/eventbus/postgres ships the transactional implementation.
+//
+// Multi-tenant apps configure eventbus.WithScope on the bus (captures the
+// tenant into every fanned-out job, fail-closed) and pass
+// queue.WithScopeContext to NewService (restores it into the handler
+// context). Single-tenant apps configure neither.
+package eventbus

--- a/async/eventbus/errors.go
+++ b/async/eventbus/errors.go
@@ -1,0 +1,18 @@
+package eventbus
+
+import "errors"
+
+var (
+	// ErrScopeMissing is returned by Publish/PublishTx when a scope hook is
+	// configured and yields an error or empty scope.
+	ErrScopeMissing = errors.New("eventbus: scope missing")
+	// ErrTxUnsupported is returned by PublishTx when the bus is sync or its
+	// broker does not implement queue.TxPusher.
+	ErrTxUnsupported = errors.New("eventbus: transactional publish unsupported")
+	// ErrNotDurable is returned by NewService on a bus built with NewSync:
+	// sync subscriptions run inside Publish and have no worker service.
+	ErrNotDurable = errors.New("eventbus: bus is not durable")
+	// ErrNoSubscriptions is returned by NewService when nothing has been
+	// subscribed: a worker with no queues to drain is a wiring error.
+	ErrNoSubscriptions = errors.New("eventbus: no subscriptions")
+)

--- a/async/eventbus/event.go
+++ b/async/eventbus/event.go
@@ -1,0 +1,57 @@
+package eventbus
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Event binds an event name to its payload type T. Declare one package-level
+// Event per event type and share it between publishers and subscribers: the
+// name string exists in exactly one place, and payload type drift between
+// Publish and Subscribe becomes a compile error.
+//
+//	var UserCreated = eventbus.NewEvent[UserCreatedPayload]("user.created")
+type Event[T any] struct {
+	name string
+}
+
+// NewEvent creates an Event for payload type T. The name must be non-empty
+// and unique across the application (convention: "domain.past_tense", e.g.
+// "user.created"). Panics on an empty name: events are package-level wiring,
+// not runtime data.
+func NewEvent[T any](name string) Event[T] {
+	if name == "" {
+		panic("eventbus: NewEvent requires a non-empty name")
+	}
+	return Event[T]{name: name}
+}
+
+// Name returns the event name.
+func (e Event[T]) Name() string { return e.name }
+
+// Delivery is what a subscription handler receives: the decoded payload plus
+// the event metadata. ID is the stable event id — every subscription's
+// delivery of one published event carries the same ID, so it is the dedup key
+// for the Inbox (and the Idempotency-Key receivers should dedup on).
+type Delivery[T any] struct {
+	OccurredAt time.Time
+	Payload    T
+	ID         string
+	Name       string
+}
+
+// wireVersion is the envelope encoding version. Bump only with a decoder
+// that still accepts every previous version: durable events published by old
+// binaries must stay deliverable.
+const wireVersion = 1
+
+// envelope is the wire form a published event travels in: it rides as the
+// queue.Job payload of every fanned-out job, so all subscriptions see the
+// same event id and timestamp.
+type envelope struct {
+	ID      string          `json:"id"`
+	Name    string          `json:"n"`
+	Payload json.RawMessage `json:"p,omitempty"`
+	V       int             `json:"v"`
+	AtMS    int64           `json:"at"`
+}

--- a/async/eventbus/example_test.go
+++ b/async/eventbus/example_test.go
@@ -1,0 +1,65 @@
+package eventbus_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+	"github.com/dmitrymomot/forge/async/queue"
+)
+
+type orderPlaced struct {
+	OrderID string `json:"order_id"`
+}
+
+var evtOrderPlaced = eventbus.NewEvent[orderPlaced]("example.order_placed")
+
+func Example() {
+	broker := queue.NewMemoryBroker()
+	bus := eventbus.New(broker)
+
+	done := make(chan struct{}, 2)
+	eventbus.Subscribe(bus, evtOrderPlaced, "receipt", func(_ context.Context, d eventbus.Delivery[orderPlaced]) error {
+		fmt.Println("receipt for", d.Payload.OrderID)
+		done <- struct{}{}
+		return nil
+	})
+	eventbus.Subscribe(bus, evtOrderPlaced, "fulfillment", func(_ context.Context, d eventbus.Delivery[orderPlaced]) error {
+		fmt.Println("fulfillment for", d.Payload.OrderID)
+		done <- struct{}{}
+		return nil
+	})
+
+	cfg := queue.DefaultConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	svc, err := eventbus.NewService(bus, queue.WithConfig(cfg))
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() { _ = svc.Run(ctx); close(stopped) }()
+
+	_ = eventbus.Publish(context.Background(), bus, evtOrderPlaced, orderPlaced{OrderID: "ord_1"})
+
+	<-done
+	<-done
+	cancel()
+	<-stopped
+	// Unordered output:
+	// receipt for ord_1
+	// fulfillment for ord_1
+}
+
+func ExampleNewSync() {
+	bus := eventbus.NewSync()
+	eventbus.Subscribe(bus, evtOrderPlaced, "audit", func(_ context.Context, d eventbus.Delivery[orderPlaced]) error {
+		fmt.Println("audited", d.Payload.OrderID)
+		return nil
+	})
+
+	_ = eventbus.Publish(context.Background(), bus, evtOrderPlaced, orderPlaced{OrderID: "ord_2"})
+	// Output: audited ord_2
+}

--- a/async/eventbus/inbox.go
+++ b/async/eventbus/inbox.go
@@ -1,0 +1,54 @@
+package eventbus
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// Inbox is the idempotency-inbox seam: it marks event ids as processed
+// inside the consumer's own database transaction, so "record the event as
+// handled" commits or rolls back atomically with the handler's writes. One
+// Inbox per subscription — deliveries of the same event to different
+// subscriptions carry the same Delivery.ID and each must process it once.
+//
+//	seen, err := inbox.Seen(ctx, tx, d.ID)
+//	if err != nil { return err }
+//	if seen { return nil } // duplicate delivery, already committed
+//	// ... handler writes in the same tx ...
+//
+// tx is driver-specific, exactly as in queue.PushTx (the postgres inbox
+// asserts pgx.Tx). Seen marks the id and reports whether it was already
+// marked: false means this call claimed the first processing.
+type Inbox interface {
+	Seen(ctx context.Context, tx any, id string) (bool, error)
+}
+
+// MemoryInbox is the in-process Inbox test double: a plain set, tx ignored.
+// It has no transactional semantics — a handler that marks an id and then
+// fails keeps the mark even though its real writes rolled back, so a retry
+// would skip the event. Tests and throwaway dev only; production consumers
+// use a transactional inbox (async/eventbus/postgres) or bring their own.
+type MemoryInbox struct {
+	seen map[string]struct{}
+	mu   sync.Mutex
+}
+
+// NewMemoryInbox builds an empty in-memory inbox.
+func NewMemoryInbox() *MemoryInbox {
+	return &MemoryInbox{seen: make(map[string]struct{})}
+}
+
+// Seen implements Inbox. The tx argument is ignored.
+func (i *MemoryInbox) Seen(_ context.Context, _ any, id string) (bool, error) {
+	if id == "" {
+		return false, errors.New("eventbus: Seen requires a non-empty event id")
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if _, ok := i.seen[id]; ok {
+		return true, nil
+	}
+	i.seen[id] = struct{}{}
+	return false, nil
+}

--- a/async/eventbus/inbox_test.go
+++ b/async/eventbus/inbox_test.go
@@ -1,0 +1,71 @@
+package eventbus_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+)
+
+var _ eventbus.Inbox = (*eventbus.MemoryInbox)(nil)
+
+func TestMemoryInbox(t *testing.T) {
+	t.Parallel()
+
+	t.Run("first claim then duplicate", func(t *testing.T) {
+		t.Parallel()
+		inbox := eventbus.NewMemoryInbox()
+		seen, err := inbox.Seen(context.Background(), nil, "evt-1")
+		require.NoError(t, err)
+		assert.False(t, seen)
+
+		seen, err = inbox.Seen(context.Background(), nil, "evt-1")
+		require.NoError(t, err)
+		assert.True(t, seen)
+	})
+
+	t.Run("ids are independent", func(t *testing.T) {
+		t.Parallel()
+		inbox := eventbus.NewMemoryInbox()
+		_, err := inbox.Seen(context.Background(), nil, "evt-1")
+		require.NoError(t, err)
+		seen, err := inbox.Seen(context.Background(), nil, "evt-2")
+		require.NoError(t, err)
+		assert.False(t, seen)
+	})
+
+	t.Run("empty id errors", func(t *testing.T) {
+		t.Parallel()
+		inbox := eventbus.NewMemoryInbox()
+		_, err := inbox.Seen(context.Background(), nil, "")
+		assert.Error(t, err)
+	})
+
+	t.Run("exactly one concurrent claimer wins", func(t *testing.T) {
+		t.Parallel()
+		inbox := eventbus.NewMemoryInbox()
+		const claimers = 32
+		firsts := make(chan bool, claimers)
+		var wg sync.WaitGroup
+		for range claimers {
+			wg.Go(func() {
+				seen, err := inbox.Seen(context.Background(), nil, "evt-1")
+				assert.NoError(t, err)
+				firsts <- !seen
+			})
+		}
+		wg.Wait()
+		close(firsts)
+		wins := 0
+		for first := range firsts {
+			if first {
+				wins++
+			}
+		}
+		assert.Equal(t, 1, wins)
+	})
+}

--- a/async/eventbus/options.go
+++ b/async/eventbus/options.go
@@ -1,0 +1,57 @@
+package eventbus
+
+import (
+	"context"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/resilience/backoff"
+)
+
+// Option configures New and NewSync.
+type Option func(*Bus)
+
+// WithScope installs the tenancy hook: it is called on every publish and its
+// result is captured into each fanned-out job's scope. Fail-closed: once
+// configured, a hook error or empty scope makes the publish fail with
+// ErrScopeMissing — on the sync bus too, so dev catches a missing tenant
+// context exactly like production. Single-tenant apps simply do not configure
+// it. Restore the scope on the worker side by passing queue.WithScopeContext
+// to NewService.
+func WithScope(fn func(ctx context.Context) (string, error)) Option {
+	return func(b *Bus) { b.scope = fn }
+}
+
+// WithClock injects a clock stamping Delivery.OccurredAt (tests).
+func WithClock(clk clock.Clock) Option {
+	return func(b *Bus) { b.clk = clk }
+}
+
+// SubscribeOption configures a single subscription. All of them tune the
+// durable worker's dispatch and are ignored by the sync bus, where the
+// publisher's call is the only attempt.
+type SubscribeOption func(*subscription)
+
+// WithMaxAttempts sets this subscription's delivery attempt budget
+// (overrides the worker's Config.MaxAttempts); once spent, the event
+// dead-letters on this subscription only.
+func WithMaxAttempts(n int) SubscribeOption {
+	qo := queue.WithHandlerMaxAttempts(n)
+	return func(s *subscription) { s.hopts = append(s.hopts, qo) }
+}
+
+// WithRetryBackoff overrides the worker's default retry backoff for this
+// subscription.
+func WithRetryBackoff(b backoff.Backoff) SubscribeOption {
+	qo := queue.WithHandlerBackoff(b)
+	return func(s *subscription) { s.hopts = append(s.hopts, qo) }
+}
+
+// WithHandlerTimeout bounds each durable invocation of this subscription's
+// handler; expiry counts as a failure and takes the retry path. 0 disables
+// the worker's default timeout; panics on a negative duration.
+func WithHandlerTimeout(d time.Duration) SubscribeOption {
+	qo := queue.WithHandlerTimeout(d)
+	return func(s *subscription) { s.hopts = append(s.hopts, qo) }
+}

--- a/async/eventbus/postgres/bench_test.go
+++ b/async/eventbus/postgres/bench_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+
+package pgeventbus_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	pgeventbus "github.com/dmitrymomot/forge/async/eventbus/postgres"
+)
+
+func BenchmarkInboxSeen(b *testing.B) {
+	pool := openPool(b)
+	ctx := context.Background()
+	inbox, err := pgeventbus.NewInbox("bench.consumer")
+	require.NoError(b, err)
+
+	b.Run("first_claim", func(b *testing.B) {
+		i := 0
+		b.ReportAllocs()
+		for b.Loop() {
+			i++
+			id := fmt.Sprintf("bench-first-%d", i)
+			if err := pgx.BeginFunc(ctx, pool, func(tx pgx.Tx) error {
+				_, err := inbox.Seen(ctx, tx, id)
+				return err
+			}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("duplicate", func(b *testing.B) {
+		require.NoError(b, pgx.BeginFunc(ctx, pool, func(tx pgx.Tx) error {
+			_, err := inbox.Seen(ctx, tx, "bench-dup")
+			return err
+		}))
+		b.ReportAllocs()
+		for b.Loop() {
+			if err := pgx.BeginFunc(ctx, pool, func(tx pgx.Tx) error {
+				seen, err := inbox.Seen(ctx, tx, "bench-dup")
+				if err == nil && !seen {
+					b.Fatal("expected duplicate")
+				}
+				return err
+			}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/async/eventbus/postgres/doc.go
+++ b/async/eventbus/postgres/doc.go
@@ -1,0 +1,22 @@
+// Package pgeventbus is the Postgres eventbus.Inbox: an idempotency inbox
+// keyed by (consumer, event id) that rides the handler's own pgx.Tx, so
+// marking an event processed commits or rolls back atomically with the
+// handler's writes. Apply Migrations with data/migration before use.
+//
+//	inbox, _ := pgeventbus.NewInbox("user.created.send_welcome")
+//	eventbus.Subscribe(bus, UserCreated, "send_welcome", func(ctx context.Context, d eventbus.Delivery[UserCreatedPayload]) error {
+//		return pgx.BeginFunc(ctx, pool, func(tx pgx.Tx) error {
+//			seen, err := inbox.Seen(ctx, tx, d.ID)
+//			if err != nil || seen {
+//				return err
+//			}
+//			// ... handler writes in the same tx ...
+//			return nil
+//		})
+//	})
+//
+// The inbox only dedups deliveries that can still arrive, so rows need to
+// outlive the worker's retry horizon, not live forever: schedule
+// PurgeSeenBefore (e.g. daily with a cutoff a few multiples of the retry
+// horizon back) to keep the table bounded.
+package pgeventbus

--- a/async/eventbus/postgres/migrations/20260720120000_eventbus_inbox.sql
+++ b/async/eventbus/postgres/migrations/20260720120000_eventbus_inbox.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+CREATE TABLE eventbus_inbox (
+    consumer text NOT NULL,
+    event_id text NOT NULL,
+    seen_at  timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (consumer, event_id)
+);
+
+CREATE INDEX eventbus_inbox_sweep_idx ON eventbus_inbox (seen_at);
+
+-- +goose Down
+DROP TABLE eventbus_inbox;

--- a/async/eventbus/postgres/pgeventbus.go
+++ b/async/eventbus/postgres/pgeventbus.go
@@ -1,0 +1,143 @@
+package pgeventbus
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating eventbus_inbox, rooted so its
+// .sql files sit at fsys root. Apply via data/migration under its own version
+// table.
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+var tableNameRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+type config struct {
+	table string
+}
+
+// Option configures NewInbox and PurgeSeenBefore.
+type Option func(*config)
+
+// WithTable overrides the inbox table name (default "eventbus_inbox"). The
+// shipped migration creates the default; a custom name requires a
+// caller-managed schema of the same shape.
+func WithTable(name string) Option {
+	return func(c *config) { c.table = name }
+}
+
+func newConfig(opts []Option) (config, error) {
+	c := config{table: "eventbus_inbox"}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	if !tableNameRe.MatchString(c.table) {
+		return config{}, fmt.Errorf("pgeventbus: invalid table name %q", c.table)
+	}
+	return c, nil
+}
+
+// Inbox is the transactional eventbus.Inbox for one consumer: Seen rides the
+// caller's pgx.Tx, so marking an event processed commits or rolls back
+// atomically with the handler's own writes. Consumers share one table keyed
+// by (consumer, event id); build one Inbox per subscription with the
+// subscription's name as consumer.
+type Inbox struct {
+	consumer string
+	seenSQL  string
+}
+
+// NewInbox builds an Inbox for consumer (convention: the full subscription
+// name, e.g. "user.created.send_welcome"). Errors on an empty consumer or an
+// invalid table name.
+func NewInbox(consumer string, opts ...Option) (*Inbox, error) {
+	if consumer == "" {
+		return nil, errors.New("pgeventbus: NewInbox requires a non-empty consumer")
+	}
+	c, err := newConfig(opts)
+	if err != nil {
+		return nil, err
+	}
+	return &Inbox{
+		consumer: consumer,
+		seenSQL:  fmt.Sprintf("INSERT INTO %s (consumer, event_id) VALUES ($1, $2) ON CONFLICT DO NOTHING", c.table),
+	}, nil
+}
+
+// Seen implements eventbus.Inbox: it claims id for this consumer inside tx
+// and reports whether it was already claimed. tx must be a pgx.Tx — the same
+// transaction the handler writes in, or the claim would not roll back with a
+// failed handler.
+func (i *Inbox) Seen(ctx context.Context, tx any, id string) (bool, error) {
+	pgtx, ok := tx.(pgx.Tx)
+	if !ok {
+		return false, fmt.Errorf("pgeventbus: Seen requires a pgx.Tx, got %T", tx)
+	}
+	if id == "" {
+		return false, errors.New("pgeventbus: Seen requires a non-empty event id")
+	}
+	tag, err := pgtx.Exec(ctx, i.seenSQL, i.consumer, id)
+	if err != nil {
+		return false, fmt.Errorf("pgeventbus: seen: %w", err)
+	}
+	return tag.RowsAffected() == 0, nil
+}
+
+// purgeBatch bounds one PurgeSeenBefore statement, keeping each delete a
+// short transaction with WAL and vacuum debt paid off between batches
+// instead of accumulated across one multi-million-row delete (pgqueue
+// precedent).
+const purgeBatch = 5000
+
+// PurgeSeenBefore deletes inbox rows — across all consumers — marked
+// strictly before cutoff, and returns how many were removed. The inbox only
+// dedups deliveries that can still arrive, so retention needs to outlive the
+// worker's retry horizon, not grow forever; run this from a scheduled job.
+// Deletes are batched, so it is safe on an unswept backlog.
+func PurgeSeenBefore(ctx context.Context, pool *pgxpool.Pool, cutoff time.Time, opts ...Option) (int, error) {
+	if pool == nil {
+		return 0, errors.New("pgeventbus: PurgeSeenBefore requires a pool")
+	}
+	c, err := newConfig(opts)
+	if err != nil {
+		return 0, err
+	}
+	// ctid batching: one InitPlan picks the batch by the seen_at index, and
+	// the delete addresses rows directly — no per-batch semi-join over the
+	// whole table.
+	sql := fmt.Sprintf(`DELETE FROM %[1]s WHERE ctid = ANY(ARRAY(SELECT ctid FROM %[1]s WHERE seen_at < $1 LIMIT %[2]d))`, c.table, purgeBatch)
+	total := 0
+	for {
+		tag, err := pool.Exec(ctx, sql, cutoff)
+		if err != nil {
+			return total, fmt.Errorf("pgeventbus: purge seen before: %w", err)
+		}
+		n := int(tag.RowsAffected())
+		total += n
+		// Terminate on an empty batch, not a short one: a concurrent purge
+		// deleting part of this run's selected batch would otherwise make both
+		// runs exit early with purgeable rows remaining.
+		if n == 0 {
+			return total, nil
+		}
+	}
+}

--- a/async/eventbus/postgres/pgeventbus.go
+++ b/async/eventbus/postgres/pgeventbus.go
@@ -53,6 +53,11 @@ func newConfig(opts []Option) (config, error) {
 	if !tableNameRe.MatchString(c.table) {
 		return config{}, fmt.Errorf("pgeventbus: invalid table name %q", c.table)
 	}
+	// Postgres truncates identifiers past 63 bytes: two longer names sharing a
+	// prefix would silently collide on one physical table.
+	if len(c.table) > 63 {
+		return config{}, fmt.Errorf("pgeventbus: table name %q exceeds the 63-byte identifier limit", c.table)
+	}
 	return c, nil
 }
 

--- a/async/eventbus/postgres/pgeventbus_test.go
+++ b/async/eventbus/postgres/pgeventbus_test.go
@@ -1,0 +1,172 @@
+//go:build integration
+
+package pgeventbus_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+	pgeventbus "github.com/dmitrymomot/forge/async/eventbus/postgres"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+)
+
+var _ eventbus.Inbox = (*pgeventbus.Inbox)(nil)
+
+// openPool connects to the suite's Postgres (via pgtest.DSN) and applies the
+// inbox migration.
+func openPool(tb testing.TB) *pgxpool.Pool {
+	tb.Helper()
+	cfg := postgres.DefaultConfig()
+	cfg.URL = pgtest.DSN(tb)
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(tb, err)
+	tb.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	tb.Cleanup(func() { _ = db.Close() })
+	require.NoError(tb, migration.New(pgeventbus.Migrations, migration.WithTable("forge_eventbus_schema")).Up(context.Background(), db))
+	_, err = pool.Exec(context.Background(), "TRUNCATE eventbus_inbox")
+	require.NoError(tb, err)
+	return pool
+}
+
+func inTx(tb testing.TB, pool *pgxpool.Pool, fn func(tx pgx.Tx) error) error {
+	tb.Helper()
+	return pgx.BeginFunc(context.Background(), pool, fn)
+}
+
+func TestNewInbox(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty consumer", func(t *testing.T) {
+		t.Parallel()
+		_, err := pgeventbus.NewInbox("")
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid table", func(t *testing.T) {
+		t.Parallel()
+		_, err := pgeventbus.NewInbox("c", pgeventbus.WithTable("bad; DROP TABLE x"))
+		assert.Error(t, err)
+	})
+}
+
+func TestInbox_Seen(t *testing.T) {
+	pool := openPool(t)
+	ctx := context.Background()
+
+	t.Run("first claim then duplicate", func(t *testing.T) {
+		inbox, err := pgeventbus.NewInbox("sub.first")
+		require.NoError(t, err)
+
+		require.NoError(t, inTx(t, pool, func(tx pgx.Tx) error {
+			seen, err := inbox.Seen(ctx, tx, "evt-1")
+			require.NoError(t, err)
+			assert.False(t, seen)
+			return nil
+		}))
+		require.NoError(t, inTx(t, pool, func(tx pgx.Tx) error {
+			seen, err := inbox.Seen(ctx, tx, "evt-1")
+			require.NoError(t, err)
+			assert.True(t, seen)
+			return nil
+		}))
+	})
+
+	t.Run("rollback releases the claim", func(t *testing.T) {
+		inbox, err := pgeventbus.NewInbox("sub.rollback")
+		require.NoError(t, err)
+
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+		seen, err := inbox.Seen(ctx, tx, "evt-1")
+		require.NoError(t, err)
+		assert.False(t, seen)
+		require.NoError(t, tx.Rollback(ctx))
+
+		require.NoError(t, inTx(t, pool, func(tx pgx.Tx) error {
+			seen, err := inbox.Seen(ctx, tx, "evt-1")
+			require.NoError(t, err)
+			assert.False(t, seen, "a rolled-back claim must not stick")
+			return nil
+		}))
+	})
+
+	t.Run("consumers dedup independently", func(t *testing.T) {
+		a, err := pgeventbus.NewInbox("sub.a")
+		require.NoError(t, err)
+		b, err := pgeventbus.NewInbox("sub.b")
+		require.NoError(t, err)
+
+		require.NoError(t, inTx(t, pool, func(tx pgx.Tx) error {
+			seen, err := a.Seen(ctx, tx, "evt-shared")
+			require.NoError(t, err)
+			assert.False(t, seen)
+			return nil
+		}))
+		require.NoError(t, inTx(t, pool, func(tx pgx.Tx) error {
+			seen, err := b.Seen(ctx, tx, "evt-shared")
+			require.NoError(t, err)
+			assert.False(t, seen, "another consumer's claim must not shadow this one")
+			return nil
+		}))
+	})
+
+	t.Run("rejects non-pgx tx and empty id", func(t *testing.T) {
+		inbox, err := pgeventbus.NewInbox("sub.guard")
+		require.NoError(t, err)
+		_, err = inbox.Seen(ctx, "not a tx", "evt-1")
+		assert.Error(t, err)
+		require.NoError(t, inTx(t, pool, func(tx pgx.Tx) error {
+			_, err := inbox.Seen(ctx, tx, "")
+			assert.Error(t, err)
+			return nil
+		}))
+	})
+}
+
+func TestPurgeSeenBefore(t *testing.T) {
+	pool := openPool(t)
+	ctx := context.Background()
+
+	inbox, err := pgeventbus.NewInbox("sub.purge")
+	require.NoError(t, err)
+	require.NoError(t, inTx(t, pool, func(tx pgx.Tx) error {
+		for _, id := range []string{"old-1", "old-2", "fresh-1"} {
+			if _, err := inbox.Seen(ctx, tx, id); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+	_, err = pool.Exec(ctx, "UPDATE eventbus_inbox SET seen_at = now() - interval '48 hours' WHERE event_id LIKE 'old-%'")
+	require.NoError(t, err)
+
+	n, err := pgeventbus.PurgeSeenBefore(ctx, pool, time.Now().UTC().Add(-24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	require.NoError(t, inTx(t, pool, func(tx pgx.Tx) error {
+		seen, err := inbox.Seen(ctx, tx, "fresh-1")
+		require.NoError(t, err)
+		assert.True(t, seen, "fresh rows must survive the purge")
+		seen, err = inbox.Seen(ctx, tx, "old-1")
+		require.NoError(t, err)
+		assert.False(t, seen, "purged rows are claimable again")
+		return nil
+	}))
+
+	t.Run("nil pool", func(t *testing.T) {
+		_, err := pgeventbus.PurgeSeenBefore(ctx, nil, time.Now())
+		assert.Error(t, err)
+	})
+}

--- a/async/eventbus/postgres/pgeventbus_test.go
+++ b/async/eventbus/postgres/pgeventbus_test.go
@@ -4,6 +4,7 @@ package pgeventbus_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,6 +57,12 @@ func TestNewInbox(t *testing.T) {
 	t.Run("invalid table", func(t *testing.T) {
 		t.Parallel()
 		_, err := pgeventbus.NewInbox("c", pgeventbus.WithTable("bad; DROP TABLE x"))
+		assert.Error(t, err)
+	})
+
+	t.Run("table name over the identifier limit", func(t *testing.T) {
+		t.Parallel()
+		_, err := pgeventbus.NewInbox("c", pgeventbus.WithTable(strings.Repeat("x", 64)))
 		assert.Error(t, err)
 	})
 }

--- a/async/eventbus/service.go
+++ b/async/eventbus/service.go
@@ -1,0 +1,48 @@
+package eventbus
+
+import (
+	"github.com/dmitrymomot/forge/async/queue"
+)
+
+// NewService builds the worker that drains a durable bus: a queue.Service
+// over the bus's broker with one equal-weight queue per subscription (slow
+// subscriptions only delay themselves) and every handler registered. Run it
+// under ops/supervisor next to any job-queue Service — the default service
+// name is "eventbus".
+//
+// opts pass through to queue.NewService: concurrency, logger, config,
+// queue.WithScopeContext for tenancy restore, and a name override all work as
+// on a plain queue worker. Do not pass queue.WithQueues — the bus owns the
+// queue set, and NewService overrides it.
+//
+// The service snapshots the bus's subscriptions at construction: Subscribe
+// everything first, then build the service.
+//
+// Returns ErrNotDurable on a sync bus and ErrNoSubscriptions when nothing was
+// subscribed.
+func NewService(bus *Bus, opts ...queue.ServiceOption) (*queue.Service, error) {
+	if bus.broker == nil {
+		return nil, ErrNotDurable
+	}
+	weights := make(map[string]int, len(bus.names))
+	for name := range bus.names {
+		weights[name] = 1
+	}
+	if len(weights) == 0 {
+		return nil, ErrNoSubscriptions
+	}
+	svcOpts := make([]queue.ServiceOption, 0, len(opts)+2)
+	svcOpts = append(svcOpts, queue.WithName("eventbus"))
+	svcOpts = append(svcOpts, opts...)
+	svcOpts = append(svcOpts, queue.WithQueues(weights))
+	svc, err := queue.NewService(bus.broker, svcOpts...)
+	if err != nil {
+		return nil, err
+	}
+	for _, subs := range bus.subs {
+		for _, s := range subs {
+			queue.Register(svc, queue.NewKind[envelope](s.name), s.handle, s.hopts...)
+		}
+	}
+	return svc, nil
+}

--- a/async/eventbus/service_test.go
+++ b/async/eventbus/service_test.go
@@ -1,0 +1,240 @@
+package eventbus_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+	"github.com/dmitrymomot/forge/async/queue"
+)
+
+func fastConfig() queue.Config {
+	cfg := queue.DefaultConfig()
+	cfg.PollInterval = 5 * time.Millisecond
+	return cfg
+}
+
+// runService starts svc and returns a stop func that cancels it and waits for
+// drain.
+func runService(t *testing.T, svc *queue.Service) func() {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() { _ = svc.Run(ctx); close(stopped) }()
+	return func() {
+		cancel()
+		<-stopped
+	}
+}
+
+func TestNewService(t *testing.T) {
+	t.Parallel()
+	evt := eventbus.NewEvent[userCreated]("user.created")
+
+	t.Run("sync bus", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.NewSync()
+		eventbus.Subscribe(bus, evt, "s", func(context.Context, eventbus.Delivery[userCreated]) error { return nil })
+		_, err := eventbus.NewService(bus)
+		assert.ErrorIs(t, err, eventbus.ErrNotDurable)
+	})
+
+	t.Run("no subscriptions", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.New(queue.NewMemoryBroker())
+		_, err := eventbus.NewService(bus)
+		assert.ErrorIs(t, err, eventbus.ErrNoSubscriptions)
+	})
+
+	t.Run("default name is eventbus and caller can override", func(t *testing.T) {
+		t.Parallel()
+		bus := eventbus.New(queue.NewMemoryBroker())
+		eventbus.Subscribe(bus, evt, "s", func(context.Context, eventbus.Delivery[userCreated]) error { return nil })
+		svc, err := eventbus.NewService(bus)
+		require.NoError(t, err)
+		assert.Equal(t, "eventbus", svc.Name())
+
+		named, err := eventbus.NewService(bus, queue.WithName("events-worker"))
+		require.NoError(t, err)
+		assert.Equal(t, "events-worker", named.Name())
+	})
+}
+
+func TestService_EndToEnd(t *testing.T) {
+	t.Parallel()
+	evt := eventbus.NewEvent[userCreated]("user.created")
+
+	t.Run("delivers to every subscription", func(t *testing.T) {
+		t.Parallel()
+		broker := queue.NewMemoryBroker()
+		bus := eventbus.New(broker)
+
+		var mu sync.Mutex
+		got := map[string]eventbus.Delivery[userCreated]{}
+		done := make(chan struct{}, 2)
+		record := func(name string) func(context.Context, eventbus.Delivery[userCreated]) error {
+			return func(_ context.Context, d eventbus.Delivery[userCreated]) error {
+				mu.Lock()
+				got[name] = d
+				mu.Unlock()
+				done <- struct{}{}
+				return nil
+			}
+		}
+		eventbus.Subscribe(bus, evt, "send_welcome", record("send_welcome"))
+		eventbus.Subscribe(bus, evt, "provision", record("provision"))
+
+		svc, err := eventbus.NewService(bus, queue.WithConfig(fastConfig()))
+		require.NoError(t, err)
+		stop := runService(t, svc)
+		defer stop()
+
+		require.NoError(t, eventbus.Publish(context.Background(), bus, evt, userCreated{Email: "a@b.c"}))
+
+		for range 2 {
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for deliveries")
+			}
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, got, 2)
+		assert.Equal(t, "a@b.c", got["send_welcome"].Payload.Email)
+		assert.Equal(t, got["send_welcome"].ID, got["provision"].ID)
+		assert.Equal(t, "user.created", got["provision"].Name)
+	})
+
+	t.Run("failing subscription retries without touching the healthy one", func(t *testing.T) {
+		t.Parallel()
+		broker := queue.NewMemoryBroker()
+		bus := eventbus.New(broker)
+
+		var attempts atomic.Int32
+		flakyDone := make(chan struct{})
+		eventbus.Subscribe(bus, evt, "flaky", func(context.Context, eventbus.Delivery[userCreated]) error {
+			if attempts.Add(1) == 1 {
+				return errors.New("transient")
+			}
+			close(flakyDone)
+			return nil
+		}, eventbus.WithRetryBackoff(backoffZero{}))
+		healthy := make(chan struct{})
+		eventbus.Subscribe(bus, evt, "healthy", func(context.Context, eventbus.Delivery[userCreated]) error {
+			close(healthy)
+			return nil
+		})
+
+		svc, err := eventbus.NewService(bus, queue.WithConfig(fastConfig()))
+		require.NoError(t, err)
+		stop := runService(t, svc)
+		defer stop()
+
+		require.NoError(t, eventbus.Publish(context.Background(), bus, evt, userCreated{}))
+
+		select {
+		case <-flakyDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for retry")
+		}
+		assert.Equal(t, int32(2), attempts.Load())
+		select {
+		case <-healthy:
+		case <-time.After(5 * time.Second):
+			t.Fatal("healthy subscription never ran")
+		}
+	})
+
+	t.Run("undecodable payload dead-letters as poison", func(t *testing.T) {
+		t.Parallel()
+		broker := queue.NewMemoryBroker()
+		bus := eventbus.New(broker)
+		eventbus.Subscribe(bus, evt, "strict", func(context.Context, eventbus.Delivery[userCreated]) error {
+			t.Error("handler must not run on poison payload")
+			return nil
+		})
+
+		// A foreign envelope version, a payload that does not decode into T,
+		// and a missing event id must all dead-letter, not retry forever.
+		require.NoError(t, broker.Push(context.Background(), queue.Job{
+			ID: "0198f5c4-0000-7000-8000-000000000001", Queue: "user.created.strict", Type: "user.created.strict",
+			Payload: []byte(`{"v":99,"id":"x","n":"user.created","at":1}`),
+			RunAt:   time.Now().UTC().Add(-time.Second), CreatedAt: time.Now().UTC(),
+		}, queue.Job{
+			ID: "0198f5c4-0000-7000-8000-000000000002", Queue: "user.created.strict", Type: "user.created.strict",
+			Payload: []byte(`{"v":1,"id":"x","n":"user.created","at":1,"p":[1,2,3]}`),
+			RunAt:   time.Now().UTC().Add(-time.Second), CreatedAt: time.Now().UTC(),
+		}, queue.Job{
+			ID: "0198f5c4-0000-7000-8000-000000000003", Queue: "user.created.strict", Type: "user.created.strict",
+			Payload: []byte(`{"v":1,"n":"user.created","at":1,"p":{}}`),
+			RunAt:   time.Now().UTC().Add(-time.Second), CreatedAt: time.Now().UTC(),
+		}))
+
+		svc, err := eventbus.NewService(bus, queue.WithConfig(fastConfig()))
+		require.NoError(t, err)
+		stop := runService(t, svc)
+		defer stop()
+
+		require.Eventually(t, func() bool {
+			dead, err := broker.ListDead(context.Background(), "user.created.strict", 10)
+			return err == nil && len(dead) == 3
+		}, 5*time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("subscription attempt budget dead-letters when spent", func(t *testing.T) {
+		t.Parallel()
+		broker := queue.NewMemoryBroker()
+		bus := eventbus.New(broker)
+		var attempts atomic.Int32
+		eventbus.Subscribe(bus, evt, "budget", func(context.Context, eventbus.Delivery[userCreated]) error {
+			attempts.Add(1)
+			return errors.New("always fails")
+		}, eventbus.WithMaxAttempts(1), eventbus.WithRetryBackoff(backoffZero{}))
+
+		svc, err := eventbus.NewService(bus, queue.WithConfig(fastConfig()))
+		require.NoError(t, err)
+		stop := runService(t, svc)
+		defer stop()
+
+		require.NoError(t, eventbus.Publish(context.Background(), bus, evt, userCreated{}))
+		require.Eventually(t, func() bool {
+			dead, err := broker.ListDead(context.Background(), "user.created.budget", 10)
+			return err == nil && len(dead) == 1
+		}, 5*time.Second, 10*time.Millisecond)
+		assert.Equal(t, int32(1), attempts.Load())
+	})
+
+	t.Run("handler timeout takes the retry path", func(t *testing.T) {
+		t.Parallel()
+		broker := queue.NewMemoryBroker()
+		bus := eventbus.New(broker)
+		eventbus.Subscribe(bus, evt, "slow", func(ctx context.Context, _ eventbus.Delivery[userCreated]) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}, eventbus.WithHandlerTimeout(10*time.Millisecond), eventbus.WithMaxAttempts(1))
+
+		svc, err := eventbus.NewService(bus, queue.WithConfig(fastConfig()))
+		require.NoError(t, err)
+		stop := runService(t, svc)
+		defer stop()
+
+		require.NoError(t, eventbus.Publish(context.Background(), bus, evt, userCreated{}))
+		require.Eventually(t, func() bool {
+			dead, err := broker.ListDead(context.Background(), "user.created.slow", 10)
+			return err == nil && len(dead) == 1
+		}, 5*time.Second, 10*time.Millisecond)
+	})
+}
+
+// backoffZero retries immediately (tests).
+type backoffZero struct{}
+
+func (backoffZero) Next(int) time.Duration { return 0 }

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -360,19 +360,6 @@ Deps: `ops/supervisor`; `async/queue`.
 
 ---
 
-**async/eventbus**
-
-Typed events over the same `Broker` drivers, two modes: sync in-process
-observer (no durability) and durable mode — each named subscription is its
-own queue, publish fans out one message per subscription, competing
-consumers within one, at-least-once. Transactional publish on SQL drivers;
-exports the `Seen(ctx, tx, id)` idempotency inbox. Handlers must be
-idempotent.
-
-Deps: `async/queue`.
-
----
-
 **async/eventrouter**
 
 Event egress over `eventbus`: each destination is its own named
@@ -388,8 +375,8 @@ delivery (`Idempotency-Key` header / payload field) and receivers dedup
 — the Stripe contract (in-router suppression would trade duplicates for
 silent loss).
 
-Deps: `web/httpclient`, `comms/postback`; `async/eventbus`,
-`comms/webhook` (both planned).
+Deps: `web/httpclient`, `comms/postback`, `async/eventbus`;
+`comms/webhook` (planned).
 
 ---
 


### PR DESCRIPTION
## Summary

Implements the `async/eventbus` roadmap entry: typed events over the same `queue.Broker` drivers, two modes behind one wiring API, transactional publish on SQL drivers, and the exported `Seen(ctx, tx, id)` idempotency inbox.

### Design

- **Typed wiring**: `Event[T]` / `Delivery[T]` mirror `queue.Kind[T]` — the event name lives in one place, payload type drift between Publish and Subscribe is a compile error. Duplicate `NewEvent` declarations sharing a name with different payload types panic at Subscribe / error at Publish instead of silently zero-filling fields through lenient JSON decoding.
- **Durable mode** (`New(broker)`): each named subscription is its own queue AND its own job type (`<event>.<name>`), publish fans out one job per subscription in a single all-or-nothing `Broker.Push` batch. All fanned-out jobs share one envelope: same event id everywhere (the receiver dedup key), distinct job ids. `NewService` composes a plain `queue.Service` over the bus's broker — retry, backoff, lease heartbeat, per-subscription dead-lettering, and competing consumers come from the engine unchanged.
- **Sync mode** (`NewSync()`): in-process observer, no durability — handlers run on the publisher's goroutine, errors joined (one failing observer never starves the rest), panics recovered, `queue.Cancel` honored as success for mode parity.
- **Transactional publish**: `PublishTx` rides `queue.TxPusher` (pgqueue/mongoqueue); brokers without it get `ErrTxUnsupported` (→ `async/outbox` later, per catalog).
- **Idempotency inbox**: core exports the `Inbox` seam + `MemoryInbox` test double; `async/eventbus/postgres` (pgeventbus) ships the transactional implementation — `Seen` rides the handler's own `pgx.Tx` keyed `(consumer, event_id)` via `INSERT … ON CONFLICT DO NOTHING`, embedded goose migration, batched `PurgeSeenBefore` retention (ctid batches, terminates on empty batch so concurrent purges can't both exit early).
- **Tenancy**: fail-closed `WithScope` capture on every publish path — enforced on the sync bus too, so dev catches a missing tenant context exactly like production — restored worker-side via `queue.WithScopeContext`. Single-tenant apps configure neither.

### Pre-PR adversarial review

An independent review pass found and I fixed: `queue.Cancel` surfacing as a Publish error on the sync bus (mode-parity break), the conflicting-payload-type silent corruption above, foreign v1 envelopes without an event id burning the full 25-attempt retry budget instead of dead-lettering as poison, and the concurrent-purge early-exit. Confirmed sound: fan-out atomicity, event-id stability, sync-mode isolation, option-ordering in `NewService`, `ON CONFLICT` semantics under concurrent transactions, fail-closed tenancy on all paths.

### Benchmarks (Apple M3 Max)

```
BenchmarkSyncPublish/subs_1-14        708.5 ns/op    384 B/op   10 allocs/op
BenchmarkSyncPublish/subs_4-14       1955 ns/op    1152 B/op   31 allocs/op
BenchmarkDurablePublish/subs_1-14    1297 ns/op    1094 B/op    8 allocs/op   (memory broker)
BenchmarkDurablePublish/subs_4-14    3192 ns/op    3297 B/op   14 allocs/op
BenchmarkMemoryInboxSeen-14           257.3 ns/op     96 B/op    2 allocs/op
BenchmarkInboxSeen/first_claim-14  412221 ns/op     282 B/op   10 allocs/op   (integration, tx per op)
BenchmarkInboxSeen/duplicate-14    403589 ns/op     257 B/op    9 allocs/op
```

Post-benchmark optimization pass: no optimization applied — publish is 0.7–3.2 µs dominated by JSON encode + UUID generation with no hot spot; per design.md §Performance, perf-motivated complexity requires a proven hot path.

### Testing

- Unit: 95.8% coverage, `-race`, black-box (`eventbus_test`) — fan-out, envelope stability, scope fail-closed, PublishTx routing, sync error joining/panic/cancel semantics, end-to-end delivery/retry/DLQ through a real `queue.Service` over the memory broker, poison-payload dead-lettering (bad version, undecodable payload, missing id).
- Integration (`just test-integration`, 90.5% coverage): pg inbox first-claim/duplicate, rollback releases the claim, per-consumer independence, guard rejections, purge retention.

### Docs

Removed the shipped `async/eventbus` entry from `docs/packages.md` (roadmap lists only unbuilt packages) and updated `async/eventrouter` deps accordingly.