### PR TITLE
fix(resilience/singleflight): deregister a completed flight before releasing its waiters

### DIFF
--- a/resilience/singleflight/singleflight.go
+++ b/resilience/singleflight/singleflight.go
@@ -85,19 +85,22 @@ func (g *Group[V]) join(key string) (*call[V], bool) {
 
 // run executes fn into c and closes c.done exactly once, converting a panic
 // to an error and deregistering the flight so the next call for key starts
-// fresh.
+// fresh. The flight is deleted from the map BEFORE done is closed (matching
+// x/sync/singleflight): a waiter woken by the close may immediately re-call
+// the same key, and it must start a fresh execution, never rejoin this dead
+// flight. The close stays outside the lock (no mutex across channel ops).
 func (g *Group[V]) run(ctx context.Context, key string, c *call[V], fn func(context.Context) (V, error)) {
 	defer func() {
 		if r := recover(); r != nil {
 			c.panicVal = r
 			c.err = fmt.Errorf("singleflight: panic in fn: %v", r)
 		}
-		close(c.done)
 		g.mu.Lock()
 		if g.m[key] == c {
 			delete(g.m, key)
 		}
 		g.mu.Unlock()
+		close(c.done)
 	}()
 	c.val, c.err = fn(ctx)
 }

--- a/resilience/singleflight/singleflight_test.go
+++ b/resilience/singleflight/singleflight_test.go
@@ -2,6 +2,7 @@ package singleflight_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -217,6 +218,45 @@ func TestCompletedFlightDeregistersBeforeReleasingWaiters(t *testing.T) {
 		})
 		if err != nil || shared || v != 7 {
 			t.Fatalf("iteration %d joined a dead flight: v=%d shared=%v err=%v", i, v, shared, err)
+		}
+	}
+}
+
+func TestDoJoinerImmediateRetryStartsFreshFlight(t *testing.T) {
+	var g singleflight.Group[int]
+	errBoom := errors.New("boom")
+	// Companion to the regression above, driving the same window through a
+	// Do joiner: a caller that waited out a shared flight and immediately
+	// re-calls the key must lead a fresh execution, never rejoin the dead
+	// flight (the synchronous Do leader path was always safe; its joiners
+	// shared run's close-before-delete window).
+	for i := range 2000 {
+		started := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			_, _, _ = g.DoDetached(t.Context(), "k", func(context.Context) (int, error) {
+				close(started) // flight is registered and running
+				return 0, errBoom
+			})
+		})
+		var retryV int
+		var retryShared bool
+		retryErr := errBoom
+		wg.Go(func() {
+			<-started // the detached flight is registered: this Do joins it (or, harmlessly, leads fresh after its cleanup)
+			_, _, _ = g.Do(t.Context(), "k", func(context.Context) (int, error) {
+				return 0, errBoom
+			})
+			retryV, retryShared, retryErr = g.Do(t.Context(), "k", func(context.Context) (int, error) {
+				return 7, nil
+			})
+		})
+		wg.Wait()
+		// Once the first flight resolves no other caller touches "k", so the
+		// retry must lead its own execution — even when the first Do joined
+		// the dead flight's completed call.
+		if retryErr != nil || retryShared || retryV != 7 {
+			t.Fatalf("iteration %d: Do retry joined a dead flight: v=%d shared=%v err=%v", i, retryV, retryShared, retryErr)
 		}
 	}
 }

--- a/resilience/singleflight/singleflight_test.go
+++ b/resilience/singleflight/singleflight_test.go
@@ -200,6 +200,27 @@ func TestDoDetachedPanicBecomesErrorForAllWaiters(t *testing.T) {
 	assert.Equal(t, 7, v)
 }
 
+func TestCompletedFlightDeregistersBeforeReleasingWaiters(t *testing.T) {
+	var g singleflight.Group[int]
+	// Regression: run used to close c.done before deleting the key from the
+	// map, so a caller woken by the close could immediately re-call the same
+	// key, join the already-completed flight still sitting in the map, and
+	// get its stale error with shared=true. A few hundred iterations hit
+	// that window reliably under the old ordering.
+	for i := range 2000 {
+		_, _, err := g.DoDetached(t.Context(), "k", func(context.Context) (int, error) {
+			panic("boom")
+		})
+		assert.ErrorContains(t, err, "panic in fn")
+		v, shared, err := g.DoDetached(t.Context(), "k", func(context.Context) (int, error) {
+			return 7, nil
+		})
+		if err != nil || shared || v != 7 {
+			t.Fatalf("iteration %d joined a dead flight: v=%d shared=%v err=%v", i, v, shared, err)
+		}
+	}
+}
+
 func TestPanicInFnRePanicsAndDoesNotPoisonKey(t *testing.T) {
 	var g singleflight.Group[int]
 	assert.Panics(t, func() {


### PR DESCRIPTION
## Summary

Fixes a stale-join race in `resilience/singleflight`: `run()`'s deferred cleanup closed `c.done` **before** taking the lock and deleting the key from the map. A caller woken by the close could immediately issue a new call for the same key while the dead flight was still registered — `join()` returned the completed call and the caller received the stale result/error with `shared=true` instead of a fresh execution.

Observed in the wild as a CI flake on #84: `TestDoDetachedPanicBecomesErrorForAllWaiters` failed because the follow-up `DoDetached("k")` joined the panicked flight (`singleflight: panic in fn: boom`, `shared=true`) instead of re-executing and returning 7. The window cuts both ways: a new call can also inherit a stale *success* and silently skip its own fn — the regression test caught that manifestation first.

## Fix

Reorder the deferred cleanup: delete the key under the lock **first**, then `close(c.done)` after unlocking (no mutex held across the channel op, per the docs/design.md lock-hygiene rule). This matches `x/sync/singleflight`'s ordering guarantee — waiters are only released once the flight is deregistered. The same `run()` serves both `Do` and `DoDetached`, so one reorder covers both paths; the synchronous `Do` leader path was already safe (cleanup completes before `Do` returns) but its joiners shared the same window.

## Regression test

`TestCompletedFlightDeregistersBeforeReleasingWaiters` loops panic-then-immediate-retry 2000×. Against the old ordering it fails within a single run (verified before applying the fix — it surfaced both the stale-error and stale-success manifestations); with the fix it is deterministic across `-race -count=5`.

## Testing

- `just test ./resilience/singleflight/...` — race-clean, 100% coverage
- Consumers exercised: `resilience/cache`, `web/smartlink` test suites pass
- `just lint` — clean (vet, golangci-lint, nilaway, betteralign, modernize, integration tier)

No API or behavior change for correct callers; only the impossible-to-rely-on stale join is eliminated.