### PR TITLE
Add async/collector: write-behind batch ingestion for fire-and-forget paths

### DIFF
--- a/async/collector/bench_test.go
+++ b/async/collector/bench_test.go
@@ -1,0 +1,77 @@
+package collector_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/collector"
+)
+
+type click struct {
+	path   string
+	tenant string
+}
+
+func benchCollector(b *testing.B, opts ...collector.Option) (*collector.Collector[click], func()) {
+	b.Helper()
+	sink := collector.SinkFunc[click](func(context.Context, []click) error { return nil })
+	opts = append([]collector.Option{collector.WithConfig(collector.Config{BufferSize: 1 << 16, BatchSize: 4096, FlushInterval: time.Millisecond, FlushTimeout: time.Second})}, opts...)
+	c, err := collector.New(sink, opts...)
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = c.Run(ctx) }()
+	return c, func() {
+		cancel()
+		<-done
+	}
+}
+
+func BenchmarkAdd(b *testing.B) {
+	c, stop := benchCollector(b)
+	defer stop()
+	ctx := context.Background()
+	ev := click{path: "/pricing"}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = c.Add(ctx, ev)
+	}
+}
+
+func BenchmarkAddParallel(b *testing.B) {
+	c, stop := benchCollector(b)
+	defer stop()
+	ev := click{path: "/pricing"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		ctx := context.Background()
+		for pb.Next() {
+			_ = c.Add(ctx, ev)
+		}
+	})
+}
+
+type benchTenantKey struct{}
+
+func BenchmarkAddScoped(b *testing.B) {
+	c, stop := benchCollector(b,
+		collector.WithScope(func(ctx context.Context) (string, error) {
+			v, _ := ctx.Value(benchTenantKey{}).(string)
+			return v, nil
+		}),
+		collector.WithScopeContext(func(ctx context.Context, scope string) context.Context {
+			return context.WithValue(ctx, benchTenantKey{}, scope)
+		}),
+	)
+	defer stop()
+	ctx := context.WithValue(context.Background(), benchTenantKey{}, "tenant-a")
+	ev := click{path: "/pricing", tenant: "a"}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = c.Add(ctx, ev)
+	}
+}

--- a/async/collector/collector.go
+++ b/async/collector/collector.go
@@ -58,7 +58,8 @@ type Collector[T any] struct {
 	lost    atomic.Uint64
 
 	// mu makes the closed check and the buffer send atomic against shutdown:
-	// Add holds the read side, Run's shutdown takes the write side to flip
+	// Add holds the read side (across the scope hook too, which is a trivial
+	// context read by contract), Run's shutdown takes the write side to flip
 	// closed, so once drain starts no accepted event can still be in flight
 	// into the buffer. A bare WaitGroup would race Add(1) against Wait on a
 	// zero counter (documented misuse) for Adds arriving after shutdown.
@@ -90,8 +91,14 @@ func (c *Collector[T]) Name() string { return c.name }
 // performs I/O. On a full buffer the event is dropped (drop-newest), counted,
 // and ErrBufferFull returned; fire-and-forget callers may ignore the error.
 // Returns ErrScopeMissing when a configured scope hook errors or yields an
-// empty scope, and ErrClosed once shutdown has begun.
+// empty scope, and ErrClosed once shutdown has begun; ErrClosed takes
+// precedence, so shutdown never pays for scope hook calls.
 func (c *Collector[T]) Add(ctx context.Context, event T) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.closed {
+		return ErrClosed
+	}
 	var scope string
 	if c.scope != nil {
 		s, err := c.scope(ctx)
@@ -102,11 +109,6 @@ func (c *Collector[T]) Add(ctx context.Context, event T) error {
 			return ErrScopeMissing
 		}
 		scope = s
-	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.closed {
-		return ErrClosed
 	}
 	select {
 	case c.buf <- entry[T]{event: event, scope: scope}:

--- a/async/collector/collector.go
+++ b/async/collector/collector.go
@@ -1,0 +1,228 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+// Sink receives flushed batches. Flush is called from the single flusher
+// goroutine, so implementations need no internal synchronization against
+// concurrent flushes. The batch slice is owned by the sink after the call. A
+// returned error loses the batch (counted in Stats.Lost and logged) — the
+// collector never retries; wrap the sink with resilience/retry when a
+// transient backend warrants attempts.
+type Sink[T any] interface {
+	Flush(ctx context.Context, batch []T) error
+}
+
+// SinkFunc adapts a function to Sink.
+type SinkFunc[T any] func(ctx context.Context, batch []T) error
+
+// Flush calls f.
+func (f SinkFunc[T]) Flush(ctx context.Context, batch []T) error { return f(ctx, batch) }
+
+// Stats is a snapshot of the collector's event counters.
+type Stats struct {
+	// Added is the number of events accepted into the buffer.
+	Added uint64
+	// Dropped is the number of events rejected by Add on a full buffer.
+	Dropped uint64
+	// Flushed is the number of events successfully delivered to the sink.
+	Flushed uint64
+	// Lost is the number of buffered events discarded because Flush failed.
+	Lost uint64
+}
+
+// entry pairs a buffered event with the scope captured at Add time.
+type entry[T any] struct {
+	event T
+	scope string
+}
+
+// Collector buffers events in a bounded in-memory buffer and delivers them to
+// the sink in batches. Construct with New, run under ops/supervisor.
+type Collector[T any] struct {
+	sink Sink[T]
+	buf  chan entry[T]
+	settings
+
+	added   atomic.Uint64
+	dropped atomic.Uint64
+	flushed atomic.Uint64
+	lost    atomic.Uint64
+	closed  atomic.Bool
+}
+
+// New builds a Collector delivering into sink. The default configuration is
+// DefaultConfig; returns ErrNilSink on a nil sink and ErrInvalidConfig
+// (matchable via errors.Is) on bad knobs.
+func New[T any](sink Sink[T], opts ...Option) (*Collector[T], error) {
+	if sink == nil {
+		return nil, ErrNilSink
+	}
+	s := settings{cfg: DefaultConfig(), name: "collector", log: logger.NewNope()}
+	for _, opt := range opts {
+		opt(&s)
+	}
+	if err := s.cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &Collector[T]{sink: sink, buf: make(chan entry[T], s.cfg.BufferSize), settings: s}, nil
+}
+
+// Name returns the supervisor service name.
+func (c *Collector[T]) Name() string { return c.name }
+
+// Add buffers one event and returns immediately — it never blocks and never
+// performs I/O. On a full buffer the event is dropped (drop-newest), counted,
+// and ErrBufferFull returned; fire-and-forget callers may ignore the error.
+// Returns ErrScopeMissing when a configured scope hook errors or yields an
+// empty scope, and ErrClosed once shutdown has begun.
+func (c *Collector[T]) Add(ctx context.Context, event T) error {
+	var scope string
+	if c.scope != nil {
+		s, err := c.scope(ctx)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrScopeMissing, err)
+		}
+		if s == "" {
+			return ErrScopeMissing
+		}
+		scope = s
+	}
+	if c.closed.Load() {
+		return ErrClosed
+	}
+	select {
+	case c.buf <- entry[T]{event: event, scope: scope}:
+		c.added.Add(1)
+		return nil
+	default:
+		c.dropped.Add(1)
+		return ErrBufferFull
+	}
+}
+
+// Stats returns a snapshot of the event counters.
+func (c *Collector[T]) Stats() Stats {
+	return Stats{Added: c.added.Load(), Dropped: c.dropped.Load(), Flushed: c.flushed.Load(), Lost: c.lost.Load()}
+}
+
+// Run is the flusher loop: it accumulates buffered events and flushes when a
+// batch reaches Config.BatchSize or Config.FlushInterval elapses, whichever
+// comes first. On ctx cancellation it stops accepting (Add returns ErrClosed),
+// drains everything already buffered through the sink, and returns nil.
+func (c *Collector[T]) Run(ctx context.Context) error {
+	c.log.InfoContext(ctx, "collector started", slog.String("service", c.name), slog.Int("buffer", c.cfg.BufferSize), slog.Int("batch", c.cfg.BatchSize), slog.Duration("interval", c.cfg.FlushInterval))
+	batch := make([]entry[T], 0, c.cfg.BatchSize)
+	timer := time.NewTimer(c.cfg.FlushInterval)
+	defer timer.Stop()
+	var reported uint64
+	for {
+		select {
+		case e := <-c.buf:
+			batch = append(batch, e)
+			if len(batch) >= c.cfg.BatchSize {
+				c.flush(ctx, batch)
+				batch = batch[:0]
+				timer.Reset(c.cfg.FlushInterval)
+			}
+		case <-timer.C:
+			if len(batch) > 0 {
+				c.flush(ctx, batch)
+				batch = batch[:0]
+			}
+			reported = c.reportDrops(ctx, reported)
+			timer.Reset(c.cfg.FlushInterval)
+		case <-ctx.Done():
+			c.closed.Store(true)
+			c.log.InfoContext(ctx, "collector draining", slog.String("service", c.name))
+			c.drain(ctx, batch)
+			c.reportDrops(ctx, reported)
+			c.log.InfoContext(ctx, "collector stopped", slog.String("service", c.name))
+			return nil
+		}
+	}
+}
+
+// drain empties the buffer after shutdown began and flushes everything,
+// including the partial batch carried in from the main loop.
+func (c *Collector[T]) drain(ctx context.Context, batch []entry[T]) {
+	for {
+		select {
+		case e := <-c.buf:
+			batch = append(batch, e)
+			if len(batch) >= c.cfg.BatchSize {
+				c.flush(ctx, batch)
+				batch = batch[:0]
+			}
+		default:
+			if len(batch) > 0 {
+				c.flush(ctx, batch)
+			}
+			return
+		}
+	}
+}
+
+// flush partitions the batch by captured scope (preserving first-seen order
+// and per-scope event order) and delivers one Flush call per scope. Without a
+// scope hook every event carries the empty scope and the batch flushes whole.
+func (c *Collector[T]) flush(ctx context.Context, batch []entry[T]) {
+	if c.scope == nil {
+		events := make([]T, len(batch))
+		for i, e := range batch {
+			events[i] = e.event
+		}
+		c.deliver(ctx, "", events)
+		return
+	}
+	grouped := make(map[string][]T)
+	order := make([]string, 0, 1)
+	for _, e := range batch {
+		if _, ok := grouped[e.scope]; !ok {
+			order = append(order, e.scope)
+		}
+		grouped[e.scope] = append(grouped[e.scope], e.event)
+	}
+	for _, scope := range order {
+		c.deliver(ctx, scope, grouped[scope])
+	}
+}
+
+// deliver flushes one scoped batch. The sink context survives Run's
+// cancellation so shutdown drain still delivers, is bounded by
+// Config.FlushTimeout, and passes through the scope restore hook when one is
+// configured.
+func (c *Collector[T]) deliver(ctx context.Context, scope string, events []T) {
+	fctx := context.WithoutCancel(ctx)
+	if c.scopeCtx != nil {
+		fctx = c.scopeCtx(fctx, scope)
+	}
+	if c.cfg.FlushTimeout > 0 {
+		var cancel context.CancelFunc
+		fctx, cancel = context.WithTimeout(fctx, c.cfg.FlushTimeout)
+		defer cancel()
+	}
+	if err := c.sink.Flush(fctx, events); err != nil {
+		c.lost.Add(uint64(len(events)))
+		c.log.ErrorContext(ctx, "collector flush failed, batch lost", slog.String("service", c.name), slog.String("scope", scope), slog.Int("events", len(events)), slog.Any("error", err))
+		return
+	}
+	c.flushed.Add(uint64(len(events)))
+}
+
+// reportDrops logs the drop delta since the last report and returns the new
+// watermark, keeping loss visible without per-event log spam.
+func (c *Collector[T]) reportDrops(ctx context.Context, reported uint64) uint64 {
+	d := c.dropped.Load()
+	if d > reported {
+		c.log.WarnContext(ctx, "collector dropped events, buffer full", slog.String("service", c.name), slog.Uint64("dropped", d-reported), slog.Uint64("dropped_total", d))
+	}
+	return d
+}

--- a/async/collector/collector.go
+++ b/async/collector/collector.go
@@ -120,8 +120,8 @@ func (c *Collector[T]) Stats() Stats {
 func (c *Collector[T]) Run(ctx context.Context) error {
 	c.log.InfoContext(ctx, "collector started", slog.String("service", c.name), slog.Int("buffer", c.cfg.BufferSize), slog.Int("batch", c.cfg.BatchSize), slog.Duration("interval", c.cfg.FlushInterval))
 	batch := make([]entry[T], 0, c.cfg.BatchSize)
-	timer := time.NewTimer(c.cfg.FlushInterval)
-	defer timer.Stop()
+	ticker := time.NewTicker(c.cfg.FlushInterval)
+	defer ticker.Stop()
 	var reported uint64
 	for {
 		select {
@@ -130,15 +130,16 @@ func (c *Collector[T]) Run(ctx context.Context) error {
 			if len(batch) >= c.cfg.BatchSize {
 				c.flush(ctx, batch)
 				batch = batch[:0]
-				timer.Reset(c.cfg.FlushInterval)
 			}
-		case <-timer.C:
+		case <-ticker.C:
+			// The tick fires every interval even under sustained size-triggered
+			// flushing, so an event waits at most one interval and drop deltas
+			// keep getting reported under exactly the load that causes drops.
 			if len(batch) > 0 {
 				c.flush(ctx, batch)
 				batch = batch[:0]
 			}
 			reported = c.reportDrops(ctx, reported)
-			timer.Reset(c.cfg.FlushInterval)
 		case <-ctx.Done():
 			c.closed.Store(true)
 			c.log.InfoContext(ctx, "collector draining", slog.String("service", c.name))

--- a/async/collector/collector.go
+++ b/async/collector/collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -55,7 +56,14 @@ type Collector[T any] struct {
 	dropped atomic.Uint64
 	flushed atomic.Uint64
 	lost    atomic.Uint64
-	closed  atomic.Bool
+
+	// mu makes the closed check and the buffer send atomic against shutdown:
+	// Add holds the read side, Run's shutdown takes the write side to flip
+	// closed, so once drain starts no accepted event can still be in flight
+	// into the buffer. A bare WaitGroup would race Add(1) against Wait on a
+	// zero counter (documented misuse) for Adds arriving after shutdown.
+	mu     sync.RWMutex
+	closed bool
 }
 
 // New builds a Collector delivering into sink. The default configuration is
@@ -95,7 +103,9 @@ func (c *Collector[T]) Add(ctx context.Context, event T) error {
 		}
 		scope = s
 	}
-	if c.closed.Load() {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.closed {
 		return ErrClosed
 	}
 	select {
@@ -116,7 +126,9 @@ func (c *Collector[T]) Stats() Stats {
 // Run is the flusher loop: it accumulates buffered events and flushes when a
 // batch reaches Config.BatchSize or Config.FlushInterval elapses, whichever
 // comes first. On ctx cancellation it stops accepting (Add returns ErrClosed),
-// drains everything already buffered through the sink, and returns nil.
+// drains everything already buffered through the sink, and returns nil: after
+// Run returns, every accepted event is accounted for — Stats.Added equals
+// Stats.Flushed plus Stats.Lost.
 func (c *Collector[T]) Run(ctx context.Context) error {
 	c.log.InfoContext(ctx, "collector started", slog.String("service", c.name), slog.Int("buffer", c.cfg.BufferSize), slog.Int("batch", c.cfg.BatchSize), slog.Duration("interval", c.cfg.FlushInterval))
 	batch := make([]entry[T], 0, c.cfg.BatchSize)
@@ -141,7 +153,9 @@ func (c *Collector[T]) Run(ctx context.Context) error {
 			}
 			reported = c.reportDrops(ctx, reported)
 		case <-ctx.Done():
-			c.closed.Store(true)
+			c.mu.Lock()
+			c.closed = true
+			c.mu.Unlock()
 			c.log.InfoContext(ctx, "collector draining", slog.String("service", c.name))
 			c.drain(ctx, batch)
 			c.reportDrops(ctx, reported)

--- a/async/collector/collector_test.go
+++ b/async/collector/collector_test.go
@@ -269,6 +269,29 @@ func TestAddAfterShutdown(t *testing.T) {
 	}
 }
 
+func TestAddAfterShutdownSkipsScopeHook(t *testing.T) {
+	t.Parallel()
+	sink := newRecordSink[int]()
+	hookCalled := false
+	c, err := collector.New(sink, collector.WithScope(func(context.Context) (string, error) {
+		hookCalled = true
+		return "", errors.New("hook must not run after shutdown")
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCollector(t, c)()
+
+	// ErrClosed takes precedence over the failing scope hook, which is never
+	// invoked once shutdown has begun.
+	if err := c.Add(context.Background(), 1); !errors.Is(err, collector.ErrClosed) {
+		t.Fatalf("Add after shutdown: got %v, want ErrClosed", err)
+	}
+	if hookCalled {
+		t.Fatal("scope hook ran after shutdown")
+	}
+}
+
 func TestSinkErrorLosesBatchAndRecovers(t *testing.T) {
 	t.Parallel()
 	sink := newRecordSink[int]()

--- a/async/collector/collector_test.go
+++ b/async/collector/collector_test.go
@@ -1,0 +1,505 @@
+package collector_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/collector"
+)
+
+// recordSink is a race-safe sink recording every Flush call.
+type recordSink[T any] struct {
+	mu      sync.Mutex
+	batches [][]T
+	ctxs    []context.Context
+	err     error
+	flushed chan struct{}
+}
+
+func newRecordSink[T any]() *recordSink[T] {
+	return &recordSink[T]{flushed: make(chan struct{}, 64)}
+}
+
+func (s *recordSink[T]) Flush(ctx context.Context, batch []T) error {
+	s.mu.Lock()
+	s.batches = append(s.batches, batch)
+	s.ctxs = append(s.ctxs, ctx)
+	err := s.err
+	s.mu.Unlock()
+	select {
+	case s.flushed <- struct{}{}:
+	default:
+	}
+	return err
+}
+
+func (s *recordSink[T]) setErr(err error) {
+	s.mu.Lock()
+	s.err = err
+	s.mu.Unlock()
+}
+
+func (s *recordSink[T]) snapshot() [][]T {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([][]T, len(s.batches))
+	copy(out, s.batches)
+	return out
+}
+
+func (s *recordSink[T]) waitFlush(t *testing.T) {
+	t.Helper()
+	select {
+	case <-s.flushed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for flush")
+	}
+}
+
+// runCollector starts c.Run in a goroutine and returns a stop func that
+// cancels it and waits for Run to return.
+func runCollector[T any](t *testing.T, c *collector.Collector[T]) (stop func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Run(ctx) }()
+	var once sync.Once
+	stop = func() {
+		once.Do(func() {
+			cancel()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Errorf("Run returned %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Error("Run did not return after cancel")
+			}
+		})
+	}
+	t.Cleanup(stop)
+	return stop
+}
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil sink", func(t *testing.T) {
+		t.Parallel()
+		_, err := collector.New[int](nil)
+		if !errors.Is(err, collector.ErrNilSink) {
+			t.Fatalf("got %v, want ErrNilSink", err)
+		}
+	})
+
+	t.Run("invalid config", func(t *testing.T) {
+		t.Parallel()
+		bad := []collector.Config{
+			{BufferSize: 0, BatchSize: 1, FlushInterval: time.Second},
+			{BufferSize: 10, BatchSize: 0, FlushInterval: time.Second},
+			{BufferSize: 10, BatchSize: 11, FlushInterval: time.Second},
+			{BufferSize: 10, BatchSize: 5, FlushInterval: 0},
+			{BufferSize: 10, BatchSize: 5, FlushInterval: time.Second, FlushTimeout: -1},
+		}
+		for _, cfg := range bad {
+			_, err := collector.New(newRecordSink[int](), collector.WithConfig(cfg))
+			if !errors.Is(err, collector.ErrInvalidConfig) {
+				t.Errorf("config %+v: got %v, want ErrInvalidConfig", cfg, err)
+			}
+		}
+	})
+
+	t.Run("defaults valid", func(t *testing.T) {
+		t.Parallel()
+		if err := collector.DefaultConfig().Validate(); err != nil {
+			t.Fatalf("DefaultConfig invalid: %v", err)
+		}
+	})
+}
+
+func TestName(t *testing.T) {
+	t.Parallel()
+	c, err := collector.New(newRecordSink[int]())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := c.Name(); got != "collector" {
+		t.Fatalf("default name %q, want collector", got)
+	}
+	c2, err := collector.New(newRecordSink[int](), collector.WithName("clicks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := c2.Name(); got != "clicks" {
+		t.Fatalf("name %q, want clicks", got)
+	}
+}
+
+func TestFlushBySize(t *testing.T) {
+	t.Parallel()
+	sink := newRecordSink[int]()
+	c, err := collector.New(sink, collector.WithConfig(collector.Config{BufferSize: 16, BatchSize: 2, FlushInterval: time.Minute, FlushTimeout: time.Second}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCollector(t, c)
+
+	ctx := context.Background()
+	for i := range 4 {
+		if err := c.Add(ctx, i); err != nil {
+			t.Fatalf("Add(%d): %v", i, err)
+		}
+	}
+	sink.waitFlush(t)
+	sink.waitFlush(t)
+
+	batches := sink.snapshot()
+	if len(batches) != 2 || len(batches[0]) != 2 || len(batches[1]) != 2 {
+		t.Fatalf("batches %v, want two batches of two", batches)
+	}
+	if batches[0][0] != 0 || batches[0][1] != 1 || batches[1][0] != 2 || batches[1][1] != 3 {
+		t.Fatalf("batches %v, want ordered [0 1] [2 3]", batches)
+	}
+	st := c.Stats()
+	if st.Added != 4 || st.Flushed != 4 || st.Dropped != 0 || st.Lost != 0 {
+		t.Fatalf("stats %+v", st)
+	}
+}
+
+func TestFlushByAge(t *testing.T) {
+	t.Parallel()
+	sink := newRecordSink[string]()
+	c, err := collector.New(sink, collector.WithConfig(collector.Config{BufferSize: 16, BatchSize: 10, FlushInterval: 20 * time.Millisecond, FlushTimeout: time.Second}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCollector(t, c)
+
+	if err := c.Add(context.Background(), "lonely"); err != nil {
+		t.Fatal(err)
+	}
+	sink.waitFlush(t)
+
+	batches := sink.snapshot()
+	if len(batches) != 1 || len(batches[0]) != 1 || batches[0][0] != "lonely" {
+		t.Fatalf("batches %v, want single [lonely]", batches)
+	}
+}
+
+func TestDropNewestOnFullBuffer(t *testing.T) {
+	t.Parallel()
+	sink := newRecordSink[int]()
+	c, err := collector.New(sink, collector.WithConfig(collector.Config{BufferSize: 2, BatchSize: 2, FlushInterval: time.Minute, FlushTimeout: time.Second}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	start := time.Now()
+	if err := c.Add(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Add(ctx, 2); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Add(ctx, 3); !errors.Is(err, collector.ErrBufferFull) {
+		t.Fatalf("third Add: got %v, want ErrBufferFull", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Add blocked for %v, must be non-blocking", elapsed)
+	}
+	if st := c.Stats(); st.Added != 2 || st.Dropped != 1 {
+		t.Fatalf("stats %+v, want Added=2 Dropped=1", st)
+	}
+
+	// The oldest events survive: draining flushes [1 2], never 3.
+	runCollector(t, c)()
+	batches := sink.snapshot()
+	if len(batches) != 1 || len(batches[0]) != 2 || batches[0][0] != 1 || batches[0][1] != 2 {
+		t.Fatalf("batches %v, want [1 2]", batches)
+	}
+}
+
+func TestDrainOnShutdown(t *testing.T) {
+	t.Parallel()
+	sink := newRecordSink[int]()
+	c, err := collector.New(sink, collector.WithConfig(collector.Config{BufferSize: 64, BatchSize: 10, FlushInterval: time.Minute, FlushTimeout: time.Second}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := runCollector(t, c)
+
+	ctx := context.Background()
+	for i := range 25 {
+		if err := c.Add(ctx, i); err != nil {
+			t.Fatalf("Add(%d): %v", i, err)
+		}
+	}
+	stop()
+
+	var total int
+	for _, b := range sink.snapshot() {
+		total += len(b)
+	}
+	if total != 25 {
+		t.Fatalf("drained %d events, want 25", total)
+	}
+	if st := c.Stats(); st.Flushed != 25 {
+		t.Fatalf("stats %+v, want Flushed=25", st)
+	}
+}
+
+func TestAddAfterShutdown(t *testing.T) {
+	t.Parallel()
+	sink := newRecordSink[int]()
+	c, err := collector.New(sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCollector(t, c)()
+
+	if err := c.Add(context.Background(), 1); !errors.Is(err, collector.ErrClosed) {
+		t.Fatalf("Add after shutdown: got %v, want ErrClosed", err)
+	}
+}
+
+func TestSinkErrorLosesBatchAndRecovers(t *testing.T) {
+	t.Parallel()
+	sink := newRecordSink[int]()
+	sink.setErr(errors.New("backend down"))
+	c, err := collector.New(sink, collector.WithConfig(collector.Config{BufferSize: 16, BatchSize: 2, FlushInterval: time.Minute, FlushTimeout: time.Second}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCollector(t, c)
+
+	ctx := context.Background()
+	if err := c.Add(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Add(ctx, 2); err != nil {
+		t.Fatal(err)
+	}
+	sink.waitFlush(t)
+	if st := c.Stats(); st.Lost != 2 || st.Flushed != 0 {
+		t.Fatalf("stats %+v, want Lost=2 Flushed=0", st)
+	}
+
+	// The flusher keeps running after a sink failure.
+	sink.setErr(nil)
+	if err := c.Add(ctx, 3); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Add(ctx, 4); err != nil {
+		t.Fatal(err)
+	}
+	sink.waitFlush(t)
+	if st := c.Stats(); st.Lost != 2 || st.Flushed != 2 {
+		t.Fatalf("stats %+v, want Lost=2 Flushed=2", st)
+	}
+}
+
+func TestFlushTimeoutBoundsSink(t *testing.T) {
+	t.Parallel()
+	deadlineSeen := make(chan bool, 1)
+	sink := collector.SinkFunc[int](func(ctx context.Context, _ []int) error {
+		_, ok := ctx.Deadline()
+		deadlineSeen <- ok
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	c, err := collector.New(sink, collector.WithConfig(collector.Config{BufferSize: 4, BatchSize: 1, FlushInterval: time.Minute, FlushTimeout: 20 * time.Millisecond}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCollector(t, c)
+
+	if err := c.Add(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case ok := <-deadlineSeen:
+		if !ok {
+			t.Fatal("sink context has no deadline, want FlushTimeout applied")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("sink never called")
+	}
+	waitFor(t, func() bool { return c.Stats().Lost == 1 })
+}
+
+func TestScopeFailClosed(t *testing.T) {
+	t.Parallel()
+	sink := newRecordSink[int]()
+	hookErr := errors.New("no tenant")
+	c, err := collector.New(sink, collector.WithScope(func(ctx context.Context) (string, error) {
+		v, _ := ctx.Value(tenantKey{}).(string)
+		if v == "boom" {
+			return "", hookErr
+		}
+		return v, nil
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Add(context.Background(), 1); !errors.Is(err, collector.ErrScopeMissing) {
+		t.Fatalf("empty scope: got %v, want ErrScopeMissing", err)
+	}
+	err = c.Add(context.WithValue(context.Background(), tenantKey{}, "boom"), 1)
+	if !errors.Is(err, collector.ErrScopeMissing) || !errors.Is(err, hookErr) {
+		t.Fatalf("hook error: got %v, want ErrScopeMissing wrapping hook error", err)
+	}
+	if st := c.Stats(); st.Added != 0 {
+		t.Fatalf("stats %+v, want Added=0", st)
+	}
+}
+
+type tenantKey struct{}
+
+func TestScopePartitioning(t *testing.T) {
+	t.Parallel()
+	sink := newRecordSink[string]()
+	c, err := collector.New(sink,
+		collector.WithConfig(collector.Config{BufferSize: 16, BatchSize: 10, FlushInterval: time.Minute, FlushTimeout: time.Second}),
+		collector.WithScope(func(ctx context.Context) (string, error) {
+			v, _ := ctx.Value(tenantKey{}).(string)
+			return v, nil
+		}),
+		collector.WithScopeContext(func(ctx context.Context, scope string) context.Context {
+			return context.WithValue(ctx, tenantKey{}, scope)
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := runCollector(t, c)
+
+	ctxA := context.WithValue(context.Background(), tenantKey{}, "a")
+	ctxB := context.WithValue(context.Background(), tenantKey{}, "b")
+	for _, add := range []struct {
+		ctx context.Context
+		ev  string
+	}{{ctxA, "a1"}, {ctxB, "b1"}, {ctxA, "a2"}, {ctxB, "b2"}} {
+		if err := c.Add(add.ctx, add.ev); err != nil {
+			t.Fatalf("Add(%s): %v", add.ev, err)
+		}
+	}
+	stop()
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.batches) != 2 {
+		t.Fatalf("flush calls %d, want 2 (one per scope)", len(sink.batches))
+	}
+	// First-seen scope order and per-scope event order both hold.
+	if got := sink.batches[0]; len(got) != 2 || got[0] != "a1" || got[1] != "a2" {
+		t.Fatalf("scope a batch %v, want [a1 a2]", got)
+	}
+	if got := sink.batches[1]; len(got) != 2 || got[0] != "b1" || got[1] != "b2" {
+		t.Fatalf("scope b batch %v, want [b1 b2]", got)
+	}
+	for i, want := range []string{"a", "b"} {
+		if got, _ := sink.ctxs[i].Value(tenantKey{}).(string); got != want {
+			t.Fatalf("flush %d ctx scope %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestDropsLogged(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	log := slog.New(slog.NewTextHandler(lockedWriter{&mu, &buf}, nil))
+	sink := newRecordSink[int]()
+	c, err := collector.New(sink,
+		collector.WithConfig(collector.Config{BufferSize: 1, BatchSize: 1, FlushInterval: 20 * time.Millisecond, FlushTimeout: time.Second}),
+		collector.WithLogger(log),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fill the buffer and force a drop before the flusher starts.
+	ctx := context.Background()
+	if err := c.Add(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Add(ctx, 2); !errors.Is(err, collector.ErrBufferFull) {
+		t.Fatalf("got %v, want ErrBufferFull", err)
+	}
+	runCollector(t, c)
+
+	waitFor(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return strings.Contains(buf.String(), "collector dropped events")
+	})
+}
+
+type lockedWriter struct {
+	mu *sync.Mutex
+	w  *bytes.Buffer
+}
+
+func (l lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
+}
+
+func TestConcurrentAdd(t *testing.T) {
+	t.Parallel()
+	sink := newRecordSink[int]()
+	c, err := collector.New(sink, collector.WithConfig(collector.Config{BufferSize: 4096, BatchSize: 128, FlushInterval: 5 * time.Millisecond, FlushTimeout: time.Second}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := runCollector(t, c)
+
+	const goroutines, perG = 8, 500
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Go(func() {
+			ctx := context.Background()
+			for i := range perG {
+				_ = c.Add(ctx, g*perG+i)
+			}
+		})
+	}
+	wg.Wait()
+	stop()
+
+	var total int
+	for _, b := range sink.snapshot() {
+		total += len(b)
+	}
+	st := c.Stats()
+	if uint64(total) != st.Flushed {
+		t.Fatalf("sink saw %d events, stats say Flushed=%d", total, st.Flushed)
+	}
+	if st.Added+st.Dropped != goroutines*perG {
+		t.Fatalf("stats %+v, Added+Dropped want %d", st, goroutines*perG)
+	}
+	if st.Added != st.Flushed {
+		t.Fatalf("stats %+v, every accepted event must be flushed after drain", st)
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition never became true")
+}

--- a/async/collector/config.go
+++ b/async/collector/config.go
@@ -1,0 +1,40 @@
+package collector
+
+import (
+	"fmt"
+	"time"
+)
+
+// Config holds the env-loadable buffering and flushing knobs.
+type Config struct {
+	BufferSize    int           `env:"COLLECTOR_BUFFER_SIZE"`
+	BatchSize     int           `env:"COLLECTOR_BATCH_SIZE"`
+	FlushInterval time.Duration `env:"COLLECTOR_FLUSH_INTERVAL"`
+	FlushTimeout  time.Duration `env:"COLLECTOR_FLUSH_TIMEOUT"`
+}
+
+// DefaultConfig returns production defaults: 8192-event buffer, 512-event
+// batches, 1s flush interval, 10s flush timeout.
+func DefaultConfig() Config {
+	return Config{BufferSize: 8192, BatchSize: 512, FlushInterval: time.Second, FlushTimeout: 10 * time.Second}
+}
+
+// Validate checks the configuration invariants.
+func (c Config) Validate() error {
+	if c.BufferSize <= 0 {
+		return fmt.Errorf("%w: BufferSize must be > 0, got %d", ErrInvalidConfig, c.BufferSize)
+	}
+	if c.BatchSize <= 0 {
+		return fmt.Errorf("%w: BatchSize must be > 0, got %d", ErrInvalidConfig, c.BatchSize)
+	}
+	if c.BatchSize > c.BufferSize {
+		return fmt.Errorf("%w: BatchSize must be <= BufferSize, got %d > %d", ErrInvalidConfig, c.BatchSize, c.BufferSize)
+	}
+	if c.FlushInterval <= 0 {
+		return fmt.Errorf("%w: FlushInterval must be > 0, got %v", ErrInvalidConfig, c.FlushInterval)
+	}
+	if c.FlushTimeout < 0 {
+		return fmt.Errorf("%w: FlushTimeout must be >= 0 (0 disables the timeout), got %v", ErrInvalidConfig, c.FlushTimeout)
+	}
+	return nil
+}

--- a/async/collector/doc.go
+++ b/async/collector/doc.go
@@ -1,0 +1,44 @@
+// Package collector is write-behind ingestion for proven-hot fire-and-forget
+// paths — click streams, beacons, telemetry. Add buffers an event into a
+// bounded in-memory buffer and returns immediately, never blocking the
+// request path; a single flusher goroutine delivers batches to a Sink when
+// they reach Config.BatchSize or Config.FlushInterval elapses, whichever
+// comes first.
+//
+// The overload policy is explicit: when the buffer is full, Add drops the new
+// event (drop-newest), counts it, and returns ErrBufferFull; the flusher logs
+// drop deltas once per interval instead of per event. A Sink error loses that
+// batch — counted in Stats.Lost, logged, never retried; wrap the sink with
+// resilience/retry when a transient backend warrants attempts. Loss is the
+// contract: reach for async/outbox or async/eventbus first, and use this
+// package only when per-event publish provably shows up in a profile. No
+// dedup — double-fires and unique-key rules belong to the downstream
+// pipeline.
+//
+// # Usage
+//
+//	sink := collector.SinkFunc[Click](func(ctx context.Context, batch []Click) error {
+//		return warehouse.InsertClicks(ctx, batch)
+//	})
+//	c, err := collector.New(sink, collector.WithLogger(log))
+//	if err != nil {
+//		panic(err)
+//	}
+//
+//	// In the request path: never blocks, error is optional to observe.
+//	_ = c.Add(r.Context(), Click{Path: r.URL.Path})
+//
+//	// Under ops/supervisor: cancellation drains the buffer through the sink.
+//	err = supervisor.Run(ctx, supervisor.WithService(c))
+//
+// A Collector is a supervisor.Service: Run flushes until ctx is cancelled,
+// then stops accepting (Add returns ErrClosed), drains everything already
+// buffered, and returns. Events added while the collector is not running
+// simply accumulate up to BufferSize.
+//
+// Multi-tenant apps configure WithScope (captures the tenant on every Add,
+// fail-closed: a hook error or empty scope fails Add with ErrScopeMissing)
+// and WithScopeContext (flushes partition by captured scope and the hook
+// restores each scope into its Flush context). Single-tenant apps configure
+// neither and the sink receives whole batches with a plain context.
+package collector

--- a/async/collector/errors.go
+++ b/async/collector/errors.go
@@ -1,0 +1,20 @@
+package collector
+
+import "errors"
+
+var (
+	// ErrInvalidConfig is returned by New when the configuration fails
+	// validation.
+	ErrInvalidConfig = errors.New("collector: invalid config")
+	// ErrNilSink is returned by New when the sink is nil.
+	ErrNilSink = errors.New("collector: nil sink")
+	// ErrBufferFull is returned by Add when the buffer is at capacity: the
+	// event is dropped (drop-newest), counted, and reported by the flusher.
+	ErrBufferFull = errors.New("collector: buffer full, event dropped")
+	// ErrScopeMissing is returned by Add when a scope hook is configured and
+	// yields an error or empty scope.
+	ErrScopeMissing = errors.New("collector: scope missing")
+	// ErrClosed is returned by Add once the collector has begun shutting
+	// down: the flusher is draining and new events would never be delivered.
+	ErrClosed = errors.New("collector: closed")
+)

--- a/async/collector/example_test.go
+++ b/async/collector/example_test.go
@@ -1,0 +1,32 @@
+package collector_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/async/collector"
+)
+
+func Example() {
+	sink := collector.SinkFunc[string](func(_ context.Context, batch []string) error {
+		fmt.Println("flushed:", batch)
+		return nil
+	})
+	c, err := collector.New(sink)
+	if err != nil {
+		panic(err)
+	}
+
+	// In the request path: buffer and move on, never block.
+	_ = c.Add(context.Background(), "click:/pricing")
+	_ = c.Add(context.Background(), "click:/docs")
+
+	// Run under ops/supervisor in production; a cancelled context here shows
+	// the graceful drain: buffered events flush before Run returns.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = c.Run(ctx)
+
+	// Output:
+	// flushed: [click:/pricing click:/docs]
+}

--- a/async/collector/options.go
+++ b/async/collector/options.go
@@ -1,0 +1,51 @@
+package collector
+
+import (
+	"context"
+	"log/slog"
+)
+
+// settings is the non-generic construction state options mutate.
+type settings struct {
+	log      *slog.Logger
+	scope    func(ctx context.Context) (string, error)
+	scopeCtx func(ctx context.Context, scope string) context.Context
+	name     string
+	cfg      Config
+}
+
+// Option configures New.
+type Option func(*settings)
+
+// WithConfig replaces the Config (validated by New).
+func WithConfig(cfg Config) Option {
+	return func(s *settings) { s.cfg = cfg }
+}
+
+// WithName overrides the supervisor service name (default "collector");
+// required when running multiple collectors under one supervisor.
+func WithName(name string) Option {
+	return func(s *settings) { s.name = name }
+}
+
+// WithLogger sets the logger (default logger.NewNope()).
+func WithLogger(l *slog.Logger) Option {
+	return func(s *settings) { s.log = l }
+}
+
+// WithScope installs the tenancy hook: it is called on every Add and its
+// result is captured into the buffered event. Fail-closed: once configured, a
+// hook error or empty scope makes Add fail with ErrScopeMissing.
+// Single-tenant apps simply do not configure it.
+func WithScope(fn func(ctx context.Context) (string, error)) Option {
+	return func(s *settings) { s.scope = fn }
+}
+
+// WithScopeContext installs the tenancy restore hook: flushes are partitioned
+// by captured scope and the hook is called once per scoped batch; the
+// returned context is the Flush call's base context. Without it the sink
+// receives a plain context (single-tenant, or a sink that does not need the
+// scope restored).
+func WithScopeContext(fn func(ctx context.Context, scope string) context.Context) Option {
+	return func(s *settings) { s.scopeCtx = fn }
+}

--- a/async/collector/stranded_test.go
+++ b/async/collector/stranded_test.go
@@ -1,0 +1,51 @@
+package collector_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/collector"
+)
+
+// TestNoStrandedEventsOnShutdown races Add against shutdown: an Add that
+// passed the closed check must have its event drained, never stranded in the
+// buffer after Run returns. After Run and all adders finish, every accepted
+// event is accounted for as flushed or lost.
+func TestNoStrandedEventsOnShutdown(t *testing.T) {
+	t.Parallel()
+	for range 300 {
+		sink := collector.SinkFunc[int](func(context.Context, []int) error { return nil })
+		c, err := collector.New(sink, collector.WithConfig(collector.Config{BufferSize: 8, BatchSize: 8, FlushInterval: time.Millisecond, FlushTimeout: time.Second}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() { defer close(done); _ = c.Run(ctx) }()
+
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Go(func() {
+				for {
+					if err := c.Add(context.Background(), 1); errors.Is(err, collector.ErrClosed) {
+						return
+					}
+				}
+			})
+		}
+		cancel()
+		wg.Wait()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Run did not return")
+		}
+
+		if st := c.Stats(); st.Added != st.Flushed+st.Lost {
+			t.Fatalf("stats %+v: %d accepted events stranded in the buffer", st, st.Added-st.Flushed-st.Lost)
+		}
+	}
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -382,22 +382,6 @@ Deps: `ops/supervisor`; `async/queue`.
 
 ---
 
-**async/collector**
-
-Write-behind ingestion for proven-hot fire-and-forget paths (click
-streams, beacons, telemetry): bounded in-memory buffer, batch flush by
-size+age into a `Sink` seam, explicit overload policy — drop-newest with
-counted, logged loss, never blocking the request path — and graceful
-drain as a `supervisor.Service`. No dedup — double-fires and unique-key
-rules are the downstream pipeline's concern. Reach for
-`outbox`/`eventbus` first: this package is justified only when per-event
-publish shows up in a profile (design.md §Performance — benchmark
-required).
-
-Deps: `ops/supervisor`.
-
----
-
 **async/workflow**
 
 DB-checkpointed linear step sequences over the engine

--- a/resilience/singleflight/singleflight_test.go
+++ b/resilience/singleflight/singleflight_test.go
@@ -168,17 +168,23 @@ func TestDoDetachedWaitBoundedByCallerContext(t *testing.T) {
 
 func TestDoDetachedExecutionSurvivesCallerCancel(t *testing.T) {
 	var g singleflight.Group[int]
+	release := make(chan struct{})
 	done := make(chan struct{})
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	_, _, err := g.DoDetached(ctx, "k", func(fnCtx context.Context) (int, error) {
 		defer close(done)
+		// Held until the caller has returned: were the fn allowed to finish
+		// first, the flight result and the cancelled ctx would race in
+		// DoDetached's select and either outcome would be valid.
+		<-release
 		// The detached fn must not observe the initiator's cancellation.
 		assert.NoError(t, fnCtx.Err())
 		return 1, nil
 	})
 	assert.ErrorIs(t, err, context.Canceled)
+	close(release)
 	select {
 	case <-done:
 	case <-time.After(time.Second):


### PR DESCRIPTION
## Summary

New `async/collector` package: write-behind ingestion for proven-hot fire-and-forget paths (click streams, beacons, telemetry), closing its roadmap entry (removed from `docs/packages.md`).

- **Non-blocking `Add`**: buffers into a bounded channel and returns immediately — never blocks the request path, never does I/O. Fire-and-forget callers may ignore the returned error.
- **Batch flush by size + age**: a single flusher goroutine delivers to a `Sink[T]` seam (`SinkFunc` adapter included) when a batch reaches `BatchSize` or `FlushInterval` elapses.
- **Explicit overload policy**: drop-newest on a full buffer — counted in `Stats.Dropped`, returned as `ErrBufferFull`, and logged as per-interval drop deltas (no per-event log spam).
- **Loss is the contract**: a sink error loses that batch (counted in `Stats.Lost`, logged, never retried) — wrap the sink with `resilience/retry` for transient backends. No dedup; docs point to `outbox`/`eventbus` first.
- **`supervisor.Service`**: on ctx cancellation `Add` starts returning `ErrClosed`, the buffer drains fully through the sink (flush contexts survive cancellation via `context.WithoutCancel`, bounded by `FlushTimeout`), then `Run` returns.
- **Tenancy**: mirrors queue/eventbus — `WithScope` captures the tenant on every `Add` (fail-closed `ErrScopeMissing` on hook error or empty scope), flushes partition per captured scope in first-seen order, `WithScopeContext` restores each scope into its `Flush` context. Single-tenant apps configure neither and pay zero ceremony.
- Env-loadable `Config` (`COLLECTOR_*`) + `DefaultConfig` + `Validate`; `errors.Is`-matchable sentinels; default logger `logger.NewNope()`.

## Benchmarks (Apple M3 Max, discard sink)

```
BenchmarkAdd-14            30371641    43.64 ns/op    6 B/op    0 allocs/op
BenchmarkAddParallel-14    13168675    86.45 ns/op    1 B/op    0 allocs/op
BenchmarkAddScoped-14      31838965    37.03 ns/op   15 B/op    0 allocs/op
```

Post-benchmark pass: the hot path (`Add`) is already 0 allocs/op — the amortized bytes are flusher-side batch/partition allocations, one per flush, dominated by sink I/O in any real deployment. No perf-motivated complexity added (none had a measured win).

## Testing

- `just test ./async/collector/...` — race + cover, **100.0% statement coverage**
- Covers: size flush, age flush, drop-newest preserving oldest, non-blocking guarantee, graceful drain, `ErrClosed` after shutdown, sink error → lost + recovery, `FlushTimeout` propagation, fail-closed scope, per-scope partitioning + ctx restore, drop-delta logging, concurrent adders with stats reconciliation
- `just lint` — clean (vet, golangci-lint, nilaway, betteralign, modernize, integration tags)
