### PR TITLE
feat(async/eventrouter): batched event egress over eventbus with per-destination isolation

### DIFF
--- a/async/eventrouter/bench_test.go
+++ b/async/eventrouter/bench_test.go
@@ -1,0 +1,81 @@
+package eventrouter_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+	"github.com/dmitrymomot/forge/async/eventrouter"
+)
+
+type nopDeliverer struct{}
+
+func (nopDeliverer) Deliver(context.Context, []eventrouter.Event) error { return nil }
+
+// BenchmarkPublishRouted measures the full sync-bus publish → route → deliver
+// path with batching disabled: envelope marshal, handler dispatch, payload
+// re-marshal, and the destination's singleton fast path.
+func BenchmarkPublishRouted(b *testing.B) {
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("bench.routed")
+	dest := eventrouter.NewDestination("nop", nopDeliverer{}, eventrouter.WithBatchSize(1))
+	eventrouter.Route(bus, evt, dest)
+	ctx := context.Background()
+	p := payload{V: "bench"}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := eventbus.Publish(ctx, bus, evt, p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkPublishRoutedBatched measures the batching path under concurrent
+// publishers: joins coordinate through the destination mutex and flush by
+// size.
+func BenchmarkPublishRoutedBatched(b *testing.B) {
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("bench.batched")
+	dest := eventrouter.NewDestination("nop", nopDeliverer{},
+		eventrouter.WithBatchSize(8), eventrouter.WithBatchAge(time.Millisecond))
+	eventrouter.Route(bus, evt, dest)
+	ctx := context.Background()
+	p := payload{V: "bench"}
+
+	b.ReportAllocs()
+	var wg sync.WaitGroup
+	for b.Loop() {
+		wg.Add(8)
+		for range 8 {
+			go func() {
+				defer wg.Done()
+				_ = eventbus.Publish(ctx, bus, evt, p)
+			}()
+		}
+		wg.Wait()
+	}
+}
+
+// BenchmarkBatchEncode measures the wire encoding the HTTP and webhook
+// deliverers pay per flush.
+func BenchmarkBatchEncode(b *testing.B) {
+	events := make([]eventrouter.Event, 100)
+	for i := range events {
+		events[i] = eventrouter.Event{
+			OccurredAt: time.Now().UTC(),
+			Payload:    json.RawMessage(`{"order_id":"ord_123","total_cents":4200}`),
+			ID:         "evt_0123456789abcdef",
+			Name:       "order.placed",
+		}
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := json.Marshal(events); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/async/eventrouter/deliverer.go
+++ b/async/eventrouter/deliverer.go
@@ -1,0 +1,32 @@
+package eventrouter
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Event is the unit of egress a route hands to a destination: the stable
+// event identity plus the outbound payload (the remapped form when the route
+// remaps, the published payload otherwise). ID is the same on every delivery
+// of one published event — across retries, batches, and destinations — so it
+// is the key receivers dedup on. The JSON tags are the wire form the
+// HTTP and webhook deliverers batch-encode.
+type Event struct {
+	OccurredAt time.Time       `json:"occurred_at"`
+	ID         string          `json:"id"`
+	Name       string          `json:"name"`
+	Payload    json.RawMessage `json:"payload,omitempty"`
+}
+
+// Deliverer ships one batch to an external destination and classifies the
+// outcome: nil when the destination accepted it, a Permanent-wrapped error
+// when retrying cannot help (the router dead-letters, isolating the poison
+// event first on multi-event batches), and any other error for transient
+// failures (every event in the batch retries on the queue's backoff).
+//
+// Deliver is called concurrently when batches overlap, and the events slice
+// is only valid for the duration of the call.
+type Deliverer interface {
+	Deliver(ctx context.Context, events []Event) error
+}

--- a/async/eventrouter/deliverers_test.go
+++ b/async/eventrouter/deliverers_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dmitrymomot/forge/async/eventbus"
 	"github.com/dmitrymomot/forge/async/eventrouter"
+	"github.com/dmitrymomot/forge/async/queue"
 	"github.com/dmitrymomot/forge/comms/postback"
 	"github.com/dmitrymomot/forge/comms/webhook"
 )
@@ -225,7 +227,7 @@ func TestPostbackDeliverer_Deliver(t *testing.T) {
 		return map[string]string{"event_id": e.ID, "value": p.V}, nil
 	}
 
-	t.Run("renders macros per event", func(t *testing.T) {
+	t.Run("renders macros", func(t *testing.T) {
 		t.Parallel()
 		var mu sync.Mutex
 		var urls []string
@@ -240,10 +242,24 @@ func TestPostbackDeliverer_Deliver(t *testing.T) {
 		require.NoError(t, err)
 		d := eventrouter.NewPostbackDeliverer(postback.New(), dest, values)
 
-		require.NoError(t, d.Deliver(context.Background(), testEvents(2)))
+		require.NoError(t, d.Deliver(context.Background(), testEvents(1)))
 		mu.Lock()
 		defer mu.Unlock()
-		assert.ElementsMatch(t, []string{"/pb?eid=evt_a&v=a", "/pb?eid=evt_b&v=b"}, urls)
+		assert.Equal(t, []string{"/pb?eid=evt_a&v=a"}, urls)
+	})
+
+	t.Run("multi-event batch is refused without firing", func(t *testing.T) {
+		t.Parallel()
+		srv, c := captureServer(t, http.StatusOK)
+		dest, err := postback.NewDestination(srv.URL+"/pb?eid={event_id}", vocab)
+		require.NoError(t, err)
+		d := eventrouter.NewPostbackDeliverer(postback.New(), dest, values)
+
+		err = d.Deliver(context.Background(), testEvents(2))
+		assert.ErrorIs(t, err, eventrouter.ErrPermanent, "refusal routes the batch through poison isolation")
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		assert.Empty(t, c.method, "no ping fires for a refused batch")
 	})
 
 	t.Run("status mapping", func(t *testing.T) {
@@ -280,20 +296,48 @@ func TestPostbackDeliverer_Deliver(t *testing.T) {
 		assert.Nil(t, c.body, "no request fired for an unmappable event")
 	})
 
-	t.Run("permanent outranks transient in mixed batches", func(t *testing.T) {
+	// The scenario the batch refusal exists for: a batched destination with a
+	// mixed per-event outcome must never re-fire an accepted ping. The refused
+	// batch goes through the router's isolation pass, so every event fires
+	// exactly once and each carries its own verdict.
+	t.Run("routed batch pings each event exactly once with precise verdicts", func(t *testing.T) {
 		t.Parallel()
-		srv, _ := captureServer(t, http.StatusOK)
-		dest, err := postback.NewDestination(srv.URL+"/pb?eid={event_id}", vocab)
+		var mu sync.Mutex
+		pings := make(map[string]int)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			v := r.URL.Query().Get("v")
+			mu.Lock()
+			pings[v]++
+			mu.Unlock()
+			if v == "bad" {
+				// Permanent (4xx) so neither the router nor the sender's own
+				// GET-retrying httpclient re-fires it: ping counts stay exact.
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+		pbDest, err := postback.NewDestination(srv.URL+"/pb?eid={event_id}&v={value}", vocab)
 		require.NoError(t, err)
-		d := eventrouter.NewPostbackDeliverer(postback.New(), dest,
-			func(e eventrouter.Event) (map[string]string, error) {
-				if e.ID == "evt_a" {
-					return nil, context.Canceled
-				}
-				return map[string]string{"event_id": e.ID}, nil
-			})
-		err = d.Deliver(context.Background(), testEvents(2))
-		assert.ErrorIs(t, err, eventrouter.ErrPermanent, "isolation splits the batch into per-event verdicts")
+
+		routerDest := eventrouter.NewDestination("tracker", eventrouter.NewPostbackDeliverer(postback.New(), pbDest, values),
+			eventrouter.WithBatchSize(3), eventrouter.WithBatchAge(time.Hour))
+		bus := eventbus.NewSync()
+		evt := eventbus.NewEvent[payload]("postback.batched")
+		eventrouter.Route(bus, evt, routerDest)
+
+		errs := publishAll(context.Background(), bus, evt, "ok1", "bad", "ok2")
+		assert.NoError(t, errs["ok1"])
+		assert.NoError(t, errs["ok2"])
+		require.Error(t, errs["bad"])
+		assert.True(t, queue.IsSkipRetry(errs["bad"]), "the rejected ping dead-letters alone")
+		assert.ErrorIs(t, errs["bad"], postback.ErrClientStatus)
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(t, map[string]int{"ok1": 1, "bad": 1, "ok2": 1}, pings,
+			"accepted pings are never re-fired by a batchmate's failure")
 	})
 
 	t.Run("validation", func(t *testing.T) {

--- a/async/eventrouter/deliverers_test.go
+++ b/async/eventrouter/deliverers_test.go
@@ -1,0 +1,306 @@
+package eventrouter_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/eventrouter"
+	"github.com/dmitrymomot/forge/comms/postback"
+	"github.com/dmitrymomot/forge/comms/webhook"
+)
+
+func testEvents(n int) []eventrouter.Event {
+	events := make([]eventrouter.Event, 0, n)
+	for i := range n {
+		events = append(events, eventrouter.Event{
+			OccurredAt: time.Date(2026, 7, 20, 12, 0, i, 0, time.UTC),
+			Payload:    json.RawMessage(`{"v":"` + string(rune('a'+i)) + `"}`),
+			ID:         "evt_" + string(rune('a'+i)),
+			Name:       "order.placed",
+		})
+	}
+	return events
+}
+
+// capture records the last request a test server saw.
+type capture struct {
+	header http.Header
+	body   []byte
+	method string
+	mu     sync.Mutex
+}
+
+func captureServer(t *testing.T, status int) (*httptest.Server, *capture) {
+	t.Helper()
+	c := &capture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		c.mu.Lock()
+		c.method = r.Method
+		c.header = r.Header.Clone()
+		c.body = body
+		c.mu.Unlock()
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, c
+}
+
+func TestHTTPDeliverer_Deliver(t *testing.T) {
+	t.Parallel()
+
+	t.Run("batch body and headers", func(t *testing.T) {
+		t.Parallel()
+		srv, c := captureServer(t, http.StatusOK)
+		d, err := eventrouter.NewHTTPDeliverer(srv.URL+"/collect",
+			eventrouter.WithHTTPHeader("Authorization", "Bearer tok"))
+		require.NoError(t, err)
+
+		require.NoError(t, d.Deliver(context.Background(), testEvents(2)))
+
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		assert.Equal(t, http.MethodPost, c.method)
+		assert.Equal(t, "application/json", c.header.Get("Content-Type"))
+		assert.Equal(t, "Bearer tok", c.header.Get("Authorization"))
+		assert.Empty(t, c.header.Get("Idempotency-Key"), "batches carry ids in the payload, not the header")
+
+		var got []map[string]any
+		require.NoError(t, json.Unmarshal(c.body, &got))
+		require.Len(t, got, 2)
+		assert.Equal(t, "evt_a", got[0]["id"])
+		assert.Equal(t, "order.placed", got[0]["name"])
+		assert.NotEmpty(t, got[0]["occurred_at"])
+		assert.Equal(t, map[string]any{"v": "a"}, got[0]["payload"])
+	})
+
+	t.Run("single event carries Idempotency-Key", func(t *testing.T) {
+		t.Parallel()
+		srv, c := captureServer(t, http.StatusOK)
+		d, err := eventrouter.NewHTTPDeliverer(srv.URL)
+		require.NoError(t, err)
+
+		require.NoError(t, d.Deliver(context.Background(), testEvents(1)))
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		assert.Equal(t, "evt_a", c.header.Get("Idempotency-Key"))
+	})
+
+	t.Run("status classes", func(t *testing.T) {
+		t.Parallel()
+		for status, wantPermanent := range map[int]bool{
+			http.StatusNoContent:           false, // 2xx → nil error, checked below
+			http.StatusBadRequest:          true,
+			http.StatusNotFound:            true,
+			http.StatusGone:                true,
+			http.StatusRequestTimeout:      false,
+			http.StatusTooManyRequests:     false,
+			http.StatusInternalServerError: false,
+			http.StatusServiceUnavailable:  false,
+		} {
+			srv, _ := captureServer(t, status)
+			d, err := eventrouter.NewHTTPDeliverer(srv.URL)
+			require.NoError(t, err)
+			err = d.Deliver(context.Background(), testEvents(1))
+			if status < 300 {
+				assert.NoError(t, err, "status %d", status)
+				continue
+			}
+			require.Error(t, err, "status %d", status)
+			assert.Equal(t, wantPermanent, errors.Is(err, eventrouter.ErrPermanent), "status %d", status)
+		}
+	})
+
+	t.Run("transport failure is transient", func(t *testing.T) {
+		t.Parallel()
+		srv, _ := captureServer(t, http.StatusOK)
+		d, err := eventrouter.NewHTTPDeliverer(srv.URL)
+		require.NoError(t, err)
+		srv.Close()
+		err = d.Deliver(context.Background(), testEvents(1))
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, eventrouter.ErrPermanent))
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		t.Parallel()
+		for _, u := range []string{"", "not a url", "ftp://host/x", "/relative", "https://"} {
+			_, err := eventrouter.NewHTTPDeliverer(u)
+			assert.ErrorIs(t, err, eventrouter.ErrInvalidURL, "url %q", u)
+		}
+	})
+
+	t.Run("zero deliverer errors instead of panicking", func(t *testing.T) {
+		t.Parallel()
+		var d eventrouter.HTTPDeliverer
+		assert.Error(t, d.Deliver(context.Background(), testEvents(1)))
+	})
+}
+
+func TestWebhookDeliverer_Deliver(t *testing.T) {
+	t.Parallel()
+	endpoint := func(url string) webhook.Endpoint {
+		return webhook.Endpoint{URL: url, Secret: []byte("shhh")}
+	}
+
+	t.Run("signs and keys single deliveries", func(t *testing.T) {
+		t.Parallel()
+		srv, c := captureServer(t, http.StatusOK)
+		d := eventrouter.NewWebhookDeliverer(webhook.New(), endpoint(srv.URL))
+
+		require.NoError(t, d.Deliver(context.Background(), testEvents(1)))
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		assert.NotEmpty(t, c.header.Get("Webhook-Signature"), "deliveries are signed")
+		assert.Equal(t, "evt_a", c.header.Get("Webhook-Id"))
+
+		var got []map[string]any
+		require.NoError(t, json.Unmarshal(c.body, &got))
+		require.Len(t, got, 1)
+		assert.Equal(t, "evt_a", got[0]["id"])
+	})
+
+	t.Run("batches are signed without a batch key", func(t *testing.T) {
+		t.Parallel()
+		srv, c := captureServer(t, http.StatusOK)
+		d := eventrouter.NewWebhookDeliverer(webhook.New(), endpoint(srv.URL))
+
+		require.NoError(t, d.Deliver(context.Background(), testEvents(3)))
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		assert.NotEmpty(t, c.header.Get("Webhook-Signature"))
+		assert.Empty(t, c.header.Get("Webhook-Id"), "a re-formed batch has no stable identity")
+	})
+
+	t.Run("status mapping", func(t *testing.T) {
+		t.Parallel()
+		srv400, _ := captureServer(t, http.StatusBadRequest)
+		d := eventrouter.NewWebhookDeliverer(webhook.New(), endpoint(srv400.URL))
+		err := d.Deliver(context.Background(), testEvents(1))
+		assert.ErrorIs(t, err, eventrouter.ErrPermanent)
+		assert.ErrorIs(t, err, webhook.ErrPermanentStatus)
+
+		srv500, _ := captureServer(t, http.StatusInternalServerError)
+		d = eventrouter.NewWebhookDeliverer(webhook.New(), endpoint(srv500.URL))
+		err = d.Deliver(context.Background(), testEvents(1))
+		assert.ErrorIs(t, err, webhook.ErrTransientStatus)
+		assert.False(t, errors.Is(err, eventrouter.ErrPermanent))
+	})
+
+	t.Run("invalid endpoint is permanent", func(t *testing.T) {
+		t.Parallel()
+		d := eventrouter.NewWebhookDeliverer(webhook.New(), webhook.Endpoint{URL: "https://example.com"})
+		err := d.Deliver(context.Background(), testEvents(1))
+		assert.ErrorIs(t, err, eventrouter.ErrPermanent)
+	})
+
+	t.Run("validation", func(t *testing.T) {
+		t.Parallel()
+		assert.Panics(t, func() { eventrouter.NewWebhookDeliverer(nil, webhook.Endpoint{}) })
+		var d eventrouter.WebhookDeliverer
+		assert.Error(t, d.Deliver(context.Background(), testEvents(1)))
+	})
+}
+
+func TestPostbackDeliverer_Deliver(t *testing.T) {
+	t.Parallel()
+	vocab, err := postback.NewVocabulary("event_id", "value")
+	require.NoError(t, err)
+	values := func(e eventrouter.Event) (map[string]string, error) {
+		var p payload
+		if err := json.Unmarshal(e.Payload, &p); err != nil {
+			return nil, err
+		}
+		return map[string]string{"event_id": e.ID, "value": p.V}, nil
+	}
+
+	t.Run("renders macros per event", func(t *testing.T) {
+		t.Parallel()
+		var mu sync.Mutex
+		var urls []string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			urls = append(urls, r.URL.String())
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+		dest, err := postback.NewDestination(srv.URL+"/pb?eid={event_id}&v={value}", vocab)
+		require.NoError(t, err)
+		d := eventrouter.NewPostbackDeliverer(postback.New(), dest, values)
+
+		require.NoError(t, d.Deliver(context.Background(), testEvents(2)))
+		mu.Lock()
+		defer mu.Unlock()
+		assert.ElementsMatch(t, []string{"/pb?eid=evt_a&v=a", "/pb?eid=evt_b&v=b"}, urls)
+	})
+
+	t.Run("status mapping", func(t *testing.T) {
+		t.Parallel()
+		srv500, _ := captureServer(t, http.StatusInternalServerError)
+		dest, err := postback.NewDestination(srv500.URL+"/pb?eid={event_id}", vocab)
+		require.NoError(t, err)
+		d := eventrouter.NewPostbackDeliverer(postback.New(), dest, values)
+		err = d.Deliver(context.Background(), testEvents(1))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, postback.ErrServerStatus)
+		assert.False(t, errors.Is(err, eventrouter.ErrPermanent), "5xx retries")
+
+		srv404, _ := captureServer(t, http.StatusNotFound)
+		dest404, err := postback.NewDestination(srv404.URL+"/pb?eid={event_id}", vocab)
+		require.NoError(t, err)
+		d = eventrouter.NewPostbackDeliverer(postback.New(), dest404, values)
+		err = d.Deliver(context.Background(), testEvents(1))
+		assert.ErrorIs(t, err, eventrouter.ErrPermanent)
+		assert.ErrorIs(t, err, postback.ErrClientStatus)
+	})
+
+	t.Run("values error is permanent and skips the ping", func(t *testing.T) {
+		t.Parallel()
+		srv, c := captureServer(t, http.StatusOK)
+		dest, err := postback.NewDestination(srv.URL+"/pb?eid={event_id}", vocab)
+		require.NoError(t, err)
+		d := eventrouter.NewPostbackDeliverer(postback.New(), dest,
+			func(eventrouter.Event) (map[string]string, error) { return nil, context.Canceled })
+		err = d.Deliver(context.Background(), testEvents(1))
+		assert.ErrorIs(t, err, eventrouter.ErrPermanent)
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		assert.Nil(t, c.body, "no request fired for an unmappable event")
+	})
+
+	t.Run("permanent outranks transient in mixed batches", func(t *testing.T) {
+		t.Parallel()
+		srv, _ := captureServer(t, http.StatusOK)
+		dest, err := postback.NewDestination(srv.URL+"/pb?eid={event_id}", vocab)
+		require.NoError(t, err)
+		d := eventrouter.NewPostbackDeliverer(postback.New(), dest,
+			func(e eventrouter.Event) (map[string]string, error) {
+				if e.ID == "evt_a" {
+					return nil, context.Canceled
+				}
+				return map[string]string{"event_id": e.ID}, nil
+			})
+		err = d.Deliver(context.Background(), testEvents(2))
+		assert.ErrorIs(t, err, eventrouter.ErrPermanent, "isolation splits the batch into per-event verdicts")
+	})
+
+	t.Run("validation", func(t *testing.T) {
+		t.Parallel()
+		assert.Panics(t, func() { eventrouter.NewPostbackDeliverer(nil, postback.Destination{}, values) })
+		assert.Panics(t, func() { eventrouter.NewPostbackDeliverer(postback.New(), postback.Destination{}, nil) })
+		var d eventrouter.PostbackDeliverer
+		assert.Error(t, d.Deliver(context.Background(), testEvents(1)))
+	})
+}

--- a/async/eventrouter/destination.go
+++ b/async/eventrouter/destination.go
@@ -1,0 +1,186 @@
+package eventrouter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/queue"
+)
+
+// Destination is one external delivery target: a named Deliverer plus the
+// batching policy in front of it. Construct once at startup and Route events
+// into it; its name becomes the eventbus subscription name of every route, so
+// it must be unique among the app's subscriptions. A Destination is safe for
+// concurrent use and may be routed from any number of events — a batch mixes
+// events, never tenants.
+type Destination struct {
+	deliverer Deliverer
+	scope     func(ctx context.Context) (string, error)
+	open      map[string]*batch // keyed by tenancy scope, "" without a hook
+	name      string
+	maxAge    time.Duration
+	timeout   time.Duration
+	maxSize   int
+	mu        sync.Mutex
+}
+
+// batch is one open accumulation window. Joining jobs block on done; whoever
+// detaches the batch from Destination.open (the size-filling join or the age
+// timer, exactly one) flushes it and resolves every waiter's verdict.
+type batch struct {
+	ctx      context.Context // values of the first joiner, never cancelled
+	timer    *time.Timer
+	done     chan struct{}
+	events   []Event
+	verdicts []error
+}
+
+// NewDestination builds a Destination delivering through d. Defaults: batches
+// of up to 100 events flushed after at most 1s, a 30s delivery timeout per
+// flush, and no tenancy scoping. Panics on an empty name or nil deliverer —
+// destinations are startup wiring, not runtime data.
+func NewDestination(name string, d Deliverer, opts ...Option) *Destination {
+	if name == "" {
+		panic("eventrouter: NewDestination requires a non-empty name")
+	}
+	if d == nil {
+		panic(fmt.Sprintf("eventrouter: NewDestination(%q) with nil deliverer", name))
+	}
+	dest := &Destination{
+		name:      name,
+		deliverer: d,
+		open:      make(map[string]*batch),
+		maxSize:   100,
+		maxAge:    time.Second,
+		timeout:   30 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(dest)
+	}
+	return dest
+}
+
+// Name returns the destination name — the eventbus subscription name of every
+// route into it.
+func (d *Destination) Name() string { return d.name }
+
+// join adds e to the destination's open batch for the caller's scope and
+// blocks until the batch flushes, returning this event's queue verdict. A
+// cancelled ctx returns early with ctx.Err() — the event still rides the
+// flush, and the retried job may deliver a duplicate receivers dedup.
+func (d *Destination) join(ctx context.Context, e Event) error {
+	scope := ""
+	if d.scope != nil {
+		s, err := d.scope(ctx)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrScopeMissing, err)
+		}
+		if s == "" {
+			return ErrScopeMissing
+		}
+		scope = s
+	}
+	if d.maxSize == 1 {
+		return verdict(d.deliver(ctx, []Event{e}))
+	}
+	d.mu.Lock()
+	b, ok := d.open[scope]
+	if !ok {
+		b = &batch{
+			ctx:    context.WithoutCancel(ctx),
+			done:   make(chan struct{}),
+			events: make([]Event, 0, d.maxSize),
+		}
+		b.timer = time.AfterFunc(d.maxAge, func() { d.flushExpired(scope, b) })
+		d.open[scope] = b
+	}
+	b.events = append(b.events, e)
+	idx := len(b.events) - 1
+	full := len(b.events) >= d.maxSize
+	if full {
+		delete(d.open, scope)
+	}
+	d.mu.Unlock()
+	if full {
+		b.timer.Stop()
+		d.flush(b)
+	}
+	select {
+	case <-b.done:
+		return b.verdicts[idx]
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// flushExpired is the age-timer path: it claims the batch unless a
+// size-filling join already did, so exactly one flush runs per batch.
+func (d *Destination) flushExpired(scope string, b *batch) {
+	d.mu.Lock()
+	if d.open[scope] != b {
+		d.mu.Unlock()
+		return
+	}
+	delete(d.open, scope)
+	d.mu.Unlock()
+	d.flush(b)
+}
+
+// flush delivers a detached batch and resolves every waiter's verdict: nil
+// acknowledges, a transient error retries the whole batch, and a permanent
+// error on a multi-event batch takes the poison-isolation path.
+func (d *Destination) flush(b *batch) {
+	b.verdicts = make([]error, len(b.events))
+	err := d.deliver(b.ctx, b.events)
+	switch {
+	case err == nil:
+	case errors.Is(err, ErrPermanent) && len(b.events) > 1:
+		d.isolate(b)
+	default:
+		v := verdict(err)
+		for i := range b.verdicts {
+			b.verdicts[i] = v
+		}
+	}
+	close(b.done)
+}
+
+// isolate re-delivers each event of a permanently rejected batch alone, so
+// the poison event dead-letters by itself instead of taking its batchmates
+// with it. Events the batch attempt already landed may be re-sent — receivers
+// dedup by event ID; in-router suppression would risk silent loss instead.
+func (d *Destination) isolate(b *batch) {
+	for i := range b.events {
+		b.verdicts[i] = verdict(d.deliver(b.ctx, b.events[i:i+1]))
+	}
+}
+
+// deliver invokes the Deliverer under the per-flush timeout with panic
+// recovery: a panicking deliverer is a failed (retryable) delivery, not a
+// crashed worker or timer goroutine.
+func (d *Destination) deliver(ctx context.Context, events []Event) (err error) {
+	if d.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, d.timeout)
+		defer cancel()
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("eventrouter: deliverer panic: %v", r)
+		}
+	}()
+	return d.deliverer.Deliver(ctx, events)
+}
+
+// verdict maps a Deliverer outcome onto the queue's retry decision:
+// permanent failures dead-letter without burning attempts, everything else
+// retries.
+func verdict(err error) error {
+	if err != nil && errors.Is(err, ErrPermanent) {
+		return queue.SkipRetry(err)
+	}
+	return err
+}

--- a/async/eventrouter/destination_test.go
+++ b/async/eventrouter/destination_test.go
@@ -1,0 +1,333 @@
+package eventrouter_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+	"github.com/dmitrymomot/forge/async/eventrouter"
+	"github.com/dmitrymomot/forge/async/queue"
+)
+
+type payload struct {
+	V string `json:"v"`
+}
+
+// stub is a scripted Deliverer: fn (when set) decides each call's outcome by
+// call ordinal; calls are recorded as defensive copies.
+type stub struct {
+	fn    func(ctx context.Context, call int, events []eventrouter.Event) error
+	calls [][]eventrouter.Event
+	mu    sync.Mutex
+}
+
+func (s *stub) Deliver(ctx context.Context, events []eventrouter.Event) error {
+	s.mu.Lock()
+	call := len(s.calls)
+	s.calls = append(s.calls, slices.Clone(events))
+	fn := s.fn
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, call, events)
+	}
+	return nil
+}
+
+func (s *stub) snapshot() [][]eventrouter.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([][]eventrouter.Event, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+// publishAll publishes one event per payload value concurrently on the sync
+// bus and returns each publish's error keyed by value.
+func publishAll(ctx context.Context, bus *eventbus.Bus, evt eventbus.Event[payload], values ...string) map[string]error {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	errs := make(map[string]error, len(values))
+	for _, v := range values {
+		wg.Go(func() {
+			err := eventbus.Publish(ctx, bus, evt, payload{V: v})
+			mu.Lock()
+			errs[v] = err
+			mu.Unlock()
+		})
+	}
+	wg.Wait()
+	return errs
+}
+
+func TestDestination_BatchBySize(t *testing.T) {
+	t.Parallel()
+	s := &stub{}
+	dest := eventrouter.NewDestination("size", s,
+		eventrouter.WithBatchSize(3), eventrouter.WithBatchAge(time.Hour))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("router.size")
+	eventrouter.Route(bus, evt, dest)
+
+	errs := publishAll(context.Background(), bus, evt, "a", "b", "c")
+	for v, err := range errs {
+		assert.NoError(t, err, "publish %q", v)
+	}
+	calls := s.snapshot()
+	require.Len(t, calls, 1, "size-filled batch flushes as one delivery")
+	require.Len(t, calls[0], 3)
+
+	ids := make(map[string]struct{})
+	for _, e := range calls[0] {
+		assert.Equal(t, "router.size", e.Name)
+		assert.NotEmpty(t, e.ID)
+		assert.False(t, e.OccurredAt.IsZero())
+		ids[e.ID] = struct{}{}
+	}
+	assert.Len(t, ids, 3, "every event keeps its own stable id")
+}
+
+func TestDestination_BatchByAge(t *testing.T) {
+	t.Parallel()
+	s := &stub{}
+	dest := eventrouter.NewDestination("age", s,
+		eventrouter.WithBatchSize(100), eventrouter.WithBatchAge(150*time.Millisecond))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("router.age")
+	eventrouter.Route(bus, evt, dest)
+
+	errs := publishAll(context.Background(), bus, evt, "a", "b")
+	for v, err := range errs {
+		assert.NoError(t, err, "publish %q", v)
+	}
+	calls := s.snapshot()
+	require.Len(t, calls, 1, "partial batch flushes by age")
+	assert.Len(t, calls[0], 2)
+}
+
+func TestDestination_TransientErrorFailsWholeBatch(t *testing.T) {
+	t.Parallel()
+	errBoom := errors.New("boom")
+	s := &stub{fn: func(context.Context, int, []eventrouter.Event) error { return errBoom }}
+	dest := eventrouter.NewDestination("transient", s,
+		eventrouter.WithBatchSize(2), eventrouter.WithBatchAge(time.Hour))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("router.transient")
+	eventrouter.Route(bus, evt, dest)
+
+	errs := publishAll(context.Background(), bus, evt, "a", "b")
+	for v, err := range errs {
+		require.Error(t, err, "publish %q", v)
+		assert.ErrorIs(t, err, errBoom)
+		assert.False(t, queue.IsSkipRetry(err), "transient failures retry, never dead-letter")
+	}
+}
+
+func TestDestination_PermanentSingletonDeadLetters(t *testing.T) {
+	t.Parallel()
+	errBad := errors.New("rejected")
+	s := &stub{fn: func(context.Context, int, []eventrouter.Event) error {
+		return eventrouter.Permanent(errBad)
+	}}
+	dest := eventrouter.NewDestination("permanent", s, eventrouter.WithBatchSize(1))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("router.permanent")
+	eventrouter.Route(bus, evt, dest)
+
+	err := eventbus.Publish(context.Background(), bus, evt, payload{V: "a"})
+	require.Error(t, err)
+	assert.True(t, queue.IsSkipRetry(err), "permanent failures dead-letter without burning attempts")
+	assert.ErrorIs(t, err, eventrouter.ErrPermanent)
+	assert.ErrorIs(t, err, errBad)
+}
+
+func TestDestination_PoisonIsolation(t *testing.T) {
+	t.Parallel()
+	poison := `{"v":"poison"}`
+	s := &stub{fn: func(_ context.Context, _ int, events []eventrouter.Event) error {
+		for _, e := range events {
+			if string(e.Payload) == poison {
+				return eventrouter.Permanent(errors.New("bad event"))
+			}
+		}
+		return nil
+	}}
+	dest := eventrouter.NewDestination("isolate", s,
+		eventrouter.WithBatchSize(3), eventrouter.WithBatchAge(time.Hour))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("router.isolate")
+	eventrouter.Route(bus, evt, dest)
+
+	errs := publishAll(context.Background(), bus, evt, "a", "poison", "b")
+	assert.NoError(t, errs["a"], "innocent batchmates are acknowledged")
+	assert.NoError(t, errs["b"], "innocent batchmates are acknowledged")
+	require.Error(t, errs["poison"])
+	assert.True(t, queue.IsSkipRetry(errs["poison"]), "the poison event dead-letters alone")
+	assert.ErrorIs(t, errs["poison"], eventrouter.ErrPermanent)
+
+	calls := s.snapshot()
+	require.Len(t, calls, 4, "one batch attempt plus one isolation delivery per event")
+	assert.Len(t, calls[0], 3)
+	for _, call := range calls[1:] {
+		assert.Len(t, call, 1)
+	}
+}
+
+func TestDestination_IsolationVerdictsSplit(t *testing.T) {
+	t.Parallel()
+	errTransient := errors.New("flaky")
+	s := &stub{fn: func(_ context.Context, call int, events []eventrouter.Event) error {
+		if call == 0 {
+			return eventrouter.Permanent(errors.New("batch rejected"))
+		}
+		switch string(events[0].Payload) {
+		case `{"v":"poison"}`:
+			return eventrouter.Permanent(errors.New("bad event"))
+		case `{"v":"flaky"}`:
+			return errTransient
+		default:
+			return nil
+		}
+	}}
+	dest := eventrouter.NewDestination("split", s,
+		eventrouter.WithBatchSize(3), eventrouter.WithBatchAge(time.Hour))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("router.split")
+	eventrouter.Route(bus, evt, dest)
+
+	errs := publishAll(context.Background(), bus, evt, "ok", "poison", "flaky")
+	assert.NoError(t, errs["ok"])
+	assert.True(t, queue.IsSkipRetry(errs["poison"]))
+	require.Error(t, errs["flaky"])
+	assert.ErrorIs(t, errs["flaky"], errTransient)
+	assert.False(t, queue.IsSkipRetry(errs["flaky"]), "transient isolation outcomes keep retrying")
+}
+
+func TestDestination_DelivererPanicIsRetryable(t *testing.T) {
+	t.Parallel()
+	s := &stub{fn: func(context.Context, int, []eventrouter.Event) error { panic("kaboom") }}
+	dest := eventrouter.NewDestination("panicky", s, eventrouter.WithBatchSize(1))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("router.panic")
+	eventrouter.Route(bus, evt, dest)
+
+	err := eventbus.Publish(context.Background(), bus, evt, payload{V: "a"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deliverer panic")
+	assert.False(t, queue.IsSkipRetry(err))
+}
+
+func TestDestination_DeliveryTimeout(t *testing.T) {
+	t.Parallel()
+	s := &stub{fn: func(ctx context.Context, _ int, _ []eventrouter.Event) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}}
+	dest := eventrouter.NewDestination("slow", s,
+		eventrouter.WithBatchSize(1), eventrouter.WithDeliveryTimeout(30*time.Millisecond))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("router.slow")
+	eventrouter.Route(bus, evt, dest)
+
+	err := eventbus.Publish(context.Background(), bus, evt, payload{V: "a"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+type scopeKey struct{}
+
+func scopeHook(ctx context.Context) (string, error) {
+	s, _ := ctx.Value(scopeKey{}).(string)
+	return s, nil
+}
+
+func TestDestination_ScopeKeysBatches(t *testing.T) {
+	t.Parallel()
+	s := &stub{}
+	dest := eventrouter.NewDestination("tenant", s,
+		eventrouter.WithBatchSize(2), eventrouter.WithBatchAge(150*time.Millisecond),
+		eventrouter.WithScope(scopeHook))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("router.tenant")
+	eventrouter.Route(bus, evt, dest)
+
+	ctxA := context.WithValue(context.Background(), scopeKey{}, "tenant-a")
+	ctxB := context.WithValue(context.Background(), scopeKey{}, "tenant-b")
+
+	var wg sync.WaitGroup
+	errs := make([]error, 3)
+	for i, c := range []struct {
+		ctx context.Context
+		v   string
+	}{{ctxA, "a1"}, {ctxA, "a2"}, {ctxB, "b1"}} {
+		wg.Go(func() {
+			errs[i] = eventbus.Publish(c.ctx, bus, evt, payload{V: c.v})
+		})
+	}
+	wg.Wait()
+	for i, err := range errs {
+		assert.NoError(t, err, "publish %d", i)
+	}
+
+	calls := s.snapshot()
+	require.Len(t, calls, 2, "one batch per tenant")
+	for _, call := range calls {
+		tenants := make(map[string]struct{})
+		for _, e := range call {
+			var p payload
+			require.NoError(t, json.Unmarshal(e.Payload, &p))
+			tenants[p.V[:1]] = struct{}{}
+		}
+		assert.Len(t, tenants, 1, "batches never mix tenants")
+	}
+}
+
+func TestDestination_ScopeFailsClosed(t *testing.T) {
+	t.Parallel()
+	s := &stub{}
+	dest := eventrouter.NewDestination("closed", s,
+		eventrouter.WithBatchSize(1), eventrouter.WithScope(scopeHook))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("router.closed")
+	eventrouter.Route(bus, evt, dest)
+
+	err := eventbus.Publish(context.Background(), bus, evt, payload{V: "a"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, eventrouter.ErrScopeMissing)
+	assert.Empty(t, s.snapshot(), "nothing is delivered without a scope")
+
+	hookErr := errors.New("no tenant")
+	evt2 := eventbus.NewEvent[payload]("router.closed2")
+	failing := eventrouter.NewDestination("closed2", s,
+		eventrouter.WithBatchSize(1),
+		eventrouter.WithScope(func(context.Context) (string, error) { return "", hookErr }))
+	eventrouter.Route(bus, evt2, failing)
+	err = eventbus.Publish(context.Background(), bus, evt2, payload{V: "a"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, eventrouter.ErrScopeMissing)
+	assert.ErrorIs(t, err, hookErr)
+}
+
+func TestNewDestination_Validation(t *testing.T) {
+	t.Parallel()
+	s := &stub{}
+	assert.Panics(t, func() { eventrouter.NewDestination("", s) })
+	assert.Panics(t, func() { eventrouter.NewDestination("d", nil) })
+	assert.Panics(t, func() { eventrouter.WithBatchSize(0) })
+	assert.Panics(t, func() { eventrouter.WithBatchAge(0) })
+	assert.Panics(t, func() { eventrouter.WithDeliveryTimeout(-time.Second) })
+	assert.Panics(t, func() { eventrouter.WithScope(nil) })
+	assert.Equal(t, "d", eventrouter.NewDestination("d", s).Name())
+}
+
+func TestPermanent_NilIsNil(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, eventrouter.Permanent(nil))
+}

--- a/async/eventrouter/doc.go
+++ b/async/eventrouter/doc.go
@@ -1,0 +1,73 @@
+// Package eventrouter is event egress over async/eventbus: it routes
+// published events to external destinations — analytics warehouses, partner
+// endpoints, affiliate trackers — with per-destination isolation, batched
+// delivery, and queue-grade retry.
+//
+// Each Route binds one event to one Destination as its own named eventbus
+// subscription, so every (event, destination) pair is a separate durable
+// queue: a slow or failing destination only delays itself. Filtering and
+// remapping are registered Go functions on the route — never a mapping DSL.
+// Events reaching a destination accumulate into a batch flushed by size or
+// age; the delivering jobs block until the flush resolves, so nothing is
+// acknowledged before the destination accepted it.
+//
+// # Usage
+//
+//	warehouse, _ := eventrouter.NewHTTPDeliverer("https://collect.example.com/batch",
+//		eventrouter.WithHTTPHeader("Authorization", "Bearer "+token))
+//	dest := eventrouter.NewDestination("warehouse", warehouse,
+//		eventrouter.WithBatchSize(200), eventrouter.WithBatchAge(2*time.Second))
+//
+//	eventrouter.Route(bus, OrderPlaced, dest)
+//	eventrouter.Route(bus, UserCreated, dest,
+//		eventrouter.WithFilter(func(d eventbus.Delivery[UserCreatedPayload]) bool {
+//			return !d.Payload.Internal
+//		}),
+//		eventrouter.WithRemap(func(d eventbus.Delivery[UserCreatedPayload]) (any, error) {
+//			return warehouseUser{ID: d.Payload.ID, Plan: d.Payload.Plan}, nil
+//		}))
+//
+// Routes are startup wiring on the same bus the app publishes to; the
+// eventbus Service drains them alongside every other subscription. On a sync
+// bus (eventbus.NewSync) routes work too, but Publish blocks until the batch
+// flushes — pair sync buses with WithBatchSize(1).
+//
+// # Delivery semantics
+//
+// Delivery is at-least-once and the router never dedups: suppressing a
+// redelivery in the router would trade a duplicate for silent loss. Stable
+// event IDs ride every delivery — an "id" field on every batched event and
+// an Idempotency-Key header on single-event deliveries — and receivers dedup
+// on them (the Stripe contract).
+//
+// A batch resolves to per-event queue verdicts. Success acknowledges every
+// job in the batch. A transient failure retries every job on the queue's
+// backoff — events re-batch on redelivery. A permanent failure (an error
+// marked with Permanent) on a multi-event batch triggers poison isolation:
+// each event is re-delivered alone, so the poison event dead-letters by
+// itself instead of taking its batchmates with it — already-accepted events
+// may be re-sent, which receivers dedup. A permanent failure on a
+// single-event batch dead-letters that event without burning retry attempts,
+// as do filter-independent poison conditions: a failing remap and an
+// unmarshalable remapped payload.
+//
+// # Deliverers
+//
+// A Deliverer ships one batch and classifies the outcome: nil for accepted,
+// Permanent-wrapped for rejections retrying cannot fix, any other error for
+// transient failures. Deliver is called concurrently when batches overlap.
+// Three reference adapters ship in the package: NewHTTPDeliverer (generic
+// JSON-batch POST), NewWebhookDeliverer (HMAC-signed deliveries via
+// comms/webhook), and NewPostbackDeliverer (tracker macro-URL pings via
+// comms/postback). Destination configs — URLs, secrets, macro templates —
+// are consumer data; forge ships the engine, never a connector catalog.
+//
+// # Tenancy
+//
+// Multi-tenant apps configure WithScope on the destination with a hook
+// reading the tenant from the handler context (restored by
+// queue.WithScopeContext on the eventbus Service): batches are keyed by
+// scope and never mix tenants, and a configured hook fails closed — a
+// missing scope is a delivery error, never a cross-tenant batch.
+// Single-tenant apps configure nothing.
+package eventrouter

--- a/async/eventrouter/errors.go
+++ b/async/eventrouter/errors.go
@@ -1,0 +1,33 @@
+package eventrouter
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrPermanent marks a delivery failure retrying cannot fix: the
+	// destination rejected the payload, not the moment. The router
+	// dead-letters instead of retrying; deliverers wrap with Permanent.
+	ErrPermanent = errors.New("eventrouter: permanent delivery failure")
+
+	// ErrScopeMissing is returned as the delivery verdict when a destination's
+	// scope hook is configured and yields an error or empty scope — fail
+	// closed, the event retries instead of joining a cross-tenant batch.
+	ErrScopeMissing = errors.New("eventrouter: scope missing")
+
+	// ErrInvalidURL is returned by NewHTTPDeliverer when the destination URL
+	// is not absolute http(s).
+	ErrInvalidURL = errors.New("eventrouter: invalid destination URL")
+)
+
+// Permanent wraps err into a Deliverer verdict: the destination rejected this
+// delivery and retrying cannot help, so the router dead-letters instead of
+// retrying (isolating the poison event first on multi-event batches).
+// Permanent(nil) returns nil.
+func Permanent(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: %w", ErrPermanent, err)
+}

--- a/async/eventrouter/example_test.go
+++ b/async/eventrouter/example_test.go
@@ -1,0 +1,51 @@
+package eventrouter_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+	"github.com/dmitrymomot/forge/async/eventrouter"
+)
+
+type signupPayload struct {
+	Email    string `json:"email"`
+	Internal bool   `json:"internal"`
+}
+
+var evtSignup = eventbus.NewEvent[signupPayload]("example.signup")
+
+// printDeliverer stands in for a real adapter (NewHTTPDeliverer,
+// NewWebhookDeliverer, NewPostbackDeliverer) so the example is runnable
+// offline.
+type printDeliverer struct{}
+
+func (printDeliverer) Deliver(_ context.Context, events []eventrouter.Event) error {
+	for _, e := range events {
+		fmt.Printf("delivered %s %s\n", e.Name, e.Payload)
+	}
+	return nil
+}
+
+func Example() {
+	bus := eventbus.NewSync() // production: eventbus.New(broker) + eventbus.NewService
+
+	dest := eventrouter.NewDestination("warehouse", printDeliverer{},
+		eventrouter.WithBatchSize(1)) // sync buses pair with size-1 batches
+
+	eventrouter.Route(bus, evtSignup, dest,
+		eventrouter.WithFilter(func(d eventbus.Delivery[signupPayload]) bool {
+			return !d.Payload.Internal
+		}),
+		eventrouter.WithRemap(func(d eventbus.Delivery[signupPayload]) (any, error) {
+			return map[string]string{"email": d.Payload.Email}, nil
+		}),
+	)
+
+	ctx := context.Background()
+	_ = eventbus.Publish(ctx, bus, evtSignup, signupPayload{Email: "ada@example.com"})
+	_ = eventbus.Publish(ctx, bus, evtSignup, signupPayload{Email: "ops@corp.test", Internal: true})
+
+	// Output:
+	// delivered example.signup {"email":"ada@example.com"}
+}

--- a/async/eventrouter/helpers_test.go
+++ b/async/eventrouter/helpers_test.go
@@ -1,0 +1,30 @@
+package eventrouter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/queue"
+)
+
+// fastQueueConfig shrinks the worker poll interval so durable tests settle
+// quickly.
+func fastQueueConfig() queue.Config {
+	cfg := queue.DefaultConfig()
+	cfg.PollInterval = 5 * time.Millisecond
+	return cfg
+}
+
+// startService runs svc in the background and returns a stop func that
+// cancels it and waits for drain.
+func startService(t *testing.T, svc *queue.Service) func() {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() { _ = svc.Run(ctx); close(stopped) }()
+	return func() {
+		cancel()
+		<-stopped
+	}
+}

--- a/async/eventrouter/http.go
+++ b/async/eventrouter/http.go
@@ -1,0 +1,98 @@
+package eventrouter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/dmitrymomot/forge/web/httpclient"
+)
+
+// HTTPDeliverer is the generic JSON-batch adapter: it POSTs each batch as a
+// JSON array of Event objects. Single-event deliveries additionally carry the
+// event ID in an Idempotency-Key header; in batches the per-event "id" field
+// is the dedup key.
+type HTTPDeliverer struct {
+	client *http.Client
+	header http.Header
+	url    string
+}
+
+// HTTPOption configures NewHTTPDeliverer.
+type HTTPOption func(*HTTPDeliverer)
+
+// WithHTTPClient replaces the default client (an httpclient.New with a 10s
+// overall timeout; POSTs are not transport-retried — the router owns retry).
+func WithHTTPClient(client *http.Client) HTTPOption {
+	return func(h *HTTPDeliverer) { h.client = client }
+}
+
+// WithHTTPHeader adds a static header to every delivery (auth tokens,
+// content-type overrides).
+func WithHTTPHeader(key, value string) HTTPOption {
+	return func(h *HTTPDeliverer) { h.header.Set(key, value) }
+}
+
+// NewHTTPDeliverer builds an HTTPDeliverer POSTing to rawURL. The URL is
+// consumer config, so a non-absolute or non-http(s) URL is an ErrInvalidURL
+// error, not a panic.
+func NewHTTPDeliverer(rawURL string, opts ...HTTPOption) (*HTTPDeliverer, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return nil, fmt.Errorf("%w: %q is not an absolute http(s) URL", ErrInvalidURL, rawURL)
+	}
+	h := &HTTPDeliverer{url: rawURL, header: http.Header{}}
+	for _, opt := range opts {
+		opt(h)
+	}
+	if h.client == nil {
+		h.client = httpclient.New(httpclient.WithTimeout(10 * time.Second))
+	}
+	return h, nil
+}
+
+// Deliver POSTs the batch and classifies the response by status class: nil
+// for 2xx, transient (retryable) for 408/429/5xx and transport failures,
+// Permanent for everything else.
+func (h *HTTPDeliverer) Deliver(ctx context.Context, events []Event) error {
+	if h == nil || h.client == nil { // zero deliverer bypassed NewHTTPDeliverer
+		return errors.New("eventrouter: http deliverer not constructed with NewHTTPDeliverer")
+	}
+	body, err := json.Marshal(events)
+	if err != nil {
+		return Permanent(fmt.Errorf("eventrouter: encode batch: %w", err))
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.url, bytes.NewReader(body))
+	if err != nil {
+		return Permanent(fmt.Errorf("eventrouter: build request: %w", err))
+	}
+	req.Header.Set("Content-Type", "application/json")
+	maps.Copy(req.Header, h.header)
+	if len(events) == 1 {
+		req.Header.Set("Idempotency-Key", events[0].ID)
+	}
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("eventrouter: deliver: %w", err)
+	}
+	// Bounded drain so the connection is reusable; receivers answer tiny bodies.
+	//nolint:nilaway // resp is non-nil whenever err is nil, per http.Client.Do's contract
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+	_ = resp.Body.Close()
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return nil
+	case resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
+		return fmt.Errorf("eventrouter: transient status %d", resp.StatusCode)
+	default:
+		return Permanent(fmt.Errorf("eventrouter: status %d", resp.StatusCode))
+	}
+}

--- a/async/eventrouter/options.go
+++ b/async/eventrouter/options.go
@@ -1,0 +1,55 @@
+package eventrouter
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Option configures NewDestination.
+type Option func(*Destination)
+
+// WithBatchSize caps how many events one delivery carries; a filling batch
+// flushes immediately. Size 1 disables batching: every event delivers alone,
+// synchronously on its own job (the right setting for sync buses and
+// per-event destinations like trackers). Panics on n < 1.
+func WithBatchSize(n int) Option {
+	if n < 1 {
+		panic(fmt.Sprintf("eventrouter: WithBatchSize(%d): size must be >= 1", n))
+	}
+	return func(d *Destination) { d.maxSize = n }
+}
+
+// WithBatchAge caps how long a partial batch waits for more events before
+// flushing — the egress latency floor under light traffic. Panics on a
+// non-positive duration.
+func WithBatchAge(age time.Duration) Option {
+	if age <= 0 {
+		panic(fmt.Sprintf("eventrouter: WithBatchAge(%v): age must be > 0", age))
+	}
+	return func(d *Destination) { d.maxAge = age }
+}
+
+// WithDeliveryTimeout bounds each Deliver call (the batch attempt and every
+// poison-isolation re-delivery separately); expiry is a transient failure. 0
+// disables the bound — the deliverer's own timeouts rule. Panics on a
+// negative duration.
+func WithDeliveryTimeout(timeout time.Duration) Option {
+	if timeout < 0 {
+		panic(fmt.Sprintf("eventrouter: WithDeliveryTimeout(%v): timeout must be >= 0 (0 disables it)", timeout))
+	}
+	return func(d *Destination) { d.timeout = timeout }
+}
+
+// WithScope installs the tenancy hook: called with each delivering job's
+// context (restore the tenant there via queue.WithScopeContext on the
+// eventbus Service), and the returned scope keys the destination's batches so
+// they never mix tenants. Fail-closed: once configured, a hook error or empty
+// scope fails the delivery with ErrScopeMissing instead of batching.
+// Single-tenant apps do not configure it. Panics on a nil hook.
+func WithScope(fn func(ctx context.Context) (string, error)) Option {
+	if fn == nil {
+		panic("eventrouter: WithScope(nil)")
+	}
+	return func(d *Destination) { d.scope = fn }
+}

--- a/async/eventrouter/postback.go
+++ b/async/eventrouter/postback.go
@@ -10,10 +10,12 @@ import (
 
 // PostbackDeliverer fires tracker macro-URL postbacks through a
 // postback.Sender: one unsigned ping per event, values extracted by a
-// registered Go function. Trackers take one ping per conversion, so pair it
-// with WithBatchSize(1); it still handles larger batches by firing each event
-// in turn and reporting the worst outcome (permanent outranks transient, so
-// poison isolation can split the batch into precise per-event verdicts).
+// registered Go function. Trackers take one ping per conversion, so Deliver
+// only ever fires singletons: a multi-event batch is refused with a Permanent
+// error before anything fires, which makes the router's poison-isolation pass
+// deliver each event alone with its own precise verdict. Partial batch
+// outcomes therefore cannot re-fire already-accepted pings — any batch size
+// works; WithBatchSize(1) merely skips the refused batch attempt.
 type PostbackDeliverer struct {
 	sender *postback.Sender
 	values func(e Event) (map[string]string, error)
@@ -35,33 +37,35 @@ func NewPostbackDeliverer(sender *postback.Sender, dest postback.Destination, fn
 	return &PostbackDeliverer{sender: sender, dest: dest, values: fn}
 }
 
-// Deliver fires one postback per event and classifies the joined outcome:
-// nil when every ping landed, Permanent when any event failed permanently (a
-// values error, a non-2xx non-5xx status, or an invalid destination — the
-// router then isolates per event), otherwise the joined transient errors.
+// Deliver fires the single event's postback and classifies the outcome: nil
+// for 2xx, Permanent for a values error, a non-2xx non-5xx status, or an
+// invalid destination, otherwise the transient error (5xx and transport
+// failures — worth retrying). A multi-event batch is refused with Permanent
+// without firing anything: pings are per-event, and the refusal routes the
+// batch through poison isolation so every event still fires exactly once.
 func (p *PostbackDeliverer) Deliver(ctx context.Context, events []Event) error {
 	if p == nil || p.sender == nil || p.values == nil { // zero deliverer bypassed NewPostbackDeliverer
 		return errors.New("eventrouter: postback deliverer not constructed with NewPostbackDeliverer")
 	}
-	var transient, permanent []error
-	for i := range events {
-		vals, err := p.values(events[i])
-		if err != nil {
-			permanent = append(permanent, fmt.Errorf("event %s: values: %w", events[i].ID, err))
-			continue
-		}
-		if _, err := p.sender.Send(ctx, p.dest, vals); err != nil {
-			wrapped := fmt.Errorf("event %s: %w", events[i].ID, err)
-			switch {
-			case errors.Is(err, postback.ErrClientStatus), errors.Is(err, postback.ErrInvalidTemplate):
-				permanent = append(permanent, wrapped)
-			default: // 5xx and transport failures
-				transient = append(transient, wrapped)
-			}
+	if len(events) != 1 {
+		// Firing the batch here would couple every event's verdict to its
+		// batchmates: one transient failure would retry — and re-ping — the
+		// events the tracker already accepted. Refusing before any I/O hands
+		// the batch to the router's isolation pass instead.
+		return Permanent(fmt.Errorf("eventrouter: postbacks are per-event, got a batch of %d", len(events)))
+	}
+	e := events[0]
+	vals, err := p.values(e)
+	if err != nil {
+		return Permanent(fmt.Errorf("eventrouter: event %s: values: %w", e.ID, err))
+	}
+	if _, err := p.sender.Send(ctx, p.dest, vals); err != nil {
+		switch {
+		case errors.Is(err, postback.ErrClientStatus), errors.Is(err, postback.ErrInvalidTemplate):
+			return Permanent(fmt.Errorf("eventrouter: event %s: %w", e.ID, err))
+		default: // 5xx and transport failures
+			return fmt.Errorf("eventrouter: event %s: %w", e.ID, err)
 		}
 	}
-	if len(permanent) > 0 {
-		return Permanent(errors.Join(append(permanent, transient...)...))
-	}
-	return errors.Join(transient...)
+	return nil
 }

--- a/async/eventrouter/postback.go
+++ b/async/eventrouter/postback.go
@@ -1,0 +1,67 @@
+package eventrouter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/comms/postback"
+)
+
+// PostbackDeliverer fires tracker macro-URL postbacks through a
+// postback.Sender: one unsigned ping per event, values extracted by a
+// registered Go function. Trackers take one ping per conversion, so pair it
+// with WithBatchSize(1); it still handles larger batches by firing each event
+// in turn and reporting the worst outcome (permanent outranks transient, so
+// poison isolation can split the batch into precise per-event verdicts).
+type PostbackDeliverer struct {
+	sender *postback.Sender
+	values func(e Event) (map[string]string, error)
+	dest   postback.Destination
+}
+
+// NewPostbackDeliverer builds a PostbackDeliverer rendering dest against the
+// macro values fn extracts from each event. A fn error marks the event
+// permanently undeliverable — poison, not transient. Include the stable
+// Event.ID as a macro value so the tracker can dedup redeliveries. Panics on
+// a nil sender or fn — wiring, not runtime data.
+func NewPostbackDeliverer(sender *postback.Sender, dest postback.Destination, fn func(e Event) (map[string]string, error)) *PostbackDeliverer {
+	if sender == nil {
+		panic("eventrouter: NewPostbackDeliverer requires a sender")
+	}
+	if fn == nil {
+		panic("eventrouter: NewPostbackDeliverer requires a values function")
+	}
+	return &PostbackDeliverer{sender: sender, dest: dest, values: fn}
+}
+
+// Deliver fires one postback per event and classifies the joined outcome:
+// nil when every ping landed, Permanent when any event failed permanently (a
+// values error, a non-2xx non-5xx status, or an invalid destination — the
+// router then isolates per event), otherwise the joined transient errors.
+func (p *PostbackDeliverer) Deliver(ctx context.Context, events []Event) error {
+	if p == nil || p.sender == nil || p.values == nil { // zero deliverer bypassed NewPostbackDeliverer
+		return errors.New("eventrouter: postback deliverer not constructed with NewPostbackDeliverer")
+	}
+	var transient, permanent []error
+	for i := range events {
+		vals, err := p.values(events[i])
+		if err != nil {
+			permanent = append(permanent, fmt.Errorf("event %s: values: %w", events[i].ID, err))
+			continue
+		}
+		if _, err := p.sender.Send(ctx, p.dest, vals); err != nil {
+			wrapped := fmt.Errorf("event %s: %w", events[i].ID, err)
+			switch {
+			case errors.Is(err, postback.ErrClientStatus), errors.Is(err, postback.ErrInvalidTemplate):
+				permanent = append(permanent, wrapped)
+			default: // 5xx and transport failures
+				transient = append(transient, wrapped)
+			}
+		}
+	}
+	if len(permanent) > 0 {
+		return Permanent(errors.Join(append(permanent, transient...)...))
+	}
+	return errors.Join(transient...)
+}

--- a/async/eventrouter/route.go
+++ b/async/eventrouter/route.go
@@ -1,0 +1,87 @@
+package eventrouter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+	"github.com/dmitrymomot/forge/async/queue"
+)
+
+// routeConfig carries one route's per-event hooks.
+type routeConfig[T any] struct {
+	filter  func(d eventbus.Delivery[T]) bool
+	remap   func(d eventbus.Delivery[T]) (any, error)
+	subOpts []eventbus.SubscribeOption
+}
+
+// RouteOption configures a single Route call.
+type RouteOption[T any] func(*routeConfig[T])
+
+// WithFilter routes only deliveries fn approves; the rest are acknowledged
+// without delivery. Panics on a nil fn.
+func WithFilter[T any](fn func(d eventbus.Delivery[T]) bool) RouteOption[T] {
+	if fn == nil {
+		panic("eventrouter: WithFilter(nil)")
+	}
+	return func(r *routeConfig[T]) { r.filter = fn }
+}
+
+// WithRemap replaces the outbound payload: fn's result is marshaled into
+// Event.Payload in place of the published payload. A remap error is poison —
+// the event dead-letters on this route without burning retry attempts, since
+// a deterministic mapping cannot heal by retrying. Panics on a nil fn.
+func WithRemap[T any](fn func(d eventbus.Delivery[T]) (any, error)) RouteOption[T] {
+	if fn == nil {
+		panic("eventrouter: WithRemap(nil)")
+	}
+	return func(r *routeConfig[T]) { r.remap = fn }
+}
+
+// WithSubscribeOptions passes eventbus subscription options through to the
+// route's subscription: retry backoff, attempt budget, and handler timeout
+// tune exactly as on a hand-written subscription. The handler timeout bounds
+// the whole join — batch wait plus delivery — so keep it well above
+// WithBatchAge + WithDeliveryTimeout.
+func WithSubscribeOptions[T any](opts ...eventbus.SubscribeOption) RouteOption[T] {
+	return func(r *routeConfig[T]) { r.subOpts = append(r.subOpts, opts...) }
+}
+
+// Route binds evt to dest on bus as the named subscription dest.Name(): every
+// published evt that passes the route's filter joins the destination's batch
+// as one Event, remapped when the route remaps. Routes are startup wiring —
+// declare them before building the eventbus Service; Route panics (via
+// eventbus.Subscribe) on a duplicate (event, destination) pair.
+func Route[T any](bus *eventbus.Bus, evt eventbus.Event[T], dest *Destination, opts ...RouteOption[T]) {
+	if dest == nil {
+		panic(fmt.Sprintf("eventrouter: Route(%q) with nil destination", evt.Name()))
+	}
+	var r routeConfig[T]
+	for _, opt := range opts {
+		opt(&r)
+	}
+	eventbus.Subscribe(bus, evt, dest.name, func(ctx context.Context, d eventbus.Delivery[T]) error {
+		if r.filter != nil && !r.filter(d) {
+			return nil
+		}
+		var payload any = d.Payload
+		if r.remap != nil {
+			out, err := r.remap(d)
+			if err != nil {
+				return queue.SkipRetry(fmt.Errorf("eventrouter: remap %q for %q: %w", d.Name, dest.name, err))
+			}
+			payload = out
+		}
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return queue.SkipRetry(fmt.Errorf("eventrouter: marshal %q for %q: %w", d.Name, dest.name, err))
+		}
+		return dest.join(ctx, Event{
+			OccurredAt: d.OccurredAt,
+			Payload:    raw,
+			ID:         d.ID,
+			Name:       d.Name,
+		})
+	}, r.subOpts...)
+}

--- a/async/eventrouter/route_test.go
+++ b/async/eventrouter/route_test.go
@@ -1,0 +1,183 @@
+package eventrouter_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+	"github.com/dmitrymomot/forge/async/eventrouter"
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/resilience/backoff"
+)
+
+func TestRoute_PayloadPassthrough(t *testing.T) {
+	t.Parallel()
+	s := &stub{}
+	dest := eventrouter.NewDestination("raw", s, eventrouter.WithBatchSize(1))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("route.raw")
+	eventrouter.Route(bus, evt, dest)
+
+	require.NoError(t, eventbus.Publish(context.Background(), bus, evt, payload{V: "hello"}))
+	calls := s.snapshot()
+	require.Len(t, calls, 1)
+	assert.JSONEq(t, `{"v":"hello"}`, string(calls[0][0].Payload))
+}
+
+func TestRoute_Filter(t *testing.T) {
+	t.Parallel()
+	s := &stub{}
+	dest := eventrouter.NewDestination("filtered", s, eventrouter.WithBatchSize(1))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("route.filtered")
+	eventrouter.Route(bus, evt, dest, eventrouter.WithFilter(func(d eventbus.Delivery[payload]) bool {
+		return d.Payload.V != "skip"
+	}))
+
+	require.NoError(t, eventbus.Publish(context.Background(), bus, evt, payload{V: "skip"}))
+	assert.Empty(t, s.snapshot(), "filtered events are acknowledged without delivery")
+
+	require.NoError(t, eventbus.Publish(context.Background(), bus, evt, payload{V: "keep"}))
+	require.Len(t, s.snapshot(), 1)
+}
+
+func TestRoute_Remap(t *testing.T) {
+	t.Parallel()
+	s := &stub{}
+	dest := eventrouter.NewDestination("remapped", s, eventrouter.WithBatchSize(1))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("route.remapped")
+	eventrouter.Route(bus, evt, dest, eventrouter.WithRemap(func(d eventbus.Delivery[payload]) (any, error) {
+		return map[string]string{"value": d.Payload.V, "event": d.Name}, nil
+	}))
+
+	require.NoError(t, eventbus.Publish(context.Background(), bus, evt, payload{V: "x"}))
+	calls := s.snapshot()
+	require.Len(t, calls, 1)
+	assert.JSONEq(t, `{"value":"x","event":"route.remapped"}`, string(calls[0][0].Payload))
+}
+
+func TestRoute_RemapErrorIsPoison(t *testing.T) {
+	t.Parallel()
+	s := &stub{}
+	dest := eventrouter.NewDestination("poisonremap", s, eventrouter.WithBatchSize(1))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("route.poisonremap")
+	errMap := errors.New("cannot map")
+	eventrouter.Route(bus, evt, dest, eventrouter.WithRemap(func(eventbus.Delivery[payload]) (any, error) {
+		return nil, errMap
+	}))
+
+	err := eventbus.Publish(context.Background(), bus, evt, payload{V: "x"})
+	require.Error(t, err)
+	assert.True(t, queue.IsSkipRetry(err), "a deterministic remap failure dead-letters")
+	assert.ErrorIs(t, err, errMap)
+	assert.Empty(t, s.snapshot())
+}
+
+func TestRoute_UnmarshalableRemapIsPoison(t *testing.T) {
+	t.Parallel()
+	s := &stub{}
+	dest := eventrouter.NewDestination("badjson", s, eventrouter.WithBatchSize(1))
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("route.badjson")
+	eventrouter.Route(bus, evt, dest, eventrouter.WithRemap(func(eventbus.Delivery[payload]) (any, error) {
+		return make(chan int), nil
+	}))
+
+	err := eventbus.Publish(context.Background(), bus, evt, payload{V: "x"})
+	require.Error(t, err)
+	assert.True(t, queue.IsSkipRetry(err))
+	assert.Empty(t, s.snapshot())
+}
+
+func TestRoute_Validation(t *testing.T) {
+	t.Parallel()
+	s := &stub{}
+	bus := eventbus.NewSync()
+	evt := eventbus.NewEvent[payload]("route.validation")
+	assert.Panics(t, func() { eventrouter.Route(bus, evt, nil) })
+	assert.Panics(t, func() { eventrouter.WithFilter[payload](nil) })
+	assert.Panics(t, func() { eventrouter.WithRemap[payload](nil) })
+
+	dest := eventrouter.NewDestination("dup", s)
+	eventrouter.Route(bus, evt, dest)
+	assert.Panics(t, func() { eventrouter.Route(bus, evt, dest) }, "duplicate (event, destination) pair")
+}
+
+func TestRoute_DurableEndToEnd(t *testing.T) {
+	t.Parallel()
+	s := &stub{}
+	dest := eventrouter.NewDestination("warehouse", s,
+		eventrouter.WithBatchSize(2), eventrouter.WithBatchAge(300*time.Millisecond))
+	broker := queue.NewMemoryBroker()
+	bus := eventbus.New(broker)
+	evt := eventbus.NewEvent[payload]("durable.order")
+	eventrouter.Route(bus, evt, dest)
+
+	svc, err := eventbus.NewService(bus, queue.WithConfig(fastQueueConfig()))
+	require.NoError(t, err)
+	stop := startService(t, svc)
+	defer stop()
+
+	require.NoError(t, eventbus.Publish(context.Background(), bus, evt, payload{V: "a"}))
+	require.NoError(t, eventbus.Publish(context.Background(), bus, evt, payload{V: "b"}))
+
+	require.Eventually(t, func() bool {
+		total := 0
+		for _, call := range s.snapshot() {
+			total += len(call)
+		}
+		return total == 2
+	}, 5*time.Second, 10*time.Millisecond, "both events are delivered")
+
+	ids := make(map[string]struct{})
+	for _, call := range s.snapshot() {
+		for _, e := range call {
+			assert.Equal(t, "durable.order", e.Name)
+			ids[e.ID] = struct{}{}
+		}
+	}
+	assert.Len(t, ids, 2)
+}
+
+func TestRoute_DurableRetryKeepsEventID(t *testing.T) {
+	t.Parallel()
+	errFlaky := errors.New("first attempt fails")
+	s := &stub{fn: func(_ context.Context, call int, _ []eventrouter.Event) error {
+		if call == 0 {
+			return errFlaky
+		}
+		return nil
+	}}
+	dest := eventrouter.NewDestination("flaky", s, eventrouter.WithBatchSize(1))
+	broker := queue.NewMemoryBroker()
+	bus := eventbus.New(broker)
+	evt := eventbus.NewEvent[payload]("durable.flaky")
+	eventrouter.Route(bus, evt, dest, eventrouter.WithSubscribeOptions[payload](
+		eventbus.WithRetryBackoff(backoff.Constant(5*time.Millisecond)),
+		eventbus.WithMaxAttempts(3),
+	))
+
+	svc, err := eventbus.NewService(bus, queue.WithConfig(fastQueueConfig()))
+	require.NoError(t, err)
+	stop := startService(t, svc)
+	defer stop()
+
+	require.NoError(t, eventbus.Publish(context.Background(), bus, evt, payload{V: "a"}))
+
+	require.Eventually(t, func() bool { return len(s.snapshot()) == 2 },
+		5*time.Second, 10*time.Millisecond, "the failed delivery retries")
+	calls := s.snapshot()
+	assert.Equal(t, calls[0][0].ID, calls[1][0].ID, "retries carry the same stable event id")
+
+	var p payload
+	require.NoError(t, json.Unmarshal(calls[1][0].Payload, &p))
+	assert.Equal(t, "a", p.V)
+}

--- a/async/eventrouter/webhook.go
+++ b/async/eventrouter/webhook.go
@@ -1,0 +1,56 @@
+package eventrouter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/comms/webhook"
+)
+
+// WebhookDeliverer ships batches as HMAC-signed webhooks through a
+// webhook.Sender: the same JSON-array body as HTTPDeliverer, signed by the
+// sender's scheme, with the event ID as the idempotency key on single-event
+// deliveries. The endpoint (URL + secret) is consumer data.
+type WebhookDeliverer struct {
+	sender   *webhook.Sender
+	endpoint webhook.Endpoint
+}
+
+// NewWebhookDeliverer builds a WebhookDeliverer signing with sender and
+// delivering to ep. Panics on a nil sender — wiring, not runtime data; the
+// endpoint is validated by the sender on every delivery, and an invalid one
+// is a permanent failure.
+func NewWebhookDeliverer(sender *webhook.Sender, ep webhook.Endpoint) *WebhookDeliverer {
+	if sender == nil {
+		panic("eventrouter: NewWebhookDeliverer requires a sender")
+	}
+	return &WebhookDeliverer{sender: sender, endpoint: ep}
+}
+
+// Deliver signs and POSTs the batch, mapping the sender's status classes onto
+// the router's: 2xx nil, webhook.ErrPermanentStatus and an invalid endpoint
+// Permanent, transient statuses and transport failures retryable.
+func (w *WebhookDeliverer) Deliver(ctx context.Context, events []Event) error {
+	if w == nil || w.sender == nil { // zero deliverer bypassed NewWebhookDeliverer
+		return errors.New("eventrouter: webhook deliverer not constructed with NewWebhookDeliverer")
+	}
+	body, err := json.Marshal(events)
+	if err != nil {
+		return Permanent(fmt.Errorf("eventrouter: encode batch: %w", err))
+	}
+	key := ""
+	if len(events) == 1 {
+		key = events[0].ID
+	}
+	_, err = w.sender.Send(ctx, w.endpoint, body, key)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, webhook.ErrPermanentStatus), errors.Is(err, webhook.ErrInvalidEndpoint):
+		return Permanent(err)
+	default:
+		return err
+	}
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -351,26 +351,6 @@ Deps: `ops/supervisor`; `async/queue`.
 
 ---
 
-**async/eventrouter**
-
-Event egress over `eventbus`: each destination is its own named
-subscription (slow-destination isolation for free), filter/remap as
-registered Go functions — no mapping DSL — and batched delivery with
-size+age flush, batch-level retry, and poison-event handling. Reference
-`Deliverer` adapters: generic JSON-batch HTTP, signed postbacks via
-`comms/webhook`, and tracker macro-URL postbacks via `comms/postback`.
-Destination configs are consumer data; forge ships the
-engine, never a Segment-style connector catalog. Delivery is
-at-least-once and the router never dedups: stable event IDs ride every
-delivery (`Idempotency-Key` header / payload field) and receivers dedup
-— the Stripe contract (in-router suppression would trade duplicates for
-silent loss).
-
-Deps: `web/httpclient`, `comms/postback`, `comms/webhook`,
-`async/eventbus`.
-
----
-
 **async/outbox**
 
 Transactional outbox: intent rows committed inside the business DB


### PR DESCRIPTION
## Summary

`async/eventrouter` — event egress over `async/eventbus`: routes published events to external destinations (warehouses, partner endpoints, affiliate trackers) with per-destination isolation, batched delivery, and queue-grade retry.

- **One subscription per (event, destination)**: `Route(bus, evt, dest)` registers `dest.Name()` as an eventbus subscription, so each pair is its own durable queue — a slow or failing destination only delays itself.
- **Filter/remap as registered Go functions** (`WithFilter`, `WithRemap`) — no mapping DSL. A remap error (or unmarshalable remapped payload) is poison: `SkipRetry` dead-letter, no attempt burn.
- **Batched delivery with size+age flush**: events joining a destination accumulate into a batch (`WithBatchSize`, default 100; `WithBatchAge`, default 1s); the delivering jobs *block until the flush resolves*, so nothing is acked before the destination accepted it — at-least-once holds through crashes. `WithBatchSize(1)` disables batching (singleton fast path, right for sync buses and trackers).
- **Batch-level retry + poison isolation**: transient failure → every job in the batch retries on the queue's backoff (events re-batch on redelivery). Permanent failure (`Permanent(err)`) on a multi-event batch → each event re-delivered alone so the poison event dead-letters by itself; on a singleton → straight dead-letter.
- **Never dedups**: stable event IDs ride every delivery (per-event `id` field, `Idempotency-Key` header on single-event deliveries); receivers dedup — the Stripe contract. In-router suppression would trade duplicates for silent loss.
- **Reference deliverers** (engine only, no connector catalog): `NewHTTPDeliverer` (generic JSON-batch POST over `web/httpclient`), `NewWebhookDeliverer` (HMAC-signed via `comms/webhook`), `NewPostbackDeliverer` (tracker macro-URL pings via `comms/postback`, per-event with worst-outcome classification so isolation splits mixed batches precisely).
- **Tenancy**: optional fail-closed `WithScope` hook keys batches by tenant — batches never mix scopes, missing scope is a delivery error; single-tenant apps configure nothing. Deliverer panics are contained as retryable failures (a panicking deliverer must not crash a timer goroutine).

Catalog entry removed from `docs/packages.md` per the shipped-package rule.

## Benchmarks

Apple M3 Max, `-benchmem`:

| benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| `BenchmarkPublishRouted` (sync publish → route → singleton deliver) | 941 | 704 | 16 |
| `BenchmarkPublishRoutedBatched` (8 concurrent publishers, size-8 flush) | 24,648 (per 8 events) | 4,943 | 107 |
| `BenchmarkBatchEncode` (100-event wire encoding) | 48,642 | 21,242 | 102 |

Baseline: raw `eventbus` sync publish with 1 subscription is 730 ns / 10 allocs, so the router adds ~210 ns / 6 allocs per event (payload re-marshal + Event construction + singleton fast path). Post-benchmark pass: no optimization applied — the overhead is noise against network-bound delivery, and the perf rules forbid unproven complexity.

## Testing

- Black-box tests: size flush, age flush, transient whole-batch retry, permanent singleton dead-letter, poison isolation (including mixed transient/permanent isolation verdicts), deliverer panic containment, delivery timeout, scope keying + fail-closed missing scope, filter/remap semantics, durable end-to-end over the memory broker (batching across jobs, retry keeps the stable event ID).
- Deliverer adapters tested against `httptest` servers: body/headers/signatures, status-class mapping, macro rendering, values-fn poison.
- `just lint` clean; `go test -race -count=3` clean.
