### PR TITLE
feat(async/scheduler): cron/interval job scheduler firing once per fleet

### DIFF
--- a/async/scheduler/bench_test.go
+++ b/async/scheduler/bench_test.go
@@ -1,0 +1,82 @@
+package scheduler_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/scheduler"
+)
+
+func BenchmarkCronParse(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := scheduler.Cron("*/15 9-17 * * mon-fri"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCronNext(b *testing.B) {
+	from := time.Date(2026, 7, 20, 10, 7, 30, 0, time.UTC)
+	cases := []struct {
+		name string
+		spec string
+	}{
+		{"every_minute", "* * * * *"},
+		{"business_hours", "*/15 9-17 * * mon-fri"},
+		{"monthly", "0 3 1 * *"},
+		{"leap_day", "0 0 29 2 *"},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			sched := scheduler.MustCron(tc.spec)
+			b.ReportAllocs()
+			for b.Loop() {
+				if sched.Next(from).IsZero() {
+					b.Fatal("unexpected zero next")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkEveryNext(b *testing.B) {
+	sched := scheduler.Every(15 * time.Minute)
+	from := time.Date(2026, 7, 20, 10, 7, 30, 0, time.UTC)
+	b.ReportAllocs()
+	for b.Loop() {
+		if sched.Next(from).IsZero() {
+			b.Fatal("unexpected zero next")
+		}
+	}
+}
+
+func BenchmarkMemoryStoreClaim(b *testing.B) {
+	st := scheduler.NewMemoryStore()
+	ctx := context.Background()
+	base := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+
+	b.Run("first_claim", func(b *testing.B) {
+		i := 0
+		b.ReportAllocs()
+		for b.Loop() {
+			i++
+			if err := st.Claim(ctx, "bench", base.Add(time.Duration(i)*time.Second)); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("duplicate", func(b *testing.B) {
+		if err := st.Claim(ctx, "bench-dup", base); err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		for b.Loop() {
+			if err := st.Claim(ctx, "bench-dup", base); err == nil {
+				b.Fatal("expected ErrAlreadyClaimed")
+			}
+		}
+	})
+}

--- a/async/scheduler/config.go
+++ b/async/scheduler/config.go
@@ -1,0 +1,33 @@
+package scheduler
+
+import (
+	"fmt"
+	"time"
+)
+
+// Config holds the env-loadable scheduler knobs.
+type Config struct {
+	Retention     time.Duration `env:"SCHEDULER_RETENTION"`
+	SweepInterval time.Duration `env:"SCHEDULER_SWEEP_INTERVAL"`
+	RetryInterval time.Duration `env:"SCHEDULER_RETRY_INTERVAL"`
+}
+
+// DefaultConfig returns production defaults: 24h claim retention, hourly
+// sweep, 5s retry on a failed enqueue.
+func DefaultConfig() Config {
+	return Config{Retention: 24 * time.Hour, SweepInterval: time.Hour, RetryInterval: 5 * time.Second}
+}
+
+// Validate checks the configuration invariants.
+func (c Config) Validate() error {
+	if c.Retention <= 0 {
+		return fmt.Errorf("%w: Retention must be > 0, got %v", ErrInvalidConfig, c.Retention)
+	}
+	if c.SweepInterval < 0 {
+		return fmt.Errorf("%w: SweepInterval must be >= 0 (0 disables the sweep), got %v", ErrInvalidConfig, c.SweepInterval)
+	}
+	if c.RetryInterval <= 0 {
+		return fmt.Errorf("%w: RetryInterval must be > 0, got %v", ErrInvalidConfig, c.RetryInterval)
+	}
+	return nil
+}

--- a/async/scheduler/config.go
+++ b/async/scheduler/config.go
@@ -5,17 +5,21 @@ import (
 	"time"
 )
 
-// Config holds the env-loadable scheduler knobs.
+// Config holds the env-loadable scheduler knobs. OpTimeout bounds one tick's
+// claim/enqueue/release sequence and one sweep pass, so a wedged store or
+// broker cannot block graceful shutdown; an aborted sweep resumes at the next
+// SweepInterval (the purge is batched and keeps its progress).
 type Config struct {
 	Retention     time.Duration `env:"SCHEDULER_RETENTION"`
 	SweepInterval time.Duration `env:"SCHEDULER_SWEEP_INTERVAL"`
 	RetryInterval time.Duration `env:"SCHEDULER_RETRY_INTERVAL"`
+	OpTimeout     time.Duration `env:"SCHEDULER_OP_TIMEOUT"`
 }
 
 // DefaultConfig returns production defaults: 24h claim retention, hourly
-// sweep, 5s retry on a failed enqueue.
+// sweep, 5s retry on a failed enqueue, 30s op timeout.
 func DefaultConfig() Config {
-	return Config{Retention: 24 * time.Hour, SweepInterval: time.Hour, RetryInterval: 5 * time.Second}
+	return Config{Retention: 24 * time.Hour, SweepInterval: time.Hour, RetryInterval: 5 * time.Second, OpTimeout: 30 * time.Second}
 }
 
 // Validate checks the configuration invariants.
@@ -28,6 +32,9 @@ func (c Config) Validate() error {
 	}
 	if c.RetryInterval <= 0 {
 		return fmt.Errorf("%w: RetryInterval must be > 0, got %v", ErrInvalidConfig, c.RetryInterval)
+	}
+	if c.OpTimeout <= 0 {
+		return fmt.Errorf("%w: OpTimeout must be > 0, got %v", ErrInvalidConfig, c.OpTimeout)
 	}
 	return nil
 }

--- a/async/scheduler/config_test.go
+++ b/async/scheduler/config_test.go
@@ -45,4 +45,11 @@ func TestConfigValidate(t *testing.T) {
 		cfg.RetryInterval = 0
 		assert.ErrorIs(t, cfg.Validate(), scheduler.ErrInvalidConfig)
 	})
+
+	t.Run("zero op timeout", func(t *testing.T) {
+		t.Parallel()
+		cfg := scheduler.DefaultConfig()
+		cfg.OpTimeout = 0
+		assert.ErrorIs(t, cfg.Validate(), scheduler.ErrInvalidConfig)
+	})
 }

--- a/async/scheduler/config_test.go
+++ b/async/scheduler/config_test.go
@@ -1,0 +1,48 @@
+package scheduler_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/scheduler"
+)
+
+func TestConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults valid", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, scheduler.DefaultConfig().Validate())
+	})
+
+	t.Run("zero retention", func(t *testing.T) {
+		t.Parallel()
+		cfg := scheduler.DefaultConfig()
+		cfg.Retention = 0
+		assert.ErrorIs(t, cfg.Validate(), scheduler.ErrInvalidConfig)
+	})
+
+	t.Run("negative sweep interval", func(t *testing.T) {
+		t.Parallel()
+		cfg := scheduler.DefaultConfig()
+		cfg.SweepInterval = -time.Second
+		assert.ErrorIs(t, cfg.Validate(), scheduler.ErrInvalidConfig)
+	})
+
+	t.Run("zero sweep interval disables the sweep", func(t *testing.T) {
+		t.Parallel()
+		cfg := scheduler.DefaultConfig()
+		cfg.SweepInterval = 0
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("zero retry interval", func(t *testing.T) {
+		t.Parallel()
+		cfg := scheduler.DefaultConfig()
+		cfg.RetryInterval = 0
+		assert.ErrorIs(t, cfg.Validate(), scheduler.ErrInvalidConfig)
+	})
+}

--- a/async/scheduler/cron.go
+++ b/async/scheduler/cron.go
@@ -53,7 +53,12 @@ func CronIn(spec string, loc *time.Location) (Schedule, error) {
 	}
 	expr := strings.ToLower(strings.TrimSpace(spec))
 	if rest, ok := strings.CutPrefix(expr, "@every"); ok {
-		d, err := time.ParseDuration(strings.TrimSpace(rest))
+		dur := strings.TrimSpace(rest)
+		// Require the separating space: "@every1h" is a typo, not a spec.
+		if dur == rest || dur == "" {
+			return nil, fmt.Errorf("%w: %q: @every wants a space-separated positive Go duration (e.g. @every 1h30m)", ErrInvalidSpec, spec)
+		}
+		d, err := time.ParseDuration(dur)
 		if err != nil || d <= 0 {
 			return nil, fmt.Errorf("%w: %q: @every wants a positive Go duration (e.g. @every 1h30m)", ErrInvalidSpec, spec)
 		}

--- a/async/scheduler/cron.go
+++ b/async/scheduler/cron.go
@@ -40,6 +40,10 @@ func Cron(spec string) (Schedule, error) {
 // day-of-week combine with the standard vixie OR rule: when both are
 // restricted, a day matching either fires. Sunday is 0 or 7.
 //
+// `@every <duration>` (a positive Go duration, e.g. `@every 1h30m`) is the
+// spec-string form of Every: the same Truncate-aligned interval ticks, with
+// loc ignored — interval ticks are absolute instants, not wall times.
+//
 // Think twice before reaching for a zone with DST: ticks falling inside a
 // spring-forward gap are skipped that day, and wall times repeated by a
 // fall-back fire at both occurrences. UTC (Cron) avoids DST entirely.
@@ -47,8 +51,15 @@ func CronIn(spec string, loc *time.Location) (Schedule, error) {
 	if loc == nil {
 		return nil, fmt.Errorf("%w: %q: nil location", ErrInvalidSpec, spec)
 	}
-	expr := strings.TrimSpace(spec)
-	if alias, ok := cronAliases[strings.ToLower(expr)]; ok {
+	expr := strings.ToLower(strings.TrimSpace(spec))
+	if rest, ok := strings.CutPrefix(expr, "@every"); ok {
+		d, err := time.ParseDuration(strings.TrimSpace(rest))
+		if err != nil || d <= 0 {
+			return nil, fmt.Errorf("%w: %q: @every wants a positive Go duration (e.g. @every 1h30m)", ErrInvalidSpec, spec)
+		}
+		return intervalSchedule{d: d}, nil
+	}
+	if alias, ok := cronAliases[expr]; ok {
 		expr = alias
 	}
 	fields := strings.Fields(expr)

--- a/async/scheduler/cron.go
+++ b/async/scheduler/cron.go
@@ -1,0 +1,201 @@
+package scheduler
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// cronAliases are the standard @-shortcuts, rewritten to 5-field specs.
+var cronAliases = map[string]string{
+	"@hourly":   "0 * * * *",
+	"@daily":    "0 0 * * *",
+	"@midnight": "0 0 * * *",
+	"@weekly":   "0 0 * * 0",
+	"@monthly":  "0 0 1 * *",
+	"@yearly":   "0 0 1 1 *",
+	"@annually": "0 0 1 1 *",
+}
+
+var monthNames = map[string]int{
+	"jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
+	"jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+
+var dowNames = map[string]int{
+	"sun": 0, "mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6,
+}
+
+// Cron parses a 5-field cron expression (minute hour day-of-month month
+// day-of-week) evaluated in UTC. See CronIn for the field grammar.
+func Cron(spec string) (Schedule, error) {
+	return CronIn(spec, time.UTC)
+}
+
+// CronIn parses a 5-field cron expression evaluated in loc. Fields support
+// `*`, values, ranges (`1-5`), steps (`*/15`, `1-30/5`, `5/10`), comma lists,
+// month and weekday names (`jan`, `mon`), and the aliases @hourly, @daily,
+// @midnight, @weekly, @monthly, @yearly, @annually. Day-of-month and
+// day-of-week combine with the standard vixie OR rule: when both are
+// restricted, a day matching either fires. Sunday is 0 or 7.
+//
+// Think twice before reaching for a zone with DST: ticks falling inside a
+// spring-forward gap are skipped that day, and wall times repeated by a
+// fall-back fire at both occurrences. UTC (Cron) avoids DST entirely.
+func CronIn(spec string, loc *time.Location) (Schedule, error) {
+	if loc == nil {
+		return nil, fmt.Errorf("%w: %q: nil location", ErrInvalidSpec, spec)
+	}
+	expr := strings.TrimSpace(spec)
+	if alias, ok := cronAliases[strings.ToLower(expr)]; ok {
+		expr = alias
+	}
+	fields := strings.Fields(expr)
+	if len(fields) != 5 {
+		return nil, fmt.Errorf("%w: %q: want 5 fields (minute hour day-of-month month day-of-week), got %d", ErrInvalidSpec, spec, len(fields))
+	}
+	s := &cronSchedule{loc: loc, domStar: fields[2] == "*", dowStar: fields[4] == "*"}
+	var err error
+	if s.minute, err = parseCronField(fields[0], 0, 59, nil); err != nil {
+		return nil, fmt.Errorf("%w: %q: minute: %w", ErrInvalidSpec, spec, err)
+	}
+	if s.hour, err = parseCronField(fields[1], 0, 23, nil); err != nil {
+		return nil, fmt.Errorf("%w: %q: hour: %w", ErrInvalidSpec, spec, err)
+	}
+	if s.dom, err = parseCronField(fields[2], 1, 31, nil); err != nil {
+		return nil, fmt.Errorf("%w: %q: day-of-month: %w", ErrInvalidSpec, spec, err)
+	}
+	if s.month, err = parseCronField(fields[3], 1, 12, monthNames); err != nil {
+		return nil, fmt.Errorf("%w: %q: month: %w", ErrInvalidSpec, spec, err)
+	}
+	// Day-of-week parses over 0-7 so ranges like "5-7" work; bit 7 (the vixie
+	// second Sunday) folds into bit 0 below.
+	if s.dow, err = parseCronField(fields[4], 0, 7, dowNames); err != nil {
+		return nil, fmt.Errorf("%w: %q: day-of-week: %w", ErrInvalidSpec, spec, err)
+	}
+	if s.dow&(1<<7) != 0 {
+		s.dow = s.dow&^(1<<7) | 1
+	}
+	return s, nil
+}
+
+// MustCron is Cron for package-level wiring: it panics on a malformed spec.
+func MustCron(spec string) Schedule {
+	s, err := Cron(spec)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// parseCronField parses one comma-separated field into a bitmask over lo..hi.
+func parseCronField(expr string, lo, hi int, names map[string]int) (uint64, error) {
+	var mask uint64
+	for part := range strings.SplitSeq(expr, ",") {
+		m, err := parseCronPart(part, lo, hi, names)
+		if err != nil {
+			return 0, err
+		}
+		mask |= m
+	}
+	return mask, nil
+}
+
+// parseCronPart parses one `*`, value, range, or step term.
+func parseCronPart(part string, lo, hi int, names map[string]int) (uint64, error) {
+	rangeExpr, stepExpr, hasStep := strings.Cut(part, "/")
+	step := 1
+	if hasStep {
+		n, err := strconv.Atoi(stepExpr)
+		if err != nil || n < 1 {
+			return 0, fmt.Errorf("bad step %q", part)
+		}
+		step = n
+	}
+	from, to := lo, hi
+	if rangeExpr != "*" {
+		fromExpr, toExpr, isRange := strings.Cut(rangeExpr, "-")
+		var err error
+		if from, err = cronValue(fromExpr, names); err != nil {
+			return 0, err
+		}
+		switch {
+		case isRange:
+			if to, err = cronValue(toExpr, names); err != nil {
+				return 0, err
+			}
+		case hasStep:
+			// vixie: "N/step" means N-max/step.
+			to = hi
+		default:
+			to = from
+		}
+	}
+	if from < lo || to > hi || from > to {
+		return 0, fmt.Errorf("value out of range %d-%d in %q", lo, hi, part)
+	}
+	var mask uint64
+	for v := from; v <= to; v += step {
+		mask |= 1 << uint(v)
+	}
+	return mask, nil
+}
+
+// cronValue resolves a numeric or named field value.
+func cronValue(s string, names map[string]int) (int, error) {
+	if v, ok := names[strings.ToLower(s)]; ok {
+		return v, nil
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("bad value %q", s)
+	}
+	return v, nil
+}
+
+// cronSchedule matches times against per-field bitmasks in a fixed location.
+type cronSchedule struct {
+	loc     *time.Location
+	minute  uint64
+	hour    uint64
+	dom     uint64
+	month   uint64
+	dow     uint64
+	domStar bool
+	dowStar bool
+}
+
+// Next implements Schedule: field-by-field advance (month, then day, hour,
+// minute), resetting lower fields on every jump, bounded at five years out —
+// far enough for any satisfiable spec (a Feb 29 schedule waits at most four).
+func (s *cronSchedule) Next(t time.Time) time.Time {
+	t = t.In(s.loc).Truncate(time.Minute).Add(time.Minute)
+	limit := t.AddDate(5, 0, 0)
+	for t.Before(limit) {
+		switch {
+		case s.month&(1<<uint(t.Month())) == 0:
+			t = time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, s.loc).AddDate(0, 1, 0)
+		case !s.dayMatches(t):
+			t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, s.loc).AddDate(0, 0, 1)
+		case s.hour&(1<<uint(t.Hour())) == 0:
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, s.loc).Add(time.Hour)
+		case s.minute&(1<<uint(t.Minute())) == 0:
+			t = t.Add(time.Minute)
+		default:
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+// dayMatches applies the vixie day rule: a `*` field mask is full, so AND is
+// correct unless both fields are restricted — then a day matching either fires.
+func (s *cronSchedule) dayMatches(t time.Time) bool {
+	dom := s.dom&(1<<uint(t.Day())) != 0
+	dow := s.dow&(1<<uint(t.Weekday())) != 0
+	if !s.domStar && !s.dowStar {
+		return dom || dow
+	}
+	return dom && dow
+}

--- a/async/scheduler/cron_test.go
+++ b/async/scheduler/cron_test.go
@@ -41,6 +41,11 @@ func TestCronParseErrors(t *testing.T) {
 		"* * * * mon-sun",
 		"@nope",
 		"0 8 * * * ; DROP",
+		"@every",
+		"@every nope",
+		"@every -5m",
+		"@every 0s",
+		"@every 1h extra",
 	}
 	for _, spec := range specs {
 		_, err := scheduler.Cron(spec)
@@ -137,6 +142,42 @@ func TestCronSequence(t *testing.T) {
 		at("2026-07-21T09:00:00Z"),
 	}
 	assert.Equal(t, want, got)
+}
+
+func TestCronEvery(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same schedule as Every", func(t *testing.T) {
+		t.Parallel()
+		from := at("2026-07-20T10:23:45Z")
+		sched, err := scheduler.Cron("@every 1h")
+		require.NoError(t, err)
+		assert.Equal(t, scheduler.Every(time.Hour).Next(from), sched.Next(from))
+		assert.Equal(t, at("2026-07-20T11:00:00Z"), sched.Next(from).UTC())
+	})
+
+	t.Run("compound duration", func(t *testing.T) {
+		t.Parallel()
+		sched, err := scheduler.Cron("@every 1h30m")
+		require.NoError(t, err)
+		assert.Equal(t, scheduler.Every(90*time.Minute).Next(at("2026-07-20T10:00:00Z")), sched.Next(at("2026-07-20T10:00:00Z")))
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		t.Parallel()
+		sched, err := scheduler.Cron("@EVERY 15M")
+		require.NoError(t, err)
+		assert.Equal(t, at("2026-07-20T10:15:00Z"), sched.Next(at("2026-07-20T10:03:00Z")).UTC())
+	})
+
+	t.Run("location ignored", func(t *testing.T) {
+		t.Parallel()
+		loc := time.FixedZone("plus3", 3*3600)
+		sched, err := scheduler.CronIn("@every 10m", loc)
+		require.NoError(t, err)
+		utc := at("2026-07-20T10:03:00Z")
+		assert.True(t, sched.Next(utc).Equal(sched.Next(utc.In(loc))))
+	})
 }
 
 func TestCronIn(t *testing.T) {

--- a/async/scheduler/cron_test.go
+++ b/async/scheduler/cron_test.go
@@ -1,0 +1,180 @@
+package scheduler_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/scheduler"
+)
+
+func at(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t.UTC()
+}
+
+func TestCronParseErrors(t *testing.T) {
+	t.Parallel()
+
+	specs := []string{
+		"",
+		"* * * *",
+		"* * * * * *",
+		"60 * * * *",
+		"* 24 * * *",
+		"* * 0 * *",
+		"* * 32 * *",
+		"* * * 13 *",
+		"* * * 0 *",
+		"* * * * 8",
+		"*/0 * * * *",
+		"*/-1 * * * *",
+		"a * * * *",
+		"5-1 * * * *",
+		"1--2 * * * *",
+		"1/2/3 * * * *",
+		"* * * * mon-sun",
+		"@nope",
+		"0 8 * * * ; DROP",
+	}
+	for _, spec := range specs {
+		_, err := scheduler.Cron(spec)
+		require.ErrorIs(t, err, scheduler.ErrInvalidSpec, "spec %q", spec)
+	}
+}
+
+func TestCronNext(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		spec string
+		from string
+		want string
+	}{
+		// Every minute: strictly after, seconds truncated.
+		{"* * * * *", "2026-01-01T00:00:30Z", "2026-01-01T00:01:00Z"},
+		{"* * * * *", "2026-01-01T00:01:00Z", "2026-01-01T00:02:00Z"},
+		// Daily at 08:00.
+		{"0 8 * * *", "2026-07-20T07:59:00Z", "2026-07-20T08:00:00Z"},
+		{"0 8 * * *", "2026-07-20T08:00:00Z", "2026-07-21T08:00:00Z"},
+		// Weekday range with names; 2026-07-18 is a Saturday.
+		{"30 14 * * mon-fri", "2026-07-18T00:00:00Z", "2026-07-20T14:30:00Z"},
+		// Steps.
+		{"*/15 * * * *", "2026-01-01T10:07:00Z", "2026-01-01T10:15:00Z"},
+		{"5/20 * * * *", "2026-01-01T10:26:00Z", "2026-01-01T10:45:00Z"},
+		{"10-30/10 * * * *", "2026-01-01T10:21:00Z", "2026-01-01T10:30:00Z"},
+		// Lists and month names.
+		{"0 0 1,15 * *", "2026-01-02T00:00:00Z", "2026-01-15T00:00:00Z"},
+		{"0 0 1 jan *", "2026-03-01T00:00:00Z", "2027-01-01T00:00:00Z"},
+		// Sunday as 0 and as 7; 2026-07-26 is a Sunday.
+		{"0 0 * * 0", "2026-07-20T00:00:00Z", "2026-07-26T00:00:00Z"},
+		{"0 0 * * 7", "2026-07-20T00:00:00Z", "2026-07-26T00:00:00Z"},
+		{"0 0 * * fri-7", "2026-07-20T00:00:00Z", "2026-07-24T00:00:00Z"},
+		// Vixie OR: both day fields restricted — 13th OR Friday, whichever first.
+		{"0 0 13 * fri", "2026-07-20T00:00:00Z", "2026-07-24T00:00:00Z"},
+		// Restricted day-of-month with * day-of-week: only the 13th.
+		{"0 0 13 * *", "2026-07-20T00:00:00Z", "2026-08-13T00:00:00Z"},
+		// Leap day: from 2026, next Feb 29 is 2028.
+		{"0 0 29 2 *", "2026-03-01T00:00:00Z", "2028-02-29T00:00:00Z"},
+		// Aliases.
+		{"@daily", "2026-07-20T13:45:00Z", "2026-07-21T00:00:00Z"},
+		{"@hourly", "2026-07-20T13:45:00Z", "2026-07-20T14:00:00Z"},
+		{"@weekly", "2026-07-20T13:45:00Z", "2026-07-26T00:00:00Z"},
+		{"@monthly", "2026-07-20T13:45:00Z", "2026-08-01T00:00:00Z"},
+		{"@yearly", "2026-07-20T13:45:00Z", "2027-01-01T00:00:00Z"},
+	}
+	for _, tc := range cases {
+		sched, err := scheduler.Cron(tc.spec)
+		require.NoError(t, err, "spec %q", tc.spec)
+		got := sched.Next(at(tc.from))
+		assert.Equal(t, at(tc.want), got.UTC(), "spec %q from %s", tc.spec, tc.from)
+	}
+}
+
+func TestCronVixieOrRule(t *testing.T) {
+	t.Parallel()
+
+	sched, err := scheduler.Cron("0 0 13 * fri")
+	require.NoError(t, err)
+	// 2026-07-10 is a Friday; from the 10th the next fire is Monday the 13th
+	// (day-of-month), then Friday the 17th (day-of-week).
+	first := sched.Next(at("2026-07-10T00:00:00Z"))
+	assert.Equal(t, at("2026-07-13T00:00:00Z"), first.UTC())
+	assert.Equal(t, at("2026-07-17T00:00:00Z"), sched.Next(first).UTC())
+}
+
+func TestCronUnsatisfiable(t *testing.T) {
+	t.Parallel()
+
+	sched, err := scheduler.Cron("0 0 31 2 *")
+	require.NoError(t, err)
+	assert.True(t, sched.Next(at("2026-01-01T00:00:00Z")).IsZero())
+}
+
+func TestCronSequence(t *testing.T) {
+	t.Parallel()
+
+	sched, err := scheduler.Cron("*/20 9-10 * * *")
+	require.NoError(t, err)
+	got := make([]time.Time, 0, 7)
+	next := at("2026-07-20T08:00:00Z")
+	for range 7 {
+		next = sched.Next(next)
+		got = append(got, next.UTC())
+	}
+	want := []time.Time{
+		at("2026-07-20T09:00:00Z"),
+		at("2026-07-20T09:20:00Z"),
+		at("2026-07-20T09:40:00Z"),
+		at("2026-07-20T10:00:00Z"),
+		at("2026-07-20T10:20:00Z"),
+		at("2026-07-20T10:40:00Z"),
+		at("2026-07-21T09:00:00Z"),
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestCronIn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil location", func(t *testing.T) {
+		t.Parallel()
+		_, err := scheduler.CronIn("* * * * *", nil)
+		require.ErrorIs(t, err, scheduler.ErrInvalidSpec)
+	})
+
+	t.Run("wall clock in zone", func(t *testing.T) {
+		t.Parallel()
+		loc, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
+		sched, err := scheduler.CronIn("0 8 * * *", loc)
+		require.NoError(t, err)
+		// 2026-07-20 is EDT (UTC-4): 08:00 wall = 12:00 UTC.
+		got := sched.Next(at("2026-07-20T00:00:00Z"))
+		assert.Equal(t, at("2026-07-20T12:00:00Z"), got.UTC())
+	})
+
+	t.Run("spring forward gap skipped", func(t *testing.T) {
+		t.Parallel()
+		loc, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
+		sched, err := scheduler.CronIn("30 2 * * *", loc)
+		require.NoError(t, err)
+		// 2026-03-08 02:30 EST does not exist; the tick skips to 03-09.
+		from := time.Date(2026, 3, 8, 0, 0, 0, 0, loc)
+		got := sched.Next(from)
+		assert.Equal(t, time.Date(2026, 3, 9, 2, 30, 0, 0, loc), got)
+	})
+}
+
+func TestMustCron(t *testing.T) {
+	t.Parallel()
+
+	assert.NotNil(t, scheduler.MustCron("0 8 * * *"))
+	assert.Panics(t, func() { scheduler.MustCron("not a spec") })
+}

--- a/async/scheduler/cron_test.go
+++ b/async/scheduler/cron_test.go
@@ -42,6 +42,7 @@ func TestCronParseErrors(t *testing.T) {
 		"@nope",
 		"0 8 * * * ; DROP",
 		"@every",
+		"@every1h",
 		"@every nope",
 		"@every -5m",
 		"@every 0s",

--- a/async/scheduler/doc.go
+++ b/async/scheduler/doc.go
@@ -25,7 +25,8 @@
 //	// run sched under ops/supervisor next to the queue worker Service
 //
 // Cron specs are standard 5-field vixie expressions evaluated in UTC (CronIn
-// for another zone); Every fires on epoch-aligned interval ticks. Both are
+// for another zone); Every fires on interval-aligned ticks (time.Truncate
+// boundaries, identical on every instance). Both are
 // Schedule implementations — bring a custom one for anything else.
 //
 // Missed ticks are not replayed: an instance that was down (or woke late)

--- a/async/scheduler/doc.go
+++ b/async/scheduler/doc.go
@@ -35,7 +35,9 @@
 // claimed the older ones. A tick whose claim or enqueue fails is retried
 // every Config.RetryInterval until it fires, another instance claims it, or
 // the next tick supersedes it. Claims expire from the store after
-// Config.Retention via a periodic sweep.
+// Config.Retention via a periodic sweep, and every store/broker interaction
+// is bounded by Config.OpTimeout (SCHEDULER_OP_TIMEOUT) so a wedged backend
+// cannot block shutdown.
 //
 // Multi-tenant apps: scheduled jobs are system-initiated, so a
 // scope-configured queue.Client would fail closed on the scheduler's

--- a/async/scheduler/doc.go
+++ b/async/scheduler/doc.go
@@ -1,0 +1,43 @@
+// Package scheduler turns cron and interval schedules into queue jobs: a
+// supervisor.Service that enqueues a typed async/queue job whenever a
+// schedule comes due. The scheduler only decides when to enqueue — handlers,
+// retry, backoff, and dead-lettering stay in the queue worker, so scheduled
+// work and ad-hoc work share one execution path.
+//
+// It runs on every instance and fires once per fleet: schedules are
+// deterministic (every instance computes the same tick times), and the Store
+// claim — a unique (name, scheduled_for) insert race — lets exactly one
+// instance enqueue each tick. The in-memory store covers single-instance
+// apps and tests; fleets share async/scheduler/postgres.
+//
+// # Usage
+//
+//	var KindDigest = queue.NewKind[DigestPayload]("email.digest")
+//
+//	client := queue.NewClient(broker)
+//	sched, err := scheduler.New(client, scheduler.WithStore(store))
+//	if err != nil { ... }
+//	scheduler.Add(sched, "email.digest.daily", scheduler.MustCron("0 8 * * *"), KindDigest, DigestPayload{})
+//	scheduler.AddFunc(sched, "report.hourly", scheduler.Every(time.Hour), KindReport,
+//		func(scheduledFor time.Time) (ReportPayload, error) {
+//			return ReportPayload{PeriodEnd: scheduledFor}, nil
+//		})
+//	// run sched under ops/supervisor next to the queue worker Service
+//
+// Cron specs are standard 5-field vixie expressions evaluated in UTC (CronIn
+// for another zone); Every fires on epoch-aligned interval ticks. Both are
+// Schedule implementations — bring a custom one for anything else.
+//
+// Missed ticks are not replayed: an instance that was down (or woke late)
+// fires only the latest due tick per job, assuming a punctual instance
+// claimed the older ones. A tick whose claim or enqueue fails is retried
+// every Config.RetryInterval until it fires, another instance claims it, or
+// the next tick supersedes it. Claims expire from the store after
+// Config.Retention via a periodic sweep.
+//
+// Multi-tenant apps: scheduled jobs are system-initiated, so a
+// scope-configured queue.Client would fail closed on the scheduler's
+// background context. WithPushContext is the seam — inject the system tenant
+// there so the client's scope hook resolves. Per-tenant schedules belong in a
+// single fan-out job whose handler iterates tenants.
+package scheduler

--- a/async/scheduler/doc.go
+++ b/async/scheduler/doc.go
@@ -25,8 +25,9 @@
 //	// run sched under ops/supervisor next to the queue worker Service
 //
 // Cron specs are standard 5-field vixie expressions evaluated in UTC (CronIn
-// for another zone); Every fires on interval-aligned ticks (time.Truncate
-// boundaries, identical on every instance). Both are
+// for another zone), plus the @daily-style aliases and `@every <duration>`;
+// Every fires on interval-aligned ticks (time.Truncate boundaries, identical
+// on every instance) and `@every` is its spec-string form. Both are
 // Schedule implementations — bring a custom one for anything else.
 //
 // Missed ticks are not replayed: an instance that was down (or woke late)

--- a/async/scheduler/errors.go
+++ b/async/scheduler/errors.go
@@ -1,0 +1,16 @@
+package scheduler
+
+import "errors"
+
+var (
+	// ErrInvalidConfig is returned by Config.Validate and New on bad configuration.
+	ErrInvalidConfig = errors.New("scheduler: invalid config")
+	// ErrInvalidSpec is returned by Cron and CronIn on a malformed cron expression.
+	ErrInvalidSpec = errors.New("scheduler: invalid cron spec")
+	// ErrAlreadyClaimed is returned by Store.Claim when another instance already claimed the tick.
+	ErrAlreadyClaimed = errors.New("scheduler: tick already claimed")
+	// ErrNoJobs is returned by Run when nothing was added.
+	ErrNoJobs = errors.New("scheduler: no jobs added")
+	// ErrAlreadyRunning is returned by Run when the scheduler is already running.
+	ErrAlreadyRunning = errors.New("scheduler: already running")
+)

--- a/async/scheduler/example_test.go
+++ b/async/scheduler/example_test.go
@@ -1,0 +1,51 @@
+package scheduler_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/async/scheduler"
+)
+
+type digestPayload struct {
+	Source string `json:"source"`
+}
+
+var kindDigest = queue.NewKind[digestPayload]("example.digest")
+
+func Example() {
+	broker := queue.NewMemoryBroker()
+	client := queue.NewClient(broker)
+
+	sched, err := scheduler.New(client)
+	if err != nil {
+		panic(err)
+	}
+	scheduler.Add(sched, "example.digest.tick", scheduler.Every(20*time.Millisecond), kindDigest, digestPayload{Source: "scheduler"})
+
+	cfg := queue.DefaultConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	svc, err := queue.NewService(broker, queue.WithConfig(cfg))
+	if err != nil {
+		panic(err)
+	}
+	done := make(chan struct{})
+	var once sync.Once
+	queue.Register(svc, kindDigest, func(_ context.Context, p digestPayload) error {
+		once.Do(func() { fmt.Println("processed job from", p.Source); close(done) })
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Go(func() { _ = sched.Run(ctx) })
+	wg.Go(func() { _ = svc.Run(ctx) })
+
+	<-done
+	cancel()
+	wg.Wait()
+	// Output: processed job from scheduler
+}

--- a/async/scheduler/options.go
+++ b/async/scheduler/options.go
@@ -1,0 +1,65 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// Option configures New.
+type Option func(*Scheduler)
+
+// WithStore replaces the claim store (default NewMemoryStore). A multi-instance
+// fleet must share a durable store — async/scheduler/postgres — or every
+// instance fires every tick.
+func WithStore(st Store) Option {
+	return func(s *Scheduler) { s.store = st }
+}
+
+// WithConfig replaces the Config (validated by New).
+func WithConfig(cfg Config) Option {
+	return func(s *Scheduler) { s.cfg = cfg }
+}
+
+// WithName overrides the supervisor service name (default "scheduler");
+// required when running multiple Scheduler instances under one supervisor.
+func WithName(name string) Option {
+	return func(s *Scheduler) { s.name = name }
+}
+
+// WithLogger sets the logger (default logger.NewNope()).
+func WithLogger(l *slog.Logger) Option {
+	return func(s *Scheduler) { s.log = l }
+}
+
+// WithClock injects a clock used for tick computation and sweep cutoffs
+// (tests). Timers stay real time.
+func WithClock(clk clock.Clock) Option {
+	return func(s *Scheduler) { s.clk = clk }
+}
+
+// WithPushContext installs a hook that prepares the context every claim and
+// enqueue runs under — the tenancy seam for a scope-configured queue.Client:
+// inject the system tenant here so the client's scope hook resolves instead
+// of failing closed on the scheduler's background context. Single-tenant apps
+// do not configure it.
+func WithPushContext(fn func(ctx context.Context) context.Context) Option {
+	return func(s *Scheduler) { s.pushCtx = fn }
+}
+
+// JobOption configures a single Add or AddFunc call.
+type JobOption func(*jobConfig)
+
+type jobConfig struct {
+	push []queue.PushOption
+}
+
+// WithPushOptions forwards queue push options (queue.WithQueue,
+// queue.WithMaxAttempts) to every job this schedule enqueues. Scheduling
+// options (queue.WithDelay, queue.WithRunAt) also apply verbatim — the
+// scheduler already decides *when*, so combining them is rarely meaningful.
+func WithPushOptions(opts ...queue.PushOption) JobOption {
+	return func(c *jobConfig) { c.push = append(c.push, opts...) }
+}

--- a/async/scheduler/postgres/bench_test.go
+++ b/async/scheduler/postgres/bench_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package pgscheduler_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/scheduler"
+	pgscheduler "github.com/dmitrymomot/forge/async/scheduler/postgres"
+)
+
+func BenchmarkClaim(b *testing.B) {
+	pool := openPool(b)
+	store, err := pgscheduler.NewStore(pool)
+	require.NoError(b, err)
+	ctx := context.Background()
+	base := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+
+	b.Run("first_claim", func(b *testing.B) {
+		i := 0
+		b.ReportAllocs()
+		for b.Loop() {
+			i++
+			if err := store.Claim(ctx, "bench.first", base.Add(time.Duration(i)*time.Second)); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("duplicate", func(b *testing.B) {
+		require.NoError(b, store.Claim(ctx, "bench.dup", base))
+		b.ReportAllocs()
+		for b.Loop() {
+			if err := store.Claim(ctx, "bench.dup", base); !errors.Is(err, scheduler.ErrAlreadyClaimed) {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/async/scheduler/postgres/doc.go
+++ b/async/scheduler/postgres/doc.go
@@ -1,0 +1,17 @@
+// Package pgscheduler is the Postgres scheduler.Store: a fleet-shared claim
+// table whose unique (name, scheduled_for) primary key turns concurrent
+// instances firing the same tick into an insert race exactly one wins. Apply
+// Migrations with data/migration before use.
+//
+//	store, err := pgscheduler.NewStore(pool)
+//	if err != nil { ... }
+//	sched, err := scheduler.New(client, scheduler.WithStore(store))
+//
+// Claims only dedupe ticks a lagging instance could still fire, so rows need
+// to outlive fleet clock spread, not live forever: the scheduler's own sweep
+// (Config.Retention, Config.SweepInterval) keeps the table bounded.
+//
+// Postgres stores timestamps at microsecond precision: distinct ticks less
+// than 1µs apart would collide on one claim row, so keep Every intervals at
+// microsecond granularity or coarser (Cron ticks are whole minutes).
+package pgscheduler

--- a/async/scheduler/postgres/migrations/20260720150000_scheduler_claims.sql
+++ b/async/scheduler/postgres/migrations/20260720150000_scheduler_claims.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+CREATE TABLE scheduler_claims (
+    name          text NOT NULL,
+    scheduled_for timestamptz NOT NULL,
+    claimed_at    timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (name, scheduled_for)
+);
+
+CREATE INDEX scheduler_claims_sweep_idx ON scheduler_claims (scheduled_for);
+
+-- +goose Down
+DROP TABLE scheduler_claims;

--- a/async/scheduler/postgres/pgscheduler.go
+++ b/async/scheduler/postgres/pgscheduler.go
@@ -1,0 +1,146 @@
+package pgscheduler
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/async/scheduler"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating scheduler_claims, rooted so
+// its .sql files sit at fsys root. Apply via data/migration under its own
+// version table.
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+var tableNameRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+type config struct {
+	table string
+}
+
+// Option configures NewStore.
+type Option func(*config)
+
+// WithTable overrides the claim table name (default "scheduler_claims"). The
+// shipped migration creates the default; a custom name requires a
+// caller-managed schema of the same shape.
+func WithTable(name string) Option {
+	return func(c *config) { c.table = name }
+}
+
+func newConfig(opts []Option) (config, error) {
+	c := config{table: "scheduler_claims"}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	if !tableNameRe.MatchString(c.table) {
+		return config{}, fmt.Errorf("pgscheduler: invalid table name %q", c.table)
+	}
+	// Postgres truncates identifiers past 63 bytes: two longer names sharing a
+	// prefix would silently collide on one physical table.
+	if len(c.table) > 63 {
+		return config{}, fmt.Errorf("pgscheduler: table name %q exceeds the 63-byte identifier limit", c.table)
+	}
+	return c, nil
+}
+
+// Store is the Postgres scheduler.Store: the fleet-wide claim table whose
+// unique (name, scheduled_for) insert race decides which instance enqueues
+// each tick.
+type Store struct {
+	pool       *pgxpool.Pool
+	claimSQL   string
+	releaseSQL string
+	purgeSQL   string
+}
+
+// NewStore builds a Store over pool. Errors on a nil pool or an invalid
+// table name.
+func NewStore(pool *pgxpool.Pool, opts ...Option) (*Store, error) {
+	if pool == nil {
+		return nil, errors.New("pgscheduler: NewStore requires a pool")
+	}
+	c, err := newConfig(opts)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{
+		pool:     pool,
+		claimSQL: fmt.Sprintf("INSERT INTO %s (name, scheduled_for) VALUES ($1, $2) ON CONFLICT DO NOTHING", c.table),
+		// purgeBatch bounds one delete statement via ctid batching: one InitPlan
+		// picks the batch by the scheduled_for index, and the delete addresses
+		// rows directly (pgeventbus precedent).
+		purgeSQL:   fmt.Sprintf(`DELETE FROM %[1]s WHERE ctid = ANY(ARRAY(SELECT ctid FROM %[1]s WHERE scheduled_for < $1 LIMIT %[2]d))`, c.table, purgeBatch),
+		releaseSQL: fmt.Sprintf("DELETE FROM %s WHERE name = $1 AND scheduled_for = $2", c.table),
+	}, nil
+}
+
+// Claim implements scheduler.Store: the insert race. Exactly one Claim per
+// (name, scheduled_for) succeeds; the rest get scheduler.ErrAlreadyClaimed.
+func (s *Store) Claim(ctx context.Context, name string, scheduledFor time.Time) error {
+	if name == "" {
+		return errors.New("pgscheduler: Claim requires a non-empty job name")
+	}
+	tag, err := s.pool.Exec(ctx, s.claimSQL, name, scheduledFor)
+	if err != nil {
+		return fmt.Errorf("pgscheduler: claim: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return scheduler.ErrAlreadyClaimed
+	}
+	return nil
+}
+
+// Release implements scheduler.Store: it deletes a claim after a failed
+// enqueue so the tick can be claimed again. Releasing an absent claim is a
+// no-op.
+func (s *Store) Release(ctx context.Context, name string, scheduledFor time.Time) error {
+	if _, err := s.pool.Exec(ctx, s.releaseSQL, name, scheduledFor); err != nil {
+		return fmt.Errorf("pgscheduler: release: %w", err)
+	}
+	return nil
+}
+
+// purgeBatch keeps each PurgeBefore delete a short transaction with WAL and
+// vacuum debt paid off between batches instead of accumulated across one
+// multi-million-row delete (pgqueue precedent).
+const purgeBatch = 5000
+
+// PurgeBefore implements scheduler.Store: it deletes claims scheduled
+// strictly before cutoff and returns how many were removed. Deletes are
+// batched, so it is safe on an unswept backlog.
+func (s *Store) PurgeBefore(ctx context.Context, cutoff time.Time) (int, error) {
+	total := 0
+	for {
+		tag, err := s.pool.Exec(ctx, s.purgeSQL, cutoff)
+		if err != nil {
+			return total, fmt.Errorf("pgscheduler: purge before: %w", err)
+		}
+		n := int(tag.RowsAffected())
+		total += n
+		// Terminate on an empty batch, not a short one: a concurrent purge
+		// deleting part of this run's selected batch would otherwise make both
+		// runs exit early with purgeable rows remaining.
+		if n == 0 {
+			return total, nil
+		}
+	}
+}

--- a/async/scheduler/postgres/pgscheduler_test.go
+++ b/async/scheduler/postgres/pgscheduler_test.go
@@ -1,0 +1,151 @@
+//go:build integration
+
+package pgscheduler_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/scheduler"
+	pgscheduler "github.com/dmitrymomot/forge/async/scheduler/postgres"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+)
+
+var _ scheduler.Store = (*pgscheduler.Store)(nil)
+
+// openPool connects to the suite's Postgres (via pgtest.DSN) and applies the
+// claims migration.
+func openPool(tb testing.TB) *pgxpool.Pool {
+	tb.Helper()
+	cfg := postgres.DefaultConfig()
+	cfg.URL = pgtest.DSN(tb)
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(tb, err)
+	tb.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	tb.Cleanup(func() { _ = db.Close() })
+	require.NoError(tb, migration.New(pgscheduler.Migrations, migration.WithTable("forge_scheduler_schema")).Up(context.Background(), db))
+	_, err = pool.Exec(context.Background(), "TRUNCATE scheduler_claims")
+	require.NoError(tb, err)
+	return pool
+}
+
+func TestNewStore(t *testing.T) {
+	t.Run("nil pool", func(t *testing.T) {
+		_, err := pgscheduler.NewStore(nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid table", func(t *testing.T) {
+		pool := openPool(t)
+		_, err := pgscheduler.NewStore(pool, pgscheduler.WithTable("bad; DROP TABLE x"))
+		assert.Error(t, err)
+	})
+
+	t.Run("overlong table", func(t *testing.T) {
+		pool := openPool(t)
+		_, err := pgscheduler.NewStore(pool, pgscheduler.WithTable(strings64()))
+		assert.Error(t, err)
+	})
+}
+
+func strings64() string {
+	s := make([]byte, 64)
+	for i := range s {
+		s[i] = 'a'
+	}
+	return string(s)
+}
+
+func TestClaim(t *testing.T) {
+	pool := openPool(t)
+	store, err := pgscheduler.NewStore(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+	tick := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+
+	t.Run("claim once per tick", func(t *testing.T) {
+		require.NoError(t, store.Claim(ctx, "job.a", tick))
+		require.ErrorIs(t, store.Claim(ctx, "job.a", tick), scheduler.ErrAlreadyClaimed)
+		// Other names and ticks are independent claims.
+		require.NoError(t, store.Claim(ctx, "job.b", tick))
+		require.NoError(t, store.Claim(ctx, "job.a", tick.Add(time.Minute)))
+	})
+
+	t.Run("keyed by instant not location", func(t *testing.T) {
+		require.NoError(t, store.Claim(ctx, "job.tz", tick))
+		require.ErrorIs(t, store.Claim(ctx, "job.tz", tick.In(time.FixedZone("plus2", 7200))), scheduler.ErrAlreadyClaimed)
+	})
+
+	t.Run("empty name rejected", func(t *testing.T) {
+		require.Error(t, store.Claim(ctx, "", tick))
+	})
+}
+
+func TestClaimRace(t *testing.T) {
+	pool := openPool(t)
+	store, err := pgscheduler.NewStore(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+	tick := time.Date(2026, 7, 20, 11, 0, 0, 0, time.UTC)
+
+	const racers = 16
+	var wg sync.WaitGroup
+	wins := make(chan struct{}, racers)
+	for range racers {
+		wg.Go(func() {
+			if store.Claim(ctx, "job.race", tick) == nil {
+				wins <- struct{}{}
+			}
+		})
+	}
+	wg.Wait()
+	assert.Len(t, wins, 1)
+}
+
+func TestRelease(t *testing.T) {
+	pool := openPool(t)
+	store, err := pgscheduler.NewStore(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+	tick := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	require.NoError(t, store.Claim(ctx, "job.rel", tick))
+	require.NoError(t, store.Release(ctx, "job.rel", tick))
+	require.NoError(t, store.Claim(ctx, "job.rel", tick), "released tick must be claimable again")
+	// Releasing an absent claim is a no-op.
+	require.NoError(t, store.Release(ctx, "job.ghost", tick))
+}
+
+func TestPurgeBefore(t *testing.T) {
+	pool := openPool(t)
+	store, err := pgscheduler.NewStore(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+	base := time.Date(2026, 7, 20, 13, 0, 0, 0, time.UTC)
+
+	require.NoError(t, store.Claim(ctx, "job.p", base.Add(-2*time.Hour)))
+	require.NoError(t, store.Claim(ctx, "job.p", base.Add(-90*time.Minute)))
+	require.NoError(t, store.Claim(ctx, "job.p", base.Add(-30*time.Minute)))
+
+	n, err := store.PurgeBefore(ctx, base.Add(-time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	// Purged ticks are claimable again; the kept one is not.
+	require.NoError(t, store.Claim(ctx, "job.p", base.Add(-2*time.Hour)))
+	require.ErrorIs(t, store.Claim(ctx, "job.p", base.Add(-30*time.Minute)), scheduler.ErrAlreadyClaimed)
+
+	n, err = store.PurgeBefore(ctx, base.Add(-3*time.Hour))
+	require.NoError(t, err)
+	assert.Zero(t, n)
+}

--- a/async/scheduler/schedule.go
+++ b/async/scheduler/schedule.go
@@ -1,0 +1,35 @@
+package scheduler
+
+import (
+	"fmt"
+	"time"
+)
+
+// Schedule computes fire times. Next returns the first tick strictly after t,
+// or the zero time when the schedule never fires again. Implementations MUST
+// be deterministic — every fleet instance computes the same tick sequence, and
+// that agreement is what makes the Store claim dedupe fires — and are expected
+// to honor t's absolute instant regardless of its location.
+type Schedule interface {
+	Next(t time.Time) time.Time
+}
+
+// Every returns a Schedule that fires every d, with ticks aligned to whole
+// multiples of d (time.Truncate alignment), so every fleet instance computes
+// identical tick times regardless of when it started. Panics on d <= 0:
+// schedules are package-level wiring, not runtime data.
+func Every(d time.Duration) Schedule {
+	if d <= 0 {
+		panic(fmt.Sprintf("scheduler: Every(%v): interval must be > 0", d))
+	}
+	return intervalSchedule{d: d}
+}
+
+type intervalSchedule struct {
+	d time.Duration
+}
+
+// Next implements Schedule.
+func (s intervalSchedule) Next(t time.Time) time.Time {
+	return t.Truncate(s.d).Add(s.d)
+}

--- a/async/scheduler/schedule_test.go
+++ b/async/scheduler/schedule_test.go
@@ -1,0 +1,50 @@
+package scheduler_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dmitrymomot/forge/async/scheduler"
+)
+
+func TestEvery(t *testing.T) {
+	t.Parallel()
+
+	t.Run("aligns to interval multiples", func(t *testing.T) {
+		t.Parallel()
+		sched := scheduler.Every(time.Hour)
+		assert.Equal(t, at("2026-07-20T11:00:00Z"), sched.Next(at("2026-07-20T10:23:45Z")).UTC())
+	})
+
+	t.Run("boundary is strictly after", func(t *testing.T) {
+		t.Parallel()
+		sched := scheduler.Every(time.Hour)
+		assert.Equal(t, at("2026-07-20T11:00:00Z"), sched.Next(at("2026-07-20T10:00:00Z")).UTC())
+	})
+
+	t.Run("deterministic across instances", func(t *testing.T) {
+		t.Parallel()
+		sched := scheduler.Every(15 * time.Minute)
+		// Two instances asking at different moments within one interval agree
+		// on the tick.
+		a := sched.Next(at("2026-07-20T10:01:00Z"))
+		b := sched.Next(at("2026-07-20T10:14:59Z"))
+		assert.Equal(t, a, b)
+	})
+
+	t.Run("location independent", func(t *testing.T) {
+		t.Parallel()
+		sched := scheduler.Every(10 * time.Minute)
+		loc := time.FixedZone("plus3", 3*3600)
+		utc := at("2026-07-20T10:03:00Z")
+		assert.True(t, sched.Next(utc).Equal(sched.Next(utc.In(loc))))
+	})
+
+	t.Run("panics on non-positive interval", func(t *testing.T) {
+		t.Parallel()
+		assert.Panics(t, func() { scheduler.Every(0) })
+		assert.Panics(t, func() { scheduler.Every(-time.Second) })
+	})
+}

--- a/async/scheduler/scheduler.go
+++ b/async/scheduler/scheduler.go
@@ -184,21 +184,18 @@ func (s *Scheduler) Run(ctx context.Context) error {
 				kept = append(kept, e)
 				continue
 			}
-			// Skip past missed ticks: fire only the latest due one.
-			tick := e.next
-			for {
-				n := e.sched.Next(tick)
-				if n.IsZero() || n.After(now) {
-					break
-				}
-				tick = n
+			// Skip past missed ticks: fire only the latest due one. The walk
+			// leaves next as the first tick strictly after now (or zero).
+			tick, next := e.next, e.sched.Next(e.next)
+			for !next.IsZero() && !next.After(now) {
+				tick, next = next, e.sched.Next(next)
 			}
 			if s.fireTick(ctx, opCtx, e, tick) {
-				e.next = e.sched.Next(now)
-				if e.next.IsZero() {
+				if next.IsZero() {
 					s.log.WarnContext(ctx, "schedule exhausted, job parked", slog.String("service", s.name), slog.String("job", e.name))
 					continue
 				}
+				e.next = next
 			} else {
 				e.next = tick
 				retry = true
@@ -233,6 +230,10 @@ func (s *Scheduler) fireTick(ctx, opCtx context.Context, e *entry, tick time.Tim
 	if s.pushCtx != nil {
 		pctx = s.pushCtx(opCtx)
 	}
+	// One deadline over claim+enqueue+release: opCtx survives shutdown, so
+	// this is the only bound keeping a wedged backend from blocking drain.
+	pctx, cancel := context.WithTimeout(pctx, s.cfg.OpTimeout)
+	defer cancel()
 	tick = tick.UTC()
 	attrs := []slog.Attr{slog.String("service", s.name), slog.String("job", e.name), slog.Time("scheduled_for", tick)}
 	switch err := s.store.Claim(pctx, e.name, tick); {
@@ -273,6 +274,8 @@ func (s *Scheduler) waitFor(active []*entry, now time.Time, retry bool) time.Dur
 
 // sweep deletes claims older than the retention window.
 func (s *Scheduler) sweep(ctx, opCtx context.Context) {
+	opCtx, cancel := context.WithTimeout(opCtx, s.cfg.OpTimeout)
+	defer cancel()
 	cutoff := s.clk.Now().UTC().Add(-s.cfg.Retention)
 	n, err := s.store.PurgeBefore(opCtx, cutoff)
 	if err != nil {

--- a/async/scheduler/scheduler.go
+++ b/async/scheduler/scheduler.go
@@ -1,0 +1,285 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+// Scheduler is a supervisor.Service that enqueues a typed queue job whenever
+// one of its schedules comes due. It runs on every instance; the Store claim
+// makes each tick fire once per fleet. Add every job before Run.
+type Scheduler struct {
+	store   Store
+	clk     clock.Clock
+	client  *queue.Client
+	log     *slog.Logger
+	pushCtx func(ctx context.Context) context.Context
+	names   map[string]struct{}
+	name    string
+	entries []*entry
+	cfg     Config
+	mu      sync.Mutex
+	started bool
+}
+
+// entry is one scheduled job: its identity, tick source, and enqueue closure.
+type entry struct {
+	next  time.Time
+	sched Schedule
+	fire  func(ctx context.Context, scheduledFor time.Time) error
+	name  string
+}
+
+// New builds a Scheduler pushing through client. The default claim store is
+// in-memory — correct for a single instance; fleets pass
+// WithStore(pgscheduler) so ticks dedupe across instances.
+func New(client *queue.Client, opts ...Option) (*Scheduler, error) {
+	if client == nil {
+		return nil, fmt.Errorf("%w: nil queue client", ErrInvalidConfig)
+	}
+	s := &Scheduler{
+		client: client,
+		store:  NewMemoryStore(),
+		clk:    clock.System(),
+		log:    logger.NewNope(),
+		names:  make(map[string]struct{}),
+		name:   "scheduler",
+		cfg:    DefaultConfig(),
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if err := s.cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if s.store == nil {
+		return nil, fmt.Errorf("%w: nil store", ErrInvalidConfig)
+	}
+	if s.clk == nil {
+		return nil, fmt.Errorf("%w: nil clock", ErrInvalidConfig)
+	}
+	if s.log == nil {
+		return nil, fmt.Errorf("%w: nil logger", ErrInvalidConfig)
+	}
+	if s.name == "" {
+		return nil, fmt.Errorf("%w: empty service name", ErrInvalidConfig)
+	}
+	return s, nil
+}
+
+// Add registers a job with a fixed payload: whenever sched fires, payload is
+// enqueued as kind k. The name is the schedule's identity — it keys the fleet
+// claim and must be unique within this scheduler (convention:
+// "domain.action", independent of the kind name so one kind can run on two
+// schedules). Panics on wiring errors (empty or duplicate name, nil schedule)
+// and after Run has started: jobs are package-level wiring, not runtime data.
+func Add[T any](s *Scheduler, name string, sched Schedule, k queue.Kind[T], payload T, opts ...JobOption) {
+	AddFunc(s, name, sched, k, func(time.Time) (T, error) { return payload, nil }, opts...)
+}
+
+// AddFunc registers a job whose payload is built at fire time: build receives
+// the tick being fired (not the enqueue time — a delayed instance passes the
+// tick it is catching up on), so period-keyed payloads like "report for the
+// hour ending at scheduledFor" stay correct. A build error is logged and the
+// tick is retried. Same wiring rules and panics as Add.
+func AddFunc[T any](s *Scheduler, name string, sched Schedule, k queue.Kind[T], build func(scheduledFor time.Time) (T, error), opts ...JobOption) {
+	if name == "" {
+		panic("scheduler: AddFunc requires a non-empty job name")
+	}
+	if sched == nil {
+		panic(fmt.Sprintf("scheduler: AddFunc(%q) with nil schedule", name))
+	}
+	if build == nil {
+		panic(fmt.Sprintf("scheduler: AddFunc(%q) with nil build func", name))
+	}
+	var jc jobConfig
+	for _, opt := range opts {
+		opt(&jc)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.started {
+		panic(fmt.Sprintf("scheduler: AddFunc(%q) after Run started", name))
+	}
+	if _, dup := s.names[name]; dup {
+		panic(fmt.Sprintf("scheduler: duplicate job name %q", name))
+	}
+	s.names[name] = struct{}{}
+	s.entries = append(s.entries, &entry{
+		name:  name,
+		sched: sched,
+		fire: func(ctx context.Context, scheduledFor time.Time) error {
+			payload, err := build(scheduledFor)
+			if err != nil {
+				return fmt.Errorf("scheduler: build payload for %q: %w", name, err)
+			}
+			return queue.Push(ctx, s.client, k, payload, jc.push...)
+		},
+	})
+}
+
+// Name implements supervisor.Service.
+func (s *Scheduler) Name() string { return s.name }
+
+// Run implements supervisor.Service: wait until the earliest schedule is due,
+// claim-and-enqueue each due tick, repeat until ctx is cancelled. Ticks
+// missed while due (instance down, timer late) are not replayed: only the
+// latest due tick fires, on the assumption that a punctual instance already
+// claimed the older ones. A tick whose claim or enqueue fails is retried
+// every Config.RetryInterval until it succeeds, another instance claims it,
+// or its next tick supersedes it.
+func (s *Scheduler) Run(ctx context.Context) error {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return ErrAlreadyRunning
+	}
+	s.started = true
+	active := slices.Clone(s.entries)
+	s.mu.Unlock()
+	if len(active) == 0 {
+		return ErrNoJobs
+	}
+
+	// Claims and pushes must commit during drain; the select below is the
+	// cancellation point (pgqueue precedent).
+	opCtx := context.WithoutCancel(ctx)
+
+	now := s.clk.Now()
+	kept := active[:0]
+	for _, e := range active {
+		e.next = e.sched.Next(now)
+		if e.next.IsZero() {
+			s.log.WarnContext(ctx, "schedule never fires, job parked", slog.String("service", s.name), slog.String("job", e.name))
+			continue
+		}
+		kept = append(kept, e)
+	}
+	active = kept
+
+	var sweepC <-chan time.Time
+	if s.cfg.SweepInterval > 0 {
+		ticker := time.NewTicker(s.cfg.SweepInterval)
+		defer ticker.Stop()
+		sweepC = ticker.C
+	}
+
+	s.log.InfoContext(ctx, "scheduler started", slog.String("service", s.name), slog.Int("jobs", len(active)))
+
+	for {
+		now = s.clk.Now()
+		retry := false
+		kept := active[:0]
+		for _, e := range active {
+			if e.next.After(now) {
+				kept = append(kept, e)
+				continue
+			}
+			// Skip past missed ticks: fire only the latest due one.
+			tick := e.next
+			for {
+				n := e.sched.Next(tick)
+				if n.IsZero() || n.After(now) {
+					break
+				}
+				tick = n
+			}
+			if s.fireTick(ctx, opCtx, e, tick) {
+				e.next = e.sched.Next(now)
+				if e.next.IsZero() {
+					s.log.WarnContext(ctx, "schedule exhausted, job parked", slog.String("service", s.name), slog.String("job", e.name))
+					continue
+				}
+			} else {
+				e.next = tick
+				retry = true
+			}
+			kept = append(kept, e)
+		}
+		active = kept
+
+		if len(active) == 0 && sweepC == nil {
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		timer := time.NewTimer(s.waitFor(active, now, retry))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		case <-sweepC:
+			timer.Stop()
+			s.sweep(ctx, opCtx)
+		}
+	}
+}
+
+// fireTick claims and enqueues one tick. It reports whether the entry may
+// advance to its next tick: true on success, on a tick already claimed
+// elsewhere, and on a claim stuck after a failed release (retrying would only
+// hit ErrAlreadyClaimed); false asks the run loop to retry the same tick.
+func (s *Scheduler) fireTick(ctx, opCtx context.Context, e *entry, tick time.Time) bool {
+	pctx := opCtx
+	if s.pushCtx != nil {
+		pctx = s.pushCtx(opCtx)
+	}
+	tick = tick.UTC()
+	attrs := []slog.Attr{slog.String("service", s.name), slog.String("job", e.name), slog.Time("scheduled_for", tick)}
+	switch err := s.store.Claim(pctx, e.name, tick); {
+	case errors.Is(err, ErrAlreadyClaimed):
+		s.log.LogAttrs(ctx, slog.LevelDebug, "tick claimed elsewhere", attrs...)
+		return true
+	case err != nil:
+		s.log.LogAttrs(ctx, slog.LevelError, "tick claim failed", append(attrs, slog.Any("error", err))...)
+		return false
+	}
+	if err := e.fire(pctx, tick); err != nil {
+		s.log.LogAttrs(ctx, slog.LevelError, "scheduled enqueue failed", append(attrs, slog.Any("error", err))...)
+		if rerr := s.store.Release(pctx, e.name, tick); rerr != nil {
+			s.log.LogAttrs(ctx, slog.LevelError, "claim release failed, tick lost", append(attrs, slog.Any("error", rerr))...)
+			return true
+		}
+		return false
+	}
+	s.log.LogAttrs(ctx, slog.LevelDebug, "scheduled job enqueued", attrs...)
+	return true
+}
+
+// waitFor picks the sleep until the next actionable moment: the earliest
+// upcoming tick, RetryInterval when a failed tick is pending, and a bounded
+// park when every remaining entry is parked.
+func (s *Scheduler) waitFor(active []*entry, now time.Time, retry bool) time.Duration {
+	wait := time.Hour
+	for _, e := range active {
+		if d := e.next.Sub(now); d > 0 {
+			wait = min(wait, d)
+		}
+	}
+	if retry {
+		wait = min(wait, s.cfg.RetryInterval)
+	}
+	return wait
+}
+
+// sweep deletes claims older than the retention window.
+func (s *Scheduler) sweep(ctx, opCtx context.Context) {
+	cutoff := s.clk.Now().UTC().Add(-s.cfg.Retention)
+	n, err := s.store.PurgeBefore(opCtx, cutoff)
+	if err != nil {
+		s.log.ErrorContext(ctx, "claim sweep failed", slog.String("service", s.name), slog.Any("error", err))
+		return
+	}
+	if n > 0 {
+		s.log.DebugContext(ctx, "claims swept", slog.String("service", s.name), slog.Int("purged", n))
+	}
+}

--- a/async/scheduler/scheduler_test.go
+++ b/async/scheduler/scheduler_test.go
@@ -360,6 +360,35 @@ func TestRetriesFailedTick(t *testing.T) {
 	<-done
 }
 
+// wedgedStore blocks Claim until its context ends — a partitioned backend.
+type wedgedStore struct{}
+
+func (wedgedStore) Claim(ctx context.Context, _ string, _ time.Time) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+func (wedgedStore) Release(context.Context, string, time.Time) error    { return nil }
+func (wedgedStore) PurgeBefore(context.Context, time.Time) (int, error) { return 0, nil }
+
+func TestOpTimeoutBoundsWedgedStore(t *testing.T) {
+	t.Parallel()
+
+	// Claims run under context.WithoutCancel, so OpTimeout is the only bound:
+	// without it this Run never returns and the test times out.
+	cfg := fastConfig()
+	cfg.OpTimeout = 30 * time.Millisecond
+	s, err := scheduler.New(queue.NewClient(queue.NewMemoryBroker()),
+		scheduler.WithStore(wedgedStore{}), scheduler.WithConfig(cfg))
+	require.NoError(t, err)
+	scheduler.Add(s, "job", scheduler.Every(10*time.Millisecond), kindTick, tickPayload{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	require.ErrorIs(t, s.Run(ctx), context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 2*time.Second, "wedged store blocked shutdown")
+}
+
 type scopeKey struct{}
 
 func TestPushContextScopesJobs(t *testing.T) {

--- a/async/scheduler/scheduler_test.go
+++ b/async/scheduler/scheduler_test.go
@@ -1,0 +1,438 @@
+package scheduler_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/async/scheduler"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/supervisor"
+)
+
+var _ supervisor.Service = (*scheduler.Scheduler)(nil)
+
+type tickPayload struct {
+	Job  string    `json:"job"`
+	Tick time.Time `json:"tick"`
+}
+
+var kindTick = queue.NewKind[tickPayload]("scheduler_test.tick")
+
+// fastConfig keeps test retries snappy.
+func fastConfig() scheduler.Config {
+	cfg := scheduler.DefaultConfig()
+	cfg.RetryInterval = 20 * time.Millisecond
+	return cfg
+}
+
+// runFor runs sched for d in the background and returns after it stopped.
+func runFor(t *testing.T, sched *scheduler.Scheduler, d time.Duration) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	defer cancel()
+	err := sched.Run(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// drain claims jobs off broker until want arrived or timeout passed.
+func drain(t *testing.T, broker queue.Broker, want int, timeout time.Duration) []queue.ClaimedJob {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var jobs []queue.ClaimedJob
+	for {
+		claimed, err := broker.Claim(context.Background(), "default", 100, time.Minute)
+		require.NoError(t, err)
+		jobs = append(jobs, claimed...)
+		if len(jobs) >= want || time.Now().After(deadline) {
+			return jobs
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func decodeTicks(t *testing.T, jobs []queue.ClaimedJob) []tickPayload {
+	t.Helper()
+	out := make([]tickPayload, 0, len(jobs))
+	for _, j := range jobs {
+		require.Equal(t, kindTick.Name(), j.Type)
+		var p tickPayload
+		require.NoError(t, json.Unmarshal(j.Payload, &p))
+		out = append(out, p)
+	}
+	return out
+}
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	client := queue.NewClient(queue.NewMemoryBroker())
+
+	t.Run("nil client", func(t *testing.T) {
+		t.Parallel()
+		_, err := scheduler.New(nil)
+		require.ErrorIs(t, err, scheduler.ErrInvalidConfig)
+	})
+
+	t.Run("nil store", func(t *testing.T) {
+		t.Parallel()
+		_, err := scheduler.New(client, scheduler.WithStore(nil))
+		require.ErrorIs(t, err, scheduler.ErrInvalidConfig)
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		t.Parallel()
+		_, err := scheduler.New(client, scheduler.WithName(""))
+		require.ErrorIs(t, err, scheduler.ErrInvalidConfig)
+	})
+
+	t.Run("nil logger", func(t *testing.T) {
+		t.Parallel()
+		_, err := scheduler.New(client, scheduler.WithLogger(nil))
+		require.ErrorIs(t, err, scheduler.ErrInvalidConfig)
+	})
+
+	t.Run("nil clock", func(t *testing.T) {
+		t.Parallel()
+		_, err := scheduler.New(client, scheduler.WithClock(nil))
+		require.ErrorIs(t, err, scheduler.ErrInvalidConfig)
+	})
+
+	t.Run("bad config", func(t *testing.T) {
+		t.Parallel()
+		_, err := scheduler.New(client, scheduler.WithConfig(scheduler.Config{}))
+		require.ErrorIs(t, err, scheduler.ErrInvalidConfig)
+	})
+
+	t.Run("defaults valid", func(t *testing.T) {
+		t.Parallel()
+		s, err := scheduler.New(client)
+		require.NoError(t, err)
+		assert.Equal(t, "scheduler", s.Name())
+	})
+
+	t.Run("name override", func(t *testing.T) {
+		t.Parallel()
+		s, err := scheduler.New(client, scheduler.WithName("scheduler-eu"))
+		require.NoError(t, err)
+		assert.Equal(t, "scheduler-eu", s.Name())
+	})
+}
+
+func TestAddPanics(t *testing.T) {
+	t.Parallel()
+
+	newScheduler := func(t *testing.T) *scheduler.Scheduler {
+		t.Helper()
+		s, err := scheduler.New(queue.NewClient(queue.NewMemoryBroker()))
+		require.NoError(t, err)
+		return s
+	}
+
+	t.Run("empty name", func(t *testing.T) {
+		t.Parallel()
+		s := newScheduler(t)
+		assert.Panics(t, func() { scheduler.Add(s, "", scheduler.Every(time.Hour), kindTick, tickPayload{}) })
+	})
+
+	t.Run("nil schedule", func(t *testing.T) {
+		t.Parallel()
+		s := newScheduler(t)
+		assert.Panics(t, func() { scheduler.Add(s, "job", nil, kindTick, tickPayload{}) })
+	})
+
+	t.Run("nil build func", func(t *testing.T) {
+		t.Parallel()
+		s := newScheduler(t)
+		assert.Panics(t, func() { scheduler.AddFunc(s, "job", scheduler.Every(time.Hour), kindTick, nil) })
+	})
+
+	t.Run("duplicate name", func(t *testing.T) {
+		t.Parallel()
+		s := newScheduler(t)
+		scheduler.Add(s, "job", scheduler.Every(time.Hour), kindTick, tickPayload{})
+		assert.Panics(t, func() { scheduler.Add(s, "job", scheduler.Every(time.Minute), kindTick, tickPayload{}) })
+	})
+
+	t.Run("after run started", func(t *testing.T) {
+		t.Parallel()
+		broker := queue.NewMemoryBroker()
+		s, err := scheduler.New(queue.NewClient(broker), scheduler.WithConfig(fastConfig()))
+		require.NoError(t, err)
+		scheduler.Add(s, "job", scheduler.Every(5*time.Millisecond), kindTick, tickPayload{})
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		done := make(chan struct{})
+		go func() { _ = s.Run(ctx); close(done) }()
+		// A job on the broker proves Run is past its startup guard.
+		require.NotEmpty(t, drain(t, broker, 1, time.Second))
+		assert.Panics(t, func() { scheduler.Add(s, "late", scheduler.Every(time.Hour), kindTick, tickPayload{}) })
+		cancel()
+		<-done
+	})
+}
+
+func TestRunGuards(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no jobs", func(t *testing.T) {
+		t.Parallel()
+		s, err := scheduler.New(queue.NewClient(queue.NewMemoryBroker()))
+		require.NoError(t, err)
+		require.ErrorIs(t, s.Run(context.Background()), scheduler.ErrNoJobs)
+	})
+
+	t.Run("second run rejected", func(t *testing.T) {
+		t.Parallel()
+		broker := queue.NewMemoryBroker()
+		s, err := scheduler.New(queue.NewClient(broker), scheduler.WithConfig(fastConfig()))
+		require.NoError(t, err)
+		scheduler.Add(s, "job", scheduler.Every(5*time.Millisecond), kindTick, tickPayload{})
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		done := make(chan struct{})
+		go func() { _ = s.Run(ctx); close(done) }()
+		// A job on the broker proves Run is past its startup guard.
+		require.NotEmpty(t, drain(t, broker, 1, time.Second))
+		require.ErrorIs(t, s.Run(context.Background()), scheduler.ErrAlreadyRunning)
+		cancel()
+		<-done
+	})
+
+	t.Run("cancel stops a parked run", func(t *testing.T) {
+		t.Parallel()
+		s, err := scheduler.New(queue.NewClient(queue.NewMemoryBroker()))
+		require.NoError(t, err)
+		scheduler.Add(s, "job", scheduler.Every(time.Hour), kindTick, tickPayload{})
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- s.Run(ctx) }()
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(time.Second):
+			t.Fatal("Run did not stop on cancel")
+		}
+	})
+}
+
+func TestFiresOnSchedule(t *testing.T) {
+	t.Parallel()
+
+	broker := queue.NewMemoryBroker()
+	s, err := scheduler.New(queue.NewClient(broker), scheduler.WithConfig(fastConfig()))
+	require.NoError(t, err)
+	scheduler.Add(s, "report.tick", scheduler.Every(50*time.Millisecond), kindTick, tickPayload{Job: "report.tick"})
+
+	runFor(t, s, 300*time.Millisecond)
+
+	jobs := drain(t, broker, 2, time.Second)
+	require.GreaterOrEqual(t, len(jobs), 2)
+	for _, p := range decodeTicks(t, jobs) {
+		assert.Equal(t, "report.tick", p.Job)
+	}
+}
+
+func TestAddFuncReceivesTick(t *testing.T) {
+	t.Parallel()
+
+	broker := queue.NewMemoryBroker()
+	s, err := scheduler.New(queue.NewClient(broker), scheduler.WithConfig(fastConfig()))
+	require.NoError(t, err)
+	scheduler.AddFunc(s, "report.tick", scheduler.Every(50*time.Millisecond), kindTick,
+		func(scheduledFor time.Time) (tickPayload, error) {
+			return tickPayload{Job: "report.tick", Tick: scheduledFor}, nil
+		})
+
+	runFor(t, s, 300*time.Millisecond)
+
+	ticks := decodeTicks(t, drain(t, broker, 2, time.Second))
+	require.GreaterOrEqual(t, len(ticks), 2)
+	seen := make(map[int64]struct{}, len(ticks))
+	for _, p := range ticks {
+		require.False(t, p.Tick.IsZero())
+		assert.Zero(t, p.Tick.UnixNano()%int64(50*time.Millisecond), "tick %v not aligned to the interval", p.Tick)
+		_, dup := seen[p.Tick.UnixNano()]
+		assert.False(t, dup, "tick %v fired twice", p.Tick)
+		seen[p.Tick.UnixNano()] = struct{}{}
+	}
+}
+
+func TestFleetFiresOncePerTick(t *testing.T) {
+	t.Parallel()
+
+	broker := queue.NewMemoryBroker()
+	store := scheduler.NewMemoryStore()
+
+	newInstance := func(t *testing.T) *scheduler.Scheduler {
+		t.Helper()
+		s, err := scheduler.New(queue.NewClient(broker), scheduler.WithStore(store), scheduler.WithConfig(fastConfig()))
+		require.NoError(t, err)
+		scheduler.AddFunc(s, "report.tick", scheduler.Every(50*time.Millisecond), kindTick,
+			func(scheduledFor time.Time) (tickPayload, error) {
+				return tickPayload{Job: "report.tick", Tick: scheduledFor}, nil
+			})
+		return s
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	var wg sync.WaitGroup
+	for range 3 {
+		s := newInstance(t)
+		wg.Go(func() { _ = s.Run(ctx) })
+	}
+	wg.Wait()
+
+	ticks := decodeTicks(t, drain(t, broker, 2, time.Second))
+	require.GreaterOrEqual(t, len(ticks), 2)
+	seen := make(map[int64]struct{}, len(ticks))
+	for _, p := range ticks {
+		_, dup := seen[p.Tick.UnixNano()]
+		require.False(t, dup, "tick %v enqueued by more than one instance", p.Tick)
+		seen[p.Tick.UnixNano()] = struct{}{}
+	}
+}
+
+func TestNoCatchUpAtStart(t *testing.T) {
+	t.Parallel()
+
+	broker := queue.NewMemoryBroker()
+	s, err := scheduler.New(queue.NewClient(broker))
+	require.NoError(t, err)
+	// Hourly ticks certainly "missed" before start are not replayed.
+	scheduler.Add(s, "report.hourly", scheduler.Every(time.Hour), kindTick, tickPayload{})
+
+	runFor(t, s, 150*time.Millisecond)
+
+	assert.Empty(t, drain(t, broker, 1, 50*time.Millisecond))
+}
+
+// flakyBroker fails Push while failing is set; everything else delegates.
+type flakyBroker struct {
+	*queue.MemoryBroker
+	failing atomic.Bool
+}
+
+func (b *flakyBroker) Push(ctx context.Context, jobs ...queue.Job) error {
+	if b.failing.Load() {
+		return errors.New("broker down")
+	}
+	return b.MemoryBroker.Push(ctx, jobs...)
+}
+
+func TestRetriesFailedTick(t *testing.T) {
+	t.Parallel()
+
+	broker := &flakyBroker{MemoryBroker: queue.NewMemoryBroker()}
+	broker.failing.Store(true)
+	store := scheduler.NewMemoryStore()
+	s, err := scheduler.New(queue.NewClient(broker), scheduler.WithStore(store), scheduler.WithConfig(fastConfig()))
+	require.NoError(t, err)
+	scheduler.AddFunc(s, "report.tick", scheduler.Every(50*time.Millisecond), kindTick,
+		func(scheduledFor time.Time) (tickPayload, error) {
+			return tickPayload{Job: "report.tick", Tick: scheduledFor}, nil
+		})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+	go func() { _ = s.Run(ctx); close(done) }()
+
+	// While the broker is down nothing is enqueued and claims are released.
+	time.Sleep(150 * time.Millisecond)
+	require.Empty(t, drain(t, broker, 1, 20*time.Millisecond))
+
+	// After recovery the pending tick fires without waiting for a new one.
+	broker.failing.Store(false)
+	jobs := drain(t, broker, 1, time.Second)
+	require.NotEmpty(t, jobs, "tick was not retried after the broker recovered")
+	<-done
+}
+
+type scopeKey struct{}
+
+func TestPushContextScopesJobs(t *testing.T) {
+	t.Parallel()
+
+	broker := queue.NewMemoryBroker()
+	client := queue.NewClient(broker, queue.WithScope(func(ctx context.Context) (string, error) {
+		scope, _ := ctx.Value(scopeKey{}).(string)
+		if scope == "" {
+			return "", errors.New("no tenant in context")
+		}
+		return scope, nil
+	}))
+	s, err := scheduler.New(client,
+		scheduler.WithConfig(fastConfig()),
+		scheduler.WithPushContext(func(ctx context.Context) context.Context {
+			return context.WithValue(ctx, scopeKey{}, "system")
+		}))
+	require.NoError(t, err)
+	scheduler.Add(s, "report.tick", scheduler.Every(50*time.Millisecond), kindTick, tickPayload{Job: "report.tick"})
+
+	runFor(t, s, 200*time.Millisecond)
+
+	jobs := drain(t, broker, 1, time.Second)
+	require.NotEmpty(t, jobs)
+	for _, j := range jobs {
+		assert.Equal(t, "system", j.Scope)
+	}
+}
+
+func TestSweepPurgesOldClaims(t *testing.T) {
+	t.Parallel()
+
+	base := at("2026-07-20T10:00:00Z")
+	store := scheduler.NewMemoryStore()
+	ctx := context.Background()
+	oldTick := base.Add(-2 * time.Hour)
+	freshTick := base.Add(-30 * time.Minute)
+	require.NoError(t, store.Claim(ctx, "old", oldTick))
+	require.NoError(t, store.Claim(ctx, "fresh", freshTick))
+
+	cfg := fastConfig()
+	cfg.Retention = time.Hour
+	cfg.SweepInterval = 20 * time.Millisecond
+	s, err := scheduler.New(queue.NewClient(queue.NewMemoryBroker()),
+		scheduler.WithStore(store), scheduler.WithConfig(cfg), scheduler.WithClock(clock.NewMock(base)))
+	require.NoError(t, err)
+	scheduler.Add(s, "idle", scheduler.Every(10*time.Hour), kindTick, tickPayload{})
+
+	runFor(t, s, 150*time.Millisecond)
+
+	// The stale claim was purged (claimable again); the fresh one survived.
+	require.NoError(t, store.Claim(ctx, "old", oldTick))
+	require.ErrorIs(t, store.Claim(ctx, "fresh", freshTick), scheduler.ErrAlreadyClaimed)
+}
+
+func TestBuildErrorRetries(t *testing.T) {
+	t.Parallel()
+
+	broker := queue.NewMemoryBroker()
+	var calls atomic.Int32
+	s, err := scheduler.New(queue.NewClient(broker), scheduler.WithConfig(fastConfig()))
+	require.NoError(t, err)
+	scheduler.AddFunc(s, "report.tick", scheduler.Every(50*time.Millisecond), kindTick,
+		func(scheduledFor time.Time) (tickPayload, error) {
+			if calls.Add(1) == 1 {
+				return tickPayload{}, errors.New("upstream not ready")
+			}
+			return tickPayload{Job: "report.tick", Tick: scheduledFor}, nil
+		})
+
+	runFor(t, s, 300*time.Millisecond)
+
+	require.NotEmpty(t, drain(t, broker, 1, time.Second), "tick was not retried after a build error")
+	assert.GreaterOrEqual(t, calls.Load(), int32(2))
+}

--- a/async/scheduler/store.go
+++ b/async/scheduler/store.go
@@ -1,0 +1,77 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// Store is the fleet-dedup seam: every instance computes the same tick times,
+// and Claim is the insert race that lets exactly one of them enqueue each
+// tick — one Claim per (name, scheduledFor instant) succeeds, the rest get
+// ErrAlreadyClaimed. Release undoes a claim after a failed enqueue so the
+// tick can be retried; PurgeBefore deletes claims scheduled strictly before
+// cutoff and returns how many were removed. Implementations key claims by
+// the absolute instant, not the wall-clock representation.
+type Store interface {
+	Claim(ctx context.Context, name string, scheduledFor time.Time) error
+	Release(ctx context.Context, name string, scheduledFor time.Time) error
+	PurgeBefore(ctx context.Context, cutoff time.Time) (int, error)
+}
+
+// MemoryStore is the in-process Store: correct for a single instance and for
+// tests, invisible to other instances — a fleet shares a durable store
+// (async/scheduler/postgres) instead.
+type MemoryStore struct {
+	claims map[memoryClaim]struct{}
+	mu     sync.Mutex
+}
+
+type memoryClaim struct {
+	name string
+	tick int64
+}
+
+// NewMemoryStore builds an empty in-memory claim store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{claims: make(map[memoryClaim]struct{})}
+}
+
+// Claim implements Store.
+func (s *MemoryStore) Claim(_ context.Context, name string, scheduledFor time.Time) error {
+	if name == "" {
+		return errors.New("scheduler: Claim requires a non-empty job name")
+	}
+	key := memoryClaim{name: name, tick: scheduledFor.UnixNano()}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.claims[key]; ok {
+		return ErrAlreadyClaimed
+	}
+	s.claims[key] = struct{}{}
+	return nil
+}
+
+// Release implements Store.
+func (s *MemoryStore) Release(_ context.Context, name string, scheduledFor time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.claims, memoryClaim{name: name, tick: scheduledFor.UnixNano()})
+	return nil
+}
+
+// PurgeBefore implements Store.
+func (s *MemoryStore) PurgeBefore(_ context.Context, cutoff time.Time) (int, error) {
+	limit := cutoff.UnixNano()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for key := range s.claims {
+		if key.tick < limit {
+			delete(s.claims, key)
+			n++
+		}
+	}
+	return n, nil
+}

--- a/async/scheduler/store_test.go
+++ b/async/scheduler/store_test.go
@@ -1,0 +1,84 @@
+package scheduler_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/scheduler"
+)
+
+func TestMemoryStore(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tick := at("2026-07-20T10:00:00Z")
+
+	t.Run("claim once", func(t *testing.T) {
+		t.Parallel()
+		st := scheduler.NewMemoryStore()
+		require.NoError(t, st.Claim(ctx, "job", tick))
+		require.ErrorIs(t, st.Claim(ctx, "job", tick), scheduler.ErrAlreadyClaimed)
+		// Other names and ticks are independent.
+		require.NoError(t, st.Claim(ctx, "other", tick))
+		require.NoError(t, st.Claim(ctx, "job", tick.Add(time.Minute)))
+	})
+
+	t.Run("empty name rejected", func(t *testing.T) {
+		t.Parallel()
+		st := scheduler.NewMemoryStore()
+		require.Error(t, st.Claim(ctx, "", tick))
+	})
+
+	t.Run("keyed by instant not location", func(t *testing.T) {
+		t.Parallel()
+		st := scheduler.NewMemoryStore()
+		require.NoError(t, st.Claim(ctx, "job", tick))
+		require.ErrorIs(t, st.Claim(ctx, "job", tick.In(time.FixedZone("plus2", 7200))), scheduler.ErrAlreadyClaimed)
+	})
+
+	t.Run("release reopens the tick", func(t *testing.T) {
+		t.Parallel()
+		st := scheduler.NewMemoryStore()
+		require.NoError(t, st.Claim(ctx, "job", tick))
+		require.NoError(t, st.Release(ctx, "job", tick))
+		require.NoError(t, st.Claim(ctx, "job", tick))
+		// Releasing an absent claim is a no-op.
+		require.NoError(t, st.Release(ctx, "ghost", tick))
+	})
+
+	t.Run("purge before cutoff", func(t *testing.T) {
+		t.Parallel()
+		st := scheduler.NewMemoryStore()
+		require.NoError(t, st.Claim(ctx, "job", tick))
+		require.NoError(t, st.Claim(ctx, "job", tick.Add(time.Hour)))
+		require.NoError(t, st.Claim(ctx, "other", tick))
+		n, err := st.PurgeBefore(ctx, tick.Add(time.Minute))
+		require.NoError(t, err)
+		assert.Equal(t, 2, n)
+		// Purged ticks are claimable again; the kept one is not.
+		require.NoError(t, st.Claim(ctx, "job", tick))
+		require.ErrorIs(t, st.Claim(ctx, "job", tick.Add(time.Hour)), scheduler.ErrAlreadyClaimed)
+	})
+
+	t.Run("concurrent claims elect one winner", func(t *testing.T) {
+		t.Parallel()
+		st := scheduler.NewMemoryStore()
+		const racers = 32
+		var wg sync.WaitGroup
+		wins := make(chan struct{}, racers)
+		for range racers {
+			wg.Go(func() {
+				if st.Claim(ctx, "job", tick) == nil {
+					wins <- struct{}{}
+				}
+			})
+		}
+		wg.Wait()
+		assert.Len(t, wins, 1)
+	})
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -148,7 +148,7 @@ Named retention policies run as batched delete/anonymize sweeps via
 audit events. Handles the two-sided GDPR constraint — minimum retention
 and erasure deadlines — as declared policy, not cron scripts.
 
-Deps: `async/scheduler` (planned), `async/queue`, `ops/auditlog` (planned).
+Deps: `async/scheduler`, `async/queue`, `ops/auditlog` (planned).
 
 ---
 
@@ -338,16 +338,6 @@ transactions (redis, nats, kafka) get transactional enqueue via
 
 Deps: `async/queue`; drivers: `data/sqlite` (planned), `data/nats`
 (planned), `data/kafka` (planned).
-
----
-
-**async/scheduler**
-
-Cron/interval `supervisor.Service` that *enqueues* into the engine when
-due; fires once per fleet via a `unique(name, scheduled_for)` insert race
-on SQL drivers; small local cron parser, no robfig/cron.
-
-Deps: `ops/supervisor`; `async/queue`.
 
 ---
 


### PR DESCRIPTION
## Summary

New `async/scheduler` package: a `supervisor.Service` that enqueues typed `async/queue` jobs whenever a cron or interval schedule comes due — scheduled work and ad-hoc work share one execution path (handlers, retry, backoff, dead-lettering all stay in the queue worker).

- **Own cron parser, no robfig/cron**: standard 5-field vixie grammar (`*`, lists, ranges, `*/n` + `N/n` steps, month/weekday names, `@daily`-style aliases, Sunday as 0 or 7, dom/dow OR rule), evaluated in UTC by default (`CronIn` for zones, DST quirks documented). Field-bitmask walk, zero-alloc `Next`.
- **`Every(d)`**: Truncate-aligned interval ticks, so every instance computes identical tick times.
- **Fires once per fleet**: deterministic schedules + a `Store` claim — a unique `(name, scheduled_for)` insert race exactly one instance wins. `MemoryStore` for single-instance apps and tests; `async/scheduler/postgres` ships the shared claim table (`ON CONFLICT DO NOTHING` race, goose migration, ctid-batched purge per pgeventbus/pgqueue precedent).
- **Failure semantics**: a failed claim or enqueue releases the claim and retries every `Config.RetryInterval` until it fires, another instance claims it, or the next tick supersedes it. Missed ticks are not replayed (only the latest due tick fires). Claims expire via a periodic sweep (`Retention`/`SweepInterval`).
- **Typed payloads**: `Add` (static payload) / `AddFunc` (payload built from the tick being fired — period-keyed payloads stay correct on catch-up) over `queue.Kind`, with `WithPushOptions` passthrough.
- **Tenancy seam**: `WithPushContext` injects the system tenant so a scope-configured `queue.Client` resolves instead of failing closed; single-tenant apps configure nothing.

## Benchmarks (Apple M3 Max)

```
BenchmarkCronParse-14                       417.7 ns/op   144 B/op   2 allocs/op
BenchmarkCronNext/every_minute-14           209.3 ns/op     0 B/op   0 allocs/op
BenchmarkCronNext/business_hours-14         592.2 ns/op     0 B/op   0 allocs/op
BenchmarkCronNext/monthly-14               1484 ns/op       0 B/op   0 allocs/op
BenchmarkCronNext/leap_day-14             11793 ns/op       0 B/op   0 allocs/op
BenchmarkEveryNext-14                        52.07 ns/op    0 B/op   0 allocs/op
BenchmarkMemoryStoreClaim/first_claim-14    477.4 ns/op   118 B/op   0 allocs/op
BenchmarkMemoryStoreClaim/duplicate-14       35.14 ns/op    0 B/op   0 allocs/op

postgres (integration):
BenchmarkClaim/first_claim-14            183352 ns/op     210 B/op   6 allocs/op
BenchmarkClaim/duplicate-14              150904 ns/op     210 B/op   6 allocs/op
```

Post-bench pass: `Next` is already zero-alloc; the leap-day worst case (~12µs, day-walk across two Februaries) runs once per fire and stays as-is per the readable-first rule.

## Testing

- Unit: cron parse/Next tables (steps, names, aliases, vixie OR, leap day, unsatisfiable specs, DST gap), Every alignment/determinism, MemoryStore claim/release/purge + 32-goroutine claim race, service tests over the memory broker (fires on schedule, AddFunc tick payloads, 3-instance fleet dedup, no catch-up at start, retry after broker outage, build-error retry, push-context scoping, sweep with mock clock, run guards, wiring panics).
- Integration (`-tags=integration`, testcontainers): pg claim race (16 goroutines, one winner), instant-vs-location keying, release, batched purge.
- `just lint` clean; full unit suite green; runnable `Example` round-trips scheduler → broker → queue worker.
