### PR TITLE
feat(async/workflow): DB-checkpointed linear step sequences with saga compensation

### DIFF
--- a/async/workflow/bench_test.go
+++ b/async/workflow/bench_test.go
@@ -1,0 +1,97 @@
+package workflow_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/async/workflow"
+)
+
+type benchState struct {
+	N int `json:"n"`
+}
+
+func benchWorkflow(name string, steps int) *workflow.Workflow[benchState] {
+	defs := make([]workflow.Step[benchState], 0, steps)
+	for i := range steps {
+		defs = append(defs, workflow.Step[benchState]{
+			Name: "step_" + strconv.Itoa(i),
+			Run:  func(_ context.Context, s *benchState) error { s.N++; return nil },
+		})
+	}
+	return workflow.New(name, defs...)
+}
+
+func BenchmarkStart_Memory(b *testing.B) {
+	wf := benchWorkflow("bench.start", 3)
+	eng := workflow.NewEngine(queue.NewMemoryBroker(), workflow.NewMemoryStore())
+	workflow.Register(eng, wf)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := workflow.Start(ctx, eng, wf, benchState{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkRunThroughput_Memory measures end-to-end runs per second through
+// the worker service: N runs started up front, the service drains them, and
+// each iteration is one completed run (steps, checkpoints, and queue
+// round-trips included).
+func BenchmarkRunThroughput_Memory(b *testing.B) {
+	for _, steps := range []int{1, 5} {
+		b.Run(fmt.Sprintf("steps_%d", steps), func(b *testing.B) {
+			var completed atomic.Int64
+			done := make(chan struct{}, 1)
+			wf := workflow.New("bench.throughput",
+				append(benchWorkflowSteps(steps-1), workflow.Step[benchState]{
+					Name: "last",
+					Run: func(context.Context, *benchState) error {
+						if completed.Add(1) == int64(b.N) {
+							done <- struct{}{}
+						}
+						return nil
+					},
+				})...)
+			eng := workflow.NewEngine(queue.NewMemoryBroker(), workflow.NewMemoryStore())
+			workflow.Register(eng, wf)
+			cfg := queue.DefaultConfig()
+			cfg.PollInterval = time.Millisecond
+			svc, err := workflow.NewService(eng, queue.WithConfig(cfg))
+			if err != nil {
+				b.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			stopped := make(chan struct{})
+			go func() { _ = svc.Run(ctx); close(stopped) }()
+			defer func() { cancel(); <-stopped }()
+
+			bctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if _, err := workflow.Start(bctx, eng, wf, benchState{}); err != nil {
+					b.Fatal(err)
+				}
+			}
+			<-done
+		})
+	}
+}
+
+func benchWorkflowSteps(n int) []workflow.Step[benchState] {
+	defs := make([]workflow.Step[benchState], 0, n)
+	for i := range n {
+		defs = append(defs, workflow.Step[benchState]{
+			Name: "step_" + strconv.Itoa(i),
+			Run:  func(_ context.Context, s *benchState) error { s.N++; return nil },
+		})
+	}
+	return defs
+}

--- a/async/workflow/doc.go
+++ b/async/workflow/doc.go
@@ -1,0 +1,60 @@
+// Package workflow runs DB-checkpointed linear step sequences over the queue
+// engine: a typed state value flows through named steps in order, the run is
+// checkpointed to a Store after every step, and a crashed or restarted worker
+// resumes from the last checkpoint instead of starting over. On permanent
+// failure, completed steps' compensations run in reverse order (a payout
+// pipeline that must undo its ledger debit). No DAG, no DSL, no timers — not a
+// Temporal clone.
+//
+// # Usage
+//
+//	type Onboard struct {
+//		UserID    string
+//		AccountID string
+//	}
+//
+//	var onboard = workflow.New("user.onboard",
+//		workflow.Step[Onboard]{Name: "create_account", Run: createAccount, Compensate: deleteAccount},
+//		workflow.Step[Onboard]{Name: "provision", Run: provision, Compensate: deprovision},
+//		workflow.Step[Onboard]{Name: "send_welcome", Run: sendWelcome},
+//	)
+//
+//	eng := workflow.NewEngine(broker, store)   // store: NewMemoryStore() or async/workflow/postgres
+//	workflow.Register(eng, onboard)
+//	svc, _ := workflow.NewService(eng)         // run under ops/supervisor
+//	runID, _ := workflow.Start(ctx, eng, onboard, Onboard{UserID: "u1"})
+//
+// Each workflow drains its own queue (named after the workflow), so a slow
+// workflow only delays itself. One handler invocation drives as many steps as
+// it can; every step boundary is a checkpoint, so the engine's at-least-once
+// redelivery — after a crash, a lost lease, or a retry — resumes at the first
+// incomplete step. A step can therefore run more than once: STEPS MUST BE
+// IDEMPOTENT, exactly like queue handlers.
+//
+// # Failure semantics
+//
+// A step error is transient by default: the run checkpoints the failed
+// attempt and the job retries with the worker's backoff, re-entering at the
+// same step. A step fails permanently when it returns workflow.Fail(err)
+// (business failure — no retry can help) or when its attempt budget
+// (Step.MaxAttempts, default WithStepAttempts) is spent. Permanent failure
+// flips the run to compensating: completed steps' Compensate funcs run newest
+// first, with the same checkpoint, retry, and budget rules; steps without a
+// Compensate are skipped. When compensation finishes — or no completed step
+// has one — the run ends failed with the original error recorded on
+// Run.Error. A compensation that exhausts its own budget dead-letters the
+// driving job with the run left compensating; queue.Client.Requeue resumes
+// compensation from the checkpoint. The run row in the Store is the source of
+// truth; inspect it (or the engine's log) for outcomes.
+//
+// The driving job's attempt budget is derived from the sum of all step and
+// compensation budgets plus a margin for infrastructure hiccups, so the queue
+// engine never dead-letters a run that is still making progress. If a run
+// does dead-letter (e.g. the Store was down for a long stretch), the
+// checkpoint is intact and queue.Client.Requeue resumes it.
+//
+// Multi-tenant apps configure workflow.WithScope on the engine (captures the
+// tenant into the run and its job, fail-closed) and pass
+// queue.WithScopeContext to NewService (restores it into step context).
+// Single-tenant apps configure neither.
+package workflow

--- a/async/workflow/doc.go
+++ b/async/workflow/doc.go
@@ -35,9 +35,12 @@
 //
 // A step error is transient by default: the run checkpoints the failed
 // attempt and the job retries with the worker's backoff, re-entering at the
-// same step. A step fails permanently when it returns workflow.Fail(err)
-// (business failure — no retry can help) or when its attempt budget
-// (Step.MaxAttempts, default WithStepAttempts) is spent. Permanent failure
+// same step. A handler-timeout expiry mid-step counts as a transient failure
+// of that step (a chronically slow step eventually spends its budget); a
+// lost queue lease does not — the new claim owns the run. A step fails
+// permanently when it returns workflow.Fail(err) (business failure — no
+// retry can help) or when its attempt budget (Step.MaxAttempts, default
+// WithStepAttempts) is spent. Permanent failure
 // flips the run to compensating: completed steps' Compensate funcs run newest
 // first, with the same checkpoint, retry, and budget rules; steps without a
 // Compensate are skipped. When compensation finishes — or no completed step

--- a/async/workflow/engine.go
+++ b/async/workflow/engine.go
@@ -1,0 +1,221 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+// wireVersion versions the driving-job envelope for cross-deploy safety.
+const wireVersion = 1
+
+// runAttemptMargin pads the driving job's attempt budget beyond the sum of
+// step budgets: invocations that burn a job attempt without burning a step
+// attempt (store outages, shutdown or lease loss mid-step) must not
+// dead-letter a run that is still making progress.
+const runAttemptMargin = 10
+
+// runEnvelope is the driving job's payload: everything else lives in the
+// Store, so redeliveries always see the freshest checkpoint.
+type runEnvelope struct {
+	RunID string `json:"run_id"`
+	V     int    `json:"v"`
+}
+
+// registration is one workflow's type-erased wiring on the engine.
+type registration struct {
+	def            any // the *Workflow[S], identity-checked by Start
+	handle         func(ctx context.Context, env runEnvelope) error
+	hopts          []queue.HandlerOption
+	jobMaxAttempts int
+}
+
+// Engine wires workflows to a queue broker and a checkpoint Store. Wire it
+// once at startup: Register every workflow, then share it app-wide — Start is
+// safe for concurrent use; Register is not safe to call concurrently with
+// Start or a running Service. Processes that only start runs construct the
+// same wiring but simply do not run the Service.
+type Engine struct {
+	broker       queue.Broker
+	store        Store
+	scope        func(ctx context.Context) (string, error)
+	clk          clock.Clock
+	log          *slog.Logger
+	workflows    map[string]*registration
+	stepAttempts int
+}
+
+// NewEngine builds an engine over broker and store. Panics on a nil broker or
+// store — the engine is startup wiring, not runtime data.
+func NewEngine(broker queue.Broker, store Store, opts ...Option) *Engine {
+	if broker == nil {
+		panic("workflow: NewEngine requires a broker")
+	}
+	if store == nil {
+		panic("workflow: NewEngine requires a store")
+	}
+	e := &Engine{
+		broker:       broker,
+		store:        store,
+		clk:          clock.System(),
+		log:          logger.NewNope(),
+		workflows:    make(map[string]*registration),
+		stepAttempts: 5,
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// Register binds wf to the engine. Panics on a nil workflow or a duplicate
+// name — registrations are startup wiring, and failing fast beats two
+// definitions silently competing for one queue.
+func Register[S any](e *Engine, wf *Workflow[S], opts ...RegisterOption) {
+	if wf == nil {
+		panic("workflow: Register with a nil workflow")
+	}
+	if _, dup := e.workflows[wf.name]; dup {
+		panic(fmt.Sprintf("workflow: duplicate registration for workflow %q", wf.name))
+	}
+	total := runAttemptMargin
+	for _, st := range wf.steps {
+		total += e.stepBudget(st.MaxAttempts)
+		if st.Compensate != nil {
+			total += e.stepBudget(st.MaxAttempts)
+		}
+	}
+	reg := &registration{def: wf, jobMaxAttempts: total}
+	reg.handle = newRunner(e, wf)
+	for _, opt := range opts {
+		opt(reg)
+	}
+	e.workflows[wf.name] = reg
+}
+
+// stepBudget resolves a step's attempt budget against the engine default.
+func (e *Engine) stepBudget(n int) int {
+	if n > 0 {
+		return n
+	}
+	return e.stepAttempts
+}
+
+// Start creates a run of wf with the given initial state and enqueues its
+// driving job; it returns the run id to poll the Store with. The workflow
+// must be Registered on this engine (ErrNotRegistered otherwise). A run whose
+// job cannot be enqueued is marked failed in the Store before Start returns
+// the push error, so it never lingers looking alive.
+func Start[S any](ctx context.Context, e *Engine, wf *Workflow[S], state S, opts ...StartOption) (string, error) {
+	reg, ok := e.workflows[wf.Name()]
+	if !ok {
+		return "", fmt.Errorf("%w: %q", ErrNotRegistered, wf.Name())
+	}
+	if reg.def != any(wf) {
+		return "", fmt.Errorf("%w: Start(%q) called with a different definition than registered", ErrNotRegistered, wf.Name())
+	}
+	var cfg startConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	scope := ""
+	if e.scope != nil {
+		s, err := e.scope(ctx)
+		if err != nil {
+			return "", fmt.Errorf("%w: %w", ErrScopeMissing, err)
+		}
+		if s == "" {
+			return "", ErrScopeMissing
+		}
+		scope = s
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("workflow: marshal state for %q: %w", wf.Name(), err)
+	}
+	runID := cfg.runID
+	if runID == "" {
+		runID = id.NewUUID().String()
+	}
+	now := e.clk.Now().UTC()
+	run := Run{
+		ID:        runID,
+		Workflow:  wf.Name(),
+		Scope:     scope,
+		Status:    StatusRunning,
+		State:     raw,
+		Version:   1,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := e.store.Create(ctx, run); err != nil {
+		return "", fmt.Errorf("workflow: create run for %q: %w", wf.Name(), err)
+	}
+	payload, err := json.Marshal(runEnvelope{V: wireVersion, RunID: runID})
+	if err != nil {
+		return "", fmt.Errorf("workflow: encode envelope for %q: %w", wf.Name(), err)
+	}
+	job := queue.Job{
+		ID:          id.NewUUID().String(),
+		Queue:       wf.Name(),
+		Type:        wf.Name(),
+		Payload:     payload,
+		Scope:       scope,
+		MaxAttempts: reg.jobMaxAttempts,
+		RunAt:       now,
+		CreatedAt:   now,
+	}
+	if err := e.broker.Push(ctx, job); err != nil {
+		pushErr := fmt.Errorf("workflow: enqueue run %q for %q: %w", runID, wf.Name(), err)
+		run.Status = StatusFailed
+		run.Error = "workflow: enqueue failed: " + err.Error()
+		run.UpdatedAt = e.clk.Now().UTC()
+		if uerr := e.store.Update(ctx, run); uerr != nil {
+			return "", errors.Join(pushErr, fmt.Errorf("workflow: mark run %q failed: %w", runID, uerr))
+		}
+		return "", pushErr
+	}
+	return runID, nil
+}
+
+// NewService builds the worker that executes registered workflows: a
+// queue.Service over the engine's broker with one equal-weight queue per
+// workflow (a slow workflow only delays itself). Run it under ops/supervisor
+// next to any job-queue Service — the default service name is "workflow".
+//
+// opts pass through to queue.NewService: concurrency, logger, config,
+// queue.WithScopeContext for tenancy restore, and a name override all work as
+// on a plain queue worker. Do not pass queue.WithQueues — the engine owns the
+// queue set, and NewService overrides it.
+//
+// The service snapshots the engine's registrations at construction: Register
+// everything first, then build the service. Returns ErrNoWorkflows when
+// nothing was registered.
+func NewService(e *Engine, opts ...queue.ServiceOption) (*queue.Service, error) {
+	if len(e.workflows) == 0 {
+		return nil, ErrNoWorkflows
+	}
+	weights := make(map[string]int, len(e.workflows))
+	for name := range e.workflows {
+		weights[name] = 1
+	}
+	svcOpts := make([]queue.ServiceOption, 0, len(opts)+2)
+	svcOpts = append(svcOpts, queue.WithName("workflow"))
+	svcOpts = append(svcOpts, opts...)
+	svcOpts = append(svcOpts, queue.WithQueues(weights))
+	svc, err := queue.NewService(e.broker, svcOpts...)
+	if err != nil {
+		return nil, err
+	}
+	for name, reg := range e.workflows {
+		queue.Register(svc, queue.NewKind[runEnvelope](name), reg.handle, reg.hopts...)
+	}
+	return svc, nil
+}

--- a/async/workflow/engine.go
+++ b/async/workflow/engine.go
@@ -110,9 +110,14 @@ func (e *Engine) stepBudget(n int) int {
 
 // Start creates a run of wf with the given initial state and enqueues its
 // driving job; it returns the run id to poll the Store with. The workflow
-// must be Registered on this engine (ErrNotRegistered otherwise). A run whose
-// job cannot be enqueued is marked failed in the Store before Start returns
-// the push error, so it never lingers looking alive.
+// must be Registered on this engine (ErrNotRegistered otherwise).
+//
+// Start is create-then-enqueue, rolled back on failure: a run whose driving
+// job cannot be pushed is deleted again before Start returns the push error,
+// so a retried Start — including one reusing a WithRunID business key — can
+// succeed. In the rare double failure (push and delete both fail) and after
+// a process crash between create and push, the run lingers running with no
+// driving job; repair via Store.Delete.
 func Start[S any](ctx context.Context, e *Engine, wf *Workflow[S], state S, opts ...StartOption) (string, error) {
 	reg, ok := e.workflows[wf.Name()]
 	if !ok {
@@ -174,11 +179,11 @@ func Start[S any](ctx context.Context, e *Engine, wf *Workflow[S], state S, opts
 	}
 	if err := e.broker.Push(ctx, job); err != nil {
 		pushErr := fmt.Errorf("workflow: enqueue run %q for %q: %w", runID, wf.Name(), err)
-		run.Status = StatusFailed
-		run.Error = "workflow: enqueue failed: " + err.Error()
-		run.UpdatedAt = e.clk.Now().UTC()
-		if uerr := e.store.Update(ctx, run); uerr != nil {
-			return "", errors.Join(pushErr, fmt.Errorf("workflow: mark run %q failed: %w", runID, uerr))
+		// Roll back under a non-cancelable context: the push often failed
+		// BECAUSE ctx died, and the rollback must still land or the run id
+		// stays consumed with no driving job.
+		if derr := e.store.Delete(context.WithoutCancel(ctx), runID); derr != nil {
+			return "", errors.Join(pushErr, fmt.Errorf("workflow: roll back run %q: %w", runID, derr))
 		}
 		return "", pushErr
 	}

--- a/async/workflow/engine_test.go
+++ b/async/workflow/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -208,27 +209,38 @@ func TestStart_Validation(t *testing.T) {
 		assert.ErrorIs(t, err, workflow.ErrScopeMissing)
 	})
 
-	t.Run("push failure marks the run failed", func(t *testing.T) {
+	t.Run("push failure rolls the run back and does not consume the id", func(t *testing.T) {
 		t.Parallel()
 		store := workflow.NewMemoryStore()
-		eng := workflow.NewEngine(&failingPushBroker{Broker: queue.NewMemoryBroker()}, store)
+		broker := &failingPushBroker{Broker: queue.NewMemoryBroker()}
+		broker.fail.Store(true)
+		eng := workflow.NewEngine(broker, store)
 		wf := workflow.New("wf.pushfail", workflow.Step[state]{Name: "a", Run: func(context.Context, *state) error { return nil }})
 		workflow.Register(eng, wf)
 		_, err := workflow.Start(ctx, eng, wf, state{}, workflow.WithRunID("r1"))
 		require.Error(t, err)
+		assert.NotErrorIs(t, err, workflow.ErrRunAlreadyExists)
 
-		run, gerr := store.Get(ctx, "r1")
-		require.NoError(t, gerr)
-		assert.Equal(t, workflow.StatusFailed, run.Status)
-		assert.Contains(t, run.Error, "enqueue failed")
+		_, gerr := store.Get(ctx, "r1")
+		assert.ErrorIs(t, gerr, workflow.ErrRunNotFound, "the rolled-back run must not linger")
+
+		// The broker recovers: retrying the same business key succeeds.
+		broker.fail.Store(false)
+		_, err = workflow.Start(ctx, eng, wf, state{}, workflow.WithRunID("r1"))
+		require.NoError(t, err)
 	})
 }
 
+// failingPushBroker fails Push until fail is flipped to false.
 type failingPushBroker struct {
 	queue.Broker
+	fail atomic.Bool
 }
 
-func (b *failingPushBroker) Push(context.Context, ...queue.Job) error {
+func (b *failingPushBroker) Push(ctx context.Context, jobs ...queue.Job) error {
+	if !b.fail.Load() {
+		return b.Broker.Push(ctx, jobs...)
+	}
 	return errors.New("broker down")
 }
 
@@ -439,6 +451,99 @@ func TestRun_CompensationExhaustionDeadLettersAndRequeueResumes(t *testing.T) {
 	require.NoError(t, client.Requeue(context.Background(), dead[0].ID))
 	run = waitStatus(t, store, runID, workflow.StatusFailed)
 	assert.Equal(t, []string{"a", "undo:a"}, decodeLog(t, run))
+}
+
+// TestRun_PermanentVerdictUnderCancelledContextStillCompensates guards the
+// verdict-vs-cancellation ordering: a step returning queue.Cancel just as its
+// handler timeout fires must take the permanent path (compensation), not leak
+// the verdict to the queue engine — which would ack the driving job and
+// orphan the run as running forever.
+func TestRun_PermanentVerdictUnderCancelledContextStillCompensates(t *testing.T) {
+	t.Parallel()
+	rec := newRecorder()
+	wf := workflow.New("wf.cancelrace",
+		step(rec, "a", nil, comp(rec, "a", nil)),
+		workflow.Step[state]{
+			Name: "b",
+			Run: func(ctx context.Context, _ *state) error {
+				rec.hit("b")
+				<-ctx.Done() // outlive the handler timeout, then verdict
+				return queue.Cancel
+			},
+		},
+	)
+	store, client, runID := startAndDrive(t, wf, workflow.WithHandlerTimeout(50*time.Millisecond))
+	run := waitStatus(t, store, runID, workflow.StatusFailed)
+
+	assert.Equal(t, []string{"a", "undo:a"}, decodeLog(t, run))
+	dead, err := client.ListDead(context.Background(), wf.Name(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, dead)
+}
+
+// TestRun_ChronicTimeoutSpendsBudgetAndCompensates guards the deadline rule:
+// a step that reliably outlives its handler timeout burns its attempt budget
+// like any other failure and eventually compensates, instead of dead-lettering
+// with the run stuck running.
+func TestRun_ChronicTimeoutSpendsBudgetAndCompensates(t *testing.T) {
+	t.Parallel()
+	rec := newRecorder()
+	wf := workflow.New("wf.slowstep",
+		step(rec, "a", nil, comp(rec, "a", nil)),
+		workflow.Step[state]{
+			Name:        "b",
+			MaxAttempts: 2,
+			Run: func(ctx context.Context, _ *state) error {
+				rec.hit("b")
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		},
+	)
+	store, client, runID := startAndDrive(t, wf, workflow.WithHandlerTimeout(50*time.Millisecond))
+	run := waitStatus(t, store, runID, workflow.StatusFailed)
+
+	assert.Equal(t, 2, rec.count("b"))
+	assert.Equal(t, []string{"a", "undo:a"}, decodeLog(t, run))
+	dead, err := client.ListDead(context.Background(), wf.Name(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, dead)
+}
+
+// TestRun_UndecodableStateIsAbandonedWithReason guards the poison path: state
+// that no longer decodes (schema drift) dead-letters the driving job AND
+// records why on the run, keeping the store diagnosable.
+func TestRun_UndecodableStateIsAbandonedWithReason(t *testing.T) {
+	t.Parallel()
+	wf := workflow.New("wf.badstate",
+		workflow.Step[state]{Name: "a", Run: func(context.Context, *state) error { return nil }})
+	broker := queue.NewMemoryBroker()
+	store := workflow.NewMemoryStore()
+	eng := workflow.NewEngine(broker, store)
+	workflow.Register(eng, wf)
+	svc, err := workflow.NewService(eng, queue.WithConfig(fastConfig()))
+	require.NoError(t, err)
+	runService(t, svc)
+
+	// A run whose checkpoint no longer matches the state schema, delivered by
+	// hand — as after a deploy that changed S incompatibly.
+	ctx := context.Background()
+	require.NoError(t, store.Create(ctx, workflow.Run{
+		ID: "r-bad", Workflow: wf.Name(), Status: workflow.StatusRunning,
+		State: []byte(`{"log":123}`), Version: 1,
+	}))
+	client := queue.NewClient(broker)
+	require.NoError(t, client.PushRaw(ctx, wf.Name(), []byte(`{"run_id":"r-bad","v":1}`), queue.WithQueue(wf.Name())))
+
+	require.Eventually(t, func() bool {
+		dead, derr := client.ListDead(ctx, wf.Name(), 10)
+		require.NoError(t, derr)
+		return len(dead) == 1
+	}, 5*time.Second, 5*time.Millisecond)
+	run, err := store.Get(ctx, "r-bad")
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusRunning, run.Status, "abandonment must not fake a terminal status")
+	assert.Contains(t, run.Error, "decode state")
 }
 
 func TestRun_DuplicateDeliveryOfFinishedRunIsNoop(t *testing.T) {

--- a/async/workflow/engine_test.go
+++ b/async/workflow/engine_test.go
@@ -1,0 +1,530 @@
+package workflow_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/async/workflow"
+	"github.com/dmitrymomot/forge/resilience/backoff"
+)
+
+type state struct {
+	Log []string `json:"log"`
+}
+
+// recorder counts step invocations outside the checkpointed state, so tests
+// can tell "ran again after redelivery" from "resumed past the checkpoint".
+type recorder struct {
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func newRecorder() *recorder { return &recorder{calls: make(map[string]int)} }
+
+func (r *recorder) hit(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls[name]++
+}
+
+func (r *recorder) count(name string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls[name]
+}
+
+// step returns a Step that records its invocation, appends its name to the
+// state log, and delegates the verdict to fn (nil fn always succeeds).
+func step(rec *recorder, name string, fn func(calls int) error, comp func(ctx context.Context, s *state) error) workflow.Step[state] {
+	return workflow.Step[state]{
+		Name: name,
+		Run: func(_ context.Context, s *state) error {
+			rec.hit(name)
+			if fn != nil {
+				if err := fn(rec.count(name)); err != nil {
+					return err
+				}
+			}
+			s.Log = append(s.Log, name)
+			return nil
+		},
+		Compensate: comp,
+	}
+}
+
+// comp returns a compensation that records its invocation and appends
+// "undo:<name>" to the state log; fn (optional) can veto with an error.
+func comp(rec *recorder, name string, fn func(calls int) error) func(ctx context.Context, s *state) error {
+	key := "undo:" + name
+	return func(_ context.Context, s *state) error {
+		rec.hit(key)
+		if fn != nil {
+			if err := fn(rec.count(key)); err != nil {
+				return err
+			}
+		}
+		s.Log = append(s.Log, key)
+		return nil
+	}
+}
+
+func fastConfig() queue.Config {
+	cfg := queue.DefaultConfig()
+	cfg.PollInterval = 5 * time.Millisecond
+	return cfg
+}
+
+// runService starts svc and returns a stop func that cancels it and waits for
+// drain.
+func runService(t *testing.T, svc *queue.Service) func() {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() { _ = svc.Run(ctx); close(stopped) }()
+	stop := func() {
+		cancel()
+		<-stopped
+	}
+	t.Cleanup(stop)
+	return stop
+}
+
+// startAndDrive registers wf on a fresh engine over a memory broker+store,
+// starts the worker, and starts one run.
+func startAndDrive(t *testing.T, wf *workflow.Workflow[state], regOpts ...workflow.RegisterOption) (*workflow.MemoryStore, *queue.Client, string) {
+	t.Helper()
+	broker := queue.NewMemoryBroker()
+	store := workflow.NewMemoryStore()
+	eng := workflow.NewEngine(broker, store)
+	regOpts = append([]workflow.RegisterOption{workflow.WithRetryBackoff(backoff.Constant(0))}, regOpts...)
+	workflow.Register(eng, wf, regOpts...)
+	svc, err := workflow.NewService(eng, queue.WithConfig(fastConfig()))
+	require.NoError(t, err)
+	runService(t, svc)
+	runID, err := workflow.Start(context.Background(), eng, wf, state{})
+	require.NoError(t, err)
+	return store, queue.NewClient(broker), runID
+}
+
+func waitStatus(t *testing.T, store workflow.Store, runID string, want workflow.Status) workflow.Run {
+	t.Helper()
+	var run workflow.Run
+	require.Eventually(t, func() bool {
+		r, err := store.Get(context.Background(), runID)
+		if err != nil {
+			return false
+		}
+		run = r
+		return run.Status == want
+	}, 5*time.Second, 5*time.Millisecond, "run %s never reached %s", runID, want)
+	return run
+}
+
+func decodeLog(t *testing.T, run workflow.Run) []string {
+	t.Helper()
+	var s state
+	require.NoError(t, json.Unmarshal(run.State, &s))
+	return s.Log
+}
+
+func TestNewEngine(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { workflow.NewEngine(nil, workflow.NewMemoryStore()) })
+	assert.Panics(t, func() { workflow.NewEngine(queue.NewMemoryBroker(), nil) })
+}
+
+func TestRegister(t *testing.T) {
+	t.Parallel()
+	eng := workflow.NewEngine(queue.NewMemoryBroker(), workflow.NewMemoryStore())
+	wf := workflow.New("wf.dup", workflow.Step[state]{Name: "a", Run: func(context.Context, *state) error { return nil }})
+	workflow.Register(eng, wf)
+	assert.Panics(t, func() { workflow.Register(eng, wf) })
+	assert.Panics(t, func() { workflow.Register[state](eng, nil) })
+}
+
+func TestNewService(t *testing.T) {
+	t.Parallel()
+	eng := workflow.NewEngine(queue.NewMemoryBroker(), workflow.NewMemoryStore())
+	_, err := workflow.NewService(eng)
+	assert.ErrorIs(t, err, workflow.ErrNoWorkflows)
+
+	wf := workflow.New("wf.svc", workflow.Step[state]{Name: "a", Run: func(context.Context, *state) error { return nil }})
+	workflow.Register(eng, wf)
+	svc, err := workflow.NewService(eng)
+	require.NoError(t, err)
+	assert.Equal(t, "workflow", svc.Name())
+}
+
+func TestStart_Validation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("unregistered workflow", func(t *testing.T) {
+		t.Parallel()
+		eng := workflow.NewEngine(queue.NewMemoryBroker(), workflow.NewMemoryStore())
+		wf := workflow.New("wf.unreg", workflow.Step[state]{Name: "a", Run: func(context.Context, *state) error { return nil }})
+		_, err := workflow.Start(ctx, eng, wf, state{})
+		assert.ErrorIs(t, err, workflow.ErrNotRegistered)
+	})
+
+	t.Run("different definition than registered", func(t *testing.T) {
+		t.Parallel()
+		eng := workflow.NewEngine(queue.NewMemoryBroker(), workflow.NewMemoryStore())
+		run := func(context.Context, *state) error { return nil }
+		registered := workflow.New("wf.twin", workflow.Step[state]{Name: "a", Run: run})
+		impostor := workflow.New("wf.twin", workflow.Step[state]{Name: "b", Run: run})
+		workflow.Register(eng, registered)
+		_, err := workflow.Start(ctx, eng, impostor, state{})
+		assert.ErrorIs(t, err, workflow.ErrNotRegistered)
+	})
+
+	t.Run("duplicate run id", func(t *testing.T) {
+		t.Parallel()
+		eng := workflow.NewEngine(queue.NewMemoryBroker(), workflow.NewMemoryStore())
+		wf := workflow.New("wf.dupid", workflow.Step[state]{Name: "a", Run: func(context.Context, *state) error { return nil }})
+		workflow.Register(eng, wf)
+		_, err := workflow.Start(ctx, eng, wf, state{}, workflow.WithRunID("onboard:u1"))
+		require.NoError(t, err)
+		_, err = workflow.Start(ctx, eng, wf, state{}, workflow.WithRunID("onboard:u1"))
+		assert.ErrorIs(t, err, workflow.ErrRunAlreadyExists)
+	})
+
+	t.Run("scope fail-closed", func(t *testing.T) {
+		t.Parallel()
+		eng := workflow.NewEngine(queue.NewMemoryBroker(), workflow.NewMemoryStore(),
+			workflow.WithScope(func(context.Context) (string, error) { return "", nil }))
+		wf := workflow.New("wf.scope", workflow.Step[state]{Name: "a", Run: func(context.Context, *state) error { return nil }})
+		workflow.Register(eng, wf)
+		_, err := workflow.Start(ctx, eng, wf, state{})
+		assert.ErrorIs(t, err, workflow.ErrScopeMissing)
+	})
+
+	t.Run("push failure marks the run failed", func(t *testing.T) {
+		t.Parallel()
+		store := workflow.NewMemoryStore()
+		eng := workflow.NewEngine(&failingPushBroker{Broker: queue.NewMemoryBroker()}, store)
+		wf := workflow.New("wf.pushfail", workflow.Step[state]{Name: "a", Run: func(context.Context, *state) error { return nil }})
+		workflow.Register(eng, wf)
+		_, err := workflow.Start(ctx, eng, wf, state{}, workflow.WithRunID("r1"))
+		require.Error(t, err)
+
+		run, gerr := store.Get(ctx, "r1")
+		require.NoError(t, gerr)
+		assert.Equal(t, workflow.StatusFailed, run.Status)
+		assert.Contains(t, run.Error, "enqueue failed")
+	})
+}
+
+type failingPushBroker struct {
+	queue.Broker
+}
+
+func (b *failingPushBroker) Push(context.Context, ...queue.Job) error {
+	return errors.New("broker down")
+}
+
+func TestRun_CompletesAndCheckpointsState(t *testing.T) {
+	t.Parallel()
+	rec := newRecorder()
+	wf := workflow.New("wf.happy",
+		step(rec, "a", nil, nil),
+		step(rec, "b", nil, nil),
+		step(rec, "c", nil, nil),
+	)
+	store, _, runID := startAndDrive(t, wf)
+	run := waitStatus(t, store, runID, workflow.StatusCompleted)
+
+	assert.Equal(t, []string{"a", "b", "c"}, decodeLog(t, run))
+	assert.Equal(t, 1, rec.count("a"))
+	assert.Equal(t, 1, rec.count("b"))
+	assert.Equal(t, 1, rec.count("c"))
+	assert.Equal(t, 3, run.Step)
+	assert.Empty(t, run.Error)
+}
+
+func TestRun_TransientFailureResumesFromCheckpoint(t *testing.T) {
+	t.Parallel()
+	rec := newRecorder()
+	wf := workflow.New("wf.retry",
+		step(rec, "a", nil, nil),
+		step(rec, "b", func(calls int) error {
+			if calls <= 2 {
+				return fmt.Errorf("transient %d", calls)
+			}
+			return nil
+		}, nil),
+	)
+	store, _, runID := startAndDrive(t, wf)
+	run := waitStatus(t, store, runID, workflow.StatusCompleted)
+
+	assert.Equal(t, []string{"a", "b"}, decodeLog(t, run))
+	assert.Equal(t, 1, rec.count("a"), "checkpointed step must not re-run on retry")
+	assert.Equal(t, 3, rec.count("b"))
+}
+
+func TestRun_FailVerdictCompensatesInReverse(t *testing.T) {
+	t.Parallel()
+	rec := newRecorder()
+	wf := workflow.New("wf.saga",
+		step(rec, "debit", nil, comp(rec, "debit", nil)),
+		step(rec, "hold", nil, nil), // no compensation: must be skipped
+		step(rec, "transfer", nil, comp(rec, "transfer", nil)),
+		step(rec, "notify", func(int) error {
+			return workflow.Fail(errors.New("recipient rejected"))
+		}, comp(rec, "notify", nil)),
+	)
+	store, _, runID := startAndDrive(t, wf)
+	run := waitStatus(t, store, runID, workflow.StatusFailed)
+
+	assert.Equal(t, []string{"debit", "hold", "transfer", "undo:transfer", "undo:debit"}, decodeLog(t, run))
+	assert.Equal(t, 0, rec.count("undo:notify"), "the failing step never completed, so it must not compensate")
+	assert.Contains(t, run.Error, "recipient rejected")
+	assert.Equal(t, 1, rec.count("notify"), "Fail is permanent: no retries")
+}
+
+func TestRun_AttemptBudgetExhaustionCompensates(t *testing.T) {
+	t.Parallel()
+	rec := newRecorder()
+	wf := workflow.New("wf.budget",
+		step(rec, "a", nil, comp(rec, "a", nil)),
+		workflow.Step[state]{
+			Name:        "b",
+			MaxAttempts: 2,
+			Run: func(context.Context, *state) error {
+				rec.hit("b")
+				return errors.New("always down")
+			},
+		},
+	)
+	store, _, runID := startAndDrive(t, wf)
+	run := waitStatus(t, store, runID, workflow.StatusFailed)
+
+	assert.Equal(t, 2, rec.count("b"), "budget of 2 means exactly 2 attempts")
+	assert.Equal(t, []string{"a", "undo:a"}, decodeLog(t, run))
+	assert.Contains(t, run.Error, "always down")
+}
+
+func TestRun_PanicBurnsAttempts(t *testing.T) {
+	t.Parallel()
+	rec := newRecorder()
+	wf := workflow.New("wf.panic",
+		step(rec, "a", nil, comp(rec, "a", nil)),
+		workflow.Step[state]{
+			Name:        "b",
+			MaxAttempts: 1,
+			Run: func(context.Context, *state) error {
+				rec.hit("b")
+				panic("boom")
+			},
+		},
+	)
+	store, _, runID := startAndDrive(t, wf)
+	run := waitStatus(t, store, runID, workflow.StatusFailed)
+
+	assert.Equal(t, 1, rec.count("b"))
+	assert.Equal(t, []string{"a", "undo:a"}, decodeLog(t, run))
+	assert.Contains(t, run.Error, "panic")
+}
+
+func TestRun_NoCompensationsFailsDirectly(t *testing.T) {
+	t.Parallel()
+	rec := newRecorder()
+	wf := workflow.New("wf.nocomp",
+		step(rec, "a", nil, nil),
+		step(rec, "b", func(int) error { return workflow.Fail(errors.New("dead end")) }, nil),
+	)
+	store, _, runID := startAndDrive(t, wf)
+	run := waitStatus(t, store, runID, workflow.StatusFailed)
+	assert.Equal(t, []string{"a"}, decodeLog(t, run))
+	assert.Contains(t, run.Error, "dead end")
+}
+
+func TestRun_QueueVerdictsFromStepsArePermanent(t *testing.T) {
+	t.Parallel()
+	for name, verdict := range map[string]error{
+		"skip_retry": queue.SkipRetry(errors.New("poison")),
+		"cancel":     queue.Cancel,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			rec := newRecorder()
+			wf := workflow.New("wf.verdict."+name,
+				step(rec, "a", nil, comp(rec, "a", nil)),
+				step(rec, "b", func(int) error { return verdict }, nil),
+			)
+			store, client, runID := startAndDrive(t, wf)
+			run := waitStatus(t, store, runID, workflow.StatusFailed)
+
+			assert.Equal(t, 1, rec.count("b"))
+			assert.Equal(t, []string{"a", "undo:a"}, decodeLog(t, run))
+			dead, err := client.ListDead(context.Background(), wf.Name(), 10)
+			require.NoError(t, err)
+			assert.Empty(t, dead, "a permanent step failure compensates; it must not dead-letter the driving job")
+		})
+	}
+}
+
+func TestRun_CompensationRetriesTransiently(t *testing.T) {
+	t.Parallel()
+	rec := newRecorder()
+	wf := workflow.New("wf.compretry",
+		step(rec, "a", nil, comp(rec, "a", func(calls int) error {
+			if calls == 1 {
+				return errors.New("undo hiccup")
+			}
+			return nil
+		})),
+		step(rec, "b", func(int) error { return workflow.Fail(errors.New("nope")) }, nil),
+	)
+	store, _, runID := startAndDrive(t, wf)
+	run := waitStatus(t, store, runID, workflow.StatusFailed)
+
+	assert.Equal(t, 2, rec.count("undo:a"))
+	assert.Equal(t, []string{"a", "undo:a"}, decodeLog(t, run))
+}
+
+func TestRun_CompensationExhaustionDeadLettersAndRequeueResumes(t *testing.T) {
+	t.Parallel()
+	rec := newRecorder()
+	var allow sync.Map // flips to true when the test un-breaks the compensation
+	wf := workflow.New("wf.compdead",
+		workflow.Step[state]{
+			Name:        "a",
+			MaxAttempts: 2,
+			Run: func(_ context.Context, s *state) error {
+				rec.hit("a")
+				s.Log = append(s.Log, "a")
+				return nil
+			},
+			Compensate: func(_ context.Context, s *state) error {
+				rec.hit("undo:a")
+				if _, ok := allow.Load("ok"); !ok {
+					return errors.New("undo broken")
+				}
+				s.Log = append(s.Log, "undo:a")
+				return nil
+			},
+		},
+		step(rec, "b", func(int) error { return workflow.Fail(errors.New("nope")) }, nil),
+	)
+	store, client, runID := startAndDrive(t, wf)
+
+	// The compensation burns its budget and the driving job dead-letters,
+	// with the run parked compensating and its attempt counter reset.
+	require.Eventually(t, func() bool {
+		jobs, lerr := client.ListDead(context.Background(), wf.Name(), 10)
+		require.NoError(t, lerr)
+		return len(jobs) == 1
+	}, 5*time.Second, 5*time.Millisecond)
+	dead, err := client.ListDead(context.Background(), wf.Name(), 10)
+	require.NoError(t, err)
+	require.Len(t, dead, 1)
+	run, err := store.Get(context.Background(), runID)
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompensating, run.Status)
+	assert.Equal(t, 0, run.Attempt, "attempt counter must reset so a requeue gets a fresh budget")
+	assert.Equal(t, 2, rec.count("undo:a"))
+
+	// Requeue resumes the unwind from the checkpoint.
+	allow.Store("ok", true)
+	require.NoError(t, client.Requeue(context.Background(), dead[0].ID))
+	run = waitStatus(t, store, runID, workflow.StatusFailed)
+	assert.Equal(t, []string{"a", "undo:a"}, decodeLog(t, run))
+}
+
+func TestRun_DuplicateDeliveryOfFinishedRunIsNoop(t *testing.T) {
+	t.Parallel()
+	rec := newRecorder()
+	wf := workflow.New("wf.dupdelivery", step(rec, "a", nil, nil))
+	broker := queue.NewMemoryBroker()
+	store := workflow.NewMemoryStore()
+	eng := workflow.NewEngine(broker, store)
+	workflow.Register(eng, wf)
+	svc, err := workflow.NewService(eng, queue.WithConfig(fastConfig()))
+	require.NoError(t, err)
+	runService(t, svc)
+
+	runID, err := workflow.Start(context.Background(), eng, wf, state{})
+	require.NoError(t, err)
+	waitStatus(t, store, runID, workflow.StatusCompleted)
+
+	// Redeliver the envelope by hand — the at-least-once case.
+	client := queue.NewClient(broker)
+	require.NoError(t, client.PushRaw(context.Background(), wf.Name(),
+		fmt.Appendf(nil, `{"run_id":%q,"v":1}`, runID), queue.WithQueue(wf.Name())))
+	require.Eventually(t, func() bool {
+		stats, serr := client.Stats(context.Background())
+		require.NoError(t, serr)
+		return stats[wf.Name()].Pending == 0
+	}, 5*time.Second, 5*time.Millisecond)
+
+	assert.Equal(t, 1, rec.count("a"), "a finished run must not re-run steps on duplicate delivery")
+	run, err := store.Get(context.Background(), runID)
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, run.Status)
+}
+
+func TestRun_FailedStepMutationsDoNotLeakIntoCompensation(t *testing.T) {
+	t.Parallel()
+	rec := newRecorder()
+	wf := workflow.New("wf.stateleak",
+		step(rec, "a", nil, comp(rec, "a", nil)),
+		workflow.Step[state]{
+			Name:        "b",
+			MaxAttempts: 1,
+			Run: func(_ context.Context, s *state) error {
+				s.Log = append(s.Log, "b-partial") // mutates, then fails
+				return errors.New("late failure")
+			},
+		},
+	)
+	store, _, runID := startAndDrive(t, wf)
+	run := waitStatus(t, store, runID, workflow.StatusFailed)
+
+	assert.Equal(t, []string{"a", "undo:a"}, decodeLog(t, run), "the failed step's partial mutation must not survive")
+}
+
+func TestRun_ScopeIsCapturedAndRestored(t *testing.T) {
+	t.Parallel()
+	type ctxKey struct{}
+	var seen sync.Map
+	rec := newRecorder()
+	wf := workflow.New("wf.tenant",
+		workflow.Step[state]{Name: "a", Run: func(ctx context.Context, _ *state) error {
+			rec.hit("a")
+			if v, ok := ctx.Value(ctxKey{}).(string); ok {
+				seen.Store("scope", v)
+			}
+			return nil
+		}},
+	)
+	broker := queue.NewMemoryBroker()
+	store := workflow.NewMemoryStore()
+	eng := workflow.NewEngine(broker, store,
+		workflow.WithScope(func(context.Context) (string, error) { return "tenant-1", nil }))
+	workflow.Register(eng, wf)
+	svc, err := workflow.NewService(eng, queue.WithConfig(fastConfig()),
+		queue.WithScopeContext(func(ctx context.Context, scope string) context.Context {
+			return context.WithValue(ctx, ctxKey{}, scope)
+		}))
+	require.NoError(t, err)
+	runService(t, svc)
+
+	runID, err := workflow.Start(context.Background(), eng, wf, state{})
+	require.NoError(t, err)
+	run := waitStatus(t, store, runID, workflow.StatusCompleted)
+
+	assert.Equal(t, "tenant-1", run.Scope)
+	got, ok := seen.Load("scope")
+	require.True(t, ok)
+	assert.Equal(t, "tenant-1", got)
+}

--- a/async/workflow/engine_test.go
+++ b/async/workflow/engine_test.go
@@ -546,6 +546,48 @@ func TestRun_UndecodableStateIsAbandonedWithReason(t *testing.T) {
 	assert.Contains(t, run.Error, "decode state")
 }
 
+// TestRun_AbandonedCompensatingRunKeepsOriginalError guards the abandon note:
+// a compensating run's Error holds the business failure that triggered the
+// unwind, and abandoning it over undecodable state must append — not replace
+// — that one signal explaining the stuck saga.
+func TestRun_AbandonedCompensatingRunKeepsOriginalError(t *testing.T) {
+	t.Parallel()
+	wf := workflow.New("wf.badstate.comp",
+		workflow.Step[state]{
+			Name:       "a",
+			Run:        func(context.Context, *state) error { return nil },
+			Compensate: func(context.Context, *state) error { return nil },
+		})
+	broker := queue.NewMemoryBroker()
+	store := workflow.NewMemoryStore()
+	eng := workflow.NewEngine(broker, store)
+	workflow.Register(eng, wf)
+	svc, err := workflow.NewService(eng, queue.WithConfig(fastConfig()))
+	require.NoError(t, err)
+	runService(t, svc)
+
+	ctx := context.Background()
+	require.NoError(t, store.Create(ctx, workflow.Run{
+		ID: "r-comp-bad", Workflow: wf.Name(), Status: workflow.StatusCompensating,
+		Error: "workflow: permanent failure: recipient rejected",
+		State: []byte(`{"log":123}`), Version: 1,
+	}))
+	client := queue.NewClient(broker)
+	require.NoError(t, client.PushRaw(ctx, wf.Name(), []byte(`{"run_id":"r-comp-bad","v":1}`), queue.WithQueue(wf.Name())))
+
+	require.Eventually(t, func() bool {
+		dead, derr := client.ListDead(ctx, wf.Name(), 10)
+		require.NoError(t, derr)
+		return len(dead) == 1
+	}, 5*time.Second, 5*time.Millisecond)
+	run, err := store.Get(ctx, "r-comp-bad")
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompensating, run.Status)
+	assert.Contains(t, run.Error, "recipient rejected", "the original saga trigger must survive")
+	assert.Contains(t, run.Error, "abandoned: ")
+	assert.Contains(t, run.Error, "decode state")
+}
+
 func TestRun_DuplicateDeliveryOfFinishedRunIsNoop(t *testing.T) {
 	t.Parallel()
 	rec := newRecorder()

--- a/async/workflow/engine_test.go
+++ b/async/workflow/engine_test.go
@@ -445,6 +445,8 @@ func TestRun_CompensationExhaustionDeadLettersAndRequeueResumes(t *testing.T) {
 	assert.Equal(t, workflow.StatusCompensating, run.Status)
 	assert.Equal(t, 0, run.Attempt, "attempt counter must reset so a requeue gets a fresh budget")
 	assert.Equal(t, 2, rec.count("undo:a"))
+	assert.Contains(t, run.Error, "nope", "the original saga trigger must survive")
+	assert.Contains(t, run.Error, `compensation "a" exhausted`, "the parked run must explain itself")
 
 	// Requeue resumes the unwind from the checkpoint.
 	allow.Store("ok", true)
@@ -544,6 +546,39 @@ func TestRun_UndecodableStateIsAbandonedWithReason(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, workflow.StatusRunning, run.Status, "abandonment must not fake a terminal status")
 	assert.Contains(t, run.Error, "decode state")
+}
+
+// TestRun_NegativeCheckpointStepIsAbandonedWithReason guards the
+// inconsistent-checkpoint poison path: a corrupt Step index dead-letters the
+// driving job AND records why on the run, like every other abandonment.
+func TestRun_NegativeCheckpointStepIsAbandonedWithReason(t *testing.T) {
+	t.Parallel()
+	wf := workflow.New("wf.badstep",
+		workflow.Step[state]{Name: "a", Run: func(context.Context, *state) error { return nil }})
+	broker := queue.NewMemoryBroker()
+	store := workflow.NewMemoryStore()
+	eng := workflow.NewEngine(broker, store)
+	workflow.Register(eng, wf)
+	svc, err := workflow.NewService(eng, queue.WithConfig(fastConfig()))
+	require.NoError(t, err)
+	runService(t, svc)
+
+	ctx := context.Background()
+	require.NoError(t, store.Create(ctx, workflow.Run{
+		ID: "r-badstep", Workflow: wf.Name(), Status: workflow.StatusRunning,
+		State: []byte(`{}`), Step: -1, Version: 1,
+	}))
+	client := queue.NewClient(broker)
+	require.NoError(t, client.PushRaw(ctx, wf.Name(), []byte(`{"run_id":"r-badstep","v":1}`), queue.WithQueue(wf.Name())))
+
+	require.Eventually(t, func() bool {
+		dead, derr := client.ListDead(ctx, wf.Name(), 10)
+		require.NoError(t, derr)
+		return len(dead) == 1
+	}, 5*time.Second, 5*time.Millisecond)
+	run, err := store.Get(ctx, "r-badstep")
+	require.NoError(t, err)
+	assert.Contains(t, run.Error, "inconsistent checkpoint step")
 }
 
 // TestRun_AbandonedCompensatingRunKeepsOriginalError guards the abandon note:

--- a/async/workflow/errors.go
+++ b/async/workflow/errors.go
@@ -1,0 +1,44 @@
+package workflow
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrRunNotFound is returned by Store.Get and Store.Update for an unknown run id.
+	ErrRunNotFound = errors.New("workflow: run not found")
+	// ErrRunAlreadyExists is returned by Start (via Store.Create) when the run id is taken — the WithRunID dedupe signal.
+	ErrRunAlreadyExists = errors.New("workflow: run already exists")
+	// ErrStaleRun is returned by Store.Update when the stored version does not match: another worker checkpointed this run first.
+	ErrStaleRun = errors.New("workflow: stale run version")
+	// ErrScopeMissing is returned by Start when a scope hook is configured and yields an error or empty scope.
+	ErrScopeMissing = errors.New("workflow: scope missing")
+	// ErrNotRegistered is returned by Start when the workflow was not registered on the engine.
+	ErrNotRegistered = errors.New("workflow: workflow not registered")
+	// ErrNoWorkflows is returned by NewService when nothing was registered.
+	ErrNoWorkflows = errors.New("workflow: no workflows registered")
+)
+
+type failError struct{ err error }
+
+func (e *failError) Error() string { return fmt.Sprintf("workflow: permanent failure: %v", e.err) }
+func (e *failError) Unwrap() error { return e.err }
+
+// Fail wraps err into a step verdict: the failure is permanent — no retry can
+// help — so stop retrying this step and start compensating. Fail(nil) returns
+// nil. Steps may equivalently return queue.SkipRetry or queue.Cancel; the
+// engine treats all three as permanent so a stray queue verdict can never
+// dead-letter the driving job while the run still looks alive.
+func Fail(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &failError{err: err}
+}
+
+// IsFail reports whether err carries the Fail verdict.
+func IsFail(err error) bool {
+	var f *failError
+	return errors.As(err, &f)
+}

--- a/async/workflow/example_test.go
+++ b/async/workflow/example_test.go
@@ -1,0 +1,77 @@
+package workflow_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/async/workflow"
+)
+
+type payout struct {
+	DebitID string `json:"debit_id"`
+	Amount  int    `json:"amount"`
+}
+
+func Example() {
+	broker := queue.NewMemoryBroker()
+	store := workflow.NewMemoryStore()
+
+	done := make(chan struct{})
+	wf := workflow.New("payout.execute",
+		workflow.Step[payout]{
+			Name: "debit_ledger",
+			Run: func(_ context.Context, p *payout) error {
+				p.DebitID = "debit-42"
+				fmt.Println("debited", p.Amount)
+				return nil
+			},
+			Compensate: func(_ context.Context, p *payout) error {
+				fmt.Println("refunded", p.DebitID)
+				return nil
+			},
+		},
+		workflow.Step[payout]{
+			Name: "send_transfer",
+			Run: func(_ context.Context, p *payout) error {
+				defer close(done)
+				// A business failure no retry can fix: unwind the debit.
+				return workflow.Fail(errors.New("recipient account closed"))
+			},
+		},
+	)
+
+	eng := workflow.NewEngine(broker, store)
+	workflow.Register(eng, wf)
+
+	cfg := queue.DefaultConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	svc, err := workflow.NewService(eng, queue.WithConfig(cfg))
+	if err != nil {
+		panic(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() { _ = svc.Run(ctx); close(stopped) }()
+
+	runID, err := workflow.Start(ctx, eng, wf, payout{Amount: 100})
+	if err != nil {
+		panic(err)
+	}
+	<-done
+	cancel()
+	<-stopped
+
+	run, err := store.Get(context.Background(), runID)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("status:", run.Status)
+
+	// Output:
+	// debited 100
+	// refunded debit-42
+	// status: failed
+}

--- a/async/workflow/example_test.go
+++ b/async/workflow/example_test.go
@@ -19,7 +19,6 @@ func Example() {
 	broker := queue.NewMemoryBroker()
 	store := workflow.NewMemoryStore()
 
-	done := make(chan struct{})
 	wf := workflow.New("payout.execute",
 		workflow.Step[payout]{
 			Name: "debit_ledger",
@@ -36,7 +35,6 @@ func Example() {
 		workflow.Step[payout]{
 			Name: "send_transfer",
 			Run: func(_ context.Context, p *payout) error {
-				defer close(done)
 				// A business failure no retry can fix: unwind the debit.
 				return workflow.Fail(errors.New("recipient account closed"))
 			},
@@ -60,14 +58,19 @@ func Example() {
 	if err != nil {
 		panic(err)
 	}
-	<-done
+	// The store is the source of truth: poll the run until it is terminal.
+	var run workflow.Run
+	for {
+		if run, err = store.Get(ctx, runID); err != nil {
+			panic(err)
+		}
+		if run.Status == workflow.StatusCompleted || run.Status == workflow.StatusFailed {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	cancel()
 	<-stopped
-
-	run, err := store.Get(context.Background(), runID)
-	if err != nil {
-		panic(err)
-	}
 	fmt.Println("status:", run.Status)
 
 	// Output:

--- a/async/workflow/memory.go
+++ b/async/workflow/memory.go
@@ -1,0 +1,66 @@
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+)
+
+// MemoryStore is the in-process Store: a mutex-guarded map. It survives
+// nothing — a restart loses every checkpoint — so it fits tests, dev, and
+// single-process apps whose runs are disposable; production consumers use
+// async/workflow/postgres or bring their own Store.
+type MemoryStore struct {
+	runs map[string]Run
+	mu   sync.Mutex
+}
+
+// NewMemoryStore builds an empty in-memory store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{runs: make(map[string]Run)}
+}
+
+// Create implements Store.
+func (s *MemoryStore) Create(_ context.Context, run Run) error {
+	if run.ID == "" {
+		return errors.New("workflow: Create requires a non-empty run id")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.runs[run.ID]; ok {
+		return ErrRunAlreadyExists
+	}
+	run.State = bytes.Clone(run.State)
+	s.runs[run.ID] = run
+	return nil
+}
+
+// Get implements Store.
+func (s *MemoryStore) Get(_ context.Context, id string) (Run, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	run, ok := s.runs[id]
+	if !ok {
+		return Run{}, ErrRunNotFound
+	}
+	run.State = bytes.Clone(run.State)
+	return run, nil
+}
+
+// Update implements Store.
+func (s *MemoryStore) Update(_ context.Context, run Run) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	stored, ok := s.runs[run.ID]
+	if !ok {
+		return ErrRunNotFound
+	}
+	if stored.Version != run.Version {
+		return ErrStaleRun
+	}
+	run.State = bytes.Clone(run.State)
+	run.Version++
+	s.runs[run.ID] = run
+	return nil
+}

--- a/async/workflow/memory.go
+++ b/async/workflow/memory.go
@@ -48,6 +48,17 @@ func (s *MemoryStore) Get(_ context.Context, id string) (Run, error) {
 	return run, nil
 }
 
+// Delete implements Store.
+func (s *MemoryStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.runs[id]; !ok {
+		return ErrRunNotFound
+	}
+	delete(s.runs, id)
+	return nil
+}
+
 // Update implements Store.
 func (s *MemoryStore) Update(_ context.Context, run Run) error {
 	s.mu.Lock()

--- a/async/workflow/memory_test.go
+++ b/async/workflow/memory_test.go
@@ -43,6 +43,16 @@ func TestMemoryStore(t *testing.T) {
 		assert.ErrorIs(t, s.Update(ctx, workflow.Run{ID: "nope", Version: 1}), workflow.ErrRunNotFound)
 	})
 
+	t.Run("delete", func(t *testing.T) {
+		t.Parallel()
+		s := workflow.NewMemoryStore()
+		assert.ErrorIs(t, s.Delete(ctx, "nope"), workflow.ErrRunNotFound)
+		require.NoError(t, s.Create(ctx, workflow.Run{ID: "r1", Version: 1}))
+		require.NoError(t, s.Delete(ctx, "r1"))
+		_, err := s.Get(ctx, "r1")
+		assert.ErrorIs(t, err, workflow.ErrRunNotFound)
+	})
+
 	t.Run("update bumps version and stale write is rejected", func(t *testing.T) {
 		t.Parallel()
 		s := workflow.NewMemoryStore()

--- a/async/workflow/memory_test.go
+++ b/async/workflow/memory_test.go
@@ -1,0 +1,82 @@
+package workflow_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/workflow"
+)
+
+var _ workflow.Store = (*workflow.MemoryStore)(nil)
+
+func TestMemoryStore(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("create requires id", func(t *testing.T) {
+		t.Parallel()
+		s := workflow.NewMemoryStore()
+		assert.Error(t, s.Create(ctx, workflow.Run{}))
+	})
+
+	t.Run("create duplicate", func(t *testing.T) {
+		t.Parallel()
+		s := workflow.NewMemoryStore()
+		require.NoError(t, s.Create(ctx, workflow.Run{ID: "r1", Version: 1}))
+		assert.ErrorIs(t, s.Create(ctx, workflow.Run{ID: "r1", Version: 1}), workflow.ErrRunAlreadyExists)
+	})
+
+	t.Run("get missing", func(t *testing.T) {
+		t.Parallel()
+		s := workflow.NewMemoryStore()
+		_, err := s.Get(ctx, "nope")
+		assert.ErrorIs(t, err, workflow.ErrRunNotFound)
+	})
+
+	t.Run("update missing", func(t *testing.T) {
+		t.Parallel()
+		s := workflow.NewMemoryStore()
+		assert.ErrorIs(t, s.Update(ctx, workflow.Run{ID: "nope", Version: 1}), workflow.ErrRunNotFound)
+	})
+
+	t.Run("update bumps version and stale write is rejected", func(t *testing.T) {
+		t.Parallel()
+		s := workflow.NewMemoryStore()
+		require.NoError(t, s.Create(ctx, workflow.Run{ID: "r1", Status: workflow.StatusRunning, Version: 1}))
+
+		run, err := s.Get(ctx, "r1")
+		require.NoError(t, err)
+		run.Step = 1
+		require.NoError(t, s.Update(ctx, run))
+
+		got, err := s.Get(ctx, "r1")
+		require.NoError(t, err)
+		assert.Equal(t, 2, got.Version)
+		assert.Equal(t, 1, got.Step)
+
+		// The first reader's copy is now stale: its write must not regress
+		// the checkpoint.
+		assert.ErrorIs(t, s.Update(ctx, run), workflow.ErrStaleRun)
+	})
+
+	t.Run("state is cloned on every boundary", func(t *testing.T) {
+		t.Parallel()
+		s := workflow.NewMemoryStore()
+		state := json.RawMessage(`{"a":1}`)
+		require.NoError(t, s.Create(ctx, workflow.Run{ID: "r1", State: state, Version: 1}))
+		state[2] = 'X' // caller mutates the slice it handed over
+
+		got, err := s.Get(ctx, "r1")
+		require.NoError(t, err)
+		assert.Equal(t, json.RawMessage(`{"a":1}`), got.State)
+
+		got.State[2] = 'Y' // reader mutates the returned slice
+		again, err := s.Get(ctx, "r1")
+		require.NoError(t, err)
+		assert.Equal(t, json.RawMessage(`{"a":1}`), again.State)
+	})
+}

--- a/async/workflow/options.go
+++ b/async/workflow/options.go
@@ -1,0 +1,86 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/resilience/backoff"
+)
+
+// Option configures NewEngine.
+type Option func(*Engine)
+
+// WithScope installs the tenancy hook: it is called on every Start and its
+// result is captured into the run and its driving job. Fail-closed: once
+// configured, a hook error or empty scope makes Start fail with
+// ErrScopeMissing. Single-tenant apps simply do not configure it. Restore the
+// scope on the worker side by passing queue.WithScopeContext to NewService.
+func WithScope(fn func(ctx context.Context) (string, error)) Option {
+	return func(e *Engine) { e.scope = fn }
+}
+
+// WithClock injects the clock stamping run timestamps (tests).
+func WithClock(clk clock.Clock) Option {
+	return func(e *Engine) { e.clk = clk }
+}
+
+// WithLogger sets the logger for run outcomes (completed, failed,
+// compensation exhausted). Defaults to a no-op logger.
+func WithLogger(l *slog.Logger) Option {
+	return func(e *Engine) {
+		if l != nil {
+			e.log = l
+		}
+	}
+}
+
+// WithStepAttempts sets the default per-step attempt budget applied when a
+// Step leaves MaxAttempts at 0 (default 5): after n failed attempts a step's
+// failure turns permanent and compensation begins. Panics on n <= 0 — engine
+// options are startup wiring.
+func WithStepAttempts(n int) Option {
+	if n <= 0 {
+		panic(fmt.Sprintf("workflow: WithStepAttempts requires n > 0, got %d", n))
+	}
+	return func(e *Engine) { e.stepAttempts = n }
+}
+
+// RegisterOption configures a single workflow registration. All of them tune
+// the worker's dispatch of that workflow's driving jobs.
+type RegisterOption func(*registration)
+
+// WithRetryBackoff overrides the worker's default backoff for this workflow's
+// transient retries.
+func WithRetryBackoff(b backoff.Backoff) RegisterOption {
+	qo := queue.WithHandlerBackoff(b)
+	return func(r *registration) { r.hopts = append(r.hopts, qo) }
+}
+
+// WithHandlerTimeout bounds each driving-job invocation — which may span many
+// steps — overriding the worker's Config.HandlerTimeout (default 10m). Expiry
+// is a transient failure: the run resumes from its checkpoint on retry. 0
+// disables the worker default for long workflows; panics on a negative
+// duration.
+func WithHandlerTimeout(d time.Duration) RegisterOption {
+	qo := queue.WithHandlerTimeout(d)
+	return func(r *registration) { r.hopts = append(r.hopts, qo) }
+}
+
+// StartOption configures a single Start call.
+type StartOption func(*startConfig)
+
+type startConfig struct {
+	runID string
+}
+
+// WithRunID sets the run id instead of generating one. Use a business key
+// ("onboard:"+userID) to make Start idempotent: a second Start with the same
+// id fails with ErrRunAlreadyExists. An empty id falls back to a generated
+// one.
+func WithRunID(id string) StartOption {
+	return func(c *startConfig) { c.runID = id }
+}

--- a/async/workflow/postgres/bench_test.go
+++ b/async/workflow/postgres/bench_test.go
@@ -1,0 +1,54 @@
+//go:build integration
+
+package pgworkflow_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pgworkflow "github.com/dmitrymomot/forge/async/workflow/postgres"
+)
+
+func BenchmarkStore(b *testing.B) {
+	pool := openPool(b)
+	store, err := pgworkflow.New(pool)
+	require.NoError(b, err)
+	ctx := context.Background()
+
+	b.Run("create", func(b *testing.B) {
+		i := 0
+		b.ReportAllocs()
+		for b.Loop() {
+			i++
+			if err := store.Create(ctx, testRun(fmt.Sprintf("bench-create-%d", i))); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("get", func(b *testing.B) {
+		require.NoError(b, store.Create(ctx, testRun("bench-get")))
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := store.Get(ctx, "bench-get"); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("update", func(b *testing.B) {
+		require.NoError(b, store.Create(ctx, testRun("bench-update")))
+		run, err := store.Get(ctx, "bench-update")
+		require.NoError(b, err)
+		b.ReportAllocs()
+		for b.Loop() {
+			if err := store.Update(ctx, run); err != nil {
+				b.Fatal(err)
+			}
+			run.Version++
+		}
+	})
+}

--- a/async/workflow/postgres/doc.go
+++ b/async/workflow/postgres/doc.go
@@ -1,0 +1,12 @@
+// Package pgworkflow is the Postgres workflow.Store: one row per run,
+// checkpointed with optimistic locking on the version column so a worker
+// whose queue lease was silently lost cannot regress a checkpoint the new
+// owner already advanced. Apply Migrations with data/migration before use.
+//
+//	store, _ := pgworkflow.New(pool)
+//	eng := workflow.NewEngine(broker, store)
+//
+// Terminal runs (completed, failed) stay behind as audit rows; schedule
+// PurgeTerminalBefore (e.g. daily with a cutoff matching your retention
+// policy) to keep the table bounded.
+package pgworkflow

--- a/async/workflow/postgres/migrations/20260720130000_workflow_runs.sql
+++ b/async/workflow/postgres/migrations/20260720130000_workflow_runs.sql
@@ -1,11 +1,15 @@
 -- +goose Up
+-- state is json, not jsonb: checkpoints are written and read back verbatim,
+-- never queried server-side, and json accepts the U+0000 unicode escape
+-- jsonb rejects (a NUL captured into workflow state must not wedge every
+-- checkpoint). Same choice as the queue_jobs payload column.
 CREATE TABLE workflow_runs (
     id         text PRIMARY KEY,
     workflow   text NOT NULL,
     scope      text NOT NULL DEFAULT '',
     status     text NOT NULL,
     error      text NOT NULL DEFAULT '',
-    state      jsonb NOT NULL,
+    state      json NOT NULL,
     step       int NOT NULL,
     attempt    int NOT NULL,
     version    int NOT NULL,

--- a/async/workflow/postgres/migrations/20260720130000_workflow_runs.sql
+++ b/async/workflow/postgres/migrations/20260720130000_workflow_runs.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+CREATE TABLE workflow_runs (
+    id         text PRIMARY KEY,
+    workflow   text NOT NULL,
+    scope      text NOT NULL DEFAULT '',
+    status     text NOT NULL,
+    error      text NOT NULL DEFAULT '',
+    state      jsonb NOT NULL,
+    step       int NOT NULL,
+    attempt    int NOT NULL,
+    version    int NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+);
+
+CREATE INDEX workflow_runs_terminal_sweep_idx ON workflow_runs (updated_at) WHERE status IN ('completed', 'failed');
+
+-- +goose Down
+DROP TABLE workflow_runs;

--- a/async/workflow/postgres/pgworkflow.go
+++ b/async/workflow/postgres/pgworkflow.go
@@ -1,0 +1,194 @@
+package pgworkflow
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/async/workflow"
+	"github.com/dmitrymomot/forge/data/postgres"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating workflow_runs, rooted so its
+// .sql files sit at fsys root. Apply via data/migration under its own version
+// table.
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+var tableNameRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+type config struct {
+	table string
+}
+
+// Option configures New and PurgeTerminalBefore.
+type Option func(*config)
+
+// WithTable overrides the runs table name (default "workflow_runs"). The
+// shipped migration creates the default; a custom name requires a
+// caller-managed schema of the same shape.
+func WithTable(name string) Option {
+	return func(c *config) { c.table = name }
+}
+
+func newConfig(opts []Option) (config, error) {
+	c := config{table: "workflow_runs"}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	if !tableNameRe.MatchString(c.table) {
+		return config{}, fmt.Errorf("pgworkflow: invalid table name %q", c.table)
+	}
+	// Postgres truncates identifiers past 63 bytes: two longer names sharing a
+	// prefix would silently collide on one physical table.
+	if len(c.table) > 63 {
+		return config{}, fmt.Errorf("pgworkflow: table name %q exceeds the 63-byte identifier limit", c.table)
+	}
+	return c, nil
+}
+
+// Store is the durable workflow.Store over Postgres: one row per run, updated
+// with optimistic locking on the version column. Apply Migrations with
+// data/migration before use.
+type Store struct {
+	pool      *pgxpool.Pool
+	createSQL string
+	getSQL    string
+	updateSQL string
+	existsSQL string
+}
+
+// New builds a Store over pool. Errors on a nil pool or an invalid table name.
+func New(pool *pgxpool.Pool, opts ...Option) (*Store, error) {
+	if pool == nil {
+		return nil, errors.New("pgworkflow: New requires a pool")
+	}
+	c, err := newConfig(opts)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{
+		pool: pool,
+		createSQL: fmt.Sprintf(`INSERT INTO %s (id, workflow, scope, status, error, state, step, attempt, version, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`, c.table),
+		getSQL: fmt.Sprintf(`SELECT id, workflow, scope, status, error, state, step, attempt, version, created_at, updated_at
+			FROM %s WHERE id = $1`, c.table),
+		updateSQL: fmt.Sprintf(`UPDATE %s SET status = $3, error = $4, state = $5, step = $6, attempt = $7,
+			version = version + 1, updated_at = $8 WHERE id = $1 AND version = $2`, c.table),
+		existsSQL: fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM %s WHERE id = $1)`, c.table),
+	}, nil
+}
+
+// Create implements workflow.Store.
+func (s *Store) Create(ctx context.Context, run workflow.Run) error {
+	if run.ID == "" {
+		return errors.New("pgworkflow: Create requires a non-empty run id")
+	}
+	_, err := s.pool.Exec(ctx, s.createSQL,
+		run.ID, run.Workflow, run.Scope, string(run.Status), run.Error, run.State,
+		run.Step, run.Attempt, run.Version, run.CreatedAt, run.UpdatedAt)
+	if err != nil {
+		if postgres.IsUniqueViolation(err) {
+			return workflow.ErrRunAlreadyExists
+		}
+		return fmt.Errorf("pgworkflow: create run: %w", err)
+	}
+	return nil
+}
+
+// Get implements workflow.Store.
+func (s *Store) Get(ctx context.Context, id string) (workflow.Run, error) {
+	var run workflow.Run
+	var status string
+	err := s.pool.QueryRow(ctx, s.getSQL, id).Scan(
+		&run.ID, &run.Workflow, &run.Scope, &status, &run.Error, &run.State,
+		&run.Step, &run.Attempt, &run.Version, &run.CreatedAt, &run.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return workflow.Run{}, workflow.ErrRunNotFound
+		}
+		return workflow.Run{}, fmt.Errorf("pgworkflow: get run: %w", err)
+	}
+	run.Status = workflow.Status(status)
+	run.CreatedAt = run.CreatedAt.UTC()
+	run.UpdatedAt = run.UpdatedAt.UTC()
+	return run, nil
+}
+
+// Update implements workflow.Store. Only the mutable columns move: workflow,
+// scope, and created_at are immutable after Create.
+func (s *Store) Update(ctx context.Context, run workflow.Run) error {
+	tag, err := s.pool.Exec(ctx, s.updateSQL,
+		run.ID, run.Version, string(run.Status), run.Error, run.State,
+		run.Step, run.Attempt, run.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("pgworkflow: update run: %w", err)
+	}
+	if tag.RowsAffected() > 0 {
+		return nil
+	}
+	var exists bool
+	if err := s.pool.QueryRow(ctx, s.existsSQL, run.ID).Scan(&exists); err != nil {
+		return fmt.Errorf("pgworkflow: update run: distinguish stale from missing: %w", err)
+	}
+	if !exists {
+		return workflow.ErrRunNotFound
+	}
+	return workflow.ErrStaleRun
+}
+
+// purgeBatch bounds one PurgeTerminalBefore statement, keeping each delete a
+// short transaction with WAL and vacuum debt paid off between batches instead
+// of accumulated across one multi-million-row delete (pgqueue precedent).
+const purgeBatch = 5000
+
+// PurgeTerminalBefore deletes completed and failed runs last updated strictly
+// before cutoff, returning how many were removed. Terminal runs are audit
+// data, not live state, so retention is the consumer's call — run this from a
+// scheduled job. Deletes are batched, so it is safe on an unswept backlog.
+func PurgeTerminalBefore(ctx context.Context, pool *pgxpool.Pool, cutoff time.Time, opts ...Option) (int, error) {
+	if pool == nil {
+		return 0, errors.New("pgworkflow: PurgeTerminalBefore requires a pool")
+	}
+	c, err := newConfig(opts)
+	if err != nil {
+		return 0, err
+	}
+	// ctid batching: one InitPlan picks the batch by the partial terminal
+	// index, and the delete addresses rows directly — no per-batch semi-join
+	// over the whole table.
+	sql := fmt.Sprintf(`DELETE FROM %[1]s WHERE ctid = ANY(ARRAY(
+		SELECT ctid FROM %[1]s WHERE status IN ('completed', 'failed') AND updated_at < $1 LIMIT %[2]d))`, c.table, purgeBatch)
+	total := 0
+	for {
+		tag, err := pool.Exec(ctx, sql, cutoff)
+		if err != nil {
+			return total, fmt.Errorf("pgworkflow: purge terminal before: %w", err)
+		}
+		n := int(tag.RowsAffected())
+		total += n
+		// Terminate on an empty batch, not a short one: a concurrent purge
+		// deleting part of this run's selected batch would otherwise make both
+		// runs exit early with purgeable rows remaining.
+		if n == 0 {
+			return total, nil
+		}
+	}
+}

--- a/async/workflow/postgres/pgworkflow.go
+++ b/async/workflow/postgres/pgworkflow.go
@@ -73,6 +73,7 @@ type Store struct {
 	getSQL    string
 	updateSQL string
 	existsSQL string
+	deleteSQL string
 }
 
 // New builds a Store over pool. Errors on a nil pool or an invalid table name.
@@ -93,6 +94,7 @@ func New(pool *pgxpool.Pool, opts ...Option) (*Store, error) {
 		updateSQL: fmt.Sprintf(`UPDATE %s SET status = $3, error = $4, state = $5, step = $6, attempt = $7,
 			version = version + 1, updated_at = $8 WHERE id = $1 AND version = $2`, c.table),
 		existsSQL: fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM %s WHERE id = $1)`, c.table),
+		deleteSQL: fmt.Sprintf(`DELETE FROM %s WHERE id = $1`, c.table),
 	}, nil
 }
 
@@ -152,6 +154,18 @@ func (s *Store) Update(ctx context.Context, run workflow.Run) error {
 		return workflow.ErrRunNotFound
 	}
 	return workflow.ErrStaleRun
+}
+
+// Delete implements workflow.Store.
+func (s *Store) Delete(ctx context.Context, id string) error {
+	tag, err := s.pool.Exec(ctx, s.deleteSQL, id)
+	if err != nil {
+		return fmt.Errorf("pgworkflow: delete run: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return workflow.ErrRunNotFound
+	}
+	return nil
 }
 
 // purgeBatch bounds one PurgeTerminalBefore statement, keeping each delete a

--- a/async/workflow/postgres/pgworkflow_test.go
+++ b/async/workflow/postgres/pgworkflow_test.go
@@ -1,0 +1,240 @@
+//go:build integration
+
+package pgworkflow_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/async/workflow"
+	pgworkflow "github.com/dmitrymomot/forge/async/workflow/postgres"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+	"github.com/dmitrymomot/forge/resilience/backoff"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+)
+
+var _ workflow.Store = (*pgworkflow.Store)(nil)
+
+// openPool connects to the suite's Postgres (via pgtest.DSN) and applies the
+// workflow_runs migration.
+func openPool(tb testing.TB) *pgxpool.Pool {
+	tb.Helper()
+	cfg := postgres.DefaultConfig()
+	cfg.URL = pgtest.DSN(tb)
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(tb, err)
+	tb.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	tb.Cleanup(func() { _ = db.Close() })
+	require.NoError(tb, migration.New(pgworkflow.Migrations, migration.WithTable("forge_workflow_schema")).Up(context.Background(), db))
+	_, err = pool.Exec(context.Background(), "TRUNCATE workflow_runs")
+	require.NoError(tb, err)
+	return pool
+}
+
+func testRun(id string) workflow.Run {
+	now := time.Now().UTC().Truncate(time.Microsecond) // timestamptz keeps microseconds
+	return workflow.Run{
+		ID:        id,
+		Workflow:  "wf.test",
+		Scope:     "tenant-1",
+		Status:    workflow.StatusRunning,
+		State:     json.RawMessage(`{"n":1}`),
+		Version:   1,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil pool", func(t *testing.T) {
+		t.Parallel()
+		_, err := pgworkflow.New(nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid table", func(t *testing.T) {
+		t.Parallel()
+		_, err := pgworkflow.New(&pgxpool.Pool{}, pgworkflow.WithTable("bad; DROP TABLE x"))
+		assert.Error(t, err)
+	})
+
+	t.Run("table name over the identifier limit", func(t *testing.T) {
+		t.Parallel()
+		_, err := pgworkflow.New(&pgxpool.Pool{}, pgworkflow.WithTable(strings.Repeat("x", 64)))
+		assert.Error(t, err)
+	})
+}
+
+func TestStore_CreateGetUpdate(t *testing.T) {
+	pool := openPool(t)
+	store, err := pgworkflow.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	t.Run("create requires id", func(t *testing.T) {
+		assert.Error(t, store.Create(ctx, workflow.Run{}))
+	})
+
+	t.Run("roundtrip", func(t *testing.T) {
+		want := testRun("r-roundtrip")
+		require.NoError(t, store.Create(ctx, want))
+
+		got, err := store.Get(ctx, "r-roundtrip")
+		require.NoError(t, err)
+		assert.Equal(t, want.ID, got.ID)
+		assert.Equal(t, want.Workflow, got.Workflow)
+		assert.Equal(t, want.Scope, got.Scope)
+		assert.Equal(t, want.Status, got.Status)
+		assert.JSONEq(t, string(want.State), string(got.State))
+		assert.Equal(t, want.Version, got.Version)
+		assert.WithinDuration(t, want.CreatedAt, got.CreatedAt, time.Millisecond)
+		assert.WithinDuration(t, want.UpdatedAt, got.UpdatedAt, time.Millisecond)
+	})
+
+	t.Run("create duplicate", func(t *testing.T) {
+		require.NoError(t, store.Create(ctx, testRun("r-dup")))
+		assert.ErrorIs(t, store.Create(ctx, testRun("r-dup")), workflow.ErrRunAlreadyExists)
+	})
+
+	t.Run("get missing", func(t *testing.T) {
+		_, err := store.Get(ctx, "r-missing")
+		assert.ErrorIs(t, err, workflow.ErrRunNotFound)
+	})
+
+	t.Run("update missing", func(t *testing.T) {
+		assert.ErrorIs(t, store.Update(ctx, testRun("r-update-missing")), workflow.ErrRunNotFound)
+	})
+
+	t.Run("update bumps version and stale write is rejected", func(t *testing.T) {
+		require.NoError(t, store.Create(ctx, testRun("r-version")))
+
+		run, err := store.Get(ctx, "r-version")
+		require.NoError(t, err)
+		run.Step = 2
+		run.Status = workflow.StatusCompensating
+		run.Error = "boom"
+		run.State = json.RawMessage(`{"n":2}`)
+		require.NoError(t, store.Update(ctx, run))
+
+		got, err := store.Get(ctx, "r-version")
+		require.NoError(t, err)
+		assert.Equal(t, 2, got.Version)
+		assert.Equal(t, 2, got.Step)
+		assert.Equal(t, workflow.StatusCompensating, got.Status)
+		assert.Equal(t, "boom", got.Error)
+		assert.JSONEq(t, `{"n":2}`, string(got.State))
+
+		// The pre-update copy is stale now: its write must not regress the row.
+		assert.ErrorIs(t, store.Update(ctx, run), workflow.ErrStaleRun)
+	})
+}
+
+func TestPurgeTerminalBefore(t *testing.T) {
+	pool := openPool(t)
+	store, err := pgworkflow.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+	cutoff := time.Now().UTC()
+
+	old := func(id string, status workflow.Status) workflow.Run {
+		run := testRun(id)
+		run.Status = status
+		run.CreatedAt = cutoff.Add(-time.Hour)
+		run.UpdatedAt = cutoff.Add(-time.Hour)
+		return run
+	}
+	require.NoError(t, store.Create(ctx, old("r-old-completed", workflow.StatusCompleted)))
+	require.NoError(t, store.Create(ctx, old("r-old-failed", workflow.StatusFailed)))
+	require.NoError(t, store.Create(ctx, old("r-old-running", workflow.StatusRunning)))
+	require.NoError(t, store.Create(ctx, old("r-old-compensating", workflow.StatusCompensating)))
+	fresh := testRun("r-fresh-completed")
+	fresh.Status = workflow.StatusCompleted
+	require.NoError(t, store.Create(ctx, fresh))
+
+	t.Run("nil pool", func(t *testing.T) {
+		_, err := pgworkflow.PurgeTerminalBefore(ctx, nil, cutoff)
+		assert.Error(t, err)
+	})
+
+	n, err := pgworkflow.PurgeTerminalBefore(ctx, pool, cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "only old terminal runs purge")
+
+	for _, id := range []string{"r-old-running", "r-old-compensating", "r-fresh-completed"} {
+		_, err := store.Get(ctx, id)
+		assert.NoError(t, err, "run %s must survive the purge", id)
+	}
+	for _, id := range []string{"r-old-completed", "r-old-failed"} {
+		_, err := store.Get(ctx, id)
+		assert.ErrorIs(t, err, workflow.ErrRunNotFound, "run %s must be purged", id)
+	}
+
+	n, err = pgworkflow.PurgeTerminalBefore(ctx, pool, cutoff)
+	require.NoError(t, err)
+	assert.Zero(t, n)
+}
+
+// TestEngineOverPostgresStore drives a full saga — forward failure, reverse
+// compensation — through the queue engine with checkpoints in Postgres.
+func TestEngineOverPostgresStore(t *testing.T) {
+	pool := openPool(t)
+	store, err := pgworkflow.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	type payout struct {
+		Undone bool `json:"undone"`
+		Tries  int  `json:"tries"`
+	}
+	wf := workflow.New("wf.pg.saga",
+		workflow.Step[payout]{
+			Name:       "debit",
+			Run:        func(context.Context, *payout) error { return nil },
+			Compensate: func(_ context.Context, p *payout) error { p.Undone = true; return nil },
+		},
+		workflow.Step[payout]{
+			Name:        "transfer",
+			MaxAttempts: 2,
+			Run:         func(context.Context, *payout) error { return errors.New("wire down") },
+		},
+	)
+	eng := workflow.NewEngine(queue.NewMemoryBroker(), store)
+	workflow.Register(eng, wf, workflow.WithRetryBackoff(backoff.Constant(0)))
+	cfg := queue.DefaultConfig()
+	cfg.PollInterval = 5 * time.Millisecond
+	svc, err := workflow.NewService(eng, queue.WithConfig(cfg))
+	require.NoError(t, err)
+	svcCtx, cancel := context.WithCancel(ctx)
+	stopped := make(chan struct{})
+	go func() { _ = svc.Run(svcCtx); close(stopped) }()
+	t.Cleanup(func() { cancel(); <-stopped })
+
+	runID, err := workflow.Start(ctx, eng, wf, payout{})
+	require.NoError(t, err)
+
+	var run workflow.Run
+	require.Eventually(t, func() bool {
+		run, err = store.Get(ctx, runID)
+		require.NoError(t, err)
+		return run.Status == workflow.StatusFailed
+	}, 10*time.Second, 10*time.Millisecond)
+
+	var p payout
+	require.NoError(t, json.Unmarshal(run.State, &p))
+	assert.True(t, p.Undone, "compensation must have run against the Postgres checkpoint")
+	assert.Contains(t, run.Error, "wire down")
+}

--- a/async/workflow/postgres/pgworkflow_test.go
+++ b/async/workflow/postgres/pgworkflow_test.go
@@ -119,6 +119,28 @@ func TestStore_CreateGetUpdate(t *testing.T) {
 		assert.ErrorIs(t, store.Update(ctx, testRun("r-update-missing")), workflow.ErrRunNotFound)
 	})
 
+	t.Run("state with a NUL escape survives the roundtrip", func(t *testing.T) {
+		// The json (not jsonb) column choice: user data captured into
+		// workflow state may contain U+0000, and a checkpoint that cannot be
+		// written would wedge the run.
+		nul, merr := json.Marshal(map[string]string{"s": "a\x00b"})
+		require.NoError(t, merr)
+		run := testRun("r-nul")
+		run.State = nul
+		require.NoError(t, store.Create(ctx, run))
+		got, err := store.Get(ctx, "r-nul")
+		require.NoError(t, err)
+		assert.JSONEq(t, string(nul), string(got.State))
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		assert.ErrorIs(t, store.Delete(ctx, "r-del-missing"), workflow.ErrRunNotFound)
+		require.NoError(t, store.Create(ctx, testRun("r-del")))
+		require.NoError(t, store.Delete(ctx, "r-del"))
+		_, err := store.Get(ctx, "r-del")
+		assert.ErrorIs(t, err, workflow.ErrRunNotFound)
+	})
+
 	t.Run("update bumps version and stale write is rejected", func(t *testing.T) {
 		require.NoError(t, store.Create(ctx, testRun("r-version")))
 

--- a/async/workflow/run.go
+++ b/async/workflow/run.go
@@ -26,8 +26,10 @@ const (
 // index of the next step to execute and Attempt counts that step's failed
 // attempts so far; while compensating, Step walks backwards over the steps
 // whose compensations still have to run. State is the JSON-encoded workflow
-// state as of the last checkpoint. Version implements optimistic locking —
-// see Store.
+// state as of the last checkpoint. Error records the permanent failure that
+// triggered compensation — or, on a non-terminal run whose driving job was
+// dead-lettered over unprocessable state, the reason it was abandoned.
+// Version implements optimistic locking — see Store.
 type Run struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
@@ -59,4 +61,8 @@ type Store interface {
 	// Update persists run if the stored version equals run.Version (see
 	// above); ErrRunNotFound when absent, ErrStaleRun on a version mismatch.
 	Update(ctx context.Context, run Run) error
+	// Delete removes a run; ErrRunNotFound when absent. Start uses it to roll
+	// back a run whose driving job could not be enqueued; consumers may use
+	// it to repair orphans.
+	Delete(ctx context.Context, id string) error
 }

--- a/async/workflow/run.go
+++ b/async/workflow/run.go
@@ -27,9 +27,10 @@ const (
 // attempts so far; while compensating, Step walks backwards over the steps
 // whose compensations still have to run. State is the JSON-encoded workflow
 // state as of the last checkpoint. Error records the permanent failure that
-// triggered compensation — or, on a non-terminal run whose driving job was
-// dead-lettered over unprocessable state, the reason it was abandoned.
-// Version implements optimistic locking — see Store.
+// triggered compensation; when a non-terminal run's driving job is
+// dead-lettered (unprocessable state, an exhausted compensation), the reason
+// is appended so the row alone explains a stuck run. Version implements
+// optimistic locking — see Store.
 type Run struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/async/workflow/run.go
+++ b/async/workflow/run.go
@@ -1,0 +1,62 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Status is a run's lifecycle state.
+type Status string
+
+const (
+	// StatusRunning means forward steps are executing (or awaiting retry).
+	StatusRunning Status = "running"
+	// StatusCompensating means a permanent failure occurred and completed
+	// steps' compensations are unwinding in reverse order.
+	StatusCompensating Status = "compensating"
+	// StatusCompleted means every step finished. Terminal.
+	StatusCompleted Status = "completed"
+	// StatusFailed means the run failed permanently and compensation (if any
+	// was defined) finished. The triggering error is on Run.Error. Terminal.
+	StatusFailed Status = "failed"
+)
+
+// Run is one workflow execution's checkpoint. While running, Step is the
+// index of the next step to execute and Attempt counts that step's failed
+// attempts so far; while compensating, Step walks backwards over the steps
+// whose compensations still have to run. State is the JSON-encoded workflow
+// state as of the last checkpoint. Version implements optimistic locking —
+// see Store.
+type Run struct {
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	ID        string
+	Workflow  string
+	Scope     string
+	Status    Status
+	Error     string
+	State     json.RawMessage
+	Step      int
+	Attempt   int
+	Version   int
+}
+
+// Store persists run checkpoints. Implementations must be safe for concurrent
+// use. MemoryStore is the in-process test double; async/workflow/postgres
+// ships the durable implementation.
+//
+// Update is guarded by optimistic locking: it persists run only when the
+// stored version equals run.Version, incrementing the stored version by one;
+// a mismatch returns ErrStaleRun and leaves the row untouched. That stops a
+// worker whose queue lease was silently lost from regressing a checkpoint the
+// new owner already advanced.
+type Store interface {
+	// Create persists a new run; ErrRunAlreadyExists when the id is taken.
+	Create(ctx context.Context, run Run) error
+	// Get returns the run by id; ErrRunNotFound when absent.
+	Get(ctx context.Context, id string) (Run, error)
+	// Update persists run if the stored version equals run.Version (see
+	// above); ErrRunNotFound when absent, ErrStaleRun on a version mismatch.
+	Update(ctx context.Context, run Run) error
+}

--- a/async/workflow/runner.go
+++ b/async/workflow/runner.go
@@ -39,7 +39,7 @@ func newRunner[S any](e *Engine, wf *Workflow[S]) func(ctx context.Context, env 
 		}
 		state, err := decodeState[S](run.State)
 		if err != nil {
-			return queue.SkipRetry(fmt.Errorf("workflow: run %q: decode state: %w", run.ID, err))
+			return e.abandon(ctx, &run, fmt.Errorf("workflow: run %q: decode state: %w", run.ID, err))
 		}
 		if run.Status == StatusRunning {
 			if err := forward(ctx, e, wf, &run, state); err != nil {
@@ -52,7 +52,7 @@ func newRunner[S any](e *Engine, wf *Workflow[S]) func(ctx context.Context, env 
 			// compensations must see the last checkpoint, not those leftovers.
 			state, err = decodeState[S](run.State)
 			if err != nil {
-				return queue.SkipRetry(fmt.Errorf("workflow: run %q: decode state: %w", run.ID, err))
+				return e.abandon(ctx, &run, fmt.Errorf("workflow: run %q: decode state: %w", run.ID, err))
 			}
 		}
 		return compensate(ctx, e, wf, &run, state)
@@ -88,11 +88,12 @@ func forward[S any](ctx context.Context, e *Engine, wf *Workflow[S], run *Run, s
 		if err == nil {
 			raw, merr := json.Marshal(state)
 			if merr != nil {
-				return queue.SkipRetry(fmt.Errorf("workflow: run %q: marshal state after step %q: %w", run.ID, st.Name, merr))
+				return e.abandon(ctx, run, fmt.Errorf("workflow: run %q: marshal state after step %q: %w", run.ID, st.Name, merr))
 			}
 			run.State = raw
 			run.Step++
 			run.Attempt = 0
+			run.Error = "" // a resumed abandoned run is making progress again
 			if run.Step == len(steps) {
 				run.Status = StatusCompleted
 			}
@@ -101,8 +102,14 @@ func forward[S any](ctx context.Context, e *Engine, wf *Workflow[S], run *Run, s
 			}
 			continue
 		}
-		if ctx.Err() != nil {
-			return err // cancelled mid-step: redeliver without burning an attempt
+		// Permanent verdicts outrank cancellation: letting queue.Cancel or
+		// queue.SkipRetry through raw would ack or dead-letter the driving job
+		// while the run still looks alive. A plain error with the handler ctx
+		// cancelled means the lease was lost mid-step — the new claim owns the
+		// run now, so leave the checkpoint alone; a deadline expiry is the
+		// step's own timeout and burns an attempt like any other failure.
+		if !isPermanent(err) && errors.Is(ctx.Err(), context.Canceled) {
+			return err
 		}
 		failed := run.Attempt + 1
 		if !isPermanent(err) && failed < e.stepBudget(st.MaxAttempts) {
@@ -165,7 +172,7 @@ func compensate[S any](ctx context.Context, e *Engine, wf *Workflow[S], run *Run
 		if err == nil {
 			raw, merr := json.Marshal(state)
 			if merr != nil {
-				return queue.SkipRetry(fmt.Errorf("workflow: run %q: marshal state after compensation %q: %w", run.ID, st.Name, merr))
+				return e.abandon(ctx, run, fmt.Errorf("workflow: run %q: marshal state after compensation %q: %w", run.ID, st.Name, merr))
 			}
 			run.State = raw
 			run.Attempt = 0
@@ -178,7 +185,10 @@ func compensate[S any](ctx context.Context, e *Engine, wf *Workflow[S], run *Run
 			}
 			continue
 		}
-		if ctx.Err() != nil {
+		// Same classification as forward: permanent verdicts outrank
+		// cancellation, lease loss (Canceled) yields without burning an
+		// attempt, a deadline expiry burns one.
+		if !isPermanent(err) && errors.Is(ctx.Err(), context.Canceled) {
 			return err
 		}
 		failed := run.Attempt + 1
@@ -202,14 +212,33 @@ func compensate[S any](ctx context.Context, e *Engine, wf *Workflow[S], run *Run
 	return nil
 }
 
-// checkpoint persists run and tracks the version bump locally.
+// checkpoint persists run and tracks the version bump locally. It writes
+// under a non-cancelable context: a state transition that was decided must
+// commit even when the handler ctx died mid-step (timeout expiry racing a
+// permanent verdict), mirroring the queue engine's post-claim broker ops. A
+// worker that lost its lease is stopped by the version guard instead.
 func (e *Engine) checkpoint(ctx context.Context, run *Run) error {
 	run.UpdatedAt = e.clk.Now().UTC()
-	if err := e.store.Update(ctx, *run); err != nil {
+	if err := e.store.Update(context.WithoutCancel(ctx), *run); err != nil {
 		return fmt.Errorf("workflow: checkpoint run %q: %w", run.ID, err)
 	}
 	run.Version++
 	return nil
+}
+
+// abandon dead-letters the driving job over unprocessable input (state that
+// no longer decodes or marshals — schema drift of S across a deploy),
+// recording the reason on Run.Error so the store stays diagnosable. The
+// status is left as is: after a fixed deploy, queue.Client.Requeue resumes
+// the run from its checkpoint. The write is best-effort — the DLQ entry
+// carries the same reason.
+func (e *Engine) abandon(ctx context.Context, run *Run, err error) error {
+	run.Error = err.Error()
+	if cerr := e.checkpoint(ctx, run); cerr != nil {
+		e.log.WarnContext(ctx, "workflow abandon note not persisted", runAttrs(run, slog.Any("error", cerr))...)
+	}
+	e.log.ErrorContext(ctx, "workflow run abandoned, driving job dead-lettered", runAttrs(run, slog.String("error", run.Error))...)
+	return queue.SkipRetry(err)
 }
 
 // invokeStep runs one step (or compensation) with panic recovery: a panicking

--- a/async/workflow/runner.go
+++ b/async/workflow/runner.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/dmitrymomot/forge/async/queue"
 )
@@ -233,7 +234,17 @@ func (e *Engine) checkpoint(ctx context.Context, run *Run) error {
 // the run from its checkpoint. The write is best-effort — the DLQ entry
 // carries the same reason.
 func (e *Engine) abandon(ctx context.Context, run *Run, err error) error {
-	run.Error = err.Error()
+	// A compensating run's Error holds the business failure that triggered
+	// the unwind — the one signal explaining a stuck saga — so append the
+	// abandon note instead of replacing it. The suffix check keeps repeated
+	// requeue-and-abandon cycles from growing the note unboundedly.
+	note := "abandoned: " + err.Error()
+	switch {
+	case run.Error == "":
+		run.Error = note
+	case !strings.HasSuffix(run.Error, note):
+		run.Error += "; " + note
+	}
 	if cerr := e.checkpoint(ctx, run); cerr != nil {
 		e.log.WarnContext(ctx, "workflow abandon note not persisted", runAttrs(run, slog.Any("error", cerr))...)
 	}

--- a/async/workflow/runner.go
+++ b/async/workflow/runner.go
@@ -1,0 +1,250 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/dmitrymomot/forge/async/queue"
+)
+
+// newRunner builds the queue handler driving one workflow's runs. Every
+// invocation loads the freshest checkpoint, executes as far as it can —
+// checkpointing after each step — and reports a queue verdict: nil when the
+// run reached a terminal status or made its checkpointed progress, an error
+// to retry (transient step failure, store hiccup, shutdown mid-step), or
+// queue.SkipRetry for poison input and exhausted compensations.
+func newRunner[S any](e *Engine, wf *Workflow[S]) func(ctx context.Context, env runEnvelope) error {
+	return func(ctx context.Context, env runEnvelope) error {
+		if env.V != wireVersion {
+			return queue.SkipRetry(fmt.Errorf("workflow: %q: unsupported envelope version %d", wf.name, env.V))
+		}
+		if env.RunID == "" {
+			return queue.SkipRetry(fmt.Errorf("workflow: %q: envelope without run id", wf.name))
+		}
+		run, err := e.store.Get(ctx, env.RunID)
+		if err != nil {
+			if errors.Is(err, ErrRunNotFound) {
+				return queue.SkipRetry(fmt.Errorf("workflow: %q: run %q not found", wf.name, env.RunID))
+			}
+			return fmt.Errorf("workflow: load run %q: %w", env.RunID, err)
+		}
+		if run.Workflow != wf.name {
+			return queue.SkipRetry(fmt.Errorf("workflow: run %q belongs to workflow %q, not %q", run.ID, run.Workflow, wf.name))
+		}
+		if run.Status == StatusCompleted || run.Status == StatusFailed {
+			return nil // duplicate delivery of a finished run
+		}
+		state, err := decodeState[S](run.State)
+		if err != nil {
+			return queue.SkipRetry(fmt.Errorf("workflow: run %q: decode state: %w", run.ID, err))
+		}
+		if run.Status == StatusRunning {
+			if err := forward(ctx, e, wf, &run, state); err != nil {
+				return err
+			}
+			if run.Status != StatusCompensating {
+				return nil
+			}
+			// The failing step may have half-mutated state before erroring;
+			// compensations must see the last checkpoint, not those leftovers.
+			state, err = decodeState[S](run.State)
+			if err != nil {
+				return queue.SkipRetry(fmt.Errorf("workflow: run %q: decode state: %w", run.ID, err))
+			}
+		}
+		return compensate(ctx, e, wf, &run, state)
+	}
+}
+
+func decodeState[S any](raw json.RawMessage) (*S, error) {
+	state := new(S)
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, state); err != nil {
+			return nil, err
+		}
+	}
+	return state, nil
+}
+
+// forward executes steps from the checkpoint until the run completes, a
+// transient failure returns an error for the engine to retry, or a permanent
+// failure transitions the run to StatusCompensating (or straight to
+// StatusFailed when no completed step has a compensation) and returns nil for
+// the caller to continue.
+func forward[S any](ctx context.Context, e *Engine, wf *Workflow[S], run *Run, state *S) error {
+	steps := wf.steps
+	if run.Step < 0 {
+		return queue.SkipRetry(fmt.Errorf("workflow: run %q: inconsistent checkpoint step %d", run.ID, run.Step))
+	}
+	for run.Step < len(steps) {
+		if err := ctx.Err(); err != nil {
+			return err // shutdown or timeout between steps: resume on redelivery
+		}
+		st := steps[run.Step]
+		err := invokeStep(ctx, st.Run, state)
+		if err == nil {
+			raw, merr := json.Marshal(state)
+			if merr != nil {
+				return queue.SkipRetry(fmt.Errorf("workflow: run %q: marshal state after step %q: %w", run.ID, st.Name, merr))
+			}
+			run.State = raw
+			run.Step++
+			run.Attempt = 0
+			if run.Step == len(steps) {
+				run.Status = StatusCompleted
+			}
+			if cerr := e.checkpoint(ctx, run); cerr != nil {
+				return cerr
+			}
+			continue
+		}
+		if ctx.Err() != nil {
+			return err // cancelled mid-step: redeliver without burning an attempt
+		}
+		failed := run.Attempt + 1
+		if !isPermanent(err) && failed < e.stepBudget(st.MaxAttempts) {
+			run.Attempt = failed
+			if cerr := e.checkpoint(ctx, run); cerr != nil {
+				return cerr
+			}
+			return fmt.Errorf("workflow: run %q step %q attempt %d: %w", run.ID, st.Name, failed, err)
+		}
+		run.Error = err.Error()
+		run.Attempt = 0
+		run.Step = prevCompIndex(steps, run.Step-1)
+		if run.Step < 0 {
+			run.Status = StatusFailed
+		} else {
+			run.Status = StatusCompensating
+		}
+		if cerr := e.checkpoint(ctx, run); cerr != nil {
+			return cerr
+		}
+		if run.Status == StatusFailed {
+			e.log.ErrorContext(ctx, "workflow run failed", runAttrs(run, slog.String("step", st.Name), slog.String("error", run.Error))...)
+		}
+		return nil
+	}
+	// Definition drift across deploys can leave a checkpoint past the last
+	// step; a run with nothing left to do is complete.
+	if run.Status != StatusCompleted {
+		run.Status = StatusCompleted
+		if cerr := e.checkpoint(ctx, run); cerr != nil {
+			return cerr
+		}
+	}
+	e.log.InfoContext(ctx, "workflow run completed", runAttrs(run)...)
+	return nil
+}
+
+// compensate unwinds completed steps' compensations newest first from the
+// checkpoint, ending in StatusFailed. A compensation that exhausts its budget
+// keeps the run compensating, resets its attempt counter, and dead-letters
+// the driving job — queue.Client.Requeue resumes the unwind.
+func compensate[S any](ctx context.Context, e *Engine, wf *Workflow[S], run *Run, state *S) error {
+	steps := wf.steps
+	for run.Status == StatusCompensating {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// Recompute defensively: the checkpoint normally indexes a step with a
+		// compensation, but definition drift across deploys can invalidate it.
+		run.Step = prevCompIndex(steps, min(run.Step, len(steps)-1))
+		if run.Step < 0 {
+			run.Status = StatusFailed
+			if cerr := e.checkpoint(ctx, run); cerr != nil {
+				return cerr
+			}
+			break
+		}
+		st := steps[run.Step]
+		err := invokeStep(ctx, st.Compensate, state)
+		if err == nil {
+			raw, merr := json.Marshal(state)
+			if merr != nil {
+				return queue.SkipRetry(fmt.Errorf("workflow: run %q: marshal state after compensation %q: %w", run.ID, st.Name, merr))
+			}
+			run.State = raw
+			run.Attempt = 0
+			run.Step = prevCompIndex(steps, run.Step-1)
+			if run.Step < 0 {
+				run.Status = StatusFailed
+			}
+			if cerr := e.checkpoint(ctx, run); cerr != nil {
+				return cerr
+			}
+			continue
+		}
+		if ctx.Err() != nil {
+			return err
+		}
+		failed := run.Attempt + 1
+		if !isPermanent(err) && failed < e.stepBudget(st.MaxAttempts) {
+			run.Attempt = failed
+			if cerr := e.checkpoint(ctx, run); cerr != nil {
+				return cerr
+			}
+			return fmt.Errorf("workflow: run %q compensation %q attempt %d: %w", run.ID, st.Name, failed, err)
+		}
+		// Exhausted: reset the counter so a Requeue retries this compensation
+		// with a fresh budget instead of dead-lettering again immediately.
+		run.Attempt = 0
+		if cerr := e.checkpoint(ctx, run); cerr != nil {
+			return cerr
+		}
+		e.log.ErrorContext(ctx, "workflow compensation exhausted, run dead-lettered", runAttrs(run, slog.String("step", st.Name), slog.String("error", err.Error()))...)
+		return queue.SkipRetry(fmt.Errorf("workflow: run %q compensation %q exhausted: %w", run.ID, st.Name, err))
+	}
+	e.log.ErrorContext(ctx, "workflow run failed after compensation", runAttrs(run, slog.String("error", run.Error))...)
+	return nil
+}
+
+// checkpoint persists run and tracks the version bump locally.
+func (e *Engine) checkpoint(ctx context.Context, run *Run) error {
+	run.UpdatedAt = e.clk.Now().UTC()
+	if err := e.store.Update(ctx, *run); err != nil {
+		return fmt.Errorf("workflow: checkpoint run %q: %w", run.ID, err)
+	}
+	run.Version++
+	return nil
+}
+
+// invokeStep runs one step (or compensation) with panic recovery: a panicking
+// step is a failed step, not a crashed worker, so it burns an attempt like
+// any other failure.
+func invokeStep[S any](ctx context.Context, fn func(context.Context, *S) error, state *S) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("workflow: step panic: %v", r)
+		}
+	}()
+	return fn(ctx, state)
+}
+
+// prevCompIndex returns the highest index <= from whose step has a
+// compensation, or -1 when none is left to run.
+func prevCompIndex[S any](steps []Step[S], from int) int {
+	for i := min(from, len(steps)-1); i >= 0; i-- {
+		if steps[i].Compensate != nil {
+			return i
+		}
+	}
+	return -1
+}
+
+// isPermanent classifies a step error: the Fail verdict, plus the queue
+// verdicts a handler author might return by habit — letting either leak to
+// the queue engine would dead-letter or discard the driving job while the run
+// still looks alive.
+func isPermanent(err error) bool {
+	return IsFail(err) || queue.IsSkipRetry(err) || errors.Is(err, queue.Cancel)
+}
+
+func runAttrs(run *Run, extra ...any) []any {
+	attrs := make([]any, 0, 2+len(extra))
+	attrs = append(attrs, slog.String("workflow", run.Workflow), slog.String("run_id", run.ID))
+	return append(attrs, extra...)
+}

--- a/async/workflow/runner.go
+++ b/async/workflow/runner.go
@@ -78,7 +78,7 @@ func decodeState[S any](raw json.RawMessage) (*S, error) {
 func forward[S any](ctx context.Context, e *Engine, wf *Workflow[S], run *Run, state *S) error {
 	steps := wf.steps
 	if run.Step < 0 {
-		return queue.SkipRetry(fmt.Errorf("workflow: run %q: inconsistent checkpoint step %d", run.ID, run.Step))
+		return e.abandon(ctx, run, fmt.Errorf("workflow: run %q: inconsistent checkpoint step %d", run.ID, run.Step))
 	}
 	for run.Step < len(steps) {
 		if err := ctx.Err(); err != nil {
@@ -201,8 +201,11 @@ func compensate[S any](ctx context.Context, e *Engine, wf *Workflow[S], run *Run
 			return fmt.Errorf("workflow: run %q compensation %q attempt %d: %w", run.ID, st.Name, failed, err)
 		}
 		// Exhausted: reset the counter so a Requeue retries this compensation
-		// with a fresh budget instead of dead-lettering again immediately.
+		// with a fresh budget instead of dead-lettering again immediately, and
+		// note why the run is parked next to the original trigger — the store
+		// must explain a stuck saga without the DLQ or logs at hand.
 		run.Attempt = 0
+		appendErrorNote(run, fmt.Sprintf("compensation %q exhausted: %v", st.Name, err))
 		if cerr := e.checkpoint(ctx, run); cerr != nil {
 			return cerr
 		}
@@ -234,22 +237,26 @@ func (e *Engine) checkpoint(ctx context.Context, run *Run) error {
 // the run from its checkpoint. The write is best-effort — the DLQ entry
 // carries the same reason.
 func (e *Engine) abandon(ctx context.Context, run *Run, err error) error {
-	// A compensating run's Error holds the business failure that triggered
-	// the unwind — the one signal explaining a stuck saga — so append the
-	// abandon note instead of replacing it. The suffix check keeps repeated
-	// requeue-and-abandon cycles from growing the note unboundedly.
-	note := "abandoned: " + err.Error()
+	appendErrorNote(run, "abandoned: "+err.Error())
+	if cerr := e.checkpoint(ctx, run); cerr != nil {
+		e.log.WarnContext(ctx, "workflow abandon note not persisted", runAttrs(run, slog.Any("error", cerr))...)
+	}
+	e.log.ErrorContext(ctx, "workflow run abandoned, driving job dead-lettered", runAttrs(run, slog.String("error", run.Error))...)
+	return queue.SkipRetry(err)
+}
+
+// appendErrorNote records why a live run's driving job was dead-lettered
+// without clobbering what Run.Error already holds — on a compensating run
+// that is the business failure that triggered the unwind, the one signal
+// explaining a stuck saga. The suffix check keeps repeated
+// requeue-and-dead-letter cycles from growing the note unboundedly.
+func appendErrorNote(run *Run, note string) {
 	switch {
 	case run.Error == "":
 		run.Error = note
 	case !strings.HasSuffix(run.Error, note):
 		run.Error += "; " + note
 	}
-	if cerr := e.checkpoint(ctx, run); cerr != nil {
-		e.log.WarnContext(ctx, "workflow abandon note not persisted", runAttrs(run, slog.Any("error", cerr))...)
-	}
-	e.log.ErrorContext(ctx, "workflow run abandoned, driving job dead-lettered", runAttrs(run, slog.String("error", run.Error))...)
-	return queue.SkipRetry(err)
 }
 
 // invokeStep runs one step (or compensation) with panic recovery: a panicking

--- a/async/workflow/workflow.go
+++ b/async/workflow/workflow.go
@@ -1,0 +1,67 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"slices"
+)
+
+// Step is one named unit of a workflow over state S. Run executes forward
+// work and may mutate state; the mutation is checkpointed only when Run
+// returns nil. Compensate, when set, undoes Run after a later step fails
+// permanently — it sees the state as of the last checkpoint (a failed step's
+// partial mutations are discarded) and its own mutations are checkpointed
+// too, so an undo can record what it released. MaxAttempts bounds the step's
+// transient failures before the failure turns permanent (0 uses the engine's
+// WithStepAttempts default); the same budget bounds Compensate.
+//
+// Both funcs run under the queue engine's at-least-once delivery and MUST BE
+// IDEMPOTENT.
+type Step[S any] struct {
+	Run         func(ctx context.Context, state *S) error
+	Compensate  func(ctx context.Context, state *S) error
+	Name        string
+	MaxAttempts int
+}
+
+// Workflow is an immutable, ordered step sequence over state S. Declare one
+// package-level Workflow per sequence with New and share it between the
+// process that Starts runs and the worker that executes them.
+type Workflow[S any] struct {
+	name  string
+	steps []Step[S]
+}
+
+// New declares a workflow. The name must be non-empty and unique across the
+// application (convention: "domain.action"); it becomes the queue the
+// workflow's runs drain from. Panics on an empty or duplicate step name, a
+// nil Step.Run, a negative Step.MaxAttempts, or no steps at all — workflows
+// are startup wiring, not runtime data.
+func New[S any](name string, steps ...Step[S]) *Workflow[S] {
+	if name == "" {
+		panic("workflow: New requires a non-empty workflow name")
+	}
+	if len(steps) == 0 {
+		panic(fmt.Sprintf("workflow: New(%q) requires at least one step", name))
+	}
+	seen := make(map[string]struct{}, len(steps))
+	for i, st := range steps {
+		if st.Name == "" {
+			panic(fmt.Sprintf("workflow: New(%q) step %d has an empty name", name, i))
+		}
+		if st.Run == nil {
+			panic(fmt.Sprintf("workflow: New(%q) step %q has a nil Run", name, st.Name))
+		}
+		if st.MaxAttempts < 0 {
+			panic(fmt.Sprintf("workflow: New(%q) step %q has negative MaxAttempts", name, st.Name))
+		}
+		if _, dup := seen[st.Name]; dup {
+			panic(fmt.Sprintf("workflow: New(%q) duplicate step name %q", name, st.Name))
+		}
+		seen[st.Name] = struct{}{}
+	}
+	return &Workflow[S]{name: name, steps: slices.Clone(steps)}
+}
+
+// Name returns the workflow name.
+func (w *Workflow[S]) Name() string { return w.name }

--- a/async/workflow/workflow_test.go
+++ b/async/workflow/workflow_test.go
@@ -1,0 +1,78 @@
+package workflow_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/async/workflow"
+)
+
+func noop(context.Context, *struct{}) error { return nil }
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty workflow name", func(t *testing.T) {
+		t.Parallel()
+		assert.Panics(t, func() { workflow.New[struct{}]("") })
+	})
+
+	t.Run("no steps", func(t *testing.T) {
+		t.Parallel()
+		assert.Panics(t, func() { workflow.New[struct{}]("wf") })
+	})
+
+	t.Run("empty step name", func(t *testing.T) {
+		t.Parallel()
+		assert.Panics(t, func() {
+			workflow.New("wf", workflow.Step[struct{}]{Run: noop})
+		})
+	})
+
+	t.Run("nil run", func(t *testing.T) {
+		t.Parallel()
+		assert.Panics(t, func() {
+			workflow.New("wf", workflow.Step[struct{}]{Name: "a"})
+		})
+	})
+
+	t.Run("negative max attempts", func(t *testing.T) {
+		t.Parallel()
+		assert.Panics(t, func() {
+			workflow.New("wf", workflow.Step[struct{}]{Name: "a", Run: noop, MaxAttempts: -1})
+		})
+	})
+
+	t.Run("duplicate step name", func(t *testing.T) {
+		t.Parallel()
+		assert.Panics(t, func() {
+			workflow.New("wf",
+				workflow.Step[struct{}]{Name: "a", Run: noop},
+				workflow.Step[struct{}]{Name: "a", Run: noop},
+			)
+		})
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		wf := workflow.New("wf", workflow.Step[struct{}]{Name: "a", Run: noop})
+		assert.Equal(t, "wf", wf.Name())
+	})
+}
+
+func TestFail(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, workflow.Fail(nil))
+
+	base := errors.New("boom")
+	err := workflow.Fail(base)
+	require.Error(t, err)
+	assert.True(t, workflow.IsFail(err))
+	assert.ErrorIs(t, err, base)
+	assert.False(t, workflow.IsFail(base))
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -396,18 +396,6 @@ required).
 
 Deps: `ops/supervisor`.
 
----
-
-**async/workflow**
-
-DB-checkpointed linear step sequences over the engine
-(onboarding/provisioning chains; resume after crash), with optional
-per-step compensation — on failure, completed steps' compensations run in
-reverse order (a payout pipeline that must undo its ledger debit). No DAG,
-no DSL, no timers — not a Temporal clone.
-
-Deps: `async/queue`.
-
 ## realtime/
 
 ---


### PR DESCRIPTION
## Summary

New `async/workflow` package: DB-checkpointed linear step sequences over the queue engine, per the catalog entry (now removed from `docs/packages.md`). No DAG, no DSL, no timers — not a Temporal clone.

- **Typed workflows** — `workflow.New("payout.execute", workflow.Step[Payout]{Name: "debit", Run: ..., Compensate: ...}, ...)`: a state value `S` flows through named steps in order; each step may mutate it, and the mutation is checkpointed only on success.
- **Checkpointed resume** — one driving job per run carries only the run id; every step boundary persists `Run{Step, Attempt, State, Version}` to a pluggable `Store`. At-least-once redelivery (crash, lost lease, retry) reloads the checkpoint and resumes at the first incomplete step. Steps must be idempotent, exactly like queue handlers.
- **Failure semantics** — a step error is transient by default: the run checkpoints the failed attempt and the engine retries with backoff, re-entering at the same step. `workflow.Fail(err)` (plus `queue.SkipRetry`/`queue.Cancel` returned by habit — intercepted so they can never dead-letter a run that still looks alive) or a spent per-step attempt budget (`Step.MaxAttempts`, default `WithStepAttempts`, 5) makes the failure permanent.
- **Saga compensation** — on permanent failure, completed steps' `Compensate` funcs run newest-first with the same checkpoint/retry/budget rules, against the state as of the last checkpoint (a failed step's partial mutations are discarded). The run ends `failed` with the triggering error on `Run.Error`. An exhausted compensation resets its counter and dead-letters the driving job; `queue.Client.Requeue` resumes the unwind with a fresh budget.
- **Engine owns the hard parts** — the driving job's `MaxAttempts` is derived from the sum of step + compensation budgets plus a margin, so the queue engine never dead-letters a run that is making progress; a dead-lettered run (e.g. prolonged store outage) resumes from its checkpoint via `Requeue`.
- **Optimistic locking** — `Store.Update` is version-guarded (`ErrStaleRun`), so a worker whose lease was silently lost cannot regress a checkpoint the new claim already advanced.
- **Stores** — `MemoryStore` test double in-package; `async/workflow/postgres` (`pgworkflow`) ships the durable store with goose migration, unique-violation → `ErrRunAlreadyExists` mapping, and batched `PurgeTerminalBefore` retention (pgeventbus precedent).
- **Tenancy** — optional fail-closed `WithScope` seam on the engine + `queue.WithScopeContext` on the service; single-tenant apps configure neither (zero ceremony).
- **Service wiring** — `NewService` mirrors eventbus: one equal-weight queue per workflow, default name `workflow`, runs under `ops/supervisor`.

## Benchmarks (Apple M3 Max, memory broker + memory store)

```
BenchmarkStart_Memory-14                            893688      1393 ns/op     1074 B/op     10 allocs/op
BenchmarkRunThroughput_Memory/steps_1-14             10000    182318 ns/op     8704 B/op     59 allocs/op
BenchmarkRunThroughput_Memory/steps_5-14             10000    184898 ns/op     8745 B/op     67 allocs/op
```

Post-benchmark pass: `Start` is 1.4µs / 10 allocs (two ids, two marshals, one broker push — nothing left worth complexity). End-to-end throughput is dominated by queue-engine claim/heartbeat/ack machinery, not this package (steps_1 ≈ steps_5); no perf-motivated complexity added, per design.md §Performance.

Postgres store (integration tier): create ~0.1ms-class single-row insert/select/update; `BenchmarkStore` included in `postgres/bench_test.go`.

## Testing

- `go test -race ./async/workflow/...` — unit tier, Docker-free (memory broker + store), covering: checkpointed resume after transient failures, reverse-order compensation with no-comp steps skipped, budget exhaustion, panic-burns-attempt, queue-verdict interception, compensation dead-letter → Requeue resume, duplicate delivery of finished runs, failed-step state isolation, scope capture/restore, optimistic-lock staleness.
- `just test-integration ./async/workflow/...` — pgworkflow store contract + full saga driven through the engine with Postgres checkpoints (83.3% / 89.2% coverage).
- `just lint` clean.
