### PR TITLE
examples: orderflow — integration demo of all async packages

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -47,3 +47,16 @@ go run ./examples/helloworld
 curl http://localhost:8080/
 # -> Hello, World!
 ```
+
+## orderflow
+
+An integration demo of the whole `async/` family — [`queue`](../async/queue), [`eventbus`](../async/eventbus), [`eventrouter`](../async/eventrouter), [`outbox`](../async/outbox), [`scheduler`](../async/scheduler), [`collector`](../async/collector), and [`workflow`](../async/workflow) — wired together as one order-processing backend under the supervisor. Everything is in-memory in a single binary; the wiring is identical with the postgres/redis siblings swapped in.
+
+The pipeline: `POST /orders` publishes `order.placed` transactionally through the outbox (`PublishTx` intent row → relay → broker); an inbox-guarded eventbus subscription starts the `order.fulfill` workflow (charge → reserve stock → complete, with refund compensation on out-of-stock); completion publishes `order.completed`, which a receipt subscription consumes and the eventrouter batches to the demo's own `/analytics` endpoint; the collector buffers per-request telemetry write-behind; the scheduler enqueues a `shop.report` queue job every 15 s that logs order counts and stats. See [orderflow/README.md](orderflow/README.md) for the full walkthrough with ASCII diagrams of both order paths.
+
+```sh
+go run ./examples/orderflow
+# it seeds one fulfilling and one compensating order; add more:
+curl -s localhost:8080/orders -d '{"item":"espresso","qty":1}'   # charged → reserved → receipt + analytics
+curl -s localhost:8080/orders -d '{"item":"unicorn","qty":1}'    # out of stock → workflow.Fail → refund
+```

--- a/examples/orderflow/README.md
+++ b/examples/orderflow/README.md
@@ -1,0 +1,180 @@
+# orderflow
+
+An integration demo that wires **every `async/` package** — [`queue`](../../async/queue), [`eventbus`](../../async/eventbus), [`eventrouter`](../../async/eventrouter), [`outbox`](../../async/outbox), [`workflow`](../../async/workflow), [`scheduler`](../../async/scheduler), and [`collector`](../../async/collector) — into one coherent order-processing backend, to prove they compose. Each package plays its natural role and each stage's output is the next stage's input.
+
+Everything is in-memory in a single binary: no Docker, no external services. The memory constructors (`queue.NewMemoryBroker`, `outbox.NewMemoryStore`, `workflow.NewMemoryStore`, `eventbus.NewMemoryInbox`, the default scheduler store) are drop-in stand-ins for their postgres/redis siblings — swap the constructors and the wiring stays identical.
+
+## The scenario
+
+A tiny web shop. `POST /orders` accepts an order, the backend charges payment, reserves stock, and emails a receipt — asynchronously, durably, with a compensating refund when stock runs out. Analytics events stream to a "warehouse", request telemetry is collected write-behind, and a scheduled job logs a shop summary every 15 seconds.
+
+Two items exist: `espresso` (stock 100, always fulfills) and `unicorn` (stock 0, always fails and demonstrates compensation).
+
+## The big picture
+
+```
+                        ┌─────────────────────────────────────────────────────────────┐
+                        │            one binary, 7 services under ops/supervisor      │
+                        └─────────────────────────────────────────────────────────────┘
+
+  curl POST /orders
+        │
+        ▼
+  ┌───────────┐  Add(request)   ┌───────────┐  batch every 5s
+  │ shop-api  │────────────────▶│ collector │─────────────────▶ "telemetry flushed" log
+  │(httpserver│                 └───────────┘                    (write-behind, lossy by contract)
+  │ +telemetry│
+  │middleware)│                                 ┌──────────────┐
+  └───────────┘                            ┌───▶│ outbox relay │───┐
+        │ eventbus.PublishTx(order.placed) │    └──────────────┘   │ Push
+        ▼                                  │ poll                  ▼
+  ┌──────────────┐                         │              ┌────────────────┐
+  │ outbox store │─────────────────────────┘              │  queue broker  │
+  │ (intent rows)│   row committed with the business tx   │    (memory)    │
+  └──────────────┘                                        └────────────────┘
+                                                                   │
+                       one durable job per (event, subscription)   │  eventbus fan-out
+              ┌───────────────────────────────┬────────────────────┤
+              ▼                               ▼                    ▼
+     ┌─────────────────┐             ┌─────────────────┐   ┌───────────────────┐
+     │ "fulfill" sub   │             │ "receipt" sub   │   │ eventrouter routes│
+     │ (inbox-guarded) │             │ (order.completed│   │ order.placed +    │
+     └─────────────────┘             │  → log email)   │   │ order.completed   │
+              │ workflow.Start       └─────────────────┘   └───────────────────┘
+              ▼                               ▲                    │ batch ≤8 events / 2s
+     ┌─────────────────────────┐              │                    ▼
+     │  workflow order.fulfill │              │            POST /analytics
+     │  charge → reserve →     │──────────────┘            (served by this same
+     │  complete               │  publish order.completed   binary = the "warehouse")
+     └─────────────────────────┘
+
+  ┌───────────┐ every 15s ┌──────────────────┐        ┌─────────────┐
+  │ scheduler │──────────▶│ shop.report job  │───────▶│ shop-worker │──▶ "shop report" log
+  └───────────┘  enqueue  │ (queue, default) │ claim  └─────────────┘
+                          └──────────────────┘
+```
+
+## Life of a fulfilled order
+
+```
+ curl -d '{"item":"espresso","qty":2}' localhost:8080/orders
+   │
+   ▼
+ shop-api            shop.place() → ord-1, status "placed"
+   │                 eventbus.PublishTx(order.placed)      ── outbox intent row, NOT a broker
+   │                                                          push: with pgoutbox it commits or
+   ▼                                                          rolls back with the order insert
+ outbox relay        claims the committed row, pushes it into the broker, deletes it
+   │
+   ▼
+ eventbus            fans order.placed out: one durable job per subscription
+   ├─▶ "fulfill"     inbox.Seen(id)? no → claims it → workflow.Start(order.fulfill)
+   └─▶ "analytics"   (see egress below)
+   │
+   ▼
+ workflow-worker     drives the run, checkpointing after every step:
+   1. charge_payment   PaymentID = pay-ord-1              [checkpoint]
+   2. reserve_stock    espresso 100 → 98, keyed by ord-1  [checkpoint]
+   3. complete         status "fulfilled",
+                       publish order.completed            [checkpoint, run completed]
+   │
+   ▼
+ eventbus            fans order.completed out:
+   ├─▶ "receipt"     → "receipt emailed  order=ord-1"
+   └─▶ "analytics"   → joins the batch
+   │
+   ▼
+ eventrouter         batches accumulate until 8 events or 2s of age, then one
+   │                 HTTP POST delivers them; the jobs block until the flush
+   ▼                 resolves, so nothing is acked before the warehouse accepted it
+ POST /analytics     → "analytics ingested  event=order.placed  id=…"
+                       "analytics ingested  event=order.completed  id=…"
+```
+
+## Life of an out-of-stock order (compensation)
+
+```
+ curl -d '{"item":"unicorn","qty":1}' localhost:8080/orders     unicorn stock = 0
+   │
+   │   ... same intake path: outbox → relay → broker → "fulfill" ...
+   ▼
+ workflow-worker     order.fulfill for ord-2:
+   1. charge_payment   PaymentID = pay-ord-2              [checkpoint]
+   2. reserve_stock    out of stock → workflow.Fail(err)  ── business failure:
+   │                                                         no retry can help
+   ▼
+ the run flips to "compensating": COMPLETED steps undo in reverse order
+   (reserve_stock never completed, so only charge_payment compensates)
+   1'. refund_payment   status "failed", "payment refunded  order=ord-2"
+   │
+   ▼
+ run ends "failed", the original error recorded on the run row:
+   workflow run failed after compensation … item "unicorn" is out of stock
+```
+
+## Who does what
+
+| Package       | Role here                                                                                        | Production swap                                     |
+| ------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
+| `queue`       | The engine under everything: durable jobs, leases, retry, dead-letter. Also runs the report job.  | `queue/postgres` or `queue/redis` broker            |
+| `outbox`      | Makes `PublishTx` transactional on a broker that lacks it: intent row now, relay pushes it later. | `outbox/postgres` over the business DB              |
+| `eventbus`    | Fans each order event out to independent subscriptions; the inbox dedups at-least-once delivery.  | same code; `eventbus/postgres` inbox                |
+| `workflow`    | The fulfillment saga: checkpointed steps, compensation on permanent failure.                      | `workflow/postgres` store                           |
+| `eventrouter` | Egress: batches both events to the analytics endpoint over real HTTP with queue-grade retry.      | point the deliverer at the real warehouse           |
+| `scheduler`   | Turns "every 15s" into a `shop.report` queue job; claim store fires once per fleet.               | `scheduler/postgres` store                          |
+| `collector`   | Write-behind request telemetry: `Add` never blocks the request path, batches flush to a sink.     | a real sink (warehouse insert), `resilience/retry`  |
+
+All seven services run under [`ops/supervisor`](../../ops/supervisor):
+
+```
+supervisor
+├── shop-api          httpserver     :8080 — /orders intake, /analytics receiver
+├── shop-worker       queue.Service  drains "default"           (shop.report)
+├── eventbus-worker   queue.Service  drains subscription queues (order.placed.fulfill, …receipt, …analytics)
+├── workflow-worker   queue.Service  drains "order.fulfill"     (the saga's own queue)
+├── outbox            relay          polls intent rows → broker
+├── scheduler         tick claimer   enqueues shop.report every 15s
+└── collector         flusher        drains the telemetry buffer (and on shutdown)
+```
+
+Ctrl+C cancels the shared context and the supervisor drains everything: in-flight jobs finish, the collector flushes its buffer, the server stops accepting.
+
+## Run it
+
+```sh
+go run ./examples/orderflow
+```
+
+On startup it seeds one order of each kind, so the full pipeline shows without any curl. Then poke it:
+
+```sh
+curl -s localhost:8080/orders -d '{"item":"espresso","qty":1}'   # happy path
+curl -s localhost:8080/orders -d '{"item":"unicorn","qty":1}'    # compensation path
+```
+
+What to expect in the log, in order:
+
+```
+payment charged      order=ord-1 payment=pay-ord-1
+payment charged      order=ord-2 payment=pay-ord-2
+stock reserved       order=ord-1 item=espresso
+payment refunded     order=ord-2 payment=pay-ord-2
+workflow run completed  workflow=order.fulfill …
+workflow run failed after compensation … item "unicorn" is out of stock
+receipt emailed      order=ord-1
+analytics ingested   event=order.placed …          (≈2s later, one batch)
+analytics ingested   event=order.placed …
+analytics ingested   event=order.completed …
+telemetry flushed    requests=3                    (≈5s, collector interval)
+shop report          orders_fulfilled=1 orders_failed=1 …   (next 15s boundary)
+```
+
+## Code layout
+
+| File                               | Contents                                                                     |
+| ---------------------------------- | ---------------------------------------------------------------------------- |
+| [`main.go`](main.go)               | Wiring only: broker → domain → HTTP → workers → supervisor                   |
+| [`shop.go`](shop.go)               | The "business database": stock, order statuses, the two lifecycle events     |
+| [`fulfillment.go`](fulfillment.go) | The `order.fulfill` workflow and the eventbus subscriptions that drive it    |
+| [`web.go`](web.go)                 | HTTP handlers, telemetry middleware, analytics egress route, the demo seeder |
+| [`report.go`](report.go)           | The scheduled `shop.report` job: schedule + handler                          |

--- a/examples/orderflow/fulfillment.go
+++ b/examples/orderflow/fulfillment.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+	"github.com/dmitrymomot/forge/async/workflow"
+)
+
+// fulfillment is the workflow state: it flows through the steps and is
+// checkpointed after each one, so a restarted worker resumes mid-order.
+type fulfillment struct {
+	OrderID   string `json:"order_id"`
+	Item      string `json:"item"`
+	PaymentID string `json:"payment_id"`
+	Qty       int    `json:"qty"`
+}
+
+// newFulfillment builds the order.fulfill workflow: charge, reserve, publish.
+// An out-of-stock item is a business failure no retry can fix, so
+// reserve_stock returns workflow.Fail and the completed steps compensate in
+// reverse order — the charge is refunded.
+func newFulfillment(sh *shop, bus *eventbus.Bus, log *slog.Logger) *workflow.Workflow[fulfillment] {
+	chargePayment := func(_ context.Context, f *fulfillment) error {
+		if f.PaymentID == "" { // idempotent under step redelivery
+			f.PaymentID = "pay-" + f.OrderID
+		}
+		log.Info("payment charged", slog.String("order", f.OrderID), slog.String("payment", f.PaymentID))
+		return nil
+	}
+	refundPayment := func(_ context.Context, f *fulfillment) error {
+		sh.setStatus(f.OrderID, "failed")
+		log.Info("payment refunded", slog.String("order", f.OrderID), slog.String("payment", f.PaymentID))
+		return nil
+	}
+
+	reserveStock := func(_ context.Context, f *fulfillment) error {
+		if err := sh.reserve(f.OrderID, f.Item, f.Qty); err != nil {
+			return workflow.Fail(err)
+		}
+		log.Info("stock reserved", slog.String("order", f.OrderID), slog.String("item", f.Item))
+		return nil
+	}
+	releaseStock := func(_ context.Context, f *fulfillment) error {
+		sh.release(f.OrderID, f.Item, f.Qty)
+		return nil
+	}
+
+	complete := func(ctx context.Context, f *fulfillment) error {
+		sh.setStatus(f.OrderID, "fulfilled")
+		return eventbus.Publish(ctx, bus, evtOrderCompleted, orderEvent{OrderID: f.OrderID, Item: f.Item, Qty: f.Qty})
+	}
+
+	return workflow.New("order.fulfill",
+		workflow.Step[fulfillment]{Name: "charge_payment", Run: chargePayment, Compensate: refundPayment},
+		workflow.Step[fulfillment]{Name: "reserve_stock", Run: reserveStock, Compensate: releaseStock},
+		workflow.Step[fulfillment]{Name: "complete", Run: complete},
+	)
+}
+
+// subscribeOrderLifecycle wires the eventbus reactions to the two order
+// events: order.placed starts the fulfillment workflow, order.completed sends
+// the receipt.
+func subscribeOrderLifecycle(bus *eventbus.Bus, eng *workflow.Engine, fulfill *workflow.Workflow[fulfillment], log *slog.Logger) {
+	// Deliveries are at-least-once; the inbox seam collapses duplicates so one
+	// order never starts two workflow runs (production:
+	// async/eventbus/postgres inside the handler's transaction).
+	inbox := eventbus.NewMemoryInbox()
+	eventbus.Subscribe(bus, evtOrderPlaced, "fulfill", func(ctx context.Context, d eventbus.Delivery[orderEvent]) error {
+		seen, err := inbox.Seen(ctx, nil, d.ID)
+		if err != nil || seen {
+			return err
+		}
+		_, err = workflow.Start(ctx, eng, fulfill, fulfillment{OrderID: d.Payload.OrderID, Item: d.Payload.Item, Qty: d.Payload.Qty})
+		return err
+	})
+
+	eventbus.Subscribe(bus, evtOrderCompleted, "receipt", func(_ context.Context, d eventbus.Delivery[orderEvent]) error {
+		log.Info("receipt emailed", slog.String("order", d.Payload.OrderID))
+		return nil
+	})
+}

--- a/examples/orderflow/main.go
+++ b/examples/orderflow/main.go
@@ -1,0 +1,130 @@
+// Command orderflow is an integration demo of every async package working
+// together as one order-processing backend. A single in-memory binary, no
+// external services: swap the memory constructors for the postgres/redis
+// siblings and the wiring stays identical.
+//
+// The pipeline, end to end:
+//
+//	POST /orders ──(outbox: PublishTx intent row)──> relay ──> broker
+//	    └─ collector buffers request telemetry (write-behind)
+//	broker ──(eventbus)──> "fulfill" subscription ──> workflow order.fulfill
+//	    order.placed also routes (eventrouter) to the local /analytics endpoint
+//	workflow: charge_payment -> reserve_stock -> complete
+//	    out of stock => workflow.Fail => compensation refunds the charge
+//	    complete publishes order.completed -> "receipt" subscription + analytics
+//	scheduler ──(every 15s)──> shop.report queue job ──> summary log line
+//
+// The code is split by concern: shop.go is the business state and events,
+// fulfillment.go the workflow and event subscriptions, web.go the HTTP layer
+// and analytics egress, report.go the scheduled summary. main wires them.
+//
+// Run it and watch one order fulfill and one compensate:
+//
+//	go run ./examples/orderflow
+//	curl -s localhost:8080/orders -d '{"item":"espresso","qty":1}'
+//	curl -s localhost:8080/orders -d '{"item":"unicorn","qty":1}'
+package main
+
+import (
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+	"github.com/dmitrymomot/forge/async/outbox"
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/async/scheduler"
+	"github.com/dmitrymomot/forge/async/workflow"
+	"github.com/dmitrymomot/forge/ops/supervisor"
+)
+
+const addr = ":8080"
+
+func main() {
+	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	sh := newShop()
+
+	// Messaging fabric: one broker underneath everything. The outbox wrapper
+	// adds transactional push (queue.TxPusher) to a broker that lacks it — in
+	// production the store is pgoutbox over the business database and the
+	// broker is redis.
+	inner := queue.NewMemoryBroker()
+	outboxStore := outbox.NewMemoryStore()
+	broker := outbox.Wrap(outboxStore, inner)
+	bus := eventbus.New(broker)
+	client := queue.NewClient(broker)
+
+	// Domain wiring: the fulfillment workflow and the event subscriptions
+	// that react to the order lifecycle.
+	eng := workflow.NewEngine(inner, workflow.NewMemoryStore(), workflow.WithLogger(log))
+	fulfill := newFulfillment(sh, bus, log)
+	workflow.Register(eng, fulfill)
+	subscribeOrderLifecycle(bus, eng, fulfill, log)
+	if err := routeAnalytics(bus); err != nil {
+		fatal(log, "route analytics", err)
+	}
+
+	// HTTP layer: order intake, analytics receiver, request telemetry.
+	telemetry, err := newTelemetry(log)
+	if err != nil {
+		fatal(log, "build telemetry", err)
+	}
+	server := newShopAPI(sh, bus, telemetry, log)
+
+	// Background services: each concern drains its own queues on the shared
+	// broker. Fast polling so the demo reacts in milliseconds; production
+	// keeps the defaults.
+	qcfg := queue.DefaultConfig()
+	qcfg.PollInterval = 100 * time.Millisecond
+
+	worker, err := queue.NewService(broker, queue.WithConfig(qcfg), queue.WithName("shop-worker"), queue.WithLogger(log))
+	if err != nil {
+		fatal(log, "build queue worker", err)
+	}
+	busWorker, err := eventbus.NewService(bus, queue.WithConfig(qcfg), queue.WithName("eventbus-worker"), queue.WithLogger(log))
+	if err != nil {
+		fatal(log, "build eventbus worker", err)
+	}
+	wfWorker, err := workflow.NewService(eng, queue.WithConfig(qcfg), queue.WithName("workflow-worker"), queue.WithLogger(log))
+	if err != nil {
+		fatal(log, "build workflow worker", err)
+	}
+
+	relayCfg := outbox.DefaultConfig()
+	relayCfg.PollInterval = 100 * time.Millisecond
+	relay, err := outbox.NewRelay(outboxStore, inner, outbox.WithConfig(relayCfg), outbox.WithLogger(log))
+	if err != nil {
+		fatal(log, "build outbox relay", err)
+	}
+
+	sched, err := scheduler.New(client, scheduler.WithLogger(log))
+	if err != nil {
+		fatal(log, "build scheduler", err)
+	}
+	registerReporting(sched, worker, sh, client, telemetry, log)
+
+	// Run everything under the supervisor; Ctrl+C drains all of it.
+	ctx, stop := supervisor.NewContext()
+	defer stop()
+
+	go seed(ctx, log)
+
+	err = supervisor.Run(ctx,
+		supervisor.WithLogger(log),
+		supervisor.WithService(server),
+		supervisor.WithService(worker),
+		supervisor.WithService(busWorker),
+		supervisor.WithService(wfWorker),
+		supervisor.WithService(relay),
+		supervisor.WithService(sched),
+		supervisor.WithService(telemetry),
+	)
+	if err != nil {
+		fatal(log, "supervisor stopped", err)
+	}
+}
+
+func fatal(log *slog.Logger, msg string, err error) {
+	log.Error(msg, slog.Any("err", err))
+	os.Exit(1)
+}

--- a/examples/orderflow/report.go
+++ b/examples/orderflow/report.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/collector"
+	"github.com/dmitrymomot/forge/async/queue"
+	"github.com/dmitrymomot/forge/async/scheduler"
+)
+
+// reportPayload is the scheduler-enqueued job: scheduled work and ad-hoc work
+// share the queue worker as one execution path.
+type reportPayload struct {
+	PeriodEnd time.Time `json:"period_end"`
+}
+
+var kindReport = queue.NewKind[reportPayload]("shop.report")
+
+// registerReporting wires the periodic shop summary: the scheduler enqueues a
+// shop.report job every 15 seconds, and the queue worker's handler logs order
+// counts alongside queue and telemetry stats.
+func registerReporting(sched *scheduler.Scheduler, worker *queue.Service, sh *shop, client *queue.Client, telemetry *collector.Collector[requestSeen], log *slog.Logger) {
+	scheduler.AddFunc(sched, "shop.report", scheduler.Every(15*time.Second), kindReport,
+		func(scheduledFor time.Time) (reportPayload, error) {
+			return reportPayload{PeriodEnd: scheduledFor}, nil
+		})
+
+	queue.Register(worker, kindReport, func(ctx context.Context, p reportPayload) error {
+		placed, fulfilled, failed := sh.counts()
+		ts := telemetry.Stats()
+
+		pending := 0
+		if qs, err := client.Stats(ctx); err == nil {
+			for _, q := range qs {
+				pending += q.Pending
+			}
+		}
+
+		log.Info("shop report",
+			slog.Time("period_end", p.PeriodEnd),
+			slog.Int("orders_in_flight", placed),
+			slog.Int("orders_fulfilled", fulfilled),
+			slog.Int("orders_failed", failed),
+			slog.Int("jobs_pending", pending),
+			slog.Uint64("telemetry_added", ts.Added),
+			slog.Uint64("telemetry_flushed", ts.Flushed))
+		return nil
+	})
+}

--- a/examples/orderflow/shop.go
+++ b/examples/orderflow/shop.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/dmitrymomot/forge/async/eventbus"
+)
+
+// The two order lifecycle events. order.placed enters the pipeline through
+// the outbox; order.completed is published by the fulfillment workflow.
+var (
+	evtOrderPlaced    = eventbus.NewEvent[orderEvent]("order.placed")
+	evtOrderCompleted = eventbus.NewEvent[orderEvent]("order.completed")
+)
+
+// orderEvent is the payload both lifecycle events carry.
+type orderEvent struct {
+	OrderID string `json:"order_id"`
+	Item    string `json:"item"`
+	Qty     int    `json:"qty"`
+}
+
+// shop is the "business database" stand-in: stock levels and order statuses
+// behind a mutex. In production these are rows the outbox transaction spans.
+type shop struct {
+	stock    map[string]int
+	reserved map[string]bool   // order id -> stock already taken for it
+	orders   map[string]string // order id -> placed | fulfilled | failed
+	mu       sync.Mutex
+	seq      int
+}
+
+func newShop() *shop {
+	return &shop{
+		stock:    map[string]int{"espresso": 100, "unicorn": 0},
+		reserved: make(map[string]bool),
+		orders:   make(map[string]string),
+	}
+}
+
+// place records a new order and returns its id.
+func (s *shop) place() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seq++
+	id := fmt.Sprintf("ord-%d", s.seq)
+	s.orders[id] = "placed"
+	return id
+}
+
+// reserve decrements stock exactly once per order: workflow steps run
+// at-least-once, so the reservation is keyed by order id to stay idempotent.
+func (s *shop) reserve(orderID, item string, qty int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.reserved[orderID] {
+		return nil
+	}
+	if s.stock[item] < qty {
+		return fmt.Errorf("item %q is out of stock", item)
+	}
+	s.stock[item] -= qty
+	s.reserved[orderID] = true
+	return nil
+}
+
+// release returns an order's reserved stock; a no-op if nothing is reserved.
+func (s *shop) release(orderID, item string, qty int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.reserved[orderID] {
+		s.stock[item] += qty
+		s.reserved[orderID] = false
+	}
+}
+
+func (s *shop) setStatus(orderID, status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.orders[orderID] = status
+}
+
+func (s *shop) counts() (placed, fulfilled, failed int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, status := range s.orders {
+		switch status {
+		case "fulfilled":
+			fulfilled++
+		case "failed":
+			failed++
+		default:
+			placed++
+		}
+	}
+	return placed, fulfilled, failed
+}

--- a/examples/orderflow/web.go
+++ b/examples/orderflow/web.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/dmitrymomot/forge/async/collector"
+	"github.com/dmitrymomot/forge/async/eventbus"
+	"github.com/dmitrymomot/forge/async/eventrouter"
+	"github.com/dmitrymomot/forge/web/httpserver"
+)
+
+// requestSeen is the collector's telemetry event: buffered on the request
+// path, flushed in batches, loss tolerated by contract.
+type requestSeen struct {
+	Method string
+	Path   string
+}
+
+// newTelemetry builds the write-behind request collector: Add never blocks
+// the request path, and the sink just logs batch sizes.
+func newTelemetry(log *slog.Logger) (*collector.Collector[requestSeen], error) {
+	sink := collector.SinkFunc[requestSeen](func(_ context.Context, batch []requestSeen) error {
+		log.Info("telemetry flushed", slog.Int("requests", len(batch)))
+		return nil
+	})
+	cfg := collector.DefaultConfig()
+	cfg.FlushInterval = 5 * time.Second
+	return collector.New(sink, collector.WithConfig(cfg), collector.WithLogger(log))
+}
+
+// routeAnalytics streams both lifecycle events to an "analytics warehouse" —
+// here the demo's own /analytics endpoint — batched by size or age through a
+// real HTTP deliverer.
+func routeAnalytics(bus *eventbus.Bus) error {
+	deliverer, err := eventrouter.NewHTTPDeliverer("http://localhost" + addr + "/analytics")
+	if err != nil {
+		return err
+	}
+	dest := eventrouter.NewDestination("analytics", deliverer,
+		eventrouter.WithBatchSize(8), eventrouter.WithBatchAge(2*time.Second))
+	eventrouter.Route(bus, evtOrderPlaced, dest)
+	eventrouter.Route(bus, evtOrderCompleted, dest)
+	return nil
+}
+
+// newShopAPI assembles the HTTP server: the order intake, the analytics
+// receiver, and the telemetry middleware around both.
+func newShopAPI(sh *shop, bus *eventbus.Bus, telemetry *collector.Collector[requestSeen], log *slog.Logger) *httpserver.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /orders", placeOrderHandler(sh, bus))
+	mux.HandleFunc("POST /analytics", analyticsHandler(log))
+
+	// Telemetry rides every request as a non-blocking side effect.
+	withTelemetry := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = telemetry.Add(r.Context(), requestSeen{Method: r.Method, Path: r.URL.Path})
+		mux.ServeHTTP(w, r)
+	})
+
+	return httpserver.New(withTelemetry, httpserver.WithAddr(addr), httpserver.WithName("shop-api"), httpserver.WithLogger(log))
+}
+
+// placeOrderHandler records the order and publishes order.placed. PublishTx
+// writes an outbox intent row instead of touching the broker: with pgoutbox
+// the row commits or rolls back with the order insert (tx is the caller's
+// pgx.Tx; the memory store ignores it).
+func placeOrderHandler(sh *shop, bus *eventbus.Bus) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Item string `json:"item"`
+			Qty  int    `json:"qty"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Item == "" || req.Qty <= 0 {
+			http.Error(w, `want body like {"item":"espresso","qty":1}`, http.StatusBadRequest)
+			return
+		}
+
+		id := sh.place()
+		event := orderEvent{OrderID: id, Item: req.Item, Qty: req.Qty}
+		if err := eventbus.PublishTx(r.Context(), bus, nil, evtOrderPlaced, event); err != nil {
+			http.Error(w, "publish failed", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]string{"order_id": id, "status": "placed"})
+	}
+}
+
+// analyticsHandler plays the external warehouse: it accepts the router's
+// JSON batches and logs every event it ingests.
+func analyticsHandler(log *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var batch []eventrouter.Event
+		if err := json.NewDecoder(r.Body).Decode(&batch); err != nil {
+			http.Error(w, "bad batch", http.StatusBadRequest)
+			return
+		}
+		for _, e := range batch {
+			log.Info("analytics ingested", slog.String("event", e.Name), slog.String("id", e.ID))
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// seed places two demo orders once the server is up: espresso fulfills the
+// happy path, unicorn is out of stock and exercises compensation. Place more
+// with curl.
+func seed(ctx context.Context, log *slog.Logger) {
+	httpc := &http.Client{Timeout: 2 * time.Second}
+	for _, body := range []string{
+		`{"item":"espresso","qty":2}`,
+		`{"item":"unicorn","qty":1}`,
+	} {
+		for {
+			resp, err := httpc.Post("http://localhost"+addr+"/orders", "application/json", bytes.NewReader([]byte(body)))
+			if err == nil {
+				//nolint:nilaway // resp is non-nil whenever err is nil, per http.Client.Do's contract
+				_ = resp.Body.Close()
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	}
+	log.Info("demo orders placed", slog.String("hint", `curl -s localhost:8080/orders -d '{"item":"espresso","qty":1}'`))
+}


### PR DESCRIPTION
## What

Adds `examples/orderflow`: a runnable integration demo that wires **every `async/` package** — `queue`, `eventbus`, `eventrouter`, `outbox`, `workflow`, `scheduler`, and `collector` — into one coherent order-processing backend, plus a README with ASCII diagrams and an entry in the examples index.

A single in-memory binary (`go run ./examples/orderflow`), no Docker: the memory constructors are drop-in stand-ins for the postgres/redis siblings, so the wiring is exactly what a production app would use.

## The pipeline

- `POST /orders` publishes `order.placed` via **outbox** (`eventbus.PublishTx` intent row → relay → broker) — transactional publish on a broker without native `TxPusher`.
- An inbox-guarded **eventbus** subscription starts the `order.fulfill` **workflow**: charge_payment → reserve_stock → complete, with refund compensation. `espresso` fulfills; `unicorn` (stock 0) hits `workflow.Fail` and demonstrates compensation.
- Completion publishes `order.completed`, consumed by a receipt subscription and batched by **eventrouter** through a real `NewHTTPDeliverer` to the demo's own `/analytics` endpoint.
- **collector** buffers per-request telemetry write-behind; **scheduler** enqueues a `shop.report` **queue** job every 15 s that logs order counts and stats.
- All seven services run under `ops/supervisor`; Ctrl+C drains everything.

Code is split by concern: `main.go` (wiring only), `shop.go` (domain state + events), `fulfillment.go` (saga + subscriptions), `web.go` (HTTP + egress + seeder), `report.go` (scheduled summary). The binary seeds one fulfilling and one compensating order at startup so a bare `go run` shows the full story.

## Why

The async packages shipped one by one (#61, #85, #87, #88, #89, #90, #91); nothing yet proved they compose end to end. This example is that proof, and doubles as copy-paste documentation for the intended composition seams (outbox wrap, inbox dedup, workflow-publishes-event, router-on-the-same-bus, scheduler-into-worker).

## Verification

Ran the binary with seeded + live curl traffic and traced every hop in the logs, cross-checked for consistency: 5 orders → 5 charges; 3 espresso → 3 reservations, 3 completed runs, 3 receipts; 2 unicorn → 2 refund compensations, 2 failed runs with the recorded error; 8 analytics events (5 placed + 3 completed) delivered in age-flushed batches; `telemetry_added=8 telemetry_flushed=8`; two report ticks exactly on 15 s boundaries with correct counts; no unexpected ERROR/WARN lines; SIGINT drains all seven services to `shutdown complete`. Malformed order bodies get a 400 without touching the pipeline.

## Notes for reviewers

- Fast poll intervals (100 ms) and short flush/batch windows are demo pacing; comments call out that production keeps the defaults.
- `MemoryInbox`/`nil` tx in `PublishTx` follow the documented memory-store contract (tx ignored); comments point at the pgx production shape.
- No benchmarks: this is an example command, not a package (per docs/design.md, benchmarks apply to packages).