### PR TITLE
feat(tariff): finance/tariff — tiered/banded rate calculator

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -267,19 +267,6 @@ Deps: `core/decimal`, `web/httpclient`.
 
 ---
 
-**finance/tariff**
-
-Tiered/banded rate calculation over `core/money`/`core/decimal`:
-graduated vs volume band semantics ("25% up to 10, 30% to 50, 35%
-above") with deterministic rounding, as a pure calculator — bands are
-caller-supplied values; effective-dating is the caller choosing which
-band set applies (composes `data/settings` for deal changes). Consumers:
-usage-billing overage tiers, revenue-share deals, commission plans.
-
-Deps: `core/money`, `core/decimal`.
-
----
-
 **finance/formula**
 
 Formulas as structured, versioned data — never text: a spec of named

--- a/finance/tariff/bench_test.go
+++ b/finance/tariff/bench_test.go
@@ -1,0 +1,77 @@
+package tariff_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/core/money"
+	"github.com/dmitrymomot/forge/finance/tariff"
+)
+
+func benchSchedule(b *testing.B, mode tariff.Mode, n int) tariff.Schedule {
+	b.Helper()
+	bands := make([]tariff.Band, 0, n)
+	for i := range n - 1 {
+		bound := decimal.FromInt(int64((i + 1) * 100))
+		rate := decimal.New(int64(20+i), 2)
+		bands = append(bands, tariff.UpTo(bound, rate))
+	}
+	bands = append(bands, tariff.Above(decimal.New(int64(20+n), 2)))
+	s, err := tariff.New(mode, bands...)
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	return s
+}
+
+func BenchmarkApplyGraduated(b *testing.B) {
+	for _, n := range []int{3, 10} {
+		b.Run(strconv.Itoa(n)+"bands", func(b *testing.B) {
+			s := benchSchedule(b, tariff.Graduated, n)
+			base := decimal.FromInt(int64(n * 100)) // touches every band
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := s.Apply(base); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkApplyVolume(b *testing.B) {
+	s := benchSchedule(b, tariff.Volume, 10)
+	base := decimal.MustParse("450.50") // mid-schedule band
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := s.Apply(base); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkApplyMoney(b *testing.B) {
+	s := benchSchedule(b, tariff.Graduated, 3)
+	base := money.FromMinor(100_000, money.USD)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := s.ApplyMoney(base); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMoneyResultRound(b *testing.B) {
+	s := benchSchedule(b, tariff.Graduated, 3)
+	res, err := s.ApplyMoney(money.New(decimal.MustParse("1000.05"), money.USD))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := res.Round(decimal.HalfEven); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/finance/tariff/doc.go
+++ b/finance/tariff/doc.go
@@ -1,0 +1,52 @@
+// Package tariff calculates tiered/banded rates — "25% up to 10, 30% to 50,
+// 35% above" — as a pure calculator over decimal and money values.
+//
+// A Schedule is a validated, immutable band set with one of two rating modes:
+// Graduated rates each slice of the base by its own band (tax-bracket
+// semantics), Volume rates the entire base by the single band it falls into.
+// Apply returns an exact per-band breakdown (Result) in decimal; ApplyMoney
+// rates a monetary base with fraction rates and carries the currency through.
+// Amounts are exact products — rounding happens once, at settlement, via
+// MoneyResult.Round (per-line policy) or Total.Round (per-total policy) with
+// an explicit decimal.RoundingMode, so recomputes byte-match. Schedules
+// marshal to/from JSON and re-validate on load, so deal band sets live as
+// data (e.g. in data/settings) and an edited-invalid set fails to load.
+//
+// Bands are caller-supplied values: effective-dating is the caller choosing
+// which band set applies, and per-tenant or per-deal rating is the caller
+// passing that tenant's schedule — there is no lookup inside. Typical
+// consumers: usage-billing overage tiers (Apply on the quantity, rates as
+// unit prices, wrap with money.New), revenue-share deals and commission
+// plans (ApplyMoney, rates as fractions).
+//
+// What this is NOT: it is not a pricing engine — no effective-dating, no
+// proration, no minimums/caps beyond the band shape, and no derivation of the
+// base (finance/formula derives bases like NGR or billable usage; tariff
+// rates them). Negative (rebate) rates are rejected; corrections post
+// forward. Band bounds are plain decimals — ApplyMoney interprets them in the
+// base's currency but a Schedule itself is currency-agnostic.
+//
+// Siblings: decimal (the exact substrate); money (currency-aware amounts and
+// settlement rounding); finance/formula (derives the bases tariff rates).
+// See docs/packages.md for the package catalog.
+//
+// # Usage
+//
+//	pct := decimal.MustParse
+//	sched, err := tariff.New(tariff.Graduated,
+//		tariff.UpTo(pct("1000"), pct("0.25")),
+//		tariff.UpTo(pct("5000"), pct("0.30")),
+//		tariff.Above(pct("0.35")),
+//	)
+//	if err != nil {
+//		// invalid band set: unordered bounds, negative rate, ...
+//	}
+//
+//	res, err := sched.ApplyMoney(money.FromMinor(1_000_000, money.USD)) // 10000.00 USD
+//	if err != nil {
+//		// negative base
+//	}
+//	// res.Lines: 1000×25% + 4000×30% + 5000×35%, exact
+//	settled, _ := res.Round(decimal.HalfEven)
+//	_ = settled.Total // "3200.00 USD"
+package tariff

--- a/finance/tariff/doc.go
+++ b/finance/tariff/doc.go
@@ -32,11 +32,11 @@
 //
 // # Usage
 //
-//	pct := decimal.MustParse
+//	d := decimal.MustParse
 //	sched, err := tariff.New(tariff.Graduated,
-//		tariff.UpTo(pct("1000"), pct("0.25")),
-//		tariff.UpTo(pct("5000"), pct("0.30")),
-//		tariff.Above(pct("0.35")),
+//		tariff.UpTo(d("1000"), d("0.25")),
+//		tariff.UpTo(d("5000"), d("0.30")),
+//		tariff.Above(d("0.35")),
 //	)
 //	if err != nil {
 //		// invalid band set: unordered bounds, negative rate, ...
@@ -47,6 +47,9 @@
 //		// negative base
 //	}
 //	// res.Lines: 1000×25% + 4000×30% + 5000×35%, exact
-//	settled, _ := res.Round(decimal.HalfEven)
+//	settled, err := res.Round(decimal.HalfEven)
+//	if err != nil {
+//		// unreachable: ApplyMoney results never mix currencies
+//	}
 //	_ = settled.Total // "3200.00 USD"
 package tariff

--- a/finance/tariff/errors.go
+++ b/finance/tariff/errors.go
@@ -1,0 +1,26 @@
+package tariff
+
+import "errors"
+
+// ErrInvalidMode is returned by New (and Schedule.UnmarshalJSON) when the mode
+// is neither Graduated nor Volume.
+var ErrInvalidMode = errors.New("tariff: invalid mode")
+
+// ErrNoBands is returned by New when no bands are given, and by Apply,
+// ApplyMoney, and MarshalJSON on a zero Schedule.
+var ErrNoBands = errors.New("tariff: schedule has no bands")
+
+// ErrOpenBand is returned by New when the final band is not open, when a
+// non-final band is open, or when an open band carries an upper bound.
+var ErrOpenBand = errors.New("tariff: exactly the final band must be open")
+
+// ErrBandOrder is returned by New when a bounded band's upper bound is not
+// positive or does not strictly exceed the previous band's bound.
+var ErrBandOrder = errors.New("tariff: band bounds must be positive and strictly increasing")
+
+// ErrNegativeRate is returned by New when any band's rate is negative.
+var ErrNegativeRate = errors.New("tariff: negative rate")
+
+// ErrNegativeBase is returned by Apply and ApplyMoney when the base is
+// negative.
+var ErrNegativeBase = errors.New("tariff: negative base")

--- a/finance/tariff/json.go
+++ b/finance/tariff/json.go
@@ -1,0 +1,60 @@
+package tariff
+
+import (
+	"encoding/json"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+)
+
+type scheduleJSON struct {
+	Mode  Mode       `json:"mode"`
+	Bands []bandJSON `json:"bands"`
+}
+
+type bandJSON struct {
+	UpTo *decimal.Decimal `json:"up_to,omitempty"`
+	Rate decimal.Decimal  `json:"rate"`
+}
+
+// MarshalJSON implements json.Marshaler, so deal band sets can be stored as
+// data (e.g. in data/settings) and re-validated on load. Bounds and rates are
+// emitted as JSON strings (decimal's exact form); the open band omits
+// "up_to". Marshaling a zero Schedule returns ErrNoBands.
+func (s Schedule) MarshalJSON() ([]byte, error) {
+	if len(s.bands) == 0 {
+		return nil, ErrNoBands
+	}
+	out := scheduleJSON{Mode: s.mode, Bands: make([]bandJSON, len(s.bands))}
+	for i, b := range s.bands {
+		bj := bandJSON{Rate: b.Rate}
+		if !b.Open {
+			bj.UpTo = new(b.UpTo)
+		}
+		out.Bands[i] = bj
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON implements json.Unmarshaler. A band without "up_to" is the
+// open band. The decoded band set passes through New, so an invalid stored
+// schedule fails to load instead of silently rating wrong.
+func (s *Schedule) UnmarshalJSON(p []byte) error {
+	var in scheduleJSON
+	if err := json.Unmarshal(p, &in); err != nil {
+		return err
+	}
+	bands := make([]Band, len(in.Bands))
+	for i, bj := range in.Bands {
+		b := Band{Rate: bj.Rate, Open: bj.UpTo == nil}
+		if bj.UpTo != nil {
+			b.UpTo = *bj.UpTo
+		}
+		bands[i] = b
+	}
+	ns, err := New(in.Mode, bands...)
+	if err != nil {
+		return err
+	}
+	*s = ns
+	return nil
+}

--- a/finance/tariff/json_test.go
+++ b/finance/tariff/json_test.go
@@ -1,0 +1,107 @@
+package tariff_test
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/finance/tariff"
+)
+
+func TestScheduleJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	s := catalogSchedule(t, tariff.Graduated)
+
+	p, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// The open band omits "up_to"; bounds/rates are exact JSON strings.
+	if got := string(p); strings.Count(got, "up_to") != 2 {
+		t.Fatalf("want exactly 2 up_to keys in %s", got)
+	}
+	if !strings.Contains(string(p), `"mode":"graduated"`) {
+		t.Fatalf("mode missing in %s", p)
+	}
+
+	var back tariff.Schedule
+	if err := json.Unmarshal(p, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back.Mode() != tariff.Graduated {
+		t.Fatalf("Mode = %q", back.Mode())
+	}
+	want, err := s.Apply(d("100"))
+	if err != nil {
+		t.Fatalf("Apply original: %v", err)
+	}
+	got, err := back.Apply(d("100"))
+	if err != nil {
+		t.Fatalf("Apply round-tripped: %v", err)
+	}
+	if got.Total.Cmp(want.Total) != 0 || len(got.Lines) != len(want.Lines) {
+		t.Fatalf("round-trip drift: got %s/%d lines, want %s/%d lines", got.Total, len(got.Lines), want.Total, len(want.Lines))
+	}
+}
+
+func TestScheduleUnmarshalValidates(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want error
+	}{
+		{"bad mode", `{"mode":"tiered","bands":[{"rate":"0.1"}]}`, tariff.ErrInvalidMode},
+		{"no bands", `{"mode":"volume","bands":[]}`, tariff.ErrNoBands},
+		{"out-of-order bounds", `{"mode":"graduated","bands":[{"up_to":"50","rate":"0.2"},{"up_to":"10","rate":"0.3"},{"rate":"0.4"}]}`, tariff.ErrBandOrder},
+		{"no open band", `{"mode":"graduated","bands":[{"up_to":"10","rate":"0.2"}]}`, tariff.ErrOpenBand},
+		{"negative rate", `{"mode":"volume","bands":[{"rate":"-0.1"}]}`, tariff.ErrNegativeRate},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var s tariff.Schedule
+			if err := json.Unmarshal([]byte(tc.in), &s); !errors.Is(err, tc.want) {
+				t.Fatalf("Unmarshal = %v, want %v", err, tc.want)
+			}
+		})
+	}
+
+	t.Run("malformed json", func(t *testing.T) {
+		t.Parallel()
+		var s tariff.Schedule
+		if err := json.Unmarshal([]byte(`{"mode":`), &s); err == nil {
+			t.Fatal("want error for malformed JSON")
+		}
+	})
+
+	t.Run("malformed decimal", func(t *testing.T) {
+		t.Parallel()
+		var s tariff.Schedule
+		if err := json.Unmarshal([]byte(`{"mode":"volume","bands":[{"rate":"1.2.3"}]}`), &s); err == nil {
+			t.Fatal("want error for malformed decimal")
+		}
+	})
+}
+
+func TestScheduleMarshalZero(t *testing.T) {
+	t.Parallel()
+	var s tariff.Schedule
+	if _, err := json.Marshal(s); !errors.Is(err, tariff.ErrNoBands) {
+		t.Fatalf("Marshal zero = %v, want ErrNoBands", err)
+	}
+}
+
+func TestScheduleUnmarshalFailureLeavesReceiver(t *testing.T) {
+	t.Parallel()
+	s := catalogSchedule(t, tariff.Volume)
+	if err := json.Unmarshal([]byte(`{"mode":"bogus","bands":[{"rate":"0.1"}]}`), &s); err == nil {
+		t.Fatal("want error")
+	}
+	// A failed load must not clobber the previously valid schedule.
+	if s.Mode() != tariff.Volume || len(s.Bands()) != 3 {
+		t.Fatalf("failed Unmarshal clobbered receiver: mode %q, %d bands", s.Mode(), len(s.Bands()))
+	}
+}

--- a/finance/tariff/money.go
+++ b/finance/tariff/money.go
@@ -1,0 +1,79 @@
+package tariff
+
+import (
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/core/money"
+)
+
+// MoneyLine is one band's contribution to a MoneyResult.
+type MoneyLine struct {
+	// Slice is the portion of the base rated by this band.
+	Slice money.Money
+	// Amount is Slice × Rate, exact (never rounded) — round at settlement.
+	Amount money.Money
+	// Rate is the band's fraction, echoed for statement rendering.
+	Rate decimal.Decimal
+	// Band is the index of the band in the schedule.
+	Band int
+}
+
+// MoneyResult is the exact outcome of rating a monetary base. All amounts
+// carry the base's currency.
+type MoneyResult struct {
+	// Lines holds one entry per band that rated a non-empty slice, in band
+	// order. A zero base produces no lines.
+	Lines []MoneyLine
+	// Total is the exact sum of the line amounts.
+	Total money.Money
+}
+
+// ApplyMoney rates a monetary base — a revenue-share or commission
+// calculation. Band bounds are interpreted as amounts in the base's currency
+// and rates as fractions (0.25 = 25%). Amounts are exact; call Round (per-line
+// policy) or Total.Round (per-total policy) at settlement. For usage pricing
+// — quantity bands with per-unit money rates — use Apply on the quantity and
+// wrap the result with money.New.
+func (s Schedule) ApplyMoney(base money.Money) (MoneyResult, error) {
+	r, err := s.Apply(base.Amount())
+	if err != nil {
+		return MoneyResult{}, err
+	}
+	cur := base.Currency()
+	var lines []MoneyLine
+	if len(r.Lines) > 0 {
+		lines = make([]MoneyLine, len(r.Lines))
+		for i, l := range r.Lines {
+			lines[i] = MoneyLine{
+				Band:   l.Band,
+				Rate:   l.Rate,
+				Slice:  money.New(l.Slice, cur),
+				Amount: money.New(l.Amount, cur),
+			}
+		}
+	}
+	return MoneyResult{Lines: lines, Total: money.New(r.Total, cur)}, nil
+}
+
+// Round returns a copy with every line amount rounded to its currency's minor
+// units using mode, and Total recomputed as the sum of the rounded lines —
+// the per-line rounding policy, where statement lines are settled amounts and
+// the total is their exact sum. For the per-total policy round the total
+// alone: r.Total.Round(mode). It returns money.ErrCurrencyMismatch only for a
+// hand-assembled result whose lines mix currencies; results from ApplyMoney
+// never do.
+func (r MoneyResult) Round(mode decimal.RoundingMode) (MoneyResult, error) {
+	if len(r.Lines) == 0 {
+		return MoneyResult{Total: r.Total.Round(mode)}, nil
+	}
+	lines := make([]MoneyLine, len(r.Lines))
+	total := money.New(decimal.Zero, r.Lines[0].Amount.Currency())
+	for i, l := range r.Lines {
+		l.Amount = l.Amount.Round(mode)
+		lines[i] = l
+		var err error
+		if total, err = total.Add(l.Amount); err != nil {
+			return MoneyResult{}, err
+		}
+	}
+	return MoneyResult{Lines: lines, Total: total}, nil
+}

--- a/finance/tariff/money_test.go
+++ b/finance/tariff/money_test.go
@@ -1,0 +1,160 @@
+package tariff_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/core/money"
+	"github.com/dmitrymomot/forge/finance/tariff"
+)
+
+func TestApplyMoneyGraduated(t *testing.T) {
+	t.Parallel()
+	s := catalogSchedule(t, tariff.Graduated)
+
+	res, err := s.ApplyMoney(money.FromMinor(10000, money.USD)) // 100.00 USD
+	if err != nil {
+		t.Fatalf("ApplyMoney: %v", err)
+	}
+	if got := res.Total.Currency().Code; got != "USD" {
+		t.Fatalf("Total currency = %q, want USD", got)
+	}
+	if res.Total.Amount().Cmp(d("32")) != 0 {
+		t.Fatalf("Total = %s, want 32", res.Total.Amount())
+	}
+	if len(res.Lines) != 3 {
+		t.Fatalf("len(Lines) = %d, want 3", len(res.Lines))
+	}
+	for i, l := range res.Lines {
+		if l.Slice.Currency().Code != "USD" || l.Amount.Currency().Code != "USD" {
+			t.Fatalf("line %d currency not propagated: slice %s, amount %s", i, l.Slice, l.Amount)
+		}
+	}
+	if res.Lines[2].Amount.Amount().Cmp(d("17.5")) != 0 {
+		t.Fatalf("open-band amount = %s, want 17.5", res.Lines[2].Amount.Amount())
+	}
+}
+
+func TestApplyMoneyZeroAndNegative(t *testing.T) {
+	t.Parallel()
+	s := catalogSchedule(t, tariff.Volume)
+
+	res, err := s.ApplyMoney(money.FromMinor(0, money.EUR))
+	if err != nil {
+		t.Fatalf("ApplyMoney(0): %v", err)
+	}
+	if len(res.Lines) != 0 || !res.Total.IsZero() {
+		t.Fatalf("zero base: lines %d total %s", len(res.Lines), res.Total)
+	}
+	// The zero total still carries the base's currency.
+	if got := res.Total.Currency().Code; got != "EUR" {
+		t.Fatalf("zero-base Total currency = %q, want EUR", got)
+	}
+
+	if _, err := s.ApplyMoney(money.FromMinor(-1, money.EUR)); !errors.Is(err, tariff.ErrNegativeBase) {
+		t.Fatalf("negative base = %v, want ErrNegativeBase", err)
+	}
+
+	var zero tariff.Schedule
+	if _, err := zero.ApplyMoney(money.FromMinor(100, money.USD)); !errors.Is(err, tariff.ErrNoBands) {
+		t.Fatalf("zero Schedule = %v, want ErrNoBands", err)
+	}
+}
+
+func TestMoneyResultRound(t *testing.T) {
+	t.Parallel()
+	// 25.75% up to 10, 33.3% above — sub-cent amounts on both lines.
+	s, err := tariff.New(tariff.Graduated,
+		tariff.UpTo(d("10"), d("0.2575")),
+		tariff.Above(d("0.333")),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := s.ApplyMoney(money.New(d("10.05"), money.USD))
+	if err != nil {
+		t.Fatalf("ApplyMoney: %v", err)
+	}
+	// Exact: 10×0.2575 = 2.575; 0.05×0.333 = 0.01665; total 2.59165.
+	if res.Total.Amount().Cmp(d("2.59165")) != 0 {
+		t.Fatalf("exact Total = %s, want 2.59165", res.Total.Amount())
+	}
+
+	settled, err := res.Round(decimal.HalfEven)
+	if err != nil {
+		t.Fatalf("Round: %v", err)
+	}
+	// Per-line: 2.575 → 2.58 (half-even to even cent), 0.01665 → 0.02; total 2.60.
+	if got := settled.Lines[0].Amount.Amount(); got.Cmp(d("2.58")) != 0 {
+		t.Fatalf("line 0 rounded = %s, want 2.58", got)
+	}
+	if got := settled.Lines[1].Amount.Amount(); got.Cmp(d("0.02")) != 0 {
+		t.Fatalf("line 1 rounded = %s, want 0.02", got)
+	}
+	if got := settled.Total.Amount(); got.Cmp(d("2.60")) != 0 {
+		t.Fatalf("per-line Total = %s, want 2.60", got)
+	}
+	// Per-total policy differs: 2.59165 → 2.59.
+	if got := res.Total.Round(decimal.HalfEven).Amount(); got.Cmp(d("2.59")) != 0 {
+		t.Fatalf("per-total = %s, want 2.59", got)
+	}
+	// Rounding must not mutate the exact result.
+	if res.Lines[0].Amount.Amount().Cmp(d("2.575")) != 0 {
+		t.Fatalf("Round mutated the exact result: %s", res.Lines[0].Amount.Amount())
+	}
+}
+
+func TestMoneyResultRoundEmpty(t *testing.T) {
+	t.Parallel()
+	s := catalogSchedule(t, tariff.Graduated)
+	res, err := s.ApplyMoney(money.FromMinor(0, money.USD))
+	if err != nil {
+		t.Fatalf("ApplyMoney: %v", err)
+	}
+	settled, err := res.Round(decimal.HalfUp)
+	if err != nil {
+		t.Fatalf("Round: %v", err)
+	}
+	if len(settled.Lines) != 0 || !settled.Total.IsZero() {
+		t.Fatalf("empty round: lines %d total %s", len(settled.Lines), settled.Total)
+	}
+	if got := settled.Total.Currency().Code; got != "USD" {
+		t.Fatalf("empty round Total currency = %q, want USD", got)
+	}
+}
+
+func TestMoneyResultRoundMixedCurrencies(t *testing.T) {
+	t.Parallel()
+	// A hand-assembled result mixing currencies must fail closed, not sum.
+	mixed := tariff.MoneyResult{Lines: []tariff.MoneyLine{
+		{Amount: money.FromMinor(100, money.USD)},
+		{Amount: money.FromMinor(100, money.EUR)},
+	}}
+	if _, err := mixed.Round(decimal.HalfEven); !errors.Is(err, money.ErrCurrencyMismatch) {
+		t.Fatalf("mixed Round = %v, want ErrCurrencyMismatch", err)
+	}
+}
+
+func TestApplyMoneyJPYSettlement(t *testing.T) {
+	t.Parallel()
+	// Zero-minor-unit currency: settlement rounds to whole yen.
+	s, err := tariff.New(tariff.Volume, tariff.Above(d("0.155")))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := s.ApplyMoney(money.FromMinor(999, money.JPY))
+	if err != nil {
+		t.Fatalf("ApplyMoney: %v", err)
+	}
+	if res.Total.Amount().Cmp(d("154.845")) != 0 {
+		t.Fatalf("exact Total = %s, want 154.845", res.Total.Amount())
+	}
+	settled, err := res.Round(decimal.HalfEven)
+	if err != nil {
+		t.Fatalf("Round: %v", err)
+	}
+	if got := settled.Total.Amount(); got.Cmp(d("155")) != 0 {
+		t.Fatalf("settled Total = %s, want 155", got)
+	}
+}

--- a/finance/tariff/tariff.go
+++ b/finance/tariff/tariff.go
@@ -1,0 +1,168 @@
+package tariff
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+)
+
+// Mode selects how a schedule's bands rate a base.
+type Mode string
+
+const (
+	// Graduated rates each slice of the base by its own band, like tax
+	// brackets: a base of 100 against "25% up to 10, 30% to 50, 35% above"
+	// pays 25% on the first 10, 30% on the next 40, and 35% on the final 50.
+	Graduated Mode = "graduated"
+	// Volume rates the entire base by the single band the base falls into:
+	// a base of 100 against the same schedule pays 35% on all 100.
+	Volume Mode = "volume"
+)
+
+// Band is one rate step of a Schedule. A schedule's bands partition the
+// non-negative base axis: band i covers (previous bound, UpTo], and the final
+// band is Open — it has no upper bound and covers everything above the last
+// bound. Construct bands with UpTo and Above rather than struct literals.
+type Band struct {
+	// UpTo is the band's inclusive upper bound. It must be zero on an open
+	// band (New rejects an open band that carries a bound).
+	UpTo decimal.Decimal
+	// Rate is the multiplier applied to base amounts in this band: a fraction
+	// for percentage schedules (0.25 = 25%) or a unit price for usage
+	// pricing. Zero is a valid rate (a free tier); negative rates are
+	// rejected.
+	Rate decimal.Decimal
+	// Open marks the final, unbounded band.
+	Open bool
+}
+
+// UpTo returns a bounded band: rate applies up to and including bound.
+func UpTo(bound, rate decimal.Decimal) Band {
+	return Band{UpTo: bound, Rate: rate}
+}
+
+// Above returns the open final band: rate applies to everything above the
+// previous band's bound.
+func Above(rate decimal.Decimal) Band {
+	return Band{Rate: rate, Open: true}
+}
+
+// Schedule is a validated, immutable band set with a rating mode. The zero
+// value is invalid; construct with New and share freely — Schedule is safe
+// for concurrent use.
+type Schedule struct {
+	mode  Mode
+	bands []Band
+}
+
+// New validates the band set and returns a Schedule. The final band must be
+// created with Above (open), every earlier band with UpTo; bounds must be
+// positive and strictly increasing, rates non-negative.
+func New(mode Mode, bands ...Band) (Schedule, error) {
+	if mode != Graduated && mode != Volume {
+		return Schedule{}, fmt.Errorf("%w: %q", ErrInvalidMode, string(mode))
+	}
+	if len(bands) == 0 {
+		return Schedule{}, ErrNoBands
+	}
+	for i, b := range bands {
+		last := i == len(bands)-1
+		if b.Open != last {
+			return Schedule{}, fmt.Errorf("%w: band %d", ErrOpenBand, i)
+		}
+		if b.Open && !b.UpTo.IsZero() {
+			return Schedule{}, fmt.Errorf("%w: open band %d carries an upper bound", ErrOpenBand, i)
+		}
+		if b.Rate.IsNegative() {
+			return Schedule{}, fmt.Errorf("%w: band %d", ErrNegativeRate, i)
+		}
+		if !b.Open {
+			if !b.UpTo.IsPositive() {
+				return Schedule{}, fmt.Errorf("%w: band %d", ErrBandOrder, i)
+			}
+			if i > 0 && b.UpTo.Cmp(bands[i-1].UpTo) <= 0 {
+				return Schedule{}, fmt.Errorf("%w: band %d", ErrBandOrder, i)
+			}
+		}
+	}
+	return Schedule{bands: slices.Clone(bands), mode: mode}, nil
+}
+
+// Mode reports the schedule's rating mode.
+func (s Schedule) Mode() Mode { return s.mode }
+
+// Bands returns a copy of the schedule's bands.
+func (s Schedule) Bands() []Band { return slices.Clone(s.bands) }
+
+// Line is one band's contribution to a Result.
+type Line struct {
+	// Slice is the portion of the base rated by this band: the in-band slice
+	// under Graduated, the entire base under Volume.
+	Slice decimal.Decimal
+	// Rate is the band's rate, echoed for statement rendering.
+	Rate decimal.Decimal
+	// Amount is Slice × Rate, exact (never rounded).
+	Amount decimal.Decimal
+	// Band is the index of the band in the schedule.
+	Band int
+}
+
+// Result is the exact outcome of rating a base against a schedule.
+type Result struct {
+	// Lines holds one entry per band that rated a non-empty slice, in band
+	// order. A zero base produces no lines.
+	Lines []Line
+	// Total is the exact sum of the line amounts.
+	Total decimal.Decimal
+}
+
+// Apply rates a non-negative base against the schedule and returns the exact
+// per-band breakdown. Under Graduated each band rates its own slice of the
+// base; under Volume the single band containing the base (bounds inclusive)
+// rates the whole base. Amounts are exact decimal products — rounding is the
+// caller's settlement step (decimal.Round, or money.Round via ApplyMoney).
+func (s Schedule) Apply(base decimal.Decimal) (Result, error) {
+	if len(s.bands) == 0 {
+		return Result{}, ErrNoBands
+	}
+	if base.IsNegative() {
+		return Result{}, ErrNegativeBase
+	}
+	if base.IsZero() {
+		return Result{}, nil
+	}
+	if s.mode == Volume {
+		idx := len(s.bands) - 1
+		for i, b := range s.bands[:idx] {
+			if base.Cmp(b.UpTo) <= 0 {
+				idx = i
+				break
+			}
+		}
+		amount := base.Mul(s.bands[idx].Rate)
+		return Result{
+			Lines: []Line{{Band: idx, Slice: base, Rate: s.bands[idx].Rate, Amount: amount}},
+			Total: amount,
+		}, nil
+	}
+
+	lines := make([]Line, 0, len(s.bands))
+	total := decimal.Zero
+	prev := decimal.Zero
+	for i, b := range s.bands {
+		hi := base
+		if !b.Open && b.UpTo.Cmp(base) < 0 {
+			hi = b.UpTo
+		}
+		slice := hi.Sub(prev)
+		amount := slice.Mul(b.Rate)
+		lines = append(lines, Line{Band: i, Slice: slice, Rate: b.Rate, Amount: amount})
+		total = total.Add(amount)
+		if hi.Cmp(base) == 0 {
+			break
+		}
+		prev = b.UpTo
+	}
+	return Result{Lines: lines, Total: total}, nil
+}

--- a/finance/tariff/tariff_test.go
+++ b/finance/tariff/tariff_test.go
@@ -1,0 +1,298 @@
+package tariff_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/finance/tariff"
+)
+
+func d(s string) decimal.Decimal { return decimal.MustParse(s) }
+
+// catalogSchedule is the catalog example: 25% up to 10, 30% to 50, 35% above.
+func catalogSchedule(t *testing.T, mode tariff.Mode) tariff.Schedule {
+	t.Helper()
+	s, err := tariff.New(mode,
+		tariff.UpTo(d("10"), d("0.25")),
+		tariff.UpTo(d("50"), d("0.30")),
+		tariff.Above(d("0.35")),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return s
+}
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		mode  tariff.Mode
+		bands []tariff.Band
+		want  error
+	}{
+		{"invalid mode", tariff.Mode("banded"), []tariff.Band{tariff.Above(d("0.1"))}, tariff.ErrInvalidMode},
+		{"empty mode", tariff.Mode(""), []tariff.Band{tariff.Above(d("0.1"))}, tariff.ErrInvalidMode},
+		{"no bands", tariff.Graduated, nil, tariff.ErrNoBands},
+		{"last band not open", tariff.Graduated, []tariff.Band{tariff.UpTo(d("10"), d("0.25"))}, tariff.ErrOpenBand},
+		{"open band not last", tariff.Graduated, []tariff.Band{tariff.Above(d("0.25")), tariff.Above(d("0.30"))}, tariff.ErrOpenBand},
+		{"open band with bound", tariff.Graduated, []tariff.Band{{UpTo: d("10"), Rate: d("0.25"), Open: true}}, tariff.ErrOpenBand},
+		{"zero bound", tariff.Graduated, []tariff.Band{tariff.UpTo(d("0"), d("0.25")), tariff.Above(d("0.30"))}, tariff.ErrBandOrder},
+		{"negative bound", tariff.Graduated, []tariff.Band{tariff.UpTo(d("-1"), d("0.25")), tariff.Above(d("0.30"))}, tariff.ErrBandOrder},
+		{"non-increasing bounds", tariff.Graduated, []tariff.Band{tariff.UpTo(d("10"), d("0.25")), tariff.UpTo(d("10"), d("0.30")), tariff.Above(d("0.35"))}, tariff.ErrBandOrder},
+		{"decreasing bounds", tariff.Volume, []tariff.Band{tariff.UpTo(d("50"), d("0.25")), tariff.UpTo(d("10"), d("0.30")), tariff.Above(d("0.35"))}, tariff.ErrBandOrder},
+		{"negative rate", tariff.Graduated, []tariff.Band{tariff.UpTo(d("10"), d("-0.25")), tariff.Above(d("0.30"))}, tariff.ErrNegativeRate},
+		{"negative open rate", tariff.Volume, []tariff.Band{tariff.Above(d("-0.1"))}, tariff.ErrNegativeRate},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tariff.New(tc.mode, tc.bands...)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("New = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewValid(t *testing.T) {
+	t.Parallel()
+
+	// Single open band: a flat rate.
+	flat, err := tariff.New(tariff.Volume, tariff.Above(d("0.15")))
+	if err != nil {
+		t.Fatalf("New flat: %v", err)
+	}
+	if flat.Mode() != tariff.Volume {
+		t.Fatalf("Mode = %q, want %q", flat.Mode(), tariff.Volume)
+	}
+	if n := len(flat.Bands()); n != 1 {
+		t.Fatalf("len(Bands) = %d, want 1", n)
+	}
+
+	// Zero rate is a valid free tier; scale-differing bounds still order
+	// correctly (10.00 < 10.5).
+	if _, err := tariff.New(tariff.Graduated,
+		tariff.UpTo(d("10.00"), d("0")),
+		tariff.UpTo(d("10.5"), d("0.30")),
+		tariff.Above(d("0.35")),
+	); err != nil {
+		t.Fatalf("New free tier: %v", err)
+	}
+}
+
+func TestScheduleImmutable(t *testing.T) {
+	t.Parallel()
+
+	bands := []tariff.Band{
+		tariff.UpTo(d("10"), d("0.25")),
+		tariff.Above(d("0.35")),
+	}
+	s, err := tariff.New(tariff.Graduated, bands...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// The schedule must not see mutations of the caller's slice or of a
+	// Bands() copy: the bounded band's rate stays 0.25 throughout.
+	check := func(context string) {
+		t.Helper()
+		for _, b := range s.Bands() {
+			if !b.Open && !b.Rate.Equal(d("0.25")) {
+				t.Fatalf("schedule saw %s: rate = %s", context, b.Rate)
+			}
+		}
+	}
+
+	bands[0].Rate = d("0.99")
+	check("caller mutation")
+
+	clone := s.Bands()
+	for i := range clone {
+		clone[i].Rate = d("0.77")
+	}
+	check("accessor mutation")
+}
+
+func TestApplyGraduated(t *testing.T) {
+	t.Parallel()
+	s := catalogSchedule(t, tariff.Graduated)
+
+	cases := []struct {
+		base   string
+		total  string
+		slices []string
+	}{
+		{"7", "1.75", []string{"7"}},                             // inside first band
+		{"10", "2.50", []string{"10"}},                           // exactly on first bound
+		{"10.5", "2.65", []string{"10", "0.5"}},                  // just over first bound
+		{"50", "14.50", []string{"10", "40"}},                    // exactly on second bound
+		{"100", "32.00", []string{"10", "40", "50"}},             // catalog example
+		{"1000000", "349997.00", []string{"10", "40", "999950"}}, // deep in open band
+	}
+	for _, tc := range cases {
+		t.Run(tc.base, func(t *testing.T) {
+			t.Parallel()
+			res, err := s.Apply(d(tc.base))
+			if err != nil {
+				t.Fatalf("Apply(%s): %v", tc.base, err)
+			}
+			if res.Total.Cmp(d(tc.total)) != 0 {
+				t.Fatalf("Total = %s, want %s", res.Total, tc.total)
+			}
+			if len(res.Lines) != len(tc.slices) {
+				t.Fatalf("len(Lines) = %d, want %d", len(res.Lines), len(tc.slices))
+			}
+			sum := decimal.Zero
+			for i, l := range res.Lines {
+				if l.Band != i {
+					t.Fatalf("line %d Band = %d", i, l.Band)
+				}
+				if l.Slice.Cmp(d(tc.slices[i])) != 0 {
+					t.Fatalf("line %d Slice = %s, want %s", i, l.Slice, tc.slices[i])
+				}
+				if !l.Amount.Equal(l.Slice.Mul(l.Rate)) {
+					t.Fatalf("line %d Amount = %s, want Slice×Rate = %s", i, l.Amount, l.Slice.Mul(l.Rate))
+				}
+				sum = sum.Add(l.Slice)
+			}
+			if sum.Cmp(d(tc.base)) != 0 {
+				t.Fatalf("slices sum to %s, want base %s", sum, tc.base)
+			}
+		})
+	}
+}
+
+func TestApplyVolume(t *testing.T) {
+	t.Parallel()
+	s := catalogSchedule(t, tariff.Volume)
+
+	cases := []struct {
+		base  string
+		band  int
+		total string
+	}{
+		{"7", 0, "1.75"},
+		{"10", 0, "2.50"},     // bounds are inclusive
+		{"10.01", 1, "3.003"}, // just past the bound → next band
+		{"50", 1, "15.00"},
+		{"50.5", 2, "17.675"},
+		{"100", 2, "35.00"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.base, func(t *testing.T) {
+			t.Parallel()
+			res, err := s.Apply(d(tc.base))
+			if err != nil {
+				t.Fatalf("Apply(%s): %v", tc.base, err)
+			}
+			if len(res.Lines) != 1 {
+				t.Fatalf("len(Lines) = %d, want 1", len(res.Lines))
+			}
+			l := res.Lines[0]
+			if l.Band != tc.band {
+				t.Fatalf("Band = %d, want %d", l.Band, tc.band)
+			}
+			if l.Slice.Cmp(d(tc.base)) != 0 {
+				t.Fatalf("Slice = %s, want whole base %s", l.Slice, tc.base)
+			}
+			if res.Total.Cmp(d(tc.total)) != 0 {
+				t.Fatalf("Total = %s, want %s", res.Total, tc.total)
+			}
+		})
+	}
+}
+
+func TestApplyZeroBase(t *testing.T) {
+	t.Parallel()
+	for _, mode := range []tariff.Mode{tariff.Graduated, tariff.Volume} {
+		s := catalogSchedule(t, mode)
+		res, err := s.Apply(decimal.Zero)
+		if err != nil {
+			t.Fatalf("%s: Apply(0): %v", mode, err)
+		}
+		if len(res.Lines) != 0 {
+			t.Fatalf("%s: len(Lines) = %d, want 0", mode, len(res.Lines))
+		}
+		if !res.Total.IsZero() {
+			t.Fatalf("%s: Total = %s, want 0", mode, res.Total)
+		}
+	}
+}
+
+func TestApplyNegativeBase(t *testing.T) {
+	t.Parallel()
+	s := catalogSchedule(t, tariff.Graduated)
+	if _, err := s.Apply(d("-1")); !errors.Is(err, tariff.ErrNegativeBase) {
+		t.Fatalf("Apply(-1) = %v, want ErrNegativeBase", err)
+	}
+}
+
+func TestApplyZeroSchedule(t *testing.T) {
+	t.Parallel()
+	var s tariff.Schedule
+	if _, err := s.Apply(d("10")); !errors.Is(err, tariff.ErrNoBands) {
+		t.Fatalf("zero Schedule Apply = %v, want ErrNoBands", err)
+	}
+}
+
+func TestApplyFreeTier(t *testing.T) {
+	t.Parallel()
+	s, err := tariff.New(tariff.Graduated,
+		tariff.UpTo(d("1000"), d("0")),
+		tariff.Above(d("0.01")),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := s.Apply(d("1500"))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// The free tier still emits its statement line with a zero amount.
+	if len(res.Lines) != 2 {
+		t.Fatalf("len(Lines) = %d, want 2", len(res.Lines))
+	}
+	if !res.Lines[0].Amount.IsZero() {
+		t.Fatalf("free-tier Amount = %s, want 0", res.Lines[0].Amount)
+	}
+	if res.Total.Cmp(d("5.00")) != 0 {
+		t.Fatalf("Total = %s, want 5.00", res.Total)
+	}
+}
+
+func TestApplyExactness(t *testing.T) {
+	t.Parallel()
+	// High-scale rate and base: products must be exact, never float-drifted.
+	s, err := tariff.New(tariff.Volume, tariff.Above(d("0.0333")))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := s.Apply(d("12345.6789"))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got, want := res.Total.String(), "411.11110737"; got != want {
+		t.Fatalf("Total = %s, want %s", got, want)
+	}
+}
+
+func TestApplyGraduatedMonotone(t *testing.T) {
+	t.Parallel()
+	s := catalogSchedule(t, tariff.Graduated)
+	bases := []string{"0", "1", "9.99", "10", "10.01", "25", "50", "50.01", "75", "100", "12345"}
+	prev := decimal.Zero.Sub(d("1"))
+	prevTotal := decimal.Zero
+	for _, b := range bases {
+		res, err := s.Apply(d(b))
+		if err != nil {
+			t.Fatalf("Apply(%s): %v", b, err)
+		}
+		if res.Total.Cmp(prevTotal) < 0 {
+			t.Fatalf("total decreased: Apply(%s) = %s after %s at base %s", b, res.Total, prevTotal, prev)
+		}
+		prev, prevTotal = d(b), res.Total
+	}
+}


### PR DESCRIPTION
## Summary

Implements `finance/tariff` per the catalog entry: tiered/banded rate calculation over `core/money`/`core/decimal` — graduated vs volume band semantics ("25% up to 10, 30% to 50, 35% above") as a pure calculator. Bands are caller-supplied values; effective-dating is the caller choosing which band set applies (composes `data/settings` for deal changes). Consumers: usage-billing overage tiers, revenue-share deals, commission plans. The shipped entry is removed from `docs/packages.md` per the roadmap rule.

## Design

- **`Schedule`** — validated, immutable band set + mode. Bands built with `UpTo(bound, rate)` / `Above(rate)`: bounds inclusive, positive, strictly increasing; exactly the final band is open; rates non-negative (zero = free tier; rebates are rejected — corrections post forward). Constructor clones the variadic slice; `Bands()` returns a copy.
- **`Apply(base)`** — exact decimal breakdown. Graduated rates each slice by its own band (tax-bracket semantics); Volume rates the whole base by the single band containing it. Amounts are exact `Slice × Rate` products — no rounding inside the calculator, so recomputes byte-match. Zero base → no lines; negative base and zero-value `Schedule` fail closed.
- **`ApplyMoney(base)`** — revenue-share/commission shape: bounds read as amounts in the base's currency, rates as fractions; currency carried through lines and total. Usage pricing (quantity bands × unit prices) is the documented `Apply` + `money.New` recipe.
- **`MoneyResult.Round(mode)`** — per-line settlement policy (each line rounded to minor units, total = exact sum of rounded lines); per-total policy is `Total.Round(mode)`. Deterministic via explicit `decimal.RoundingMode`; fails closed with `money.ErrCurrencyMismatch` on hand-assembled mixed-currency results.
- **JSON** — `Schedule` marshals to `{"mode":..., "bands":[{"up_to","rate"}...]}` (open band omits `up_to`, decimals as exact strings) and re-validates through `New` on unmarshal, so a stored deal's band set fails to load instead of silently rating wrong; failed unmarshal leaves the receiver untouched.
- **Tenancy** — pure calculator: per-tenant/per-deal rating is the caller passing that deal's schedule; no lookup inside (passed-value pattern, same as `core/country`/`core/phone`).

## Benchmarks

Apple M3 Max, `just bench ./finance/tariff/...`:

| benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| ApplyGraduated/3bands | 82.99 | 240 | 1 |
| ApplyGraduated/10bands | 240.4 | 896 | 1 |
| ApplyVolume | 666.5 | 1160 | 41 |
| ApplyMoney | 737.3 | 1745 | 34 |
| MoneyResultRound | 311.6 | 872 | 11 |

Post-benchmark pass: hoisting the duplicated `hi.Sub(prev)` in the graduated loop took 3-band Apply 93.8 → 83.0 ns/op; the lines slice is preallocated (the single tariff-owned alloc). The remaining allocations in the Volume/Money rows are not tariff's: `decimal.Cmp` only has an int64 fast path for equal scales, so comparing a scale-2 base against scale-0 bounds goes through `alignBig`/`big.Int` (~40 allocs). That's a `core/decimal` improvement, spun off as a separate task rather than expanding this PR's scope.

## Testing

- Black-box suite (`tariff_test`), 100% statement coverage: constructor validation table, catalog example, band-boundary cases (inclusive bounds, just-past-bound), zero/negative base, zero-value Schedule, free tier, exactness, graduated monotonicity + slices-sum-to-base invariants, currency propagation, JPY zero-minor-unit settlement, per-line vs per-total rounding divergence, JSON round-trip + validation-on-load + receiver preservation, immutability against caller and accessor mutation.
- `just lint` clean (vet, golangci-lint, nilaway, betteralign, modernize, both test tiers).
