### PR TITLE
finance/formula: staged linear formula specs with explanation records

### DIFF
--- a/core/decimal/compare.go
+++ b/core/decimal/compare.go
@@ -16,12 +16,47 @@ func (d Decimal) Cmp(e Decimal) int {
 			return 0
 		}
 	}
+	// Both int64 at different scales: align on int64 when it cannot overflow.
+	if d.big == nil && e.big == nil {
+		if c, ok := cmpInt64(d, e); ok {
+			return c
+		}
+	}
 	da, eb := alignBig(d, e)
 	return da.Cmp(eb)
 }
 
 // Equal reports whether d and e are numerically equal (scale-normalized).
 func (d Decimal) Equal(e Decimal) bool { return d.Cmp(e) == 0 }
+
+// cmpInt64 compares two int64-mode decimals by aligning the lower-scale
+// coefficient up on int64. ok is false when the alignment would overflow,
+// sending the caller to the big path.
+func cmpInt64(d, e Decimal) (int, bool) {
+	dc, ec := d.coef, e.coef
+	switch {
+	case d.scale < e.scale:
+		v, ok := mulPow10Int64(dc, e.scale-d.scale)
+		if !ok {
+			return 0, false
+		}
+		dc = v
+	case e.scale < d.scale:
+		v, ok := mulPow10Int64(ec, d.scale-e.scale)
+		if !ok {
+			return 0, false
+		}
+		ec = v
+	}
+	switch {
+	case dc < ec:
+		return -1, true
+	case dc > ec:
+		return 1, true
+	default:
+		return 0, true
+	}
+}
 
 // alignBig returns the two coefficients scaled to a common (maximum) scale as
 // *big.Int, so comparison/addition never overflows.

--- a/core/decimal/decimal.go
+++ b/core/decimal/decimal.go
@@ -107,3 +107,23 @@ func (d Decimal) mulPow10(n int32) Decimal {
 func pow10Big(n int32) *big.Int {
 	return new(big.Int).Exp(bigTen, big.NewInt(int64(n)), nil)
 }
+
+// pow10Int64 holds the powers of ten representable in an int64 (10^0..10^18).
+var pow10Int64 = [...]int64{
+	1, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
+	1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18,
+}
+
+// mulPow10Int64 returns v × 10^n if it fits in an int64, reporting overflow
+// (or n beyond the table) as ok == false.
+func mulPow10Int64(v int64, n int32) (int64, bool) {
+	if n < 0 || int(n) >= len(pow10Int64) {
+		return 0, false
+	}
+	p := pow10Int64[n]
+	hi := v * p
+	if v != 0 && hi/p != v {
+		return 0, false
+	}
+	return hi, true
+}

--- a/core/decimal/errors.go
+++ b/core/decimal/errors.go
@@ -2,7 +2,9 @@ package decimal
 
 import "errors"
 
-// ErrSyntax is returned by Parse for input that is not a valid decimal literal.
+// ErrSyntax is returned by Parse for input that is not a valid decimal literal,
+// and by RoundingMode text (un)marshaling for a value or name outside the
+// defined modes.
 var ErrSyntax = errors.New("decimal: invalid syntax")
 
 // ErrDivByZero is returned by Div, QuoRem, and Mod when the divisor is zero.

--- a/core/decimal/fuzz_test.go
+++ b/core/decimal/fuzz_test.go
@@ -30,6 +30,56 @@ func FuzzParse(f *testing.F) {
 	})
 }
 
+// FuzzRescaleCmpOracle checks Rescale and Cmp against independent big.Rat /
+// big.Int math, so the int64 fast paths and the big path can never drift from
+// each other or from the definition.
+func FuzzRescaleCmpOracle(f *testing.F) {
+	seeds := []struct {
+		a, b        int64
+		sa, sb, tgt uint8
+		mode        uint8
+	}{
+		{1749755, -4000, 2, 2, 3, 0},
+		{-4000005, 17, 5, 2, 0, 3},
+		{9223372036854775807, 1, 18, 0, 2, 1},
+		{-9223372036854775808, -1, 3, 9, 1, 6},
+		{25, 245, 1, 2, 0, 2},
+	}
+	for _, s := range seeds {
+		f.Add(s.a, s.b, s.sa, s.sb, s.tgt, s.mode)
+	}
+	f.Fuzz(func(t *testing.T, a, b int64, sa, sb, tgt, mode uint8) {
+		da := decimal.New(a, int32(sa%25))
+		db := decimal.New(b, int32(sb%25))
+		m := decimal.RoundingMode(mode % 7)
+		scale := int32(tgt % 25)
+
+		got := da.Rescale(scale, m)
+		require.Equal(t, scale, got.Scale())
+		// Oracle: the rounded value must be within one ulp of the true value,
+		// on the correct side for the mode, and exact when no digits drop.
+		ulp := new(big.Rat).SetFrac(big.NewInt(1), pow10(scale))
+		diff := new(big.Rat).Sub(toRat(got), toRat(da))
+		require.Truef(t, diff.Abs(diff).Cmp(ulp) < 0, "rescale(%s,%d,%v)=%s drifted a full unit", da, scale, m, got)
+		switch m {
+		case decimal.Down:
+			require.True(t, toRat(got).Abs(toRat(got)).Cmp(toRat(da).Abs(toRat(da))) <= 0, "Down grew magnitude")
+		case decimal.Up:
+			require.True(t, toRat(got).Abs(toRat(got)).Cmp(toRat(da).Abs(toRat(da))) >= 0, "Up shrank magnitude")
+		case decimal.Ceil:
+			require.True(t, toRat(got).Cmp(toRat(da)) >= 0, "Ceil went down")
+		case decimal.Floor:
+			require.True(t, toRat(got).Cmp(toRat(da)) <= 0, "Floor went up")
+		}
+
+		require.Equal(t, toRat(da).Cmp(toRat(db)), da.Cmp(db), "Cmp(%s,%s) disagrees with big.Rat", da, db)
+	})
+}
+
+func pow10(n int32) *big.Int {
+	return new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(n)), nil)
+}
+
 func FuzzAddMulOracle(f *testing.F) {
 	seeds := []struct{ a, b string }{
 		{"2.50", "0.25"},

--- a/core/decimal/round.go
+++ b/core/decimal/round.go
@@ -1,6 +1,10 @@
 package decimal
 
-import "math/big"
+import (
+	"fmt"
+	"math"
+	"math/big"
+)
 
 // RoundingMode selects how discarded low-order digits are handled when reducing
 // scale. HalfEven (banker's rounding) is the default and zero value.
@@ -22,6 +26,50 @@ const (
 	// Floor always rounds toward -∞.
 	Floor
 )
+
+// roundingModeNames maps each RoundingMode to its canonical text form. The
+// names are part of the serialized representation of any config or spec that
+// stores a mode, so they are frozen.
+var roundingModeNames = [...]string{
+	HalfEven: "half_even",
+	HalfUp:   "half_up",
+	HalfDown: "half_down",
+	Up:       "up",
+	Down:     "down",
+	Ceil:     "ceil",
+	Floor:    "floor",
+}
+
+// String returns the canonical text form of m ("half_even", "up", ...), or
+// "invalid" for a value outside the defined modes.
+func (m RoundingMode) String() string {
+	if m < 0 || int(m) >= len(roundingModeNames) {
+		return "invalid"
+	}
+	return roundingModeNames[m]
+}
+
+// MarshalText implements encoding.TextMarshaler, emitting the same form as
+// String. A mode outside the defined range is an error.
+func (m RoundingMode) MarshalText() ([]byte, error) {
+	if m < 0 || int(m) >= len(roundingModeNames) {
+		return nil, fmt.Errorf("%w: rounding mode %d", ErrSyntax, int(m))
+	}
+	return []byte(roundingModeNames[m]), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler, parsing the form produced
+// by MarshalText. Unknown input returns ErrSyntax.
+func (m *RoundingMode) UnmarshalText(p []byte) error {
+	s := string(p)
+	for i, name := range roundingModeNames {
+		if s == name {
+			*m = RoundingMode(i)
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: rounding mode %q", ErrSyntax, s)
+}
 
 // Round returns d rounded to places fractional digits using mode. It is an alias
 // for Rescale(places, mode).
@@ -47,8 +95,63 @@ func (d Decimal) Rescale(scale int32, mode RoundingMode) Decimal {
 	}
 	// Reduce scale: drop (d.scale - scale) low digits with rounding.
 	drop := d.scale - scale
+	// Int64 fast path: same semantics as roundBig without big.Int allocation.
+	// MinInt64 is excluded because its magnitude is not representable.
+	if d.big == nil && d.coef != math.MinInt64 && int(drop) < len(pow10Int64) {
+		return Decimal{coef: roundInt64(d.coef, pow10Int64[drop], mode), scale: scale}
+	}
 	rounded := roundBig(d.bigCoef(), drop, mode)
 	return fromBig(rounded, scale)
+}
+
+// roundInt64 divides coef by div (a positive power of ten), applying mode to
+// the remainder — the int64 mirror of roundBig. coef must not be MinInt64.
+func roundInt64(coef, div int64, mode RoundingMode) int64 {
+	neg := coef < 0
+	abs := coef
+	if neg {
+		abs = -abs
+	}
+	q, r := abs/div, abs%div
+	if r != 0 && roundAwayFromZeroInt64(q, r, div, mode, neg) {
+		q++
+	}
+	if neg {
+		q = -q
+	}
+	return q
+}
+
+// roundAwayFromZeroInt64 mirrors roundAwayFromZero on int64 magnitudes:
+// for a nonzero remainder r (0 < r < div), it decides whether the magnitude
+// quotient q gains one. 2*r cannot overflow because div ≤ 10^18.
+func roundAwayFromZeroInt64(q, r, div int64, mode RoundingMode, neg bool) bool {
+	switch mode {
+	case Down:
+		return false
+	case Up:
+		return true
+	case Ceil:
+		return !neg
+	case Floor:
+		return neg
+	default:
+		switch twice := 2 * r; {
+		case twice < div:
+			return false
+		case twice > div:
+			return true
+		default:
+			switch mode {
+			case HalfUp:
+				return true
+			case HalfDown:
+				return false
+			default: // HalfEven
+				return q&1 == 1
+			}
+		}
+	}
 }
 
 // RescaleExact is like Rescale but also reports whether the operation was

--- a/core/decimal/roundingmode_test.go
+++ b/core/decimal/roundingmode_test.go
@@ -1,0 +1,60 @@
+package decimal_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+)
+
+func TestRoundingModeText(t *testing.T) {
+	names := map[decimal.RoundingMode]string{
+		decimal.HalfEven: "half_even",
+		decimal.HalfUp:   "half_up",
+		decimal.HalfDown: "half_down",
+		decimal.Up:       "up",
+		decimal.Down:     "down",
+		decimal.Ceil:     "ceil",
+		decimal.Floor:    "floor",
+	}
+	for mode, name := range names {
+		assert.Equal(t, name, mode.String())
+
+		text, err := mode.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, name, string(text))
+
+		var back decimal.RoundingMode
+		require.NoError(t, back.UnmarshalText([]byte(name)))
+		assert.Equal(t, mode, back)
+	}
+
+	t.Run("invalid values", func(t *testing.T) {
+		bad := decimal.RoundingMode(99)
+		assert.Equal(t, "invalid", bad.String())
+		_, err := bad.MarshalText()
+		assert.ErrorIs(t, err, decimal.ErrSyntax)
+		_, err = decimal.RoundingMode(-1).MarshalText()
+		assert.ErrorIs(t, err, decimal.ErrSyntax)
+
+		var m decimal.RoundingMode
+		assert.ErrorIs(t, m.UnmarshalText([]byte("nearest")), decimal.ErrSyntax)
+		assert.ErrorIs(t, m.UnmarshalText([]byte("")), decimal.ErrSyntax)
+	})
+
+	t.Run("json round trip", func(t *testing.T) {
+		type wrapper struct {
+			Mode decimal.RoundingMode `json:"mode"`
+		}
+		raw, err := json.Marshal(wrapper{Mode: decimal.Ceil})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"mode":"ceil"}`, string(raw))
+
+		var w wrapper
+		require.NoError(t, json.Unmarshal([]byte(`{"mode":"floor"}`), &w))
+		assert.Equal(t, decimal.Floor, w.Mode)
+	})
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -280,26 +280,6 @@ Deps: `core/money`, `core/decimal`.
 
 ---
 
-**finance/formula**
-
-Formulas as structured, versioned data — never text: a spec of named
-derived metrics, each a list of (metric, decimal coefficient) terms over
-inputs or prior stages plus an optional clamp, evaluated in
-`core/decimal` with deterministic rounding. Evaluation returns an
-explanation record — every stage, every term's contribution, spec
-version, inputs — the statement line item and the dispute answer (the
-`fxrate` record-the-evaluation philosophy). Specs are immutable once
-referenced; recomputes byte-match. Derives the base (NGR, billable
-usage, commission bases) that `tariff` rates and `ledger` posts. Hard
-anti-scope: no string parsing, no conditionals, no user-typed
-expressions — anything beyond staged linear terms + clamp is a
-registered Go function; for fixed deal shapes the documented default is
-named Go functions with per-deal parameters as data.
-
-Deps: `core/decimal`.
-
----
-
 **finance/invoice**
 
 The invoice document model — invariants, not rendering: numbering via a

--- a/finance/formula/bench_test.go
+++ b/finance/formula/bench_test.go
@@ -1,0 +1,85 @@
+package formula_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/finance/formula"
+)
+
+func benchSpec() formula.Spec {
+	one := decimal.FromInt(1)
+	minusOne := decimal.FromInt(-1)
+	return formula.Spec{
+		Version: "bench-v1",
+		Stages: []formula.Stage{
+			{
+				Name: "ngr",
+				Terms: []formula.Term{
+					{Metric: "bets", Coefficient: one},
+					{Metric: "wins", Coefficient: minusOne},
+					{Metric: "bonus_cost", Coefficient: minusOne},
+					{Metric: "provider_fees", Coefficient: minusOne},
+				},
+			},
+			{
+				Name: "base",
+				Terms: []formula.Term{
+					{Metric: "ngr", Coefficient: one},
+					{Metric: "carry_in", Coefficient: one},
+				},
+				Round: &formula.Round{Scale: 2, Mode: decimal.HalfEven},
+				Clamp: &formula.Clamp{Min: new(decimal.Zero)},
+			},
+			{
+				Name: "commission",
+				Terms: []formula.Term{
+					{Metric: "base", Coefficient: decimal.MustParse("0.35")},
+				},
+				Round: &formula.Round{Scale: 2, Mode: decimal.HalfEven},
+			},
+		},
+	}
+}
+
+func benchInputs() map[string]decimal.Decimal {
+	return map[string]decimal.Decimal{
+		"bets":          decimal.MustParse("125000.00"),
+		"wins":          decimal.MustParse("118400.50"),
+		"bonus_cost":    decimal.MustParse("2100.00"),
+		"provider_fees": decimal.MustParse("1249.75"),
+		"carry_in":      decimal.MustParse("-1500.00"),
+	}
+}
+
+func BenchmarkCompile(b *testing.B) {
+	spec := benchSpec()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := formula.Compile(spec); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEval(b *testing.B) {
+	compiled, err := formula.Compile(benchSpec())
+	if err != nil {
+		b.Fatal(err)
+	}
+	inputs := benchInputs()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := compiled.Eval(inputs); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFingerprint(b *testing.B) {
+	spec := benchSpec()
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = spec.Fingerprint()
+	}
+}

--- a/finance/formula/compile.go
+++ b/finance/formula/compile.go
@@ -1,0 +1,123 @@
+package formula
+
+import (
+	"fmt"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+)
+
+// Compiled is a validated, fingerprinted spec with all stage references
+// resolved and registered functions bound, ready for repeated Eval calls.
+// Compile once per spec and reuse — a Compiled is immutable and safe for
+// concurrent use.
+type Compiled struct {
+	stageIndex  map[string]int
+	fingerprint string
+	spec        Spec
+	stages      []compiledStage
+}
+
+// ref points a term or arg at its value source: a prior stage by index, or —
+// when stage is -1 — an input looked up by name at Eval time.
+type ref struct {
+	input string
+	stage int
+}
+
+type compiledTerm struct {
+	ref         ref
+	coefficient decimal.Decimal
+}
+
+type compiledStage struct {
+	fn       Func
+	clamp    *Clamp
+	round    *Round
+	name     string
+	fnName   string
+	terms    []compiledTerm
+	argNames []string
+	args     []ref
+}
+
+// Compile validates spec, binds every func stage to a function registered via
+// WithFunc, resolves term and arg references, and computes the fingerprint.
+// The spec is deep-copied, so later mutation of the caller's value cannot
+// desync the fingerprint from what evaluates. Errors wrap ErrInvalidSpec,
+// ErrInvalidFunc, or ErrUnknownFunc.
+func Compile(spec Spec, opts ...Option) (*Compiled, error) {
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+	var cfg config
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	funcs := make(map[string]Func, len(cfg.funcs))
+	for _, nf := range cfg.funcs {
+		if nf.name == "" {
+			return nil, fmt.Errorf("%w: empty name", ErrInvalidFunc)
+		}
+		if nf.fn == nil {
+			return nil, fmt.Errorf("%w: nil func %q", ErrInvalidFunc, nf.name)
+		}
+		if _, dup := funcs[nf.name]; dup {
+			return nil, fmt.Errorf("%w: duplicate func %q", ErrInvalidFunc, nf.name)
+		}
+		funcs[nf.name] = nf.fn
+	}
+
+	spec = spec.clone()
+	c := &Compiled{
+		spec:        spec,
+		fingerprint: spec.Fingerprint(),
+		stages:      make([]compiledStage, len(spec.Stages)),
+		stageIndex:  make(map[string]int, len(spec.Stages)),
+	}
+	for i, st := range spec.Stages {
+		c.stageIndex[st.Name] = i
+	}
+	for i, st := range spec.Stages {
+		cs := compiledStage{name: st.Name, clamp: st.Clamp, round: st.Round}
+		if st.Func != "" {
+			fn, ok := funcs[st.Func]
+			if !ok {
+				return nil, fmt.Errorf("%w: stage %q references %q", ErrUnknownFunc, st.Name, st.Func)
+			}
+			cs.fnName = st.Func
+			cs.fn = fn
+			cs.argNames = st.Args
+			cs.args = make([]ref, len(st.Args))
+			for j, a := range st.Args {
+				cs.args[j] = c.resolve(a)
+			}
+		} else {
+			cs.terms = make([]compiledTerm, len(st.Terms))
+			for j, t := range st.Terms {
+				cs.terms[j] = compiledTerm{ref: c.resolve(t.Metric), coefficient: t.Coefficient}
+			}
+		}
+		c.stages[i] = cs
+	}
+	return c, nil
+}
+
+// resolve maps a metric name to its source. Validate already rejected self and
+// forward stage references, so any stage-name hit here is a prior stage;
+// everything else must arrive as an input at Eval time.
+func (c *Compiled) resolve(metric string) ref {
+	if i, isStage := c.stageIndex[metric]; isStage {
+		return ref{stage: i}
+	}
+	return ref{stage: -1, input: metric}
+}
+
+// Spec returns a deep copy of the compiled spec, so callers can serialize or
+// inspect it without being able to mutate what evaluates.
+func (c *Compiled) Spec() Spec { return c.spec.clone() }
+
+// Version returns the compiled spec's version.
+func (c *Compiled) Version() string { return c.spec.Version }
+
+// Fingerprint returns the compiled spec's fingerprint (see Spec.Fingerprint).
+func (c *Compiled) Fingerprint() string { return c.fingerprint }

--- a/finance/formula/doc.go
+++ b/finance/formula/doc.go
@@ -1,0 +1,97 @@
+// Package formula evaluates formulas kept as structured, versioned data —
+// never text: a Spec of named derived metrics, each an ordered list of
+// (metric, decimal coefficient) terms over inputs or prior stages plus an
+// optional clamp and rounding, evaluated exactly in core/decimal. It derives
+// the bases (NGR, billable usage, commission bases) that tariff rates and a
+// ledger posts.
+//
+// Every evaluation returns a Result explanation record — spec version and
+// fingerprint, every input, every stage, every term's contribution — the
+// statement line item and the dispute answer. Specs are immutable once
+// referenced: store them verbatim, mint a new Version for any change, and a
+// recompute of the same spec over the same inputs byte-matches the original
+// (json.Marshal of Result is deterministic).
+//
+// Hard anti-scope: no string parsing, no conditionals, no user-typed
+// expressions (they evaluate in float and can't explain a payout). Anything
+// beyond staged linear terms + clamp is a registered Go function — for fixed
+// deal shapes the documented default is named Go functions with per-deal
+// parameters closed over as data (see WithFunc).
+//
+// # Usage — revenue-share NGR with negative carry-over
+//
+// NGR is a linear combination of period totals; the commission base adds the
+// (negative or zero) carry-in and clamps at zero, so a losing month carries
+// forward instead of going negative — carry-over policy stays in the
+// consumer's domain table, the formula just takes it as an input:
+//
+//	spec := formula.Spec{
+//		Version: "revshare-2026-07",
+//		Stages: []formula.Stage{
+//			{
+//				Name: "ngr",
+//				Terms: []formula.Term{
+//					{Metric: "bets", Coefficient: decimal.FromInt(1)},
+//					{Metric: "wins", Coefficient: decimal.FromInt(-1)},
+//					{Metric: "bonus_cost", Coefficient: decimal.FromInt(-1)},
+//					{Metric: "provider_fees", Coefficient: decimal.FromInt(-1)},
+//				},
+//			},
+//			{
+//				Name: "commission_base",
+//				Terms: []formula.Term{
+//					{Metric: "ngr", Coefficient: decimal.FromInt(1)},
+//					{Metric: "carry_in", Coefficient: decimal.FromInt(1)},
+//				},
+//				Round: &formula.Round{Scale: 2, Mode: decimal.HalfEven},
+//				Clamp: &formula.Clamp{Min: new(decimal.Zero)},
+//			},
+//		},
+//	}
+//
+//	compiled, err := formula.Compile(spec)
+//	if err != nil {
+//		panic(err)
+//	}
+//
+//	res, err := compiled.Eval(map[string]decimal.Decimal{
+//		"bets":          decimal.MustParse("125000.00"),
+//		"wins":          decimal.MustParse("118400.50"),
+//		"bonus_cost":    decimal.MustParse("2100.00"),
+//		"provider_fees": decimal.MustParse("1249.75"),
+//		"carry_in":      decimal.MustParse("-4000.00"),
+//	})
+//	if err != nil {
+//		return err
+//	}
+//	base := res.Final() // "0.00" — NGR 3249.75 + carry -4000 clamps at zero
+//	// Persist res (json.Marshal) as the statement explanation; feed base to
+//	// tariff for the banded rate, post the outcome via the ledger.
+//
+// Each stage's value is the exact sum of coefficient × metric, then rounded
+// (if Round is set), then clamped (if Clamp is set) — in that order, so the
+// final value always honors the bounds. Later stages consume that final
+// value.
+//
+// # Beyond linear — registered functions
+//
+// A shape staged linear terms can't express is a named Go function; per-deal
+// parameters are data closed over at registration, and the Result records the
+// function name and the exact args it received:
+//
+//	capped := func(cap decimal.Decimal) formula.Func {
+//		return func(args []decimal.Decimal) (decimal.Decimal, error) {
+//			if args[0].Cmp(cap) > 0 {
+//				return cap, nil
+//			}
+//			return args[0], nil
+//		}
+//	}
+//	compiled, err := formula.Compile(spec,
+//		formula.WithFunc("cap_monthly", capped(decimal.MustParse("50000"))))
+//
+// The package is a pure calculator: no storage, no goroutines, no context.
+// Tenancy is not a seam here — specs and inputs are caller-supplied values,
+// so a multi-tenant app simply loads the tenant's spec. A Compiled is
+// immutable and safe for concurrent use.
+package formula

--- a/finance/formula/errors.go
+++ b/finance/formula/errors.go
@@ -1,0 +1,30 @@
+package formula
+
+import "errors"
+
+// ErrInvalidSpec is returned by Spec.Validate (and therefore Compile) when the
+// spec structure is invalid: missing version, no stages, duplicate or empty
+// stage names, a term or arg referencing the stage itself or a later stage, an
+// empty clamp, min > max, or a bad round scale/mode. The wrapping error names
+// the offending stage.
+var ErrInvalidSpec = errors.New("formula: invalid spec")
+
+// ErrInvalidFunc is returned by Compile when a WithFunc registration is
+// unusable: an empty name, a nil function, or a duplicate name.
+var ErrInvalidFunc = errors.New("formula: invalid func registration")
+
+// ErrUnknownFunc is returned by Compile when a func stage references a name
+// that no WithFunc option registered.
+var ErrUnknownFunc = errors.New("formula: unknown func")
+
+// ErrUnknownMetric is returned by Eval when a term or arg references a name
+// that is neither a prior stage nor a provided input.
+var ErrUnknownMetric = errors.New("formula: unknown metric")
+
+// ErrMetricCollision is returned by Eval when an input name collides with a
+// stage name, which would make the reference ambiguous.
+var ErrMetricCollision = errors.New("formula: input name collides with stage name")
+
+// ErrFuncFailed is returned by Eval when a registered function returns an
+// error; the function's own error is wrapped alongside for errors.Is matching.
+var ErrFuncFailed = errors.New("formula: func failed")

--- a/finance/formula/eval.go
+++ b/finance/formula/eval.go
@@ -1,0 +1,187 @@
+package formula
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+)
+
+// Result is the explanation record of one evaluation: the spec identity, every
+// input provided (used or not, sorted by name), and every stage with each
+// term's contribution. It is the statement line item and the dispute answer —
+// persist it next to what it justifies. Serialization is deterministic:
+// evaluating the same Compiled spec with the same inputs (same values at the
+// same scales) yields a Result whose json.Marshal output byte-matches.
+type Result struct {
+	SpecVersion     string        `json:"spec_version"`
+	SpecFingerprint string        `json:"spec_fingerprint"`
+	Inputs          []InputValue  `json:"inputs"`
+	Stages          []StageResult `json:"stages"`
+}
+
+// InputValue is one named decimal value, used for the input snapshot and for
+// func-stage arg records.
+type InputValue struct {
+	Name  string          `json:"name"`
+	Value decimal.Decimal `json:"value"`
+}
+
+// StageResult explains one stage: the exact pre-round pre-clamp sum (Raw), the
+// final value after round and clamp (Value), and either the per-term
+// breakdown (linear stages) or the func name with its resolved args (func
+// stages).
+type StageResult struct {
+	Name string `json:"name"`
+	// Terms breaks a linear stage down: Raw is the exact sum of their
+	// contributions.
+	Terms []TermResult `json:"terms,omitempty"`
+	// Func and Args record a func stage's function name and the arg values it
+	// received.
+	Func string       `json:"func,omitempty"`
+	Args []InputValue `json:"args,omitempty"`
+	// Raw is the stage value before rounding and clamping.
+	Raw decimal.Decimal `json:"raw"`
+	// Value is the final stage value — what later stages and the caller see.
+	Value decimal.Decimal `json:"value"`
+	// Clamped reports whether a clamp bound replaced the rounded value.
+	Clamped bool `json:"clamped,omitempty"`
+}
+
+// TermResult explains one linear term: Contribution = Coefficient ×
+// MetricValue, exact.
+type TermResult struct {
+	Metric       string          `json:"metric"`
+	Coefficient  decimal.Decimal `json:"coefficient"`
+	MetricValue  decimal.Decimal `json:"metric_value"`
+	Contribution decimal.Decimal `json:"contribution"`
+}
+
+// Value returns the final value of the named stage and whether it exists.
+// Inputs are not looked up — only derived metrics.
+func (r Result) Value(name string) (decimal.Decimal, bool) {
+	for _, st := range r.Stages {
+		if st.Name == name {
+			return st.Value, true
+		}
+	}
+	return decimal.Decimal{}, false
+}
+
+// Final returns the last stage's value — by convention the metric the spec
+// exists to derive. It returns zero for an empty Result.
+func (r Result) Final() decimal.Decimal {
+	if len(r.Stages) == 0 {
+		return decimal.Decimal{}
+	}
+	return r.Stages[len(r.Stages)-1].Value
+}
+
+// Eval runs the spec over inputs and returns the full explanation. Stages are
+// evaluated in order; each consumes prior stages' final (post-round,
+// post-clamp) values. Extra inputs are allowed and recorded; a missing one
+// fails with ErrUnknownMetric, an input named like a stage fails with
+// ErrMetricCollision, and a func error fails with ErrFuncFailed wrapping the
+// cause. Evaluation is deterministic: no clocks, no randomness, exact decimal
+// arithmetic with rounding only where the spec says so.
+func (c *Compiled) Eval(inputs map[string]decimal.Decimal) (Result, error) {
+	for name := range inputs {
+		if _, clash := c.stageIndex[name]; clash {
+			return Result{}, fmt.Errorf("%w: %q", ErrMetricCollision, name)
+		}
+	}
+
+	values := make([]decimal.Decimal, len(c.stages))
+	stages := make([]StageResult, len(c.stages))
+	for i, st := range c.stages {
+		sr := StageResult{Name: st.name}
+		var raw decimal.Decimal
+		if st.fn != nil {
+			args := make([]decimal.Decimal, len(st.args))
+			sr.Func = st.fnName
+			if len(st.args) > 0 {
+				sr.Args = make([]InputValue, len(st.args))
+			}
+			for j, r := range st.args {
+				v, err := resolveValue(r, values, inputs)
+				if err != nil {
+					return Result{}, fmt.Errorf("formula: stage %q: %w", st.name, err)
+				}
+				args[j] = v
+				sr.Args[j] = InputValue{Name: st.argNames[j], Value: v}
+			}
+			v, err := st.fn(args)
+			if err != nil {
+				return Result{}, fmt.Errorf("%w: stage %q func %q: %w", ErrFuncFailed, st.name, st.fnName, err)
+			}
+			raw = v
+		} else {
+			sr.Terms = make([]TermResult, len(st.terms))
+			for j, t := range st.terms {
+				v, err := resolveValue(t.ref, values, inputs)
+				if err != nil {
+					return Result{}, fmt.Errorf("formula: stage %q: %w", st.name, err)
+				}
+				contribution := t.coefficient.Mul(v)
+				raw = raw.Add(contribution)
+				sr.Terms[j] = TermResult{
+					Metric:       termMetric(t.ref, c),
+					Coefficient:  t.coefficient,
+					MetricValue:  v,
+					Contribution: contribution,
+				}
+			}
+		}
+		sr.Raw = raw
+
+		value := raw
+		if st.round != nil {
+			value = value.Round(st.round.Scale, st.round.Mode)
+		}
+		if st.clamp != nil {
+			if st.clamp.Min != nil && value.Cmp(*st.clamp.Min) < 0 {
+				value = *st.clamp.Min
+				sr.Clamped = true
+			}
+			if st.clamp.Max != nil && value.Cmp(*st.clamp.Max) > 0 {
+				value = *st.clamp.Max
+				sr.Clamped = true
+			}
+		}
+		sr.Value = value
+		values[i] = value
+		stages[i] = sr
+	}
+
+	snapshot := make([]InputValue, 0, len(inputs))
+	for name, value := range inputs {
+		snapshot = append(snapshot, InputValue{Name: name, Value: value})
+	}
+	slices.SortFunc(snapshot, func(a, b InputValue) int { return strings.Compare(a.Name, b.Name) })
+
+	return Result{
+		SpecVersion:     c.spec.Version,
+		SpecFingerprint: c.fingerprint,
+		Inputs:          snapshot,
+		Stages:          stages,
+	}, nil
+}
+
+func resolveValue(r ref, values []decimal.Decimal, inputs map[string]decimal.Decimal) (decimal.Decimal, error) {
+	if r.stage >= 0 {
+		return values[r.stage], nil
+	}
+	v, ok := inputs[r.input]
+	if !ok {
+		return decimal.Decimal{}, fmt.Errorf("%w: %q", ErrUnknownMetric, r.input)
+	}
+	return v, nil
+}
+
+func termMetric(r ref, c *Compiled) string {
+	if r.stage >= 0 {
+		return c.stages[r.stage].name
+	}
+	return r.input
+}

--- a/finance/formula/eval.go
+++ b/finance/formula/eval.go
@@ -86,9 +86,11 @@ func (r Result) Final() decimal.Decimal {
 // cause. Evaluation is deterministic: no clocks, no randomness, exact decimal
 // arithmetic with rounding only where the spec says so.
 func (c *Compiled) Eval(inputs map[string]decimal.Decimal) (Result, error) {
-	for name := range inputs {
-		if _, clash := c.stageIndex[name]; clash {
-			return Result{}, fmt.Errorf("%w: %q", ErrMetricCollision, name)
+	// Scan stages in spec order so the reported name is deterministic when
+	// several inputs collide.
+	for _, st := range c.stages {
+		if _, clash := inputs[st.name]; clash {
+			return Result{}, fmt.Errorf("%w: %q", ErrMetricCollision, st.name)
 		}
 	}
 

--- a/finance/formula/eval_test.go
+++ b/finance/formula/eval_test.go
@@ -1,0 +1,357 @@
+package formula_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/finance/formula"
+)
+
+func revshareInputs(t *testing.T) map[string]decimal.Decimal {
+	t.Helper()
+	return map[string]decimal.Decimal{
+		"bets":     d(t, "125000.00"),
+		"wins":     d(t, "118400.50"),
+		"carry_in": d(t, "-4000.00"),
+	}
+}
+
+func TestCompile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid spec rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := formula.Compile(formula.Spec{})
+		assert.ErrorIs(t, err, formula.ErrInvalidSpec)
+	})
+
+	t.Run("unknown func", func(t *testing.T) {
+		t.Parallel()
+		spec := validSpec()
+		spec.Stages = append(spec.Stages, formula.Stage{Name: "capped", Func: "cap", Args: []string{"base"}})
+		_, err := formula.Compile(spec)
+		assert.ErrorIs(t, err, formula.ErrUnknownFunc)
+	})
+
+	identity := func(args []decimal.Decimal) (decimal.Decimal, error) { return args[0], nil }
+
+	t.Run("bad registrations", func(t *testing.T) {
+		t.Parallel()
+		spec := validSpec()
+		for name, opt := range map[string]formula.Option{
+			"empty name": formula.WithFunc("", identity),
+			"nil func":   formula.WithFunc("f", nil),
+		} {
+			_, err := formula.Compile(spec, opt)
+			assert.ErrorIs(t, err, formula.ErrInvalidFunc, name)
+		}
+		_, err := formula.Compile(spec, formula.WithFunc("f", identity), formula.WithFunc("f", identity))
+		assert.ErrorIs(t, err, formula.ErrInvalidFunc, "duplicate name")
+	})
+
+	t.Run("spec is copied at compile", func(t *testing.T) {
+		t.Parallel()
+		spec := validSpec()
+		compiled, err := formula.Compile(spec)
+		require.NoError(t, err)
+		want := compiled.Fingerprint()
+
+		spec.Stages[0].Terms[0].Coefficient = decimal.FromInt(999)
+		spec.Version = "tampered"
+		res, err := compiled.Eval(revshareInputs(t))
+		require.NoError(t, err)
+		assert.Equal(t, want, compiled.Fingerprint())
+		assert.Equal(t, "v1", res.SpecVersion)
+		assert.Equal(t, "6599.50", res.Stages[0].Value.String(), "eval unaffected by caller mutation")
+	})
+
+	t.Run("Spec returns a copy", func(t *testing.T) {
+		t.Parallel()
+		compiled, err := formula.Compile(validSpec())
+		require.NoError(t, err)
+		got := compiled.Spec()
+		got.Stages[0].Name = "tampered"
+		assert.Equal(t, validSpec().Fingerprint(), compiled.Spec().Fingerprint())
+		assert.Equal(t, "v1", compiled.Version())
+	})
+}
+
+func TestEvalRevshare(t *testing.T) {
+	t.Parallel()
+
+	spec := formula.Spec{
+		Version: "revshare-2026-07",
+		Stages: []formula.Stage{
+			{
+				Name: "ngr",
+				Terms: []formula.Term{
+					{Metric: "bets", Coefficient: decimal.FromInt(1)},
+					{Metric: "wins", Coefficient: decimal.FromInt(-1)},
+					{Metric: "bonus_cost", Coefficient: decimal.FromInt(-1)},
+					{Metric: "provider_fees", Coefficient: decimal.FromInt(-1)},
+				},
+			},
+			{
+				Name: "base",
+				Terms: []formula.Term{
+					{Metric: "ngr", Coefficient: decimal.FromInt(1)},
+					{Metric: "carry_in", Coefficient: decimal.FromInt(1)},
+				},
+				Round: &formula.Round{Scale: 2, Mode: decimal.HalfEven},
+				Clamp: &formula.Clamp{Min: new(decimal.Zero)},
+			},
+		},
+	}
+	compiled, err := formula.Compile(spec)
+	require.NoError(t, err)
+
+	inputs := map[string]decimal.Decimal{
+		"bets":          d(t, "125000.00"),
+		"wins":          d(t, "118400.50"),
+		"bonus_cost":    d(t, "2100.00"),
+		"provider_fees": d(t, "1249.75"),
+		"carry_in":      d(t, "-4000.00"),
+	}
+	res, err := compiled.Eval(inputs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "revshare-2026-07", res.SpecVersion)
+	assert.Equal(t, spec.Fingerprint(), res.SpecFingerprint)
+
+	ngr, ok := res.Value("ngr")
+	require.True(t, ok)
+	assert.Equal(t, "3249.75", ngr.String())
+
+	assert.Equal(t, "0", res.Final().String(), "negative base clamps to the Min bound")
+	require.Len(t, res.Stages, 2)
+	base := res.Stages[1]
+	assert.Equal(t, "-750.25", base.Raw.String())
+	assert.True(t, base.Clamped)
+
+	require.Len(t, base.Terms, 2)
+	assert.Equal(t, "ngr", base.Terms[0].Metric)
+	assert.Equal(t, "3249.75", base.Terms[0].MetricValue.String())
+	assert.Equal(t, "3249.75", base.Terms[0].Contribution.String())
+	assert.Equal(t, "carry_in", base.Terms[1].Metric)
+	assert.Equal(t, "-4000.00", base.Terms[1].Contribution.String())
+
+	names := make([]string, len(res.Inputs))
+	for i, in := range res.Inputs {
+		names[i] = in.Name
+	}
+	assert.Equal(t, []string{"bets", "bonus_cost", "carry_in", "provider_fees", "wins"}, names, "inputs sorted by name")
+
+	_, ok = res.Value("bets")
+	assert.False(t, ok, "inputs are not derived metrics")
+}
+
+func TestEvalRoundThenClamp(t *testing.T) {
+	t.Parallel()
+
+	// Raw 10.007 rounds to 10.01, which exceeds max 10.005 — the clamp wins,
+	// proving round-before-clamp ordering.
+	maxBound := d(t, "10.005")
+	spec := formula.Spec{
+		Version: "v1",
+		Stages: []formula.Stage{{
+			Name:  "out",
+			Terms: []formula.Term{{Metric: "in", Coefficient: decimal.FromInt(1)}},
+			Round: &formula.Round{Scale: 2, Mode: decimal.HalfUp},
+			Clamp: &formula.Clamp{Max: &maxBound},
+		}},
+	}
+	compiled, err := formula.Compile(spec)
+	require.NoError(t, err)
+
+	res, err := compiled.Eval(map[string]decimal.Decimal{"in": d(t, "10.007")})
+	require.NoError(t, err)
+	assert.Equal(t, "10.005", res.Final().String())
+	assert.True(t, res.Stages[0].Clamped)
+	assert.Equal(t, "10.007", res.Stages[0].Raw.String())
+
+	res, err = compiled.Eval(map[string]decimal.Decimal{"in": d(t, "9.994")})
+	require.NoError(t, err)
+	assert.Equal(t, "9.99", res.Final().String())
+	assert.False(t, res.Stages[0].Clamped)
+}
+
+func TestEvalRoundingModes(t *testing.T) {
+	t.Parallel()
+
+	for mode, want := range map[decimal.RoundingMode]string{
+		decimal.HalfEven: "2.34",
+		decimal.HalfUp:   "2.35",
+		decimal.Floor:    "2.34",
+		decimal.Up:       "2.35",
+	} {
+		spec := formula.Spec{
+			Version: "v1",
+			Stages: []formula.Stage{{
+				Name:  "out",
+				Terms: []formula.Term{{Metric: "in", Coefficient: decimal.FromInt(1)}},
+				Round: &formula.Round{Scale: 2, Mode: mode},
+			}},
+		}
+		compiled, err := formula.Compile(spec)
+		require.NoError(t, err)
+		res, err := compiled.Eval(map[string]decimal.Decimal{"in": d(t, "2.345")})
+		require.NoError(t, err)
+		assert.Equal(t, want, res.Final().String(), mode.String())
+	}
+}
+
+func TestEvalStageChainingUsesFinalValues(t *testing.T) {
+	t.Parallel()
+
+	// Stage one rounds 1.005 down to 1.00; stage two must see 1.00, not the
+	// raw 1.005.
+	spec := formula.Spec{
+		Version: "v1",
+		Stages: []formula.Stage{
+			{
+				Name:  "first",
+				Terms: []formula.Term{{Metric: "in", Coefficient: decimal.FromInt(1)}},
+				Round: &formula.Round{Scale: 2, Mode: decimal.Down},
+			},
+			{
+				Name:  "second",
+				Terms: []formula.Term{{Metric: "first", Coefficient: decimal.FromInt(100)}},
+			},
+		},
+	}
+	compiled, err := formula.Compile(spec)
+	require.NoError(t, err)
+	res, err := compiled.Eval(map[string]decimal.Decimal{"in": d(t, "1.005")})
+	require.NoError(t, err)
+	assert.Equal(t, "100.00", res.Final().String())
+}
+
+func TestEvalFuncStage(t *testing.T) {
+	t.Parallel()
+
+	cap := func(limit decimal.Decimal) formula.Func {
+		return func(args []decimal.Decimal) (decimal.Decimal, error) {
+			if args[0].Cmp(limit) > 0 {
+				return limit, nil
+			}
+			return args[0], nil
+		}
+	}
+	spec := formula.Spec{
+		Version: "v1",
+		Stages: []formula.Stage{
+			{
+				Name:  "gross",
+				Terms: []formula.Term{{Metric: "usage", Coefficient: d(t, "0.10")}},
+			},
+			{
+				Name:  "billable",
+				Func:  "cap_monthly",
+				Args:  []string{"gross"},
+				Round: &formula.Round{Scale: 2, Mode: decimal.HalfEven},
+			},
+		},
+	}
+	compiled, err := formula.Compile(spec, formula.WithFunc("cap_monthly", cap(decimal.FromInt(500))))
+	require.NoError(t, err)
+
+	res, err := compiled.Eval(map[string]decimal.Decimal{"usage": decimal.FromInt(9000)})
+	require.NoError(t, err)
+	assert.Equal(t, "500.00", res.Final().String(), "capped and rounded")
+
+	st := res.Stages[1]
+	assert.Equal(t, "cap_monthly", st.Func)
+	require.Len(t, st.Args, 1)
+	assert.Equal(t, "gross", st.Args[0].Name)
+	assert.Equal(t, "900.00", st.Args[0].Value.String())
+	assert.Equal(t, "500", st.Raw.String())
+
+	res, err = compiled.Eval(map[string]decimal.Decimal{"usage": decimal.FromInt(100)})
+	require.NoError(t, err)
+	assert.Equal(t, "10.00", res.Final().String(), "under the cap passes through")
+}
+
+func TestEvalFuncError(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("negative usage")
+	spec := formula.Spec{
+		Version: "v1",
+		Stages:  []formula.Stage{{Name: "out", Func: "guard", Args: []string{"in"}}},
+	}
+	compiled, err := formula.Compile(spec, formula.WithFunc("guard", func([]decimal.Decimal) (decimal.Decimal, error) {
+		return decimal.Decimal{}, cause
+	}))
+	require.NoError(t, err)
+
+	_, err = compiled.Eval(map[string]decimal.Decimal{"in": decimal.FromInt(1)})
+	assert.ErrorIs(t, err, formula.ErrFuncFailed)
+	assert.ErrorIs(t, err, cause, "the func's own error stays matchable")
+}
+
+func TestEvalInputErrors(t *testing.T) {
+	t.Parallel()
+
+	compiled, err := formula.Compile(validSpec())
+	require.NoError(t, err)
+
+	t.Run("missing input", func(t *testing.T) {
+		t.Parallel()
+		_, err := compiled.Eval(map[string]decimal.Decimal{"bets": decimal.FromInt(1)})
+		assert.ErrorIs(t, err, formula.ErrUnknownMetric)
+		assert.ErrorContains(t, err, `"wins"`)
+	})
+
+	t.Run("input collides with stage", func(t *testing.T) {
+		t.Parallel()
+		in := revshareInputs(t)
+		in["ngr"] = decimal.FromInt(7)
+		_, err := compiled.Eval(in)
+		assert.ErrorIs(t, err, formula.ErrMetricCollision)
+	})
+
+	t.Run("extra inputs recorded, not rejected", func(t *testing.T) {
+		t.Parallel()
+		in := revshareInputs(t)
+		in["unused"] = decimal.FromInt(42)
+		res, err := compiled.Eval(in)
+		require.NoError(t, err)
+		_, ok := res.Value("unused")
+		assert.False(t, ok)
+		var found bool
+		for _, iv := range res.Inputs {
+			found = found || iv.Name == "unused"
+		}
+		assert.True(t, found, "unused input still snapshotted for the audit record")
+	})
+}
+
+func TestEvalDeterministicByteMatch(t *testing.T) {
+	t.Parallel()
+
+	compiled, err := formula.Compile(validSpec())
+	require.NoError(t, err)
+
+	first, err := compiled.Eval(revshareInputs(t))
+	require.NoError(t, err)
+	second, err := compiled.Eval(revshareInputs(t))
+	require.NoError(t, err)
+
+	a, err := json.Marshal(first)
+	require.NoError(t, err)
+	b, err := json.Marshal(second)
+	require.NoError(t, err)
+	assert.Equal(t, string(a), string(b), "recomputes byte-match")
+}
+
+func TestResultFinalEmpty(t *testing.T) {
+	t.Parallel()
+	assert.True(t, formula.Result{}.Final().IsZero())
+	_, ok := formula.Result{}.Value("x")
+	assert.False(t, ok)
+}

--- a/finance/formula/options.go
+++ b/finance/formula/options.go
@@ -1,0 +1,31 @@
+package formula
+
+import "github.com/dmitrymomot/forge/core/decimal"
+
+// Func is a registered Go function backing a func stage: it receives the
+// resolved arg values in spec order and returns the stage's raw value. It must
+// be pure and deterministic — same args, same result — or recomputed
+// statements stop byte-matching. Per-deal parameters (rates, thresholds) are
+// closed over at registration; only metric values flow through args.
+type Func func(args []decimal.Decimal) (decimal.Decimal, error)
+
+type namedFunc struct {
+	fn   Func
+	name string
+}
+
+type config struct {
+	funcs []namedFunc
+}
+
+// Option configures Compile.
+type Option func(*config)
+
+// WithFunc registers fn under name for func stages to reference. Registering
+// an empty name, a nil fn, or the same name twice fails Compile with
+// ErrInvalidFunc.
+func WithFunc(name string, fn Func) Option {
+	return func(c *config) {
+		c.funcs = append(c.funcs, namedFunc{name: name, fn: fn})
+	}
+}

--- a/finance/formula/spec.go
+++ b/finance/formula/spec.go
@@ -139,7 +139,7 @@ func validateStage(st Stage, idx int, order map[string]int) error {
 		if st.Round.Scale < 0 {
 			return fmt.Errorf("%w: stage %q: negative round scale", ErrInvalidSpec, st.Name)
 		}
-		if st.Round.Mode < decimal.HalfEven || st.Round.Mode > decimal.Floor {
+		if _, err := st.Round.Mode.MarshalText(); err != nil {
 			return fmt.Errorf("%w: stage %q: unknown rounding mode %d", ErrInvalidSpec, st.Name, int(st.Round.Mode))
 		}
 	}

--- a/finance/formula/spec.go
+++ b/finance/formula/spec.go
@@ -1,0 +1,245 @@
+package formula
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+)
+
+// Spec is a formula as structured, versioned data: an ordered list of named
+// stages, each deriving one metric from inputs and prior stages. A spec is
+// plain data — it JSON-round-trips for storage and carries no behavior beyond
+// Validate and Fingerprint. Specs are immutable once referenced by an
+// evaluation: store them verbatim and mint a new Version for any change, so
+// recomputing an old statement byte-matches the original.
+type Spec struct {
+	// Version identifies this exact spec revision and is stamped into every
+	// Result. Required.
+	Version string `json:"version"`
+	// Stages are evaluated in order; each may reference inputs and the stages
+	// before it, never itself or later ones.
+	Stages []Stage `json:"stages"`
+}
+
+// Stage derives one named metric. Exactly one of Terms (a linear combination)
+// or Func (a registered Go function) must be set. The raw result is then
+// rounded (if Round is set) and clamped (if Clamp is set), in that order, so
+// the final value always honors the clamp bounds exactly.
+type Stage struct {
+	// Clamp optionally bounds the stage value after rounding.
+	Clamp *Clamp `json:"clamp,omitempty"`
+	// Round optionally pins the stage value to a fixed scale before clamping.
+	Round *Round `json:"round,omitempty"`
+	// Name is the metric this stage derives. Unique within the spec; later
+	// stages reference it by this name.
+	Name string `json:"name"`
+	// Func names a registered Go function (see WithFunc) for shapes beyond
+	// staged linear terms. Mutually exclusive with Terms.
+	Func string `json:"func,omitempty"`
+	// Terms is the linear form: the stage value is the exact sum of
+	// coefficient × metric over all terms.
+	Terms []Term `json:"terms,omitempty"`
+	// Args are the metric names resolved and passed to Func, in order. Only
+	// valid with Func.
+	Args []string `json:"args,omitempty"`
+}
+
+// Term is one linear contribution: Coefficient × the value of Metric, where
+// Metric names an input or a prior stage. Multiplication is exact — no
+// rounding happens inside a term.
+type Term struct {
+	Metric      string          `json:"metric"`
+	Coefficient decimal.Decimal `json:"coefficient"`
+}
+
+// Clamp bounds a stage value: values below Min become Min, values above Max
+// become Max. At least one bound must be set; when both are, Min ≤ Max.
+type Clamp struct {
+	Min *decimal.Decimal `json:"min,omitempty"`
+	Max *decimal.Decimal `json:"max,omitempty"`
+}
+
+// Round pins a stage value to Scale fractional digits using Mode. The zero
+// Mode is decimal.HalfEven (banker's rounding).
+type Round struct {
+	Scale int32                `json:"scale"`
+	Mode  decimal.RoundingMode `json:"mode"`
+}
+
+// Validate checks the spec's structure: version and stages present, stage
+// names unique and non-empty, exactly one of terms/func per stage, args only
+// with func, no reference to the stage itself or a later stage, clamps
+// non-empty with min ≤ max, and round scale/mode in range. Whether a func is
+// registered and whether inputs exist are checked later, by Compile and Eval.
+// All failures wrap ErrInvalidSpec.
+func (s Spec) Validate() error {
+	if s.Version == "" {
+		return fmt.Errorf("%w: version is required", ErrInvalidSpec)
+	}
+	if len(s.Stages) == 0 {
+		return fmt.Errorf("%w: at least one stage is required", ErrInvalidSpec)
+	}
+	order := make(map[string]int, len(s.Stages))
+	for i, st := range s.Stages {
+		if st.Name == "" {
+			return fmt.Errorf("%w: stage %d: name is required", ErrInvalidSpec, i)
+		}
+		if _, dup := order[st.Name]; dup {
+			return fmt.Errorf("%w: duplicate stage %q", ErrInvalidSpec, st.Name)
+		}
+		order[st.Name] = i
+	}
+	for i, st := range s.Stages {
+		if err := validateStage(st, i, order); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateStage(st Stage, idx int, order map[string]int) error {
+	linear, fn := len(st.Terms) > 0, st.Func != ""
+	switch {
+	case linear && fn:
+		return fmt.Errorf("%w: stage %q: terms and func are mutually exclusive", ErrInvalidSpec, st.Name)
+	case !linear && !fn:
+		return fmt.Errorf("%w: stage %q: terms or func is required", ErrInvalidSpec, st.Name)
+	case linear && len(st.Args) > 0:
+		return fmt.Errorf("%w: stage %q: args are only valid with func", ErrInvalidSpec, st.Name)
+	}
+	for _, t := range st.Terms {
+		if t.Metric == "" {
+			return fmt.Errorf("%w: stage %q: term metric is required", ErrInvalidSpec, st.Name)
+		}
+		if j, isStage := order[t.Metric]; isStage && j >= idx {
+			return fmt.Errorf("%w: stage %q: term references %q before it is computed", ErrInvalidSpec, st.Name, t.Metric)
+		}
+	}
+	for _, a := range st.Args {
+		if a == "" {
+			return fmt.Errorf("%w: stage %q: arg metric is required", ErrInvalidSpec, st.Name)
+		}
+		if j, isStage := order[a]; isStage && j >= idx {
+			return fmt.Errorf("%w: stage %q: arg references %q before it is computed", ErrInvalidSpec, st.Name, a)
+		}
+	}
+	if st.Clamp != nil {
+		if st.Clamp.Min == nil && st.Clamp.Max == nil {
+			return fmt.Errorf("%w: stage %q: clamp needs min or max", ErrInvalidSpec, st.Name)
+		}
+		if st.Clamp.Min != nil && st.Clamp.Max != nil && st.Clamp.Min.Cmp(*st.Clamp.Max) > 0 {
+			return fmt.Errorf("%w: stage %q: clamp min > max", ErrInvalidSpec, st.Name)
+		}
+	}
+	if st.Round != nil {
+		if st.Round.Scale < 0 {
+			return fmt.Errorf("%w: stage %q: negative round scale", ErrInvalidSpec, st.Name)
+		}
+		if st.Round.Mode < decimal.HalfEven || st.Round.Mode > decimal.Floor {
+			return fmt.Errorf("%w: stage %q: unknown rounding mode %d", ErrInvalidSpec, st.Name, int(st.Round.Mode))
+		}
+	}
+	return nil
+}
+
+// Fingerprint returns the audit anchor: lowercase-hex SHA-256 over the spec's
+// canonical binary encoding (every field length-prefixed, decimals in their
+// scale-preserving String form, in declaration order). Any byte-level change —
+// including a numerically equal coefficient at a different scale, or
+// reordered stages or terms — yields a different fingerprint; that
+// representation-sensitivity is the point. The encoding is frozen: it never
+// changes with Go or library versions, so stored fingerprints stay verifiable
+// forever.
+func (s Spec) Fingerprint() string {
+	h := sha256.New()
+	writeStr(h, s.Version)
+	writeLen(h, len(s.Stages))
+	for _, st := range s.Stages {
+		writeStr(h, st.Name)
+		writeLen(h, len(st.Terms))
+		for _, t := range st.Terms {
+			writeStr(h, t.Metric)
+			writeStr(h, t.Coefficient.String())
+		}
+		writeStr(h, st.Func)
+		writeLen(h, len(st.Args))
+		for _, a := range st.Args {
+			writeStr(h, a)
+		}
+		if st.Clamp == nil {
+			h.Write([]byte{0})
+		} else {
+			h.Write([]byte{1})
+			writeOptDecimal(h, st.Clamp.Min)
+			writeOptDecimal(h, st.Clamp.Max)
+		}
+		if st.Round == nil {
+			h.Write([]byte{0})
+		} else {
+			h.Write([]byte{1})
+			writeLen(h, int(st.Round.Scale))
+			writeLen(h, int(st.Round.Mode))
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func writeLen(h hash.Hash, n int) {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(n))
+	h.Write(buf[:])
+}
+
+func writeStr(h hash.Hash, s string) {
+	writeLen(h, len(s))
+	h.Write([]byte(s))
+}
+
+func writeOptDecimal(h hash.Hash, d *decimal.Decimal) {
+	if d == nil {
+		h.Write([]byte{0})
+		return
+	}
+	h.Write([]byte{1})
+	writeStr(h, d.String())
+}
+
+// clone returns a deep copy sharing no mutable memory with s, so a Compiled
+// spec cannot be changed underneath its fingerprint.
+func (s Spec) clone() Spec {
+	out := Spec{Version: s.Version}
+	if s.Stages == nil {
+		return out
+	}
+	out.Stages = make([]Stage, len(s.Stages))
+	for i, st := range s.Stages {
+		c := Stage{Name: st.Name, Func: st.Func}
+		if st.Terms != nil {
+			c.Terms = make([]Term, len(st.Terms))
+			copy(c.Terms, st.Terms)
+		}
+		if st.Args != nil {
+			c.Args = make([]string, len(st.Args))
+			copy(c.Args, st.Args)
+		}
+		if st.Clamp != nil {
+			cl := Clamp{}
+			if st.Clamp.Min != nil {
+				cl.Min = new(*st.Clamp.Min)
+			}
+			if st.Clamp.Max != nil {
+				cl.Max = new(*st.Clamp.Max)
+			}
+			c.Clamp = &cl
+		}
+		if st.Round != nil {
+			c.Round = new(*st.Round)
+		}
+		out.Stages[i] = c
+	}
+	return out
+}

--- a/finance/formula/spec_test.go
+++ b/finance/formula/spec_test.go
@@ -1,0 +1,180 @@
+package formula_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/finance/formula"
+)
+
+func d(t *testing.T, s string) decimal.Decimal {
+	t.Helper()
+	v, err := decimal.Parse(s)
+	require.NoError(t, err)
+	return v
+}
+
+func validSpec() formula.Spec {
+	return formula.Spec{
+		Version: "v1",
+		Stages: []formula.Stage{
+			{
+				Name: "ngr",
+				Terms: []formula.Term{
+					{Metric: "bets", Coefficient: decimal.FromInt(1)},
+					{Metric: "wins", Coefficient: decimal.FromInt(-1)},
+				},
+			},
+			{
+				Name: "base",
+				Terms: []formula.Term{
+					{Metric: "ngr", Coefficient: decimal.FromInt(1)},
+					{Metric: "carry_in", Coefficient: decimal.FromInt(1)},
+				},
+				Round: &formula.Round{Scale: 2, Mode: decimal.HalfEven},
+				Clamp: &formula.Clamp{Min: new(decimal.Zero)},
+			},
+		},
+	}
+}
+
+func TestSpecValidate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, validSpec().Validate())
+	})
+
+	mutations := map[string]func(*formula.Spec){
+		"empty version":        func(s *formula.Spec) { s.Version = "" },
+		"no stages":            func(s *formula.Spec) { s.Stages = nil },
+		"empty stage name":     func(s *formula.Spec) { s.Stages[0].Name = "" },
+		"duplicate stage name": func(s *formula.Spec) { s.Stages[1].Name = "ngr" },
+		"terms and func":       func(s *formula.Spec) { s.Stages[0].Func = "f" },
+		"neither terms nor func": func(s *formula.Spec) {
+			s.Stages[0].Terms = nil
+		},
+		"args without func": func(s *formula.Spec) { s.Stages[0].Args = []string{"bets"} },
+		"empty term metric": func(s *formula.Spec) { s.Stages[0].Terms[0].Metric = "" },
+		"self reference": func(s *formula.Spec) {
+			s.Stages[0].Terms[0].Metric = "ngr"
+		},
+		"forward reference": func(s *formula.Spec) {
+			s.Stages[0].Terms[0].Metric = "base"
+		},
+		"empty clamp": func(s *formula.Spec) { s.Stages[1].Clamp = &formula.Clamp{} },
+		"clamp min above max": func(s *formula.Spec) {
+			one, ten := decimal.FromInt(1), decimal.FromInt(10)
+			s.Stages[1].Clamp = &formula.Clamp{Min: &ten, Max: &one}
+		},
+		"negative round scale": func(s *formula.Spec) { s.Stages[1].Round.Scale = -1 },
+		"unknown rounding mode": func(s *formula.Spec) {
+			s.Stages[1].Round.Mode = decimal.RoundingMode(99)
+		},
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			spec := validSpec()
+			mutate(&spec)
+			assert.ErrorIs(t, spec.Validate(), formula.ErrInvalidSpec)
+		})
+	}
+
+	t.Run("func stage validation", func(t *testing.T) {
+		t.Parallel()
+		spec := formula.Spec{
+			Version: "v1",
+			Stages: []formula.Stage{
+				{Name: "a", Terms: []formula.Term{{Metric: "x", Coefficient: decimal.FromInt(1)}}},
+				{Name: "b", Func: "f", Args: []string{"a", "y"}},
+			},
+		}
+		assert.NoError(t, spec.Validate())
+
+		spec.Stages[1].Args = []string{""}
+		assert.ErrorIs(t, spec.Validate(), formula.ErrInvalidSpec)
+
+		spec.Stages[1].Args = []string{"b"}
+		assert.ErrorIs(t, spec.Validate(), formula.ErrInvalidSpec, "self reference via arg")
+	})
+
+	t.Run("clamp min equal max is valid", func(t *testing.T) {
+		t.Parallel()
+		spec := validSpec()
+		five := decimal.FromInt(5)
+		spec.Stages[1].Clamp = &formula.Clamp{Min: &five, Max: &five}
+		assert.NoError(t, spec.Validate())
+	})
+}
+
+func TestSpecFingerprint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deterministic", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, validSpec().Fingerprint(), validSpec().Fingerprint())
+	})
+
+	t.Run("golden", func(t *testing.T) {
+		t.Parallel()
+		// Frozen canonical encoding: this hash must never change across
+		// releases, or stored fingerprints stop verifying.
+		spec := formula.Spec{
+			Version: "golden-v1",
+			Stages: []formula.Stage{
+				{
+					Name:  "out",
+					Terms: []formula.Term{{Metric: "in", Coefficient: decimal.MustParse("1.50")}},
+					Round: &formula.Round{Scale: 2, Mode: decimal.HalfUp},
+					Clamp: &formula.Clamp{Min: new(decimal.Zero)},
+				},
+			},
+		}
+		assert.Equal(t, "83daa3ac17d9772d5d4689b16da2d69bf5ebb75bce5c6b4057895ff87b398d77", spec.Fingerprint())
+	})
+
+	changes := map[string]func(*formula.Spec){
+		"version":           func(s *formula.Spec) { s.Version = "v2" },
+		"stage name":        func(s *formula.Spec) { s.Stages[0].Name = "ngr2" },
+		"term metric":       func(s *formula.Spec) { s.Stages[0].Terms[0].Metric = "stakes" },
+		"coefficient scale": func(s *formula.Spec) { s.Stages[0].Terms[0].Coefficient = decimal.MustParse("1.0") },
+		"term order": func(s *formula.Spec) {
+			s.Stages[0].Terms[0], s.Stages[0].Terms[1] = s.Stages[0].Terms[1], s.Stages[0].Terms[0]
+		},
+		"drop clamp":  func(s *formula.Spec) { s.Stages[1].Clamp = nil },
+		"round mode":  func(s *formula.Spec) { s.Stages[1].Round.Mode = decimal.Floor },
+		"round scale": func(s *formula.Spec) { s.Stages[1].Round.Scale = 4 },
+	}
+	for name, mutate := range changes {
+		t.Run("changes on "+name, func(t *testing.T) {
+			t.Parallel()
+			spec := validSpec()
+			mutate(&spec)
+			assert.NotEqual(t, validSpec().Fingerprint(), spec.Fingerprint())
+		})
+	}
+}
+
+func TestSpecJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	spec := validSpec()
+	spec.Stages = append(spec.Stages, formula.Stage{Name: "capped", Func: "cap", Args: []string{"base"}})
+	raw, err := json.Marshal(spec)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"mode":"half_even"`, "rounding mode serializes as text")
+
+	var back formula.Spec
+	require.NoError(t, json.Unmarshal(raw, &back))
+	assert.Equal(t, spec.Fingerprint(), back.Fingerprint(), "round-trip preserves identity")
+
+	var bad formula.Spec
+	err = json.Unmarshal([]byte(`{"version":"v1","stages":[{"name":"a","round":{"scale":2,"mode":"sideways"}}]}`), &bad)
+	assert.ErrorIs(t, err, decimal.ErrSyntax)
+}


### PR DESCRIPTION
## Summary

Implements **finance/formula** per the catalog entry — the first package in the `finance/` namespace. Formulas live as structured, versioned data, never text:

- **`Spec`** — version + ordered stages; each stage is a linear combination of `(metric, decimal coefficient)` terms over inputs or prior stages, or a registered Go function (`WithFunc`) for shapes beyond staged-linear, plus optional `Round` and `Clamp` (applied raw → round → clamp, so the final value always honors the bounds). Plain data, JSON-round-trips for storage.
- **`Compile`** — validates structure (unique names, no self/forward references, clamp/round sanity), binds registered funcs, deep-copies the spec so caller mutation can't desync it, resolves references once, and computes a **fingerprint**: SHA-256 over a frozen canonical binary encoding. Representation-sensitive by design — a numerically equal coefficient at a different scale fingerprints differently; a golden-hash test freezes the encoding forever.
- **`Eval`** — returns a `Result` explanation record: spec version + fingerprint, every input (sorted, including unused ones), every stage with each term's exact contribution, raw vs final values, clamp flags. `json.Marshal(Result)` is deterministic, so recomputes byte-match — the statement line item and the dispute answer. Errors: `ErrUnknownMetric`, `ErrMetricCollision` (input shadowing a stage), `ErrFuncFailed` (wraps the cause for `errors.Is`).

Hard anti-scope per design.md: no string parsing, no conditionals, no user-typed expressions — anything beyond staged linear terms + clamp is a registered Go function with per-deal parameters closed over as data. Pure calculator: no storage, no goroutines, no context; tenancy is spec-selection by the caller (specs and inputs are passed values), matching the pure-calculator precedent. The shipped entry is removed from docs/packages.md per the roadmap rule.

## core/decimal changes (enabler + measured perf)

- **`RoundingMode` text marshaling** — `String`/`MarshalText`/`UnmarshalText` with frozen names (`half_even`, `up`, ...), so stored specs serialize modes readably instead of as bare ints.
- **int64 fast paths for scale-reducing `Rescale` and misaligned-scale `Cmp`** — profiling `Eval` showed 100% of its allocations inside decimal's big-path: `Rescale` always went through `roundBig` and misaligned `Cmp` through `alignBig`, even for int64-fitting coefficients (the common money case). Both now stay on int64 when magnitude and alignment fit, falling back to big otherwise (`MinInt64` and >10^18 alignments excluded). A new `FuzzRescaleCmpOracle` cross-checks both paths against independent `big.Rat`/`big.Int` math — 6.6M execs clean; the existing all-modes round tables and oracle tests also pass unchanged.

## Benchmarks (Apple M3 Max)

| benchmark | before | after |
|---|---|---|
| formula `BenchmarkEval` (3-stage revshare) | 1205 ns/op, 1721 B, 22 allocs | **572 ns/op, 1328 B, 6 allocs** |
| decimal `BenchmarkRound` (int64 path) | 379 ns/op, 328 B, 12 allocs | **3.4 ns/op, 0 B, 0 allocs** |
| decimal misaligned `Cmp` | 66 ns/op, 176 B, 4 allocs | **~2 ns/op, 0 B, 0 allocs** |
| decimal `BenchmarkCmp` (same scale) | 1.9 ns/op | 2.2 ns/op (unchanged inline path, noise) |

Remaining `Eval` allocations are the explanation record itself (result slices).

## Testing

- 99.0% coverage on formula, 97.9% on decimal; full repo `go test -race ./...` green; `just lint` clean.
- Golden fingerprint test freezes the canonical encoding; determinism test asserts byte-identical `json.Marshal` across repeated evals; round-then-clamp ordering, stage chaining on post-round values, func-stage arg recording, and all error paths covered.