### PR TITLE
feat(finance/fxrate): exchange rates with recorded-rate conversions

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -256,17 +256,6 @@ tests: `testkit/dbtest` (planned).
 
 ---
 
-**finance/fxrate**
-
-Exchange rates behind a `RateSource` seam with stored snapshots; `Convert`
-records the rate applied, so audits answer "what rate at transaction
-time". Math is multiply-and-round via `core/decimal`; providers are thin
-JSON adapters over httpclient — no provider SDKs, no live streaming.
-
-Deps: `core/decimal`, `web/httpclient`.
-
----
-
 **finance/tariff**
 
 Tiered/banded rate calculation over `core/money`/`core/decimal`:

--- a/finance/fxrate/bench_test.go
+++ b/finance/fxrate/bench_test.go
@@ -1,0 +1,84 @@
+package fxrate_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/finance/fxrate"
+)
+
+func benchSnapshot(b *testing.B) fxrate.Snapshot {
+	b.Helper()
+	rates := map[string]decimal.Decimal{
+		"USD": decimal.MustParse("1.0850"),
+		"GBP": decimal.MustParse("0.8425"),
+		"JPY": decimal.MustParse("160.23"),
+		"CHF": decimal.MustParse("0.9782"),
+	}
+	// Pad to a realistic full-table size.
+	for i := range 26 {
+		rates["X"+strconv.Itoa(i)+"A"] = decimal.MustParse("1.2345")
+	}
+	s, err := fxrate.NewSnapshot("EUR", "bench", time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC), rates)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return s
+}
+
+func BenchmarkSnapshotConvertDirect(b *testing.B) {
+	s := benchSnapshot(b)
+	amount := decimal.MustParse("99.90")
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := s.Convert(amount, "EUR", "USD", 2, decimal.HalfEven); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSnapshotConvertCross(b *testing.B) {
+	s := benchSnapshot(b)
+	amount := decimal.MustParse("99.90")
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := s.Convert(amount, "USD", "GBP", 2, decimal.HalfEven); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSnapshotRateCross(b *testing.B) {
+	s := benchSnapshot(b)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := s.Rate("JPY", "CHF"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkConverterConvertCached(b *testing.B) {
+	src, err := fxrate.NewStaticSource(benchSnapshot(b))
+	if err != nil {
+		b.Fatal(err)
+	}
+	conv, err := fxrate.New(src, "EUR", fxrate.WithTTL(24*time.Hour))
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	amount := decimal.MustParse("99.90")
+	if _, err := conv.Snapshot(ctx); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := conv.Convert(ctx, amount, "EUR", "USD", 2, decimal.HalfEven); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/finance/fxrate/converter.go
+++ b/finance/fxrate/converter.go
@@ -1,0 +1,142 @@
+package fxrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/resilience/singleflight"
+)
+
+// Converter serves conversions from a cached Snapshot, refreshed through a
+// RateSource once the cached copy is older than the configured TTL.
+// Concurrent refreshes are coalesced into one source call. It fails closed:
+// when the snapshot is stale and the source errors, callers get the error —
+// never silently-stale rates.
+type Converter struct {
+	snap    Snapshot  // guarded by mu
+	fetched time.Time // guarded by mu
+	source  RateSource
+	clk     clock.Clock
+
+	base string
+
+	group singleflight.Group[Snapshot]
+
+	quotes []string
+	ttl    time.Duration
+
+	mu sync.RWMutex
+}
+
+// New builds a Converter fetching rates denominated in base from source.
+func New(source RateSource, base string, opts ...Option) (*Converter, error) {
+	if source == nil {
+		return nil, errors.New("fxrate: nil RateSource")
+	}
+	base = normalizeCode(base)
+	if base == "" {
+		return nil, errors.New("fxrate: empty base currency")
+	}
+
+	cfg := config{ttl: time.Hour, clk: clock.System()}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.ttl <= 0 {
+		return nil, errors.New("fxrate: TTL must be positive")
+	}
+	if cfg.clk == nil {
+		return nil, errors.New("fxrate: nil clock")
+	}
+	for _, q := range cfg.quotes {
+		if q == "" {
+			return nil, errors.New("fxrate: empty quote currency")
+		}
+		if q == base {
+			return nil, fmt.Errorf("fxrate: quote %s equals base", q)
+		}
+	}
+
+	return &Converter{source: source, base: base, quotes: cfg.quotes, ttl: cfg.ttl, clk: cfg.clk}, nil
+}
+
+// Convert converts amount between two currencies using the current snapshot:
+// rate lookup, exact multiply, one rounding to scale digits with mode. The
+// returned Conversion records the applied rate for audit.
+func (c *Converter) Convert(ctx context.Context, amount decimal.Decimal, from, to string, scale int32, mode decimal.RoundingMode) (Conversion, error) {
+	s, err := c.Snapshot(ctx)
+	if err != nil {
+		return Conversion{}, err
+	}
+	return s.Convert(amount, from, to, scale, mode)
+}
+
+// Rate returns the current rate converting from into to.
+func (c *Converter) Rate(ctx context.Context, from, to string) (Rate, error) {
+	s, err := c.Snapshot(ctx)
+	if err != nil {
+		return Rate{}, err
+	}
+	return s.Rate(from, to)
+}
+
+// Snapshot returns the cached snapshot, fetching from the source when none is
+// cached yet or the cache is older than the TTL. Persist the returned value
+// alongside the transaction to make conversions recomputable forever.
+func (c *Converter) Snapshot(ctx context.Context) (Snapshot, error) {
+	if snap, ok := c.cached(); ok {
+		return snap, nil
+	}
+	snap, _, err := c.group.Do(ctx, "refresh", func(ctx context.Context) (Snapshot, error) {
+		// Re-check after winning the flight: a refresh that completed while
+		// this caller was deciding to fetch already did the work.
+		if snap, ok := c.cached(); ok {
+			return snap, nil
+		}
+		return c.fetch(ctx)
+	})
+	return snap, err
+}
+
+// cached returns the snapshot when present and fresher than the TTL.
+func (c *Converter) cached() (Snapshot, bool) {
+	c.mu.RLock()
+	snap, fetched := c.snap, c.fetched
+	c.mu.RUnlock()
+	if snap.IsZero() || c.clk.Now().Sub(fetched) >= c.ttl {
+		return Snapshot{}, false
+	}
+	return snap, true
+}
+
+// fetch pulls a fresh snapshot from the source, validates it against the
+// converter's configuration, and caches it.
+func (c *Converter) fetch(ctx context.Context) (Snapshot, error) {
+	snap, err := c.source.Fetch(ctx, c.base, slices.Clone(c.quotes))
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("%w: %w", ErrFetchFailed, err)
+	}
+	if snap.IsZero() {
+		return Snapshot{}, fmt.Errorf("%w: source returned zero snapshot", ErrFetchFailed)
+	}
+	if snap.Base() != c.base {
+		return Snapshot{}, fmt.Errorf("%w: requested %s, source returned %s", ErrBaseMismatch, c.base, snap.Base())
+	}
+	for _, q := range c.quotes {
+		if !snap.Has(q) {
+			return Snapshot{}, fmt.Errorf("%w: source omitted requested quote %s", ErrFetchFailed, q)
+		}
+	}
+
+	c.mu.Lock()
+	c.snap = snap
+	c.fetched = c.clk.Now()
+	c.mu.Unlock()
+	return snap, nil
+}

--- a/finance/fxrate/converter.go
+++ b/finance/fxrate/converter.go
@@ -93,7 +93,9 @@ func (c *Converter) Snapshot(ctx context.Context) (Snapshot, error) {
 	if snap, ok := c.cached(); ok {
 		return snap, nil
 	}
-	snap, _, err := c.group.Do(ctx, "refresh", func(ctx context.Context) (Snapshot, error) {
+	// DoDetached, not Do: a caller joining an in-flight refresh waits only
+	// until its own ctx ends; the shared fetch keeps running for the rest.
+	snap, _, err := c.group.DoDetached(ctx, "refresh", func(ctx context.Context) (Snapshot, error) {
 		// Re-check after winning the flight: a refresh that completed while
 		// this caller was deciding to fetch already did the work.
 		if snap, ok := c.cached(); ok {

--- a/finance/fxrate/converter_test.go
+++ b/finance/fxrate/converter_test.go
@@ -1,0 +1,237 @@
+package fxrate_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/finance/fxrate"
+)
+
+// fakeSource is a scriptable RateSource: it returns the queued results in
+// order and records every call.
+type fakeSource struct {
+	mu        sync.Mutex
+	calls     int
+	results   []func() (fxrate.Snapshot, error)
+	gotBase   string
+	gotQuotes []string
+	delay     time.Duration
+}
+
+func (f *fakeSource) Fetch(_ context.Context, base string, quotes []string) (fxrate.Snapshot, error) {
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.gotBase = base
+	f.gotQuotes = quotes
+	next := f.results[0]
+	if len(f.results) > 1 {
+		f.results = f.results[1:]
+	}
+	return next()
+}
+
+func (f *fakeSource) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func snapResult(s fxrate.Snapshot) func() (fxrate.Snapshot, error) {
+	return func() (fxrate.Snapshot, error) { return s, nil }
+}
+
+func errResult(err error) func() (fxrate.Snapshot, error) {
+	return func() (fxrate.Snapshot, error) { return fxrate.Snapshot{}, err }
+}
+
+func testSnapshot(t *testing.T) fxrate.Snapshot {
+	t.Helper()
+	return mustSnapshot(t, "EUR", map[string]decimal.Decimal{"USD": d("1.0850"), "GBP": d("0.8425")})
+}
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	src := &fakeSource{results: []func() (fxrate.Snapshot, error){errResult(errors.New("unused"))}}
+	tests := []struct {
+		name   string
+		source fxrate.RateSource
+		base   string
+		opts   []fxrate.Option
+	}{
+		{"nil source", nil, "EUR", nil},
+		{"empty base", src, "  ", nil},
+		{"non-positive TTL", src, "EUR", []fxrate.Option{fxrate.WithTTL(0)}},
+		{"nil clock", src, "EUR", []fxrate.Option{fxrate.WithClock(nil)}},
+		{"empty quote", src, "EUR", []fxrate.Option{fxrate.WithQuotes("USD", " ")}},
+		{"quote equals base", src, "EUR", []fxrate.Option{fxrate.WithQuotes("eur")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := fxrate.New(tt.source, tt.base, tt.opts...); err == nil {
+				t.Fatal("New succeeded, want error")
+			}
+		})
+	}
+}
+
+func TestConverterCachesWithinTTL(t *testing.T) {
+	t.Parallel()
+
+	snap := testSnapshot(t)
+	src := &fakeSource{results: []func() (fxrate.Snapshot, error){snapResult(snap)}}
+	clk := clock.NewMock(asOf)
+	conv, err := fxrate.New(src, "eur", fxrate.WithTTL(time.Hour), fxrate.WithClock(clk), fxrate.WithQuotes("usd", "GBP"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	c, err := conv.Convert(t.Context(), d("100.00"), "EUR", "USD", 2, decimal.HalfEven)
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if got := c.Result.String(); got != "108.50" {
+		t.Fatalf("Result = %s, want 108.50", got)
+	}
+	if src.gotBase != "EUR" {
+		t.Fatalf("source got base %q, want EUR", src.gotBase)
+	}
+	if len(src.gotQuotes) != 2 || src.gotQuotes[0] != "USD" || src.gotQuotes[1] != "GBP" {
+		t.Fatalf("source got quotes %v, want [USD GBP]", src.gotQuotes)
+	}
+
+	// Within the TTL every call serves the cache.
+	clk.Advance(59 * time.Minute)
+	if _, err := conv.Rate(t.Context(), "USD", "GBP"); err != nil {
+		t.Fatalf("Rate: %v", err)
+	}
+	if _, err := conv.Snapshot(t.Context()); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := src.callCount(); got != 1 {
+		t.Fatalf("source called %d times, want 1", got)
+	}
+
+	// Past the TTL the next call refreshes.
+	clk.Advance(2 * time.Minute)
+	if _, err := conv.Convert(t.Context(), d("1"), "EUR", "USD", 2, decimal.HalfEven); err != nil {
+		t.Fatalf("Convert after TTL: %v", err)
+	}
+	if got := src.callCount(); got != 2 {
+		t.Fatalf("source called %d times, want 2", got)
+	}
+}
+
+func TestConverterFailsClosedOnFetchError(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("provider down")
+	src := &fakeSource{results: []func() (fxrate.Snapshot, error){errResult(cause)}}
+	conv, err := fxrate.New(src, "EUR", fxrate.WithClock(clock.NewMock(asOf)))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = conv.Convert(t.Context(), d("1"), "EUR", "USD", 2, decimal.HalfEven)
+	if !errors.Is(err, fxrate.ErrFetchFailed) {
+		t.Fatalf("got %v, want ErrFetchFailed", err)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatalf("cause not joined: %v", err)
+	}
+}
+
+func TestConverterStalePlusFailingSourceIsAnError(t *testing.T) {
+	t.Parallel()
+
+	snap := testSnapshot(t)
+	cause := errors.New("provider down")
+	src := &fakeSource{results: []func() (fxrate.Snapshot, error){snapResult(snap), errResult(cause)}}
+	clk := clock.NewMock(asOf)
+	conv, err := fxrate.New(src, "EUR", fxrate.WithTTL(time.Hour), fxrate.WithClock(clk))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := conv.Snapshot(t.Context()); err != nil {
+		t.Fatalf("warm-up: %v", err)
+	}
+
+	// Once stale, a failing source surfaces as an error — the stale snapshot
+	// is never served silently.
+	clk.Advance(2 * time.Hour)
+	if _, err := conv.Convert(t.Context(), d("1"), "EUR", "USD", 2, decimal.HalfEven); !errors.Is(err, fxrate.ErrFetchFailed) {
+		t.Fatalf("got %v, want ErrFetchFailed", err)
+	}
+}
+
+func TestConverterRejectsBadSourceResults(t *testing.T) {
+	t.Parallel()
+
+	wrongBase := mustSnapshot(t, "USD", map[string]decimal.Decimal{"EUR": d("0.92")})
+	missingQuote := mustSnapshot(t, "EUR", map[string]decimal.Decimal{"USD": d("1.0850")})
+
+	tests := []struct {
+		name   string
+		result func() (fxrate.Snapshot, error)
+		opts   []fxrate.Option
+		want   error
+	}{
+		{"zero snapshot nil error", snapResult(fxrate.Snapshot{}), nil, fxrate.ErrFetchFailed},
+		{"base mismatch", snapResult(wrongBase), nil, fxrate.ErrBaseMismatch},
+		{"omitted requested quote", snapResult(missingQuote), []fxrate.Option{fxrate.WithQuotes("USD", "GBP")}, fxrate.ErrFetchFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			src := &fakeSource{results: []func() (fxrate.Snapshot, error){tt.result}}
+			conv, err := fxrate.New(src, "EUR", append(tt.opts, fxrate.WithClock(clock.NewMock(asOf)))...)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if _, err := conv.Snapshot(t.Context()); !errors.Is(err, tt.want) {
+				t.Fatalf("got %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestConverterCoalescesConcurrentRefreshes(t *testing.T) {
+	t.Parallel()
+
+	snap := testSnapshot(t)
+	src := &fakeSource{results: []func() (fxrate.Snapshot, error){snapResult(snap)}, delay: 50 * time.Millisecond}
+	conv, err := fxrate.New(src, "EUR", fxrate.WithClock(clock.NewMock(asOf)))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	const workers = 16
+	var wg sync.WaitGroup
+	errs := make([]error, workers)
+	for i := range workers {
+		wg.Go(func() {
+			_, errs[i] = conv.Convert(t.Context(), d("1"), "EUR", "USD", 2, decimal.HalfEven)
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("worker %d: %v", i, err)
+		}
+	}
+	if got := src.callCount(); got != 1 {
+		t.Fatalf("source called %d times, want 1 (singleflight)", got)
+	}
+}

--- a/finance/fxrate/converter_test.go
+++ b/finance/fxrate/converter_test.go
@@ -206,6 +206,41 @@ func TestConverterRejectsBadSourceResults(t *testing.T) {
 	}
 }
 
+func TestConverterFollowerWaitBoundedByOwnContext(t *testing.T) {
+	t.Parallel()
+
+	snap := testSnapshot(t)
+	src := &fakeSource{results: []func() (fxrate.Snapshot, error){snapResult(snap)}, delay: 400 * time.Millisecond}
+	conv, err := fxrate.New(src, "EUR", fxrate.WithClock(clock.NewMock(asOf)))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := conv.Snapshot(context.Background())
+		leaderDone <- err
+	}()
+	time.Sleep(50 * time.Millisecond) // let the leader's slow fetch start
+
+	// A caller with a short deadline joining the in-flight refresh must be
+	// released by its own context, not pinned until the leader's fetch ends.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err = conv.Snapshot(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("follower got %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > 300*time.Millisecond {
+		t.Fatalf("follower blocked %v — pinned to the leader's fetch", elapsed)
+	}
+
+	if err := <-leaderDone; err != nil {
+		t.Fatalf("leader: %v", err)
+	}
+}
+
 func TestConverterCoalescesConcurrentRefreshes(t *testing.T) {
 	t.Parallel()
 

--- a/finance/fxrate/doc.go
+++ b/finance/fxrate/doc.go
@@ -1,0 +1,45 @@
+// Package fxrate provides exchange rates behind a RateSource seam with stored
+// snapshots. Convert records the rate applied — provider, as-of time, value,
+// rounding — so audits answer "what rate at transaction time" and any stored
+// Conversion or Snapshot recomputes byte-for-byte.
+//
+// Math is exact multiply-and-round via core/decimal: amount × rate, rounded
+// once to the caller's scale and mode. Rates derived by division (inverse and
+// cross rates through the snapshot base) use RateScale digits half-to-even —
+// a package constant, so derivations are deterministic forever. Nothing ever
+// routes through float64.
+//
+// Providers are thin JSON adapters over web/httpclient implementing
+// RateSource (see the frankfurter subpackage); there are no provider SDKs and
+// no live streaming. StaticSource covers tests and fixed contractual rates.
+//
+// The Converter caches one snapshot and refreshes it through the source when
+// older than the TTL, coalescing concurrent refreshes into a single fetch. It
+// fails closed: a stale snapshot plus a failing source is an error, never
+// silently-stale rates. Rates are market data shared by all tenants — one
+// Converter serves a multi-tenant app; per-tenant negotiated rates are
+// separate Converter or StaticSource values chosen by the caller.
+//
+// # Usage
+//
+//	src := frankfurter.New()
+//	conv, err := fxrate.New(src, "EUR",
+//		fxrate.WithTTL(time.Hour),
+//		fxrate.WithQuotes("USD", "GBP"),
+//	)
+//	if err != nil {
+//		// invalid configuration
+//	}
+//
+//	c, err := conv.Convert(ctx, decimal.MustParse("99.90"), "USD", "GBP", 2, decimal.HalfEven)
+//	if err != nil {
+//		// unknown currency, or the source failed while the cache was stale
+//	}
+//	_ = c.Result       // GBP amount, rounded once to 2 digits
+//	_ = c.Rate.Value   // the exact rate applied
+//	_ = c.Rate.AsOf    // when the provider published it
+//
+// Persist the Conversion (or the whole Snapshot from conv.Snapshot) with the
+// transaction; replaying Amount × Rate.Value with the recorded scale and mode
+// reproduces Result exactly.
+package fxrate

--- a/finance/fxrate/errors.go
+++ b/finance/fxrate/errors.go
@@ -1,0 +1,24 @@
+package fxrate
+
+import "errors"
+
+var (
+	// ErrInvalidSnapshot reports a snapshot that violates construction
+	// invariants: empty base or provider, zero as-of time, no rates, a
+	// duplicate currency code, or a base self-rate that is not exactly 1.
+	ErrInvalidSnapshot = errors.New("fxrate: invalid snapshot")
+
+	// ErrInvalidRate reports a rate value that is zero or negative.
+	ErrInvalidRate = errors.New("fxrate: invalid rate")
+
+	// ErrUnknownCurrency reports a currency code the snapshot has no rate for.
+	ErrUnknownCurrency = errors.New("fxrate: unknown currency")
+
+	// ErrBaseMismatch reports a source that returned a snapshot denominated in
+	// a different base currency than requested.
+	ErrBaseMismatch = errors.New("fxrate: base currency mismatch")
+
+	// ErrFetchFailed wraps any failure to obtain a usable snapshot from a
+	// RateSource. The underlying cause is joined and matchable via errors.Is.
+	ErrFetchFailed = errors.New("fxrate: fetch failed")
+)

--- a/finance/fxrate/example_test.go
+++ b/finance/fxrate/example_test.go
@@ -1,0 +1,44 @@
+package fxrate_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/finance/fxrate"
+)
+
+func Example() {
+	// In production the source is a provider adapter (e.g. the frankfurter
+	// subpackage); StaticSource serves fixed rates.
+	snap, err := fxrate.NewSnapshot("EUR", "example", time.Date(2026, 7, 20, 16, 0, 0, 0, time.UTC), map[string]decimal.Decimal{
+		"USD": decimal.MustParse("1.0850"),
+		"GBP": decimal.MustParse("0.8425"),
+	})
+	if err != nil {
+		panic(err)
+	}
+	src, err := fxrate.NewStaticSource(snap)
+	if err != nil {
+		panic(err)
+	}
+
+	conv, err := fxrate.New(src, "EUR", fxrate.WithTTL(time.Hour))
+	if err != nil {
+		panic(err)
+	}
+
+	c, err := conv.Convert(context.Background(), decimal.MustParse("100.00"), "EUR", "USD", 2, decimal.HalfEven)
+	if err != nil {
+		panic(err)
+	}
+
+	// The Conversion records the applied rate — persist it with the
+	// transaction and the result recomputes byte-for-byte.
+	fmt.Println(c.Result, "USD at", c.Rate.Value, "from", c.Rate.Provider)
+	fmt.Println(c.Amount.Mul(c.Rate.Value).Round(c.Scale, c.Mode).Equal(c.Result))
+	// Output:
+	// 108.50 USD at 1.0850 from example
+	// true
+}

--- a/finance/fxrate/frankfurter/frankfurter.go
+++ b/finance/fxrate/frankfurter/frankfurter.go
@@ -89,7 +89,15 @@ func (s *Source) Fetch(ctx context.Context, base string, quotes []string) (fxrat
 
 	q := url.Values{"base": []string{base}}
 	if len(quotes) > 0 {
-		q.Set("symbols", strings.ToUpper(strings.Join(quotes, ",")))
+		symbols := make([]string, 0, len(quotes))
+		for _, code := range quotes {
+			if code = strings.ToUpper(strings.TrimSpace(code)); code != "" {
+				symbols = append(symbols, code)
+			}
+		}
+		if len(symbols) > 0 {
+			q.Set("symbols", strings.Join(symbols, ","))
+		}
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.baseURL+"/latest?"+q.Encode(), nil)
 	if err != nil {

--- a/finance/fxrate/frankfurter/frankfurter.go
+++ b/finance/fxrate/frankfurter/frankfurter.go
@@ -1,0 +1,125 @@
+// Package frankfurter is a thin JSON adapter over the Frankfurter API
+// (https://frankfurter.dev — ECB reference rates, no API key) implementing
+// fxrate.RateSource. It is deliberately minimal: one GET, a body-capped JSON
+// decode straight into core/decimal (never through float64), and
+// fxrate.NewSnapshot validation on the way out.
+//
+// # Usage
+//
+//	src := frankfurter.New()
+//	snap, err := src.Fetch(ctx, "EUR", []string{"USD", "GBP"})
+package frankfurter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/finance/fxrate"
+	"github.com/dmitrymomot/forge/web/httpclient"
+)
+
+// DefaultBaseURL is the public Frankfurter API root.
+const DefaultBaseURL = "https://api.frankfurter.dev/v1"
+
+// Provider is the source name recorded in snapshots.
+const Provider = "frankfurter"
+
+// maxBody caps the response body read; the full-table payload is ~1 KB.
+const maxBody = 1 << 20
+
+// Source implements fxrate.RateSource over the Frankfurter JSON API.
+type Source struct {
+	client  *http.Client
+	baseURL string
+}
+
+// Option configures a Source.
+type Option func(*Source)
+
+// WithBaseURL overrides the API root, e.g. for a self-hosted instance or a
+// test server. A trailing slash is trimmed.
+func WithBaseURL(u string) Option {
+	return func(s *Source) { s.baseURL = strings.TrimRight(u, "/") }
+}
+
+// WithHTTPClient overrides the HTTP client. The default is an httpclient with
+// a 15s overall timeout and 5s per attempt; GET retries are on by default.
+func WithHTTPClient(c *http.Client) Option {
+	return func(s *Source) { s.client = c }
+}
+
+// New builds a Source talking to the public Frankfurter API.
+func New(opts ...Option) *Source {
+	s := &Source{baseURL: DefaultBaseURL}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.client == nil {
+		s.client = httpclient.New(
+			httpclient.WithTimeout(15*time.Second),
+			httpclient.WithPerAttemptTimeout(5*time.Second),
+		)
+	}
+	return s
+}
+
+// payload is Frankfurter's /latest response shape. Rates arrive as bare JSON
+// numbers; decimal.UnmarshalJSON parses the token text exactly.
+type payload struct {
+	Rates map[string]decimal.Decimal `json:"rates"`
+	Base  string                     `json:"base"`
+	Date  string                     `json:"date"`
+}
+
+// Fetch implements fxrate.RateSource, requesting the latest rates for base.
+// Empty quotes fetches every currency Frankfurter publishes.
+func (s *Source) Fetch(ctx context.Context, base string, quotes []string) (fxrate.Snapshot, error) {
+	base = strings.ToUpper(strings.TrimSpace(base))
+	if base == "" {
+		return fxrate.Snapshot{}, errors.New("frankfurter: empty base currency")
+	}
+
+	q := url.Values{"base": []string{base}}
+	if len(quotes) > 0 {
+		q.Set("symbols", strings.ToUpper(strings.Join(quotes, ",")))
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.baseURL+"/latest?"+q.Encode(), nil)
+	if err != nil {
+		return fxrate.Snapshot{}, fmt.Errorf("frankfurter: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fxrate.Snapshot{}, fmt.Errorf("frankfurter: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	//nolint:nilaway // resp is non-nil whenever err is nil, per http.Client.Do's contract
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		return fxrate.Snapshot{}, fmt.Errorf("frankfurter: unexpected status %s", resp.Status)
+	}
+
+	var p payload
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxBody)).Decode(&p); err != nil {
+		return fxrate.Snapshot{}, fmt.Errorf("frankfurter: decode response: %w", err)
+	}
+	asOf, err := time.ParseInLocation(time.DateOnly, p.Date, time.UTC)
+	if err != nil {
+		return fxrate.Snapshot{}, fmt.Errorf("frankfurter: parse date %q: %w", p.Date, err)
+	}
+
+	snap, err := fxrate.NewSnapshot(p.Base, Provider, asOf, p.Rates)
+	if err != nil {
+		return fxrate.Snapshot{}, fmt.Errorf("frankfurter: %w", err)
+	}
+	return snap, nil
+}

--- a/finance/fxrate/frankfurter/frankfurter_test.go
+++ b/finance/fxrate/frankfurter/frankfurter_test.go
@@ -1,0 +1,124 @@
+package frankfurter_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/finance/fxrate"
+	"github.com/dmitrymomot/forge/finance/fxrate/frankfurter"
+)
+
+func newServer(t *testing.T, handler http.HandlerFunc) *frankfurter.Source {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return frankfurter.New(
+		frankfurter.WithBaseURL(srv.URL+"/"), // trailing slash must be tolerated
+		frankfurter.WithHTTPClient(srv.Client()),
+	)
+}
+
+func TestFetch(t *testing.T) {
+	t.Parallel()
+
+	src := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/latest" {
+			t.Errorf("path = %q, want /latest", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("base"); got != "EUR" {
+			t.Errorf("base = %q, want EUR", got)
+		}
+		if got := r.URL.Query().Get("symbols"); got != "USD,GBP" {
+			t.Errorf("symbols = %q, want USD,GBP", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"base":"EUR","date":"2026-07-18","rates":{"USD":1.0850,"GBP":0.8425}}`))
+	})
+
+	snap, err := src.Fetch(t.Context(), "eur", []string{"usd", "gbp"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if snap.Base() != "EUR" || snap.Provider() != frankfurter.Provider {
+		t.Fatalf("snapshot metadata: base %q provider %q", snap.Base(), snap.Provider())
+	}
+	if want := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC); !snap.AsOf().Equal(want) {
+		t.Fatalf("AsOf = %v, want %v", snap.AsOf(), want)
+	}
+
+	// Rates decode exactly — the bare JSON number never touches float64.
+	r, err := snap.Rate("EUR", "USD")
+	if err != nil {
+		t.Fatalf("Rate: %v", err)
+	}
+	if !r.Value.Equal(decimal.MustParse("1.0850")) {
+		t.Fatalf("USD rate = %s, want 1.0850", r.Value)
+	}
+}
+
+func TestFetchAllQuotesOmitsSymbols(t *testing.T) {
+	t.Parallel()
+
+	src := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Has("symbols") {
+			t.Errorf("symbols sent for a fetch-all: %q", r.URL.Query().Get("symbols"))
+		}
+		_, _ = w.Write([]byte(`{"base":"EUR","date":"2026-07-18","rates":{"USD":1.0850}}`))
+	})
+
+	if _, err := src.Fetch(t.Context(), "EUR", nil); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+}
+
+func TestFetchErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantIs  error
+	}{
+		{"non-200 status", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "nope", http.StatusNotFound)
+		}, nil},
+		{"malformed json", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"base":"EUR","date":`))
+		}, nil},
+		{"bad date", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"base":"EUR","date":"18-07-2026","rates":{"USD":1.0850}}`))
+		}, nil},
+		{"negative rate fails closed", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"base":"EUR","date":"2026-07-18","rates":{"USD":-1}}`))
+		}, fxrate.ErrInvalidRate},
+		{"empty rates", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"base":"EUR","date":"2026-07-18","rates":{}}`))
+		}, fxrate.ErrInvalidSnapshot},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			src := newServer(t, tt.handler)
+			_, err := src.Fetch(t.Context(), "EUR", nil)
+			if err == nil {
+				t.Fatal("Fetch succeeded, want error")
+			}
+			if tt.wantIs != nil && !errors.Is(err, tt.wantIs) {
+				t.Fatalf("got %v, want %v", err, tt.wantIs)
+			}
+		})
+	}
+}
+
+func TestFetchEmptyBase(t *testing.T) {
+	t.Parallel()
+
+	src := frankfurter.New()
+	if _, err := src.Fetch(t.Context(), "  ", nil); err == nil {
+		t.Fatal("Fetch succeeded with empty base, want error")
+	}
+}

--- a/finance/fxrate/frankfurter/frankfurter_test.go
+++ b/finance/fxrate/frankfurter/frankfurter_test.go
@@ -39,7 +39,7 @@ func TestFetch(t *testing.T) {
 		_, _ = w.Write([]byte(`{"base":"EUR","date":"2026-07-18","rates":{"USD":1.0850,"GBP":0.8425}}`))
 	})
 
-	snap, err := src.Fetch(t.Context(), "eur", []string{"usd", "gbp"})
+	snap, err := src.Fetch(t.Context(), "eur", []string{" usd", "gbp ", "  "})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}

--- a/finance/fxrate/fxrate.go
+++ b/finance/fxrate/fxrate.go
@@ -1,0 +1,74 @@
+package fxrate
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+)
+
+// RateScale is the fractional-digit precision of rates derived by division
+// (inverse and cross rates), rounded half-to-even. Direct provider quotes keep
+// the scale the provider published. The value is a package constant, not a
+// knob, so a recompute from a stored Snapshot always byte-matches.
+const RateScale = 12
+
+var one = decimal.FromInt(1)
+
+// Rate quotes one unit of Base in Quote currency: 1 Base = Value Quote, as
+// published (or derived from) Provider at AsOf.
+type Rate struct {
+	// AsOf is the provider's publication time for the underlying snapshot.
+	AsOf time.Time
+	// Base is the currency being priced, e.g. "EUR".
+	Base string
+	// Quote is the currency the price is expressed in, e.g. "USD".
+	Quote string
+	// Provider names the rate source, e.g. "frankfurter".
+	Provider string
+	// Value is the amount of Quote one Base buys.
+	Value decimal.Decimal
+}
+
+// Apply converts amount (denominated in Base) to Quote: exact multiply, then
+// one rounding to scale fractional digits using mode. The returned Conversion
+// carries everything needed to recompute the result byte-for-byte.
+func (r Rate) Apply(amount decimal.Decimal, scale int32, mode decimal.RoundingMode) Conversion {
+	return Conversion{
+		Amount: amount,
+		Result: amount.Mul(r.Value).Round(scale, mode),
+		Rate:   r,
+		Scale:  scale,
+		Mode:   mode,
+	}
+}
+
+// Conversion records a conversion and the exact rate applied — the audit
+// answer to "what rate at transaction time". Amount × Rate.Value rounded to
+// Scale digits with Mode reproduces Result exactly.
+type Conversion struct {
+	// Amount is the input, denominated in Rate.Base.
+	Amount decimal.Decimal
+	// Result is the output, denominated in Rate.Quote.
+	Result decimal.Decimal
+	// Rate is the rate applied, including provider and as-of time.
+	Rate Rate
+	// Scale is the fractional-digit count Result was rounded to.
+	Scale int32
+	// Mode is the rounding mode used.
+	Mode decimal.RoundingMode
+}
+
+// RateSource fetches a rate snapshot denominated in base. A nil or empty
+// quotes slice requests every currency the source offers; otherwise the
+// returned snapshot must cover at least the requested quotes. Implementations
+// construct the result via NewSnapshot so its invariants hold.
+type RateSource interface {
+	Fetch(ctx context.Context, base string, quotes []string) (Snapshot, error)
+}
+
+// normalizeCode canonicalizes a currency code for lookup: trimmed, uppercase.
+func normalizeCode(code string) string {
+	return strings.ToUpper(strings.TrimSpace(code))
+}

--- a/finance/fxrate/options.go
+++ b/finance/fxrate/options.go
@@ -1,0 +1,40 @@
+package fxrate
+
+import (
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type config struct {
+	clk    clock.Clock
+	quotes []string
+	ttl    time.Duration
+}
+
+// Option configures a Converter.
+type Option func(*config)
+
+// WithTTL sets how long a fetched snapshot serves conversions before the next
+// call triggers a refresh. Default 1h. The TTL paces refetching; the
+// provider's publication time stays visible as Snapshot.AsOf.
+func WithTTL(d time.Duration) Option {
+	return func(c *config) { c.ttl = d }
+}
+
+// WithQuotes restricts fetches to the given quote currencies instead of
+// everything the source offers. Fetch fails closed if the source omits any of
+// them. Codes are normalized (trimmed, uppercased).
+func WithQuotes(codes ...string) Option {
+	return func(c *config) {
+		c.quotes = make([]string, len(codes))
+		for i, code := range codes {
+			c.quotes[i] = normalizeCode(code)
+		}
+	}
+}
+
+// WithClock overrides the time source used for TTL checks. For tests.
+func WithClock(clk clock.Clock) Option {
+	return func(c *config) { c.clk = clk }
+}

--- a/finance/fxrate/snapshot.go
+++ b/finance/fxrate/snapshot.go
@@ -1,0 +1,184 @@
+package fxrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+)
+
+// Snapshot is an immutable table of exchange rates against one base currency
+// as of a point in time. It is the unit of storage: persist it (JSON) next to
+// the transaction and any later recompute reproduces the same numbers.
+// The zero value is empty and unusable; construct via NewSnapshot.
+type Snapshot struct {
+	asOf     time.Time
+	rates    map[string]decimal.Decimal
+	base     string
+	provider string
+}
+
+// NewSnapshot builds a validated snapshot. Currency codes are trimmed and
+// uppercased; rates must be strictly positive; an entry for base itself is
+// permitted only when exactly 1 and is not stored. Construction fails closed:
+// empty base or provider, zero asOf, no rates, duplicate codes (after
+// normalization), and non-positive rates are all rejected. The rates map is
+// copied, so later caller mutation cannot corrupt the snapshot.
+func NewSnapshot(base, provider string, asOf time.Time, rates map[string]decimal.Decimal) (Snapshot, error) {
+	base = normalizeCode(base)
+	if base == "" {
+		return Snapshot{}, fmt.Errorf("%w: empty base currency", ErrInvalidSnapshot)
+	}
+	if provider == "" {
+		return Snapshot{}, fmt.Errorf("%w: empty provider", ErrInvalidSnapshot)
+	}
+	if asOf.IsZero() {
+		return Snapshot{}, fmt.Errorf("%w: zero as-of time", ErrInvalidSnapshot)
+	}
+
+	normalized := make(map[string]decimal.Decimal, len(rates))
+	for code, value := range rates {
+		code = normalizeCode(code)
+		if code == "" {
+			return Snapshot{}, fmt.Errorf("%w: empty currency code", ErrInvalidSnapshot)
+		}
+		if value.Sign() <= 0 {
+			return Snapshot{}, fmt.Errorf("%w: %s = %s", ErrInvalidRate, code, value)
+		}
+		if code == base {
+			if !value.Equal(one) {
+				return Snapshot{}, fmt.Errorf("%w: base self-rate %s = %s, want 1", ErrInvalidRate, base, value)
+			}
+			continue
+		}
+		if _, dup := normalized[code]; dup {
+			return Snapshot{}, fmt.Errorf("%w: duplicate currency %s", ErrInvalidSnapshot, code)
+		}
+		normalized[code] = value
+	}
+	if len(normalized) == 0 {
+		return Snapshot{}, fmt.Errorf("%w: no rates", ErrInvalidSnapshot)
+	}
+
+	return Snapshot{asOf: asOf, base: base, provider: provider, rates: normalized}, nil
+}
+
+// Base returns the currency all stored rates are denominated against.
+func (s Snapshot) Base() string { return s.base }
+
+// Provider returns the rate source name recorded at construction.
+func (s Snapshot) Provider() string { return s.provider }
+
+// AsOf returns the provider's publication time for these rates.
+func (s Snapshot) AsOf() time.Time { return s.asOf }
+
+// IsZero reports whether s is the unusable zero value.
+func (s Snapshot) IsZero() bool { return s.rates == nil }
+
+// Has reports whether the snapshot can price code — the base itself or any
+// quoted currency.
+func (s Snapshot) Has(code string) bool {
+	if s.rates == nil {
+		return false
+	}
+	code = normalizeCode(code)
+	if code == s.base {
+		return true
+	}
+	_, ok := s.rates[code]
+	return ok
+}
+
+// Currencies returns every currency the snapshot can price — the base plus
+// all quotes — sorted for deterministic iteration.
+func (s Snapshot) Currencies() []string {
+	if s.rates == nil {
+		return nil
+	}
+	codes := make([]string, 0, len(s.rates)+1)
+	codes = append(codes, s.base)
+	for code := range s.rates {
+		codes = append(codes, code)
+	}
+	slices.Sort(codes)
+	return codes
+}
+
+// Rate returns the rate converting from into to. Direct quotes (from == base)
+// keep the provider's scale; inverse and cross rates are derived by division
+// at RateScale digits, half-to-even, so recomputes are deterministic.
+// Unknown currencies fail with ErrUnknownCurrency.
+func (s Snapshot) Rate(from, to string) (Rate, error) {
+	from = normalizeCode(from)
+	to = normalizeCode(to)
+	if !s.Has(from) {
+		return Rate{}, fmt.Errorf("%w: %s", ErrUnknownCurrency, from)
+	}
+	if !s.Has(to) {
+		return Rate{}, fmt.Errorf("%w: %s", ErrUnknownCurrency, to)
+	}
+
+	r := Rate{AsOf: s.asOf, Base: from, Quote: to, Provider: s.provider}
+	switch {
+	case from == to:
+		r.Value = one
+	case from == s.base:
+		r.Value = s.rates[to]
+	case to == s.base:
+		v, err := one.Div(s.rates[from], RateScale, decimal.HalfEven)
+		if err != nil {
+			return Rate{}, fmt.Errorf("%w: invert %s: %w", ErrInvalidRate, from, err)
+		}
+		r.Value = v
+	default:
+		v, err := s.rates[to].Div(s.rates[from], RateScale, decimal.HalfEven)
+		if err != nil {
+			return Rate{}, fmt.Errorf("%w: cross %s/%s: %w", ErrInvalidRate, to, from, err)
+		}
+		r.Value = v
+	}
+	return r, nil
+}
+
+// Convert converts amount from one currency to another: rate lookup, exact
+// multiply, one rounding to scale digits with mode. The returned Conversion
+// records the applied rate for audit.
+func (s Snapshot) Convert(amount decimal.Decimal, from, to string, scale int32, mode decimal.RoundingMode) (Conversion, error) {
+	r, err := s.Rate(from, to)
+	if err != nil {
+		return Conversion{}, err
+	}
+	return r.Apply(amount, scale, mode), nil
+}
+
+// snapshotJSON is the wire form of Snapshot. Rates marshal as strings (the
+// decimal package's exact form), never floats.
+type snapshotJSON struct {
+	AsOf     time.Time                  `json:"as_of"`
+	Rates    map[string]decimal.Decimal `json:"rates"`
+	Base     string                     `json:"base"`
+	Provider string                     `json:"provider"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (s Snapshot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(snapshotJSON{AsOf: s.asOf, Base: s.base, Provider: s.provider, Rates: s.rates})
+}
+
+// UnmarshalJSON implements json.Unmarshaler. The decoded snapshot passes
+// through NewSnapshot, so corrupt or tampered stored data fails closed
+// instead of producing an invalid table.
+func (s *Snapshot) UnmarshalJSON(p []byte) error {
+	var v snapshotJSON
+	if err := json.Unmarshal(p, &v); err != nil {
+		return err
+	}
+	snap, err := NewSnapshot(v.Base, v.Provider, v.AsOf, v.Rates)
+	if err != nil {
+		return err
+	}
+	*s = snap
+	return nil
+}

--- a/finance/fxrate/snapshot.go
+++ b/finance/fxrate/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/dmitrymomot/forge/core/decimal"
@@ -31,7 +32,7 @@ func NewSnapshot(base, provider string, asOf time.Time, rates map[string]decimal
 	if base == "" {
 		return Snapshot{}, fmt.Errorf("%w: empty base currency", ErrInvalidSnapshot)
 	}
-	if provider == "" {
+	if provider = strings.TrimSpace(provider); provider == "" {
 		return Snapshot{}, fmt.Errorf("%w: empty provider", ErrInvalidSnapshot)
 	}
 	if asOf.IsZero() {

--- a/finance/fxrate/snapshot_test.go
+++ b/finance/fxrate/snapshot_test.go
@@ -38,6 +38,7 @@ func TestNewSnapshotValidation(t *testing.T) {
 		{"empty base", "", "test", asOf, valid, fxrate.ErrInvalidSnapshot},
 		{"blank base", "   ", "test", asOf, valid, fxrate.ErrInvalidSnapshot},
 		{"empty provider", "EUR", "", asOf, valid, fxrate.ErrInvalidSnapshot},
+		{"whitespace provider", "EUR", "   ", asOf, valid, fxrate.ErrInvalidSnapshot},
 		{"zero asOf", "EUR", "test", time.Time{}, valid, fxrate.ErrInvalidSnapshot},
 		{"nil rates", "EUR", "test", asOf, nil, fxrate.ErrInvalidSnapshot},
 		{"empty rates", "EUR", "test", asOf, map[string]decimal.Decimal{}, fxrate.ErrInvalidSnapshot},

--- a/finance/fxrate/snapshot_test.go
+++ b/finance/fxrate/snapshot_test.go
@@ -1,0 +1,301 @@
+package fxrate_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/finance/fxrate"
+)
+
+var asOf = time.Date(2026, 7, 20, 16, 0, 0, 0, time.UTC)
+
+func mustSnapshot(t *testing.T, base string, rates map[string]decimal.Decimal) fxrate.Snapshot {
+	t.Helper()
+	s, err := fxrate.NewSnapshot(base, "test", asOf, rates)
+	if err != nil {
+		t.Fatalf("NewSnapshot: %v", err)
+	}
+	return s
+}
+
+func d(s string) decimal.Decimal { return decimal.MustParse(s) }
+
+func TestNewSnapshotValidation(t *testing.T) {
+	t.Parallel()
+
+	valid := map[string]decimal.Decimal{"USD": d("1.0850")}
+	tests := []struct {
+		name     string
+		base     string
+		provider string
+		asOf     time.Time
+		rates    map[string]decimal.Decimal
+		wantErr  error
+	}{
+		{"empty base", "", "test", asOf, valid, fxrate.ErrInvalidSnapshot},
+		{"blank base", "   ", "test", asOf, valid, fxrate.ErrInvalidSnapshot},
+		{"empty provider", "EUR", "", asOf, valid, fxrate.ErrInvalidSnapshot},
+		{"zero asOf", "EUR", "test", time.Time{}, valid, fxrate.ErrInvalidSnapshot},
+		{"nil rates", "EUR", "test", asOf, nil, fxrate.ErrInvalidSnapshot},
+		{"empty rates", "EUR", "test", asOf, map[string]decimal.Decimal{}, fxrate.ErrInvalidSnapshot},
+		{"empty code", "EUR", "test", asOf, map[string]decimal.Decimal{"  ": d("1")}, fxrate.ErrInvalidSnapshot},
+		{"zero rate", "EUR", "test", asOf, map[string]decimal.Decimal{"USD": decimal.Zero}, fxrate.ErrInvalidRate},
+		{"negative rate", "EUR", "test", asOf, map[string]decimal.Decimal{"USD": d("-1.08")}, fxrate.ErrInvalidRate},
+		{"base self-rate not one", "EUR", "test", asOf, map[string]decimal.Decimal{"EUR": d("1.1"), "USD": d("1.0850")}, fxrate.ErrInvalidRate},
+		{"only base self-rate", "EUR", "test", asOf, map[string]decimal.Decimal{"EUR": d("1")}, fxrate.ErrInvalidSnapshot},
+		{"duplicate after normalization", "EUR", "test", asOf, map[string]decimal.Decimal{"USD": d("1.08"), " usd": d("1.09")}, fxrate.ErrInvalidSnapshot},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := fxrate.NewSnapshot(tt.base, tt.provider, tt.asOf, tt.rates)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("got %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewSnapshotNormalizes(t *testing.T) {
+	t.Parallel()
+
+	s := mustSnapshot(t, " eur ", map[string]decimal.Decimal{" usd ": d("1.0850"), "eur": d("1.00")})
+	if s.Base() != "EUR" {
+		t.Fatalf("Base = %q, want EUR", s.Base())
+	}
+	for _, code := range []string{"USD", "usd", " Usd "} {
+		if !s.Has(code) {
+			t.Fatalf("Has(%q) = false, want true", code)
+		}
+	}
+	if !s.Has("EUR") {
+		t.Fatal("Has(base) = false, want true")
+	}
+	if s.Has("GBP") {
+		t.Fatal("Has(GBP) = true, want false")
+	}
+}
+
+func TestSnapshotAccessors(t *testing.T) {
+	t.Parallel()
+
+	s := mustSnapshot(t, "EUR", map[string]decimal.Decimal{"USD": d("1.0850"), "GBP": d("0.8425")})
+	if s.IsZero() {
+		t.Fatal("IsZero = true for constructed snapshot")
+	}
+	if s.Provider() != "test" {
+		t.Fatalf("Provider = %q", s.Provider())
+	}
+	if !s.AsOf().Equal(asOf) {
+		t.Fatalf("AsOf = %v", s.AsOf())
+	}
+	want := []string{"EUR", "GBP", "USD"}
+	got := s.Currencies()
+	if len(got) != len(want) {
+		t.Fatalf("Currencies = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Currencies = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestZeroSnapshot(t *testing.T) {
+	t.Parallel()
+
+	var s fxrate.Snapshot
+	if !s.IsZero() {
+		t.Fatal("IsZero = false for zero value")
+	}
+	if s.Has("USD") {
+		t.Fatal("zero snapshot Has = true")
+	}
+	if s.Currencies() != nil {
+		t.Fatal("zero snapshot Currencies != nil")
+	}
+	if _, err := s.Rate("USD", "EUR"); !errors.Is(err, fxrate.ErrUnknownCurrency) {
+		t.Fatalf("Rate on zero snapshot: %v", err)
+	}
+}
+
+func TestSnapshotRate(t *testing.T) {
+	t.Parallel()
+
+	s := mustSnapshot(t, "EUR", map[string]decimal.Decimal{
+		"USD": d("2"),
+		"GBP": d("0.5"),
+		"JPY": d("3"),
+	})
+
+	tests := []struct {
+		name     string
+		from, to string
+		want     decimal.Decimal
+	}{
+		{"identity", "USD", "USD", d("1")},
+		{"identity base", "EUR", "EUR", d("1")},
+		{"direct keeps provider scale", "EUR", "USD", d("2")},
+		{"inverse", "USD", "EUR", d("0.5")},
+		{"inverse rounds half-even", "JPY", "EUR", d("0.333333333333")},
+		{"cross", "USD", "GBP", d("0.25")},
+		{"cross other way", "GBP", "USD", d("4")},
+		{"case-insensitive lookup", "usd", "gbp", d("0.25")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r, err := s.Rate(tt.from, tt.to)
+			if err != nil {
+				t.Fatalf("Rate: %v", err)
+			}
+			if !r.Value.Equal(tt.want) {
+				t.Fatalf("Rate(%s→%s) = %s, want %s", tt.from, tt.to, r.Value, tt.want)
+			}
+			if r.Provider != "test" || !r.AsOf.Equal(asOf) {
+				t.Fatalf("rate metadata not carried: %+v", r)
+			}
+			if r.Base != "USD" && r.Base != "EUR" && r.Base != "JPY" && r.Base != "GBP" {
+				t.Fatalf("Base not normalized: %q", r.Base)
+			}
+		})
+	}
+
+	if _, err := s.Rate("XXX", "USD"); !errors.Is(err, fxrate.ErrUnknownCurrency) {
+		t.Fatalf("unknown from: %v", err)
+	}
+	if _, err := s.Rate("USD", "XXX"); !errors.Is(err, fxrate.ErrUnknownCurrency) {
+		t.Fatalf("unknown to: %v", err)
+	}
+}
+
+func TestSnapshotConvert(t *testing.T) {
+	t.Parallel()
+
+	s := mustSnapshot(t, "EUR", map[string]decimal.Decimal{"USD": d("1.0850"), "GBP": d("0.8425")})
+
+	c, err := s.Convert(d("100.00"), "EUR", "USD", 2, decimal.HalfEven)
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if got := c.Result.String(); got != "108.50" {
+		t.Fatalf("Result = %s, want 108.50", got)
+	}
+	if c.Rate.Base != "EUR" || c.Rate.Quote != "USD" || c.Scale != 2 || c.Mode != decimal.HalfEven {
+		t.Fatalf("conversion record incomplete: %+v", c)
+	}
+
+	// The record alone must reproduce the result: exact multiply, one round.
+	recomputed := c.Amount.Mul(c.Rate.Value).Round(c.Scale, c.Mode)
+	if recomputed.String() != c.Result.String() {
+		t.Fatalf("recompute = %s, want %s", recomputed, c.Result)
+	}
+
+	if _, err := s.Convert(d("1"), "EUR", "XXX", 2, decimal.HalfEven); !errors.Is(err, fxrate.ErrUnknownCurrency) {
+		t.Fatalf("unknown currency: %v", err)
+	}
+
+	// Negative amounts (refunds) convert like positives: -50.00 × 0.8425 =
+	// -42.125, a tie whose even neighbor is -42.12.
+	c, err = s.Convert(d("-50.00"), "EUR", "GBP", 2, decimal.HalfEven)
+	if err != nil {
+		t.Fatalf("Convert negative: %v", err)
+	}
+	if got := c.Result.String(); got != "-42.12" {
+		t.Fatalf("Result = %s, want -42.12", got)
+	}
+}
+
+func TestSnapshotImmutableFromCallerMap(t *testing.T) {
+	t.Parallel()
+
+	rates := map[string]decimal.Decimal{"USD": d("2")}
+	s := mustSnapshot(t, "EUR", rates)
+	rates["USD"] = d("999")
+	rates["GBP"] = d("1")
+
+	r, err := s.Rate("EUR", "USD")
+	if err != nil {
+		t.Fatalf("Rate: %v", err)
+	}
+	if !r.Value.Equal(d("2")) {
+		t.Fatalf("snapshot mutated through caller map: %s", r.Value)
+	}
+	if s.Has("GBP") {
+		t.Fatal("snapshot grew through caller map")
+	}
+}
+
+func TestSnapshotJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := mustSnapshot(t, "EUR", map[string]decimal.Decimal{"USD": d("1.0850"), "GBP": d("0.8425")})
+	raw, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var back fxrate.Snapshot
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back.Base() != s.Base() || back.Provider() != s.Provider() || !back.AsOf().Equal(s.AsOf()) {
+		t.Fatalf("metadata drifted: %+v", back)
+	}
+
+	// A conversion recomputed from the stored snapshot byte-matches.
+	orig, err := s.Convert(d("99.90"), "USD", "GBP", 2, decimal.HalfEven)
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	replay, err := back.Convert(d("99.90"), "USD", "GBP", 2, decimal.HalfEven)
+	if err != nil {
+		t.Fatalf("replay Convert: %v", err)
+	}
+	if orig.Result.String() != replay.Result.String() || orig.Rate.Value.String() != replay.Rate.Value.String() {
+		t.Fatalf("replay drifted: %s@%s vs %s@%s", orig.Result, orig.Rate.Value, replay.Result, replay.Rate.Value)
+	}
+}
+
+func TestSnapshotUnmarshalFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want error
+	}{
+		{"negative rate", `{"as_of":"2026-07-20T16:00:00Z","base":"EUR","provider":"test","rates":{"USD":"-1"}}`, fxrate.ErrInvalidRate},
+		{"missing base", `{"as_of":"2026-07-20T16:00:00Z","provider":"test","rates":{"USD":"1.08"}}`, fxrate.ErrInvalidSnapshot},
+		{"no rates", `{"as_of":"2026-07-20T16:00:00Z","base":"EUR","provider":"test","rates":{}}`, fxrate.ErrInvalidSnapshot},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var s fxrate.Snapshot
+			if err := json.Unmarshal([]byte(tt.raw), &s); !errors.Is(err, tt.want) {
+				t.Fatalf("got %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRateApplyRounding(t *testing.T) {
+	t.Parallel()
+
+	r := fxrate.Rate{Base: "EUR", Quote: "USD", Value: d("1.005"), AsOf: asOf, Provider: "test"}
+
+	// 1 × 1.005 = 1.005 — a tie at 2 digits: half-even goes to the even
+	// neighbor, half-up away from zero.
+	c := r.Apply(d("1"), 2, decimal.HalfEven)
+	if got := c.Result.String(); got != "1.00" {
+		t.Fatalf("HalfEven Result = %s, want 1.00", got)
+	}
+	c = r.Apply(d("1"), 2, decimal.HalfUp)
+	if got := c.Result.String(); got != "1.01" {
+		t.Fatalf("HalfUp Result = %s, want 1.01", got)
+	}
+}

--- a/finance/fxrate/static.go
+++ b/finance/fxrate/static.go
@@ -1,0 +1,48 @@
+package fxrate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+)
+
+// StaticSource serves a fixed Snapshot: the RateSource for tests and for
+// deployments with contractually fixed rates (a per-deal rate card is one
+// StaticSource per deal). It never performs I/O.
+type StaticSource struct {
+	snap Snapshot
+}
+
+// NewStaticSource wraps snap as a RateSource.
+func NewStaticSource(snap Snapshot) (*StaticSource, error) {
+	if snap.IsZero() {
+		return nil, fmt.Errorf("%w: zero snapshot", ErrInvalidSnapshot)
+	}
+	return &StaticSource{snap: snap}, nil
+}
+
+// Fetch implements RateSource. The requested base must match the wrapped
+// snapshot's base; with quotes given, the result is narrowed to exactly those
+// currencies and fails with ErrUnknownCurrency if any is missing.
+func (s *StaticSource) Fetch(_ context.Context, base string, quotes []string) (Snapshot, error) {
+	if normalizeCode(base) != s.snap.Base() {
+		return Snapshot{}, fmt.Errorf("%w: have %s, requested %s", ErrBaseMismatch, s.snap.Base(), base)
+	}
+	if len(quotes) == 0 {
+		return s.snap, nil
+	}
+	rates := make(map[string]decimal.Decimal, len(quotes))
+	for _, q := range quotes {
+		q = normalizeCode(q)
+		if q == s.snap.base {
+			continue
+		}
+		v, ok := s.snap.rates[q]
+		if !ok {
+			return Snapshot{}, fmt.Errorf("%w: %s", ErrUnknownCurrency, q)
+		}
+		rates[q] = v
+	}
+	return NewSnapshot(s.snap.base, s.snap.provider, s.snap.asOf, rates)
+}

--- a/finance/fxrate/static_test.go
+++ b/finance/fxrate/static_test.go
@@ -1,0 +1,70 @@
+package fxrate_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/finance/fxrate"
+)
+
+func TestNewStaticSourceRejectsZeroSnapshot(t *testing.T) {
+	t.Parallel()
+
+	if _, err := fxrate.NewStaticSource(fxrate.Snapshot{}); !errors.Is(err, fxrate.ErrInvalidSnapshot) {
+		t.Fatalf("got %v, want ErrInvalidSnapshot", err)
+	}
+}
+
+func TestStaticSourceFetch(t *testing.T) {
+	t.Parallel()
+
+	snap := mustSnapshot(t, "EUR", map[string]decimal.Decimal{"USD": d("1.0850"), "GBP": d("0.8425"), "JPY": d("160")})
+	src, err := fxrate.NewStaticSource(snap)
+	if err != nil {
+		t.Fatalf("NewStaticSource: %v", err)
+	}
+
+	t.Run("all quotes", func(t *testing.T) {
+		t.Parallel()
+		got, err := src.Fetch(t.Context(), "eur", nil)
+		if err != nil {
+			t.Fatalf("Fetch: %v", err)
+		}
+		if len(got.Currencies()) != 4 {
+			t.Fatalf("Currencies = %v, want 4", got.Currencies())
+		}
+	})
+
+	t.Run("narrowed quotes", func(t *testing.T) {
+		t.Parallel()
+		got, err := src.Fetch(t.Context(), "EUR", []string{"usd", "EUR"})
+		if err != nil {
+			t.Fatalf("Fetch: %v", err)
+		}
+		if got.Has("GBP") || got.Has("JPY") {
+			t.Fatalf("not narrowed: %v", got.Currencies())
+		}
+		r, err := got.Rate("EUR", "USD")
+		if err != nil {
+			t.Fatalf("Rate: %v", err)
+		}
+		if !r.Value.Equal(d("1.0850")) {
+			t.Fatalf("Rate = %s, want 1.0850", r.Value)
+		}
+	})
+
+	t.Run("base mismatch", func(t *testing.T) {
+		t.Parallel()
+		if _, err := src.Fetch(t.Context(), "USD", nil); !errors.Is(err, fxrate.ErrBaseMismatch) {
+			t.Fatalf("got %v, want ErrBaseMismatch", err)
+		}
+	})
+
+	t.Run("missing quote", func(t *testing.T) {
+		t.Parallel()
+		if _, err := src.Fetch(t.Context(), "EUR", []string{"CHF"}); !errors.Is(err, fxrate.ErrUnknownCurrency) {
+			t.Fatalf("got %v, want ErrUnknownCurrency", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

New `finance/fxrate` package (first of the `finance/` namespace): exchange rates behind a `RateSource` seam with stored snapshots. `Convert` records the rate applied — provider, as-of time, value, scale, rounding mode — so audits answer "what rate at transaction time" and any stored `Conversion` or `Snapshot` recomputes byte-for-byte. Math is exact multiply-and-round via `core/decimal`; nothing routes through float64.

- **`Snapshot`** — immutable validated rate table: normalized codes, strictly positive rates, fail-closed construction (empty base/provider, zero as-of, no rates, duplicates, non-positive rates all rejected); the caller's map is copied. JSON round-trip goes back through `NewSnapshot`, so corrupt/tampered stored data fails closed. Inverse and cross rates derive by division at a fixed `RateScale = 12` half-even (package constant, not a knob) so derivations are deterministic forever; direct quotes keep the provider's scale.
- **`Converter`** — TTL-cached snapshot over the seam (`core/clock` for testable time), concurrent refreshes coalesced via `resilience/singleflight` with a post-flight freshness re-check. Fails closed: stale cache + failing source is an error, never silently-stale rates; a source returning the wrong base, a zero snapshot, or omitting a requested quote is rejected at fetch.
- **`StaticSource`** — fixed-rate source for tests and contractual rate cards (per-deal rates = one StaticSource per deal).
- **`frankfurter` subpackage** — thin JSON adapter over `web/httpclient` (ECB reference rates, no API key, GET retries via httpclient defaults): one GET, 1 MiB body cap, bare JSON numbers decoded straight into `core/decimal`. No provider SDKs, no live streaming.

Tenancy: rates are market data shared by all tenants — one Converter serves a multi-tenant app; per-tenant negotiated rates are separate Converter/StaticSource values chosen by the caller (passed-value pattern, per the calculator-package precedent).

Roadmap entry deleted from `docs/packages.md` per the shipped-package rule.

## Benchmarks (Apple M3 Max, Go 1.26)

```
BenchmarkSnapshotConvertDirect-14     2506455   427.4 ns/op   280 B/op   11 allocs/op
BenchmarkSnapshotConvertCross-14      1037280  1109 ns/op     704 B/op   27 allocs/op
BenchmarkSnapshotRateCross-14         2184255   508.3 ns/op   424 B/op   16 allocs/op
BenchmarkConverterConvertCached-14    3920846   304.0 ns/op   280 B/op   11 allocs/op
```

**Post-benchmark optimization pass:** alloc profile shows ~100% of allocations come from `core/decimal.Rescale`, which promotes to `math/big` on every scale reduction even when the coefficient fits int64 (`roundBig`/`pow10Big`); fxrate's own code contributes essentially zero. No in-package optimization is justified (readable-first rule); an int64 fast path for `decimal.Rescale` is flagged as a follow-up task, which would take the direct-convert path to ~0 allocs framework-wide.

## Testing

- Black-box tests: snapshot invariants, rate-derivation determinism (identity/direct/inverse/cross, half-even ties incl. negatives), JSON round-trip + fail-closed unmarshal, converter TTL/singleflight/fail-closed paths (`clock.Mock`), static source narrowing, frankfurter adapter over `httptest` (query shape, exact decimal decode, error paths).
- `go test -race ./finance/...` green; `just lint` 0 issues.