### PR TITLE
feat(finance/invoice): invoice document model package

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -298,27 +298,6 @@ named Go functions with per-deal parameters as data.
 
 Deps: `core/decimal`.
 
----
-
-**finance/invoice**
-
-The invoice document model — invariants, not rendering: numbering via a
-per-series `Sequence` with two explicit modes (strict-gapless
-transactional counter vs monotonic-with-gaps — the requirement is
-jurisdictional); immutable once issued, corrections are credit notes
-back-referencing the original (the corrections-post-forward rule shared
-with `ledger`); line items → tax lines → totals in `money` with per-line
-vs per-total rounding policy via `Allocate`; draft → issued →
-paid/partially-paid/void/overdue over `fsm`, paid-matching by `ledger`
-posting refs; self-billing direction (platform issues on the supplier's
-behalf — affiliate/agent payouts); multi-currency with the `fxrate`
-snapshot recorded. Tax rates are caller-supplied data — never
-determined; rendering stays out (HTML is a `render` recipe, PDF
-consumer-side); no dunning, no e-invoicing formats, no subscription or
-pricing logic (the billing anti-scope stands).
-
-Deps: `core/money`; `core/fsm`.
-
 ## async/
 
 ---

--- a/finance/invoice/bench_test.go
+++ b/finance/invoice/bench_test.go
@@ -1,0 +1,113 @@
+package invoice_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/core/money"
+	"github.com/dmitrymomot/forge/finance/invoice"
+)
+
+func benchLines(n int) []invoice.LineItem {
+	rates := []decimal.Decimal{
+		decimal.MustParse("0"),
+		decimal.MustParse("0.07"),
+		decimal.MustParse("0.19"),
+	}
+	lines := make([]invoice.LineItem, n)
+	for i := range lines {
+		lines[i] = invoice.LineItem{
+			Description: fmt.Sprintf("line %d", i),
+			Quantity:    decimal.FromInt(int64(1 + i%3)),
+			UnitPrice:   money.FromMinor(int64(999+i*137), money.EUR),
+			TaxRate:     rates[i%len(rates)],
+		}
+	}
+	return lines
+}
+
+func BenchmarkCompute(b *testing.B) {
+	for _, n := range []int{1, 10, 100} {
+		lines := benchLines(n)
+		b.Run(fmt.Sprintf("per_line/%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := invoice.Compute(lines, invoice.RoundPerLine); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("per_total/%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := invoice.Compute(lines, invoice.RoundPerTotal); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func benchDraft(lines []invoice.LineItem) *invoice.Invoice {
+	inv := invoice.New("INV-2026", money.EUR)
+	inv.Issuer = invoice.Party{Name: "Forge GmbH"}
+	inv.Recipient = invoice.Party{Name: "ACME Ltd"}
+	inv.Lines = lines
+	return inv
+}
+
+func BenchmarkIssue(b *testing.B) {
+	seq, err := invoice.NewSequence(invoice.NewMemorySequenceStore())
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	at := time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)
+	lines := benchLines(10)
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := benchDraft(lines).Issue(ctx, seq, at); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkApplyPayment(b *testing.B) {
+	seq, err := invoice.NewSequence(invoice.NewMemorySequenceStore())
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	at := time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)
+	lines := benchLines(10)
+	proto := benchDraft(lines)
+	if err := proto.Issue(ctx, seq, at); err != nil {
+		b.Fatal(err)
+	}
+	p := invoice.Payment{Ref: "ledger:1", Amount: proto.Totals.Total, At: at}
+	b.ReportAllocs()
+	for b.Loop() {
+		inv := *proto
+		inv.Payments = nil
+		if err := inv.ApplyPayment(ctx, p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSequenceNext(b *testing.B) {
+	seq, err := invoice.NewSequence(invoice.NewMemorySequenceStore(), invoice.WithMode(invoice.WithGaps))
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := seq.Next(ctx, "INV"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/finance/invoice/doc.go
+++ b/finance/invoice/doc.go
@@ -1,0 +1,91 @@
+// Package invoice provides the invoice document model — invariants, not
+// rendering: sequential numbering, immutability once issued, penny-perfect
+// totals, a payment-matched lifecycle, and credit-note corrections.
+//
+// An Invoice is a plain, persistable struct; the caller owns storage (the
+// fsm philosophy of caller-owned state) and the package operations are the
+// only legal way to move it. A draft is freely mutable. Issue validates the
+// document, computes and freezes Totals from the line items, draws the
+// document number, and moves draft → issued; from then on the document is
+// immutable and every correction is a new credit-note document
+// back-referencing the original via Corrects (corrections post forward,
+// the rule shared with the ledger). Verify re-checks a loaded document's
+// totals against its lines to detect drift.
+//
+// Numbering is per-series through a Sequence over a small SequenceStore
+// seam, with two explicit modes because the requirement is jurisdictional:
+// Gapless (default) draws only inside Issue — inside the caller's
+// persistence transaction when the store rides ctx — and refuses pre-drawn
+// or pre-assigned numbers; WithGaps allows pre-drawing via Sequence.Next and
+// burns numbers on failed issuance. An in-memory store ships for tests and
+// development.
+//
+// Totals run over the money package with two rounding policies: RoundPerLine
+// rounds each line and its tax individually; RoundPerTotal rounds once at
+// the document level and allocates the subtotal back across lines
+// penny-perfect via money.Allocate. Tax rates are caller-supplied data per
+// line — the package never determines them — and group into per-rate
+// TaxLines. Payments match by external refs (ledger posting refs) and drive
+// issued → partially_paid → paid; MarkOverdue is the caller's sweep;
+// Void works only while no payments are recorded. Self-billing (the
+// platform issuing on the supplier's behalf — affiliate and agent payouts)
+// is the Direction field; a document issued in a non-base currency records
+// its FXSnapshot — recorded data, never conversion math.
+//
+// Lifecycle errors surface the fsm package's sentinels: paying a draft is
+// fsm.ErrIllegalTransition, voiding a paid document wraps ErrHasPayments in
+// fsm.ErrGuardDenied.
+//
+// What this is NOT: it does not render documents (HTML is a render recipe,
+// PDF stays consumer-side), determine tax rates, speak e-invoicing formats,
+// do dunning, or know about subscriptions and pricing — the billing
+// anti-scope stands.
+//
+// # Usage
+//
+//	store := invoice.NewMemorySequenceStore()
+//	seq, err := invoice.NewSequence(store)
+//	if err != nil {
+//		// nil store or invalid options
+//	}
+//
+//	inv := invoice.New("INV-2026", money.EUR)
+//	inv.Issuer = invoice.Party{Name: "Forge GmbH", TaxID: "DE123456789"}
+//	inv.Recipient = invoice.Party{Name: "ACME Ltd"}
+//	inv.Rounding = invoice.RoundPerTotal
+//	inv.Lines = []invoice.LineItem{{
+//		Description: "Platform fee, June",
+//		Quantity:    decimal.FromInt(1),
+//		UnitPrice:   money.FromMinor(49900, money.EUR),
+//		TaxRate:     decimal.MustParse("0.19"),
+//	}}
+//	inv.DueAt = issuedAt.AddDate(0, 0, 14)
+//
+//	if err := inv.Issue(ctx, seq, issuedAt); err != nil {
+//		// validation failed or the transition was illegal
+//	}
+//	_ = inv.Number             // "INV-2026-000001"
+//	_ = inv.Totals.Total       // 593.81 EUR
+//
+//	err = inv.ApplyPayment(ctx, invoice.Payment{
+//		Ref:    "ledger:posting:8f3a", // idempotent by ref
+//		Amount: inv.Totals.Total,
+//		At:     paidAt,
+//	})
+//	// inv.Status == invoice.StatusPaid
+//
+//	note, err := invoice.NewCreditNote(inv, nil) // full credit, draft
+//	if err == nil {
+//		err = note.Issue(ctx, seq, correctedAt)
+//	}
+//
+// Multi-tenant applications add WithScope to NewSequence; each tenant then
+// counts its series independently and a missing scope fails closed with
+// ErrScope. Single-tenant applications pay zero ceremony.
+//
+// Siblings: money (amounts, allocation), fsm (the lifecycle machine),
+// decimal (quantities, rates); planned: ledger (posting refs that payments
+// match), fxrate (the snapshot source), tariff and formula (derive the
+// amounts that become line items). See docs/packages.md for the package
+// catalog.
+package invoice

--- a/finance/invoice/errors.go
+++ b/finance/invoice/errors.go
@@ -20,8 +20,8 @@ var (
 	ErrCorrects = errors.New("invoice: corrects reference mismatch")
 	// ErrParty reports a missing issuer or recipient name at issue time.
 	ErrParty = errors.New("invoice: missing party name")
-	// ErrIssueTime reports a zero issue timestamp.
-	ErrIssueTime = errors.New("invoice: zero issue time")
+	// ErrZeroTime reports a zero timestamp passed to Issue or Void.
+	ErrZeroTime = errors.New("invoice: zero timestamp")
 	// ErrDueBeforeIssue reports a due date earlier than the issue date.
 	ErrDueBeforeIssue = errors.New("invoice: due date before issue date")
 	// ErrFX reports an FX snapshot with a missing base currency or a
@@ -51,8 +51,10 @@ var (
 	// ErrPaymentConflict reports a payment Ref replayed with a different
 	// amount. An identical replay (same Ref, same amount) is a no-op.
 	ErrPaymentConflict = errors.New("invoice: payment ref reused with different amount")
-	// ErrPaymentAmount reports a non-positive payment amount.
-	ErrPaymentAmount = errors.New("invoice: payment amount must be positive")
+	// ErrPaymentAmount reports a non-positive payment amount, or one not
+	// representable in the currency's minor units (totals are minor-unit
+	// precise; a sub-minor-unit payment could never reconcile against them).
+	ErrPaymentAmount = errors.New("invoice: invalid payment amount")
 	// ErrOverpayment reports a payment that would push the paid sum above the
 	// invoice total.
 	ErrOverpayment = errors.New("invoice: payments exceed total")

--- a/finance/invoice/errors.go
+++ b/finance/invoice/errors.go
@@ -1,0 +1,75 @@
+package invoice
+
+import "errors"
+
+var (
+	// ErrNoLines reports an invoice with no line items.
+	ErrNoLines = errors.New("invoice: no line items")
+	// ErrInvalidLine reports a line item with a non-positive quantity, a
+	// negative unit price, or a negative tax rate.
+	ErrInvalidLine = errors.New("invoice: invalid line item")
+	// ErrRoundingPolicy reports an unknown RoundingPolicy value.
+	ErrRoundingPolicy = errors.New("invoice: unknown rounding policy")
+	// ErrKind reports an unknown document Kind.
+	ErrKind = errors.New("invoice: unknown document kind")
+	// ErrDirection reports an unknown Direction.
+	ErrDirection = errors.New("invoice: unknown direction")
+	// ErrCorrects reports a Corrects reference that contradicts the document
+	// kind: a credit note must reference the invoice it corrects, and a
+	// standard invoice must not carry a Corrects reference.
+	ErrCorrects = errors.New("invoice: corrects reference mismatch")
+	// ErrParty reports a missing issuer or recipient name at issue time.
+	ErrParty = errors.New("invoice: missing party name")
+	// ErrIssueTime reports a zero issue timestamp.
+	ErrIssueTime = errors.New("invoice: zero issue time")
+	// ErrDueBeforeIssue reports a due date earlier than the issue date.
+	ErrDueBeforeIssue = errors.New("invoice: due date before issue date")
+	// ErrFX reports an FX snapshot with a missing base currency or a
+	// non-positive rate.
+	ErrFX = errors.New("invoice: invalid fx snapshot")
+
+	// ErrNoNumber reports issuing without a Sequence when no number was
+	// pre-assigned, or a document that unexpectedly has no number.
+	ErrNoNumber = errors.New("invoice: no number assigned")
+	// ErrNumberAssigned reports a pre-assigned number on a gapless series:
+	// gapless numbering draws exclusively at issue time.
+	ErrNumberAssigned = errors.New("invoice: number pre-assigned on gapless series")
+	// ErrNoSeries reports drawing a number for an invoice with an empty
+	// Series.
+	ErrNoSeries = errors.New("invoice: no series")
+	// ErrGapless reports a pre-draw attempt (Sequence.Next) on a gapless
+	// sequence, which draws numbers only inside Issue.
+	ErrGapless = errors.New("invoice: gapless sequence draws numbers only at issue")
+	// ErrScope reports a configured scope hook that failed or returned empty.
+	ErrScope = errors.New("invoice: scope resolution failed")
+
+	// ErrHasPayments reports an operation that requires an unpaid document
+	// (voiding, issuing) on a document that already recorded payments.
+	ErrHasPayments = errors.New("invoice: payments recorded")
+	// ErrPaymentRef reports a payment with an empty Ref.
+	ErrPaymentRef = errors.New("invoice: missing payment ref")
+	// ErrPaymentConflict reports a payment Ref replayed with a different
+	// amount. An identical replay (same Ref, same amount) is a no-op.
+	ErrPaymentConflict = errors.New("invoice: payment ref reused with different amount")
+	// ErrPaymentAmount reports a non-positive payment amount.
+	ErrPaymentAmount = errors.New("invoice: payment amount must be positive")
+	// ErrOverpayment reports a payment that would push the paid sum above the
+	// invoice total.
+	ErrOverpayment = errors.New("invoice: payments exceed total")
+
+	// ErrNoDueDate reports MarkOverdue on a document without a due date.
+	ErrNoDueDate = errors.New("invoice: no due date")
+	// ErrNotDue reports MarkOverdue before the due date has passed.
+	ErrNotDue = errors.New("invoice: due date not passed")
+
+	// ErrNotCreditable reports a credit note against a document that cannot
+	// be corrected: a draft, a void document, or another credit note.
+	ErrNotCreditable = errors.New("invoice: original not creditable")
+	// ErrCreditExceeds reports a credit note whose total exceeds the original
+	// invoice total.
+	ErrCreditExceeds = errors.New("invoice: credit note exceeds original total")
+
+	// ErrTotalsMismatch reports stored totals that no longer match the
+	// document's line items (Verify).
+	ErrTotalsMismatch = errors.New("invoice: stored totals do not match lines")
+)

--- a/finance/invoice/invoice.go
+++ b/finance/invoice/invoice.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/core/fsm"
 	"github.com/dmitrymomot/forge/core/money"
 )
 
@@ -123,7 +124,7 @@ func (inv *Invoice) Issue(ctx context.Context, seq *Sequence, at time.Time) erro
 		return err
 	}
 	if at.IsZero() {
-		return ErrIssueTime
+		return ErrZeroTime
 	}
 	kind := inv.Kind
 	if kind == "" {
@@ -207,11 +208,20 @@ func (inv *Invoice) ApplyPayment(ctx context.Context, p Payment) error {
 		return ErrPaymentRef
 	}
 	if !p.Amount.IsPositive() {
-		return ErrPaymentAmount
+		return fmt.Errorf("%w: must be positive", ErrPaymentAmount)
+	}
+	// Totals are minor-unit precise, so a sub-minor-unit payment (33.333 on
+	// a 100.00 invoice) could satisfy Outstanding visually yet never reach
+	// paid. Reject instead of rounding: the recorded amount must stay equal
+	// to the ledger posting the ref points at.
+	if !moneyEq(p.Amount, p.Amount.Round(decimal.HalfEven)) {
+		return fmt.Errorf("%w: not representable in %s minor units", ErrPaymentAmount, inv.Currency.Code)
 	}
 	if p.Amount.Currency().Code != inv.Currency.Code {
 		return fmt.Errorf("invoice: payment %q: %w", p.Ref, money.ErrCurrencyMismatch)
 	}
+	// The replay check runs before the status check so an at-least-once feed
+	// redelivering the final payment of a now-paid document still no-ops.
 	for _, applied := range inv.Payments {
 		if applied.Ref == p.Ref {
 			if eq, err := applied.Amount.Equal(p.Amount); err == nil && eq {
@@ -219,6 +229,11 @@ func (inv *Invoice) ApplyPayment(ctx context.Context, p Payment) error {
 			}
 			return fmt.Errorf("%w: %q", ErrPaymentConflict, p.Ref)
 		}
+	}
+	switch inv.Status {
+	case StatusIssued, StatusPartiallyPaid, StatusOverdue:
+	default:
+		return fmt.Errorf("%w: cannot pay a %s document", fsm.ErrIllegalTransition, inv.Status)
 	}
 	paid, err := inv.Paid()
 	if err != nil {
@@ -271,6 +286,9 @@ func (inv *Invoice) MarkOverdue(ctx context.Context, now time.Time) error {
 // voided (the lifecycle guard denies with ErrHasPayments); once money moved,
 // the correction is a credit note.
 func (inv *Invoice) Void(ctx context.Context, at time.Time) error {
+	if at.IsZero() {
+		return ErrZeroTime
+	}
 	if err := lifecycle.Fire(ctx, inv, inv.Status, StatusVoid); err != nil {
 		return err
 	}
@@ -378,13 +396,17 @@ func NewCreditNote(original *Invoice, lines []LineItem) (*Invoice, error) {
 	if over {
 		return nil, ErrCreditExceeds
 	}
+	issuer := original.Issuer
+	issuer.Address = slices.Clone(issuer.Address)
+	recipient := original.Recipient
+	recipient.Address = slices.Clone(recipient.Address)
 	return &Invoice{
 		Series:    original.Series,
 		Kind:      KindCreditNote,
 		Direction: original.Direction,
 		Status:    StatusDraft,
-		Issuer:    original.Issuer,
-		Recipient: original.Recipient,
+		Issuer:    issuer,
+		Recipient: recipient,
 		Currency:  original.Currency,
 		Lines:     lines,
 		Rounding:  original.Rounding,

--- a/finance/invoice/invoice.go
+++ b/finance/invoice/invoice.go
@@ -1,0 +1,394 @@
+package invoice
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/core/money"
+)
+
+// Party identifies one side of the document. It is inert data frozen with
+// the rest of the document at issue; only Name is required then.
+type Party struct {
+	// Name is the legal name. Required at issue.
+	Name string
+	// TaxID is the party's tax identifier (VAT number, EIN). Optional.
+	TaxID string
+	// Address holds free-form address lines. Optional.
+	Address []string
+}
+
+// FXSnapshot records the exchange rate that applied when the document was
+// issued in a currency other than the ledger's or report's base currency. It
+// is recorded data — the package does no conversion math — so audits can
+// answer "what rate at issue time".
+type FXSnapshot struct {
+	// At is when the rate was observed.
+	At time.Time
+	// Base is the reporting currency the rate converts into.
+	Base money.Currency
+	// Rate is the price of one unit of the document currency in Base units.
+	// Must be positive.
+	Rate decimal.Decimal
+}
+
+// Payment matches money received against the document, keyed by an external
+// reference — a ledger posting ref or a PSP transaction id. Refs are the
+// idempotency key: replaying a ref with the same amount is a no-op, with a
+// different amount an ErrPaymentConflict.
+type Payment struct {
+	// At is when the payment was received. Inert data.
+	At time.Time
+	// Ref is the external posting reference. Required, unique per document.
+	Ref string
+	// Amount is the paid amount in the document currency. Must be positive.
+	Amount money.Money
+}
+
+// Invoice is the document model: a plain, persistable struct whose
+// invariants are enforced at the package's operation boundary, mirroring the
+// fsm philosophy of caller-owned state — the caller stores the document, the
+// package's operations are the only legal way to move it. A draft is freely
+// mutable; Issue freezes it (number, totals, parties, lines), and every
+// later correction is a new credit-note document, never an edit. Verify
+// re-checks a loaded document's totals against its lines to detect drift.
+type Invoice struct {
+	// IssuedAt is set by Issue, VoidedAt by Void.
+	IssuedAt time.Time
+	// DueAt is the caller-set due date; zero means none (MarkOverdue then
+	// returns ErrNoDueDate).
+	DueAt    time.Time
+	VoidedAt time.Time
+	// FX optionally records the exchange-rate snapshot for documents issued
+	// in a non-base currency. Recorded, never computed.
+	FX *FXSnapshot
+	// Series is the numbering series the document belongs to, e.g.
+	// "INV-2026". Required when Issue draws the number.
+	Series string
+	// Number is the formatted document number. Assigned by Issue; may be
+	// pre-assigned only on WithGaps series or when issuing without a
+	// Sequence.
+	Number string
+	// Kind is invoice vs credit note. New and NewCreditNote set it; Issue
+	// defaults empty to KindInvoice.
+	Kind Kind
+	// Direction records who issues; Issue defaults empty to
+	// DirectionStandard.
+	Direction Direction
+	// Status is the lifecycle state, moved only by package operations.
+	Status Status
+	// Corrects back-references the corrected invoice's Number. Required on
+	// credit notes, forbidden on invoices.
+	Corrects string
+	// Totals is computed and frozen by Issue.
+	Totals Totals
+	// Issuer and Recipient are the document parties.
+	Issuer    Party
+	Recipient Party
+	// Currency is the document currency; every line and payment must match.
+	Currency money.Currency
+	// Lines are the line items. Mutable while draft.
+	Lines []LineItem
+	// Payments are the applied payments, appended by ApplyPayment.
+	Payments []Payment
+	// Rounding selects the totals rounding policy. Zero value RoundPerLine.
+	Rounding RoundingPolicy
+}
+
+// New returns a draft invoice in the given numbering series and currency.
+func New(series string, c money.Currency) *Invoice {
+	return &Invoice{
+		Series:    series,
+		Kind:      KindInvoice,
+		Direction: DirectionStandard,
+		Status:    StatusDraft,
+		Currency:  c,
+	}
+}
+
+// Issue validates the draft, freezes its totals, assigns the document
+// number, and moves it draft → issued as of at. From this point the document
+// is immutable; corrections are credit notes.
+//
+// Numbering: with a Gapless sequence the number is drawn here — inside the
+// caller's persistence transaction when the store rides ctx — and a
+// pre-assigned Number is refused with ErrNumberAssigned. With a WithGaps
+// sequence a pre-assigned Number is kept, otherwise one is drawn. With seq
+// nil the caller numbers documents itself and Number must already be set.
+func (inv *Invoice) Issue(ctx context.Context, seq *Sequence, at time.Time) error {
+	if err := lifecycle.Fire(ctx, inv, inv.Status, StatusIssued); err != nil {
+		return err
+	}
+	if at.IsZero() {
+		return ErrIssueTime
+	}
+	kind := inv.Kind
+	if kind == "" {
+		kind = KindInvoice
+	}
+	if kind != KindInvoice && kind != KindCreditNote {
+		return fmt.Errorf("%w: %q", ErrKind, inv.Kind)
+	}
+	dir := inv.Direction
+	if dir == "" {
+		dir = DirectionStandard
+	}
+	if dir != DirectionStandard && dir != DirectionSelfBilled {
+		return fmt.Errorf("%w: %q", ErrDirection, inv.Direction)
+	}
+	if kind == KindCreditNote && inv.Corrects == "" {
+		return fmt.Errorf("%w: credit note without corrects reference", ErrCorrects)
+	}
+	if kind == KindInvoice && inv.Corrects != "" {
+		return fmt.Errorf("%w: standard invoice with corrects reference", ErrCorrects)
+	}
+	if inv.Issuer.Name == "" || inv.Recipient.Name == "" {
+		return ErrParty
+	}
+	if !inv.DueAt.IsZero() && inv.DueAt.Before(at) {
+		return ErrDueBeforeIssue
+	}
+	if inv.FX != nil && (inv.FX.Base.Code == "" || !inv.FX.Rate.IsPositive()) {
+		return ErrFX
+	}
+	if len(inv.Payments) != 0 {
+		return ErrHasPayments
+	}
+
+	totals, err := Compute(inv.Lines, inv.Rounding)
+	if err != nil {
+		return err
+	}
+	if totals.Total.Currency().Code != inv.Currency.Code {
+		return fmt.Errorf("invoice: lines vs document: %w", money.ErrCurrencyMismatch)
+	}
+
+	number := inv.Number
+	switch {
+	case seq == nil:
+		if number == "" {
+			return ErrNoNumber
+		}
+	case number != "":
+		if seq.Mode() == Gapless {
+			return ErrNumberAssigned
+		}
+	default:
+		if inv.Series == "" {
+			return ErrNoSeries
+		}
+		// The number is drawn last, only after every other invariant
+		// passed, so a validation failure can never burn one.
+		if number, err = seq.next(ctx, inv.Series); err != nil {
+			return err
+		}
+	}
+
+	inv.Kind = kind
+	inv.Direction = dir
+	inv.Totals = totals
+	inv.Number = number
+	inv.IssuedAt = at
+	inv.Status = StatusIssued
+	return nil
+}
+
+// ApplyPayment records a payment against an issued document and moves it to
+// partially_paid or paid. Matching is by Ref (a ledger posting ref):
+// replaying an already-applied Ref with the same amount is an idempotent
+// no-op, so at-least-once payment feeds are safe; the same Ref with a
+// different amount is ErrPaymentConflict. A payment pushing the paid sum
+// above the total is ErrOverpayment and records nothing.
+func (inv *Invoice) ApplyPayment(ctx context.Context, p Payment) error {
+	if p.Ref == "" {
+		return ErrPaymentRef
+	}
+	if !p.Amount.IsPositive() {
+		return ErrPaymentAmount
+	}
+	if p.Amount.Currency().Code != inv.Currency.Code {
+		return fmt.Errorf("invoice: payment %q: %w", p.Ref, money.ErrCurrencyMismatch)
+	}
+	for _, applied := range inv.Payments {
+		if applied.Ref == p.Ref {
+			if eq, err := applied.Amount.Equal(p.Amount); err == nil && eq {
+				return nil
+			}
+			return fmt.Errorf("%w: %q", ErrPaymentConflict, p.Ref)
+		}
+	}
+	paid, err := inv.Paid()
+	if err != nil {
+		return err
+	}
+	if paid, err = paid.Add(p.Amount); err != nil {
+		return err
+	}
+	c, err := paid.Cmp(inv.Totals.Total)
+	if err != nil {
+		return err
+	}
+	if c > 0 {
+		return fmt.Errorf("%w: ref %q", ErrOverpayment, p.Ref)
+	}
+	target := StatusPartiallyPaid
+	if c == 0 {
+		target = StatusPaid
+	}
+	if err := lifecycle.Fire(ctx, inv, inv.Status, target); err != nil {
+		return err
+	}
+	inv.Payments = append(inv.Payments, p)
+	inv.Status = target
+	return nil
+}
+
+// MarkOverdue moves an unpaid or partially paid document past its due date
+// to overdue. It is the caller's sweep that decides when to check; now must
+// be strictly after DueAt.
+func (inv *Invoice) MarkOverdue(ctx context.Context, now time.Time) error {
+	if inv.DueAt.IsZero() {
+		return ErrNoDueDate
+	}
+	if !now.After(inv.DueAt) {
+		return ErrNotDue
+	}
+	if err := lifecycle.Fire(ctx, inv, inv.Status, StatusOverdue); err != nil {
+		return err
+	}
+	inv.Status = StatusOverdue
+	return nil
+}
+
+// Void cancels the document as of at. Only documents without payments can be
+// voided (the lifecycle guard denies with ErrHasPayments); once money moved,
+// the correction is a credit note.
+func (inv *Invoice) Void(ctx context.Context, at time.Time) error {
+	if err := lifecycle.Fire(ctx, inv, inv.Status, StatusVoid); err != nil {
+		return err
+	}
+	inv.Status = StatusVoid
+	inv.VoidedAt = at
+	return nil
+}
+
+// Paid returns the exact sum of applied payments, zero in the document
+// currency when there are none.
+func (inv *Invoice) Paid() (money.Money, error) {
+	total := money.FromMinor(0, inv.Currency)
+	for _, p := range inv.Payments {
+		var err error
+		if total, err = total.Add(p.Amount); err != nil {
+			return money.Money{}, err
+		}
+	}
+	return total, nil
+}
+
+// Outstanding returns Total minus Paid. It is never negative for documents
+// maintained through ApplyPayment, which refuses overpayment.
+func (inv *Invoice) Outstanding() (money.Money, error) {
+	paid, err := inv.Paid()
+	if err != nil {
+		return money.Money{}, err
+	}
+	return inv.Totals.Total.Sub(paid)
+}
+
+// Verify recomputes totals from the document's lines and compares them with
+// the stored Totals, returning ErrTotalsMismatch on any difference. Run it
+// on documents loaded from storage to detect drift: an issued document whose
+// lines or totals were edited behind the package's back no longer verifies.
+func (inv *Invoice) Verify() error {
+	totals, err := Compute(inv.Lines, inv.Rounding)
+	if err != nil {
+		return err
+	}
+	if !moneyEq(totals.Subtotal, inv.Totals.Subtotal) ||
+		!moneyEq(totals.Tax, inv.Totals.Tax) ||
+		!moneyEq(totals.Total, inv.Totals.Total) {
+		return ErrTotalsMismatch
+	}
+	if len(totals.LineNets) != len(inv.Totals.LineNets) ||
+		len(totals.TaxLines) != len(inv.Totals.TaxLines) {
+		return ErrTotalsMismatch
+	}
+	for i := range totals.LineNets {
+		if !moneyEq(totals.LineNets[i], inv.Totals.LineNets[i]) {
+			return ErrTotalsMismatch
+		}
+	}
+	for i := range totals.TaxLines {
+		want, got := totals.TaxLines[i], inv.Totals.TaxLines[i]
+		if want.Rate.Cmp(got.Rate) != 0 || !moneyEq(want.Base, got.Base) || !moneyEq(want.Amount, got.Amount) {
+			return ErrTotalsMismatch
+		}
+	}
+	return nil
+}
+
+// NewCreditNote builds a draft credit note correcting original. With nil or
+// empty lines it credits the original in full (lines are copied); explicit
+// lines make a partial credit. The draft back-references original.Number via
+// Corrects and inherits series, parties, currency, direction, and rounding —
+// all overridable before Issue (credit notes commonly run their own series).
+// FX is not inherited: whether a correction uses the original's rate or the
+// current one is jurisdictional, so the caller sets it.
+//
+// The credit total is checked against the original's total here, while the
+// original is in hand; the package is stateless, so keeping cumulative
+// partial credits within the original total is the caller's check.
+func NewCreditNote(original *Invoice, lines []LineItem) (*Invoice, error) {
+	if original == nil {
+		return nil, ErrNotCreditable
+	}
+	if original.Kind == KindCreditNote {
+		return nil, fmt.Errorf("%w: cannot credit a credit note", ErrNotCreditable)
+	}
+	switch original.Status {
+	case StatusIssued, StatusPartiallyPaid, StatusPaid, StatusOverdue:
+	default:
+		return nil, fmt.Errorf("%w: status %q", ErrNotCreditable, original.Status)
+	}
+	if original.Number == "" {
+		return nil, ErrNoNumber
+	}
+	if len(lines) == 0 {
+		lines = original.Lines
+	}
+	lines = slices.Clone(lines)
+	totals, err := Compute(lines, original.Rounding)
+	if err != nil {
+		return nil, err
+	}
+	if totals.Total.Currency().Code != original.Currency.Code {
+		return nil, fmt.Errorf("invoice: credit note vs original: %w", money.ErrCurrencyMismatch)
+	}
+	over, err := totals.Total.GreaterThan(original.Totals.Total)
+	if err != nil {
+		return nil, err
+	}
+	if over {
+		return nil, ErrCreditExceeds
+	}
+	return &Invoice{
+		Series:    original.Series,
+		Kind:      KindCreditNote,
+		Direction: original.Direction,
+		Status:    StatusDraft,
+		Issuer:    original.Issuer,
+		Recipient: original.Recipient,
+		Currency:  original.Currency,
+		Lines:     lines,
+		Rounding:  original.Rounding,
+		Corrects:  original.Number,
+	}, nil
+}
+
+func moneyEq(a, b money.Money) bool {
+	eq, err := a.Equal(b)
+	return err == nil && eq
+}

--- a/finance/invoice/invoice.go
+++ b/finance/invoice/invoice.go
@@ -238,8 +238,12 @@ func (inv *Invoice) ApplyPayment(ctx context.Context, p Payment) error {
 	if c == 0 {
 		target = StatusPaid
 	}
-	if err := lifecycle.Fire(ctx, inv, inv.Status, target); err != nil {
-		return err
+	// A further partial payment on a partially paid document is not a state
+	// transition; only actual moves fire the machine.
+	if target != inv.Status {
+		if err := lifecycle.Fire(ctx, inv, inv.Status, target); err != nil {
+			return err
+		}
 	}
 	inv.Payments = append(inv.Payments, p)
 	inv.Status = target

--- a/finance/invoice/invoice_test.go
+++ b/finance/invoice/invoice_test.go
@@ -415,7 +415,9 @@ func TestVoid(t *testing.T) {
 		t.Parallel()
 		inv := issued(t)
 		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "119.00")))
-		assert.ErrorIs(t, inv.Void(t.Context(), dueTime), fsm.ErrIllegalTransition)
+		err := inv.Void(t.Context(), dueTime)
+		assert.ErrorIs(t, err, fsm.ErrGuardDenied)
+		assert.ErrorIs(t, err, invoice.ErrHasPayments)
 	})
 }
 

--- a/finance/invoice/invoice_test.go
+++ b/finance/invoice/invoice_test.go
@@ -1,6 +1,7 @@
 package invoice_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -215,6 +216,16 @@ func TestApplyPayment(t *testing.T) {
 		paid, err := inv.Paid()
 		require.NoError(t, err)
 		assertMoney(t, "119.00", paid)
+	})
+	t.Run("successive partial payments stay partially paid", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		for i, amount := range []string{"19.00", "30.00", "20.00"} {
+			require.NoError(t, inv.ApplyPayment(t.Context(), payment(fmt.Sprintf("ledger:%d", i), amount)))
+			assert.Equal(t, invoice.StatusPartiallyPaid, inv.Status)
+		}
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:final", "50.00")))
+		assert.Equal(t, invoice.StatusPaid, inv.Status)
 	})
 	t.Run("exact single payment pays in full", func(t *testing.T) {
 		t.Parallel()

--- a/finance/invoice/invoice_test.go
+++ b/finance/invoice/invoice_test.go
@@ -1,0 +1,489 @@
+package invoice_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/core/fsm"
+	"github.com/dmitrymomot/forge/core/money"
+	"github.com/dmitrymomot/forge/finance/invoice"
+)
+
+var (
+	issueTime = time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)
+	dueTime   = issueTime.AddDate(0, 0, 14)
+)
+
+func newSequence(t *testing.T, opts ...invoice.Option) *invoice.Sequence {
+	t.Helper()
+	seq, err := invoice.NewSequence(invoice.NewMemorySequenceStore(), opts...)
+	require.NoError(t, err)
+	return seq
+}
+
+// draft returns a valid EUR draft: one 100.00 line at 19%, due in 14 days.
+func draft(t *testing.T) *invoice.Invoice {
+	t.Helper()
+	inv := invoice.New("INV-2026", money.EUR)
+	inv.Issuer = invoice.Party{Name: "Forge GmbH", TaxID: "DE123456789"}
+	inv.Recipient = invoice.Party{Name: "ACME Ltd"}
+	inv.Lines = []invoice.LineItem{line(t, "1", "100.00", "0.19", money.EUR)}
+	inv.DueAt = dueTime
+	return inv
+}
+
+func issued(t *testing.T) *invoice.Invoice {
+	t.Helper()
+	inv := draft(t)
+	require.NoError(t, inv.Issue(t.Context(), newSequence(t), issueTime))
+	return inv
+}
+
+func payment(ref, amount string) invoice.Payment {
+	return invoice.Payment{
+		Ref:    ref,
+		Amount: money.New(decimal.MustParse(amount), money.EUR),
+		At:     issueTime.Add(time.Hour),
+	}
+}
+
+func TestIssue(t *testing.T) {
+	t.Parallel()
+
+	inv := draft(t)
+	require.NoError(t, inv.Issue(t.Context(), newSequence(t), issueTime))
+
+	assert.Equal(t, "INV-2026-000001", inv.Number)
+	assert.Equal(t, invoice.StatusIssued, inv.Status)
+	assert.Equal(t, invoice.KindInvoice, inv.Kind)
+	assert.Equal(t, invoice.DirectionStandard, inv.Direction)
+	assert.Equal(t, issueTime, inv.IssuedAt)
+	assertMoney(t, "100.00", inv.Totals.Subtotal)
+	assertMoney(t, "19.00", inv.Totals.Tax)
+	assertMoney(t, "119.00", inv.Totals.Total)
+	assert.NoError(t, inv.Verify())
+
+	// Issued documents are immutable: a second issue is an illegal move.
+	assert.ErrorIs(t, inv.Issue(t.Context(), newSequence(t), issueTime), fsm.ErrIllegalTransition)
+}
+
+func TestIssue_SequentialNumbers(t *testing.T) {
+	t.Parallel()
+
+	seq := newSequence(t)
+	for i, want := range []string{"INV-2026-000001", "INV-2026-000002", "INV-2026-000003"} {
+		inv := draft(t)
+		require.NoError(t, inv.Issue(t.Context(), seq, issueTime), "invoice %d", i)
+		assert.Equal(t, want, inv.Number)
+	}
+}
+
+func TestIssue_ValidationFailureBurnsNoNumber(t *testing.T) {
+	t.Parallel()
+
+	seq := newSequence(t)
+	inv := draft(t)
+	inv.Issuer.Name = ""
+	require.ErrorIs(t, inv.Issue(t.Context(), seq, issueTime), invoice.ErrParty)
+
+	// The failed attempt must not have consumed a number.
+	inv.Issuer.Name = "Forge GmbH"
+	require.NoError(t, inv.Issue(t.Context(), seq, issueTime))
+	assert.Equal(t, "INV-2026-000001", inv.Number)
+}
+
+func TestIssue_NumberingModes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("gapless refuses pre-assigned number", func(t *testing.T) {
+		t.Parallel()
+		inv := draft(t)
+		inv.Number = "INV-2026-000042"
+		err := inv.Issue(t.Context(), newSequence(t), issueTime)
+		assert.ErrorIs(t, err, invoice.ErrNumberAssigned)
+	})
+	t.Run("with-gaps keeps pre-assigned number", func(t *testing.T) {
+		t.Parallel()
+		inv := draft(t)
+		inv.Number = "INV-2026-000042"
+		require.NoError(t, inv.Issue(t.Context(), newSequence(t, invoice.WithMode(invoice.WithGaps)), issueTime))
+		assert.Equal(t, "INV-2026-000042", inv.Number)
+	})
+	t.Run("with-gaps pre-draws via Next", func(t *testing.T) {
+		t.Parallel()
+		seq := newSequence(t, invoice.WithMode(invoice.WithGaps))
+		n, err := seq.Next(t.Context(), "INV-2026")
+		require.NoError(t, err)
+		assert.Equal(t, "INV-2026-000001", n)
+
+		inv := draft(t)
+		inv.Number = n
+		require.NoError(t, inv.Issue(t.Context(), seq, issueTime))
+		assert.Equal(t, "INV-2026-000001", inv.Number)
+	})
+	t.Run("nil sequence requires pre-assigned number", func(t *testing.T) {
+		t.Parallel()
+		inv := draft(t)
+		assert.ErrorIs(t, inv.Issue(t.Context(), nil, issueTime), invoice.ErrNoNumber)
+
+		inv.Number = "EXT-7"
+		require.NoError(t, inv.Issue(t.Context(), nil, issueTime))
+		assert.Equal(t, "EXT-7", inv.Number)
+	})
+	t.Run("drawing requires a series", func(t *testing.T) {
+		t.Parallel()
+		inv := draft(t)
+		inv.Series = ""
+		assert.ErrorIs(t, inv.Issue(t.Context(), newSequence(t), issueTime), invoice.ErrNoSeries)
+	})
+}
+
+func TestIssue_Validation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*invoice.Invoice)
+		want   error
+	}{
+		{"zero issue time is ErrIssueTime", nil, invoice.ErrIssueTime},
+		{"unknown kind", func(i *invoice.Invoice) { i.Kind = "receipt" }, invoice.ErrKind},
+		{"unknown direction", func(i *invoice.Invoice) { i.Direction = "sideways" }, invoice.ErrDirection},
+		{"invoice with corrects ref", func(i *invoice.Invoice) { i.Corrects = "INV-1" }, invoice.ErrCorrects},
+		{"credit note without corrects ref", func(i *invoice.Invoice) { i.Kind = invoice.KindCreditNote }, invoice.ErrCorrects},
+		{"missing issuer name", func(i *invoice.Invoice) { i.Issuer.Name = "" }, invoice.ErrParty},
+		{"missing recipient name", func(i *invoice.Invoice) { i.Recipient.Name = "" }, invoice.ErrParty},
+		{"due before issue", func(i *invoice.Invoice) { i.DueAt = issueTime.Add(-time.Hour) }, invoice.ErrDueBeforeIssue},
+		{"fx without base", func(i *invoice.Invoice) {
+			i.FX = &invoice.FXSnapshot{Rate: decimal.MustParse("1.08")}
+		}, invoice.ErrFX},
+		{"fx with non-positive rate", func(i *invoice.Invoice) {
+			i.FX = &invoice.FXSnapshot{Base: money.USD, Rate: decimal.Zero}
+		}, invoice.ErrFX},
+		{"draft with payments", func(i *invoice.Invoice) {
+			i.Payments = []invoice.Payment{payment("p1", "10.00")}
+		}, invoice.ErrHasPayments},
+		{"no lines", func(i *invoice.Invoice) { i.Lines = nil }, invoice.ErrNoLines},
+		{"lines vs document currency", func(i *invoice.Invoice) { i.Currency = money.USD }, money.ErrCurrencyMismatch},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			inv := draft(t)
+			at := issueTime
+			if tt.mutate == nil {
+				at = time.Time{}
+			} else {
+				tt.mutate(inv)
+			}
+			err := inv.Issue(t.Context(), newSequence(t), at)
+			assert.ErrorIs(t, err, tt.want)
+			assert.Equal(t, invoice.StatusDraft, inv.Status, "failed issue must not move the document")
+		})
+	}
+}
+
+func TestIssue_WithFXSnapshot(t *testing.T) {
+	t.Parallel()
+
+	inv := draft(t)
+	inv.FX = &invoice.FXSnapshot{Base: money.USD, Rate: decimal.MustParse("1.0842"), At: issueTime}
+	require.NoError(t, inv.Issue(t.Context(), newSequence(t), issueTime))
+	assert.Equal(t, "1.0842", inv.FX.Rate.String())
+}
+
+func TestApplyPayment(t *testing.T) {
+	t.Parallel()
+
+	t.Run("partial then full", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "19.00")))
+		assert.Equal(t, invoice.StatusPartiallyPaid, inv.Status)
+
+		out, err := inv.Outstanding()
+		require.NoError(t, err)
+		assertMoney(t, "100.00", out)
+
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:2", "100.00")))
+		assert.Equal(t, invoice.StatusPaid, inv.Status)
+
+		paid, err := inv.Paid()
+		require.NoError(t, err)
+		assertMoney(t, "119.00", paid)
+	})
+	t.Run("exact single payment pays in full", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "119.00")))
+		assert.Equal(t, invoice.StatusPaid, inv.Status)
+	})
+	t.Run("replay with same amount is a no-op", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "19.00")))
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "19.00")))
+		assert.Len(t, inv.Payments, 1)
+		assert.Equal(t, invoice.StatusPartiallyPaid, inv.Status)
+	})
+	t.Run("replay with different amount conflicts", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "19.00")))
+		err := inv.ApplyPayment(t.Context(), payment("ledger:1", "20.00"))
+		assert.ErrorIs(t, err, invoice.ErrPaymentConflict)
+	})
+	t.Run("overpayment records nothing", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		err := inv.ApplyPayment(t.Context(), payment("ledger:1", "119.01"))
+		assert.ErrorIs(t, err, invoice.ErrOverpayment)
+		assert.Empty(t, inv.Payments)
+		assert.Equal(t, invoice.StatusIssued, inv.Status)
+	})
+	t.Run("empty ref", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		assert.ErrorIs(t, inv.ApplyPayment(t.Context(), payment("", "10.00")), invoice.ErrPaymentRef)
+	})
+	t.Run("non-positive amount", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		assert.ErrorIs(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "0")), invoice.ErrPaymentAmount)
+		assert.ErrorIs(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "-5.00")), invoice.ErrPaymentAmount)
+	})
+	t.Run("currency mismatch", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		p := invoice.Payment{Ref: "ledger:1", Amount: money.FromMinor(1000, money.USD)}
+		assert.ErrorIs(t, inv.ApplyPayment(t.Context(), p), money.ErrCurrencyMismatch)
+	})
+	t.Run("paying a draft is illegal", func(t *testing.T) {
+		t.Parallel()
+		inv := draft(t)
+		inv.Totals.Total = money.FromMinor(11900, money.EUR)
+		err := inv.ApplyPayment(t.Context(), payment("ledger:1", "10.00"))
+		assert.ErrorIs(t, err, fsm.ErrIllegalTransition)
+	})
+	t.Run("paying a paid document overpays", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "119.00")))
+		err := inv.ApplyPayment(t.Context(), payment("ledger:2", "1.00"))
+		assert.ErrorIs(t, err, invoice.ErrOverpayment)
+	})
+	t.Run("paying a void document is illegal", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.Void(t.Context(), issueTime))
+		err := inv.ApplyPayment(t.Context(), payment("ledger:1", "10.00"))
+		assert.ErrorIs(t, err, fsm.ErrIllegalTransition)
+	})
+}
+
+func TestMarkOverdue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("past due", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.MarkOverdue(t.Context(), dueTime.Add(time.Hour)))
+		assert.Equal(t, invoice.StatusOverdue, inv.Status)
+
+		// An overdue document still collects payments.
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "119.00")))
+		assert.Equal(t, invoice.StatusPaid, inv.Status)
+	})
+	t.Run("partially paid goes overdue and back", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "19.00")))
+		require.NoError(t, inv.MarkOverdue(t.Context(), dueTime.Add(time.Hour)))
+		assert.Equal(t, invoice.StatusOverdue, inv.Status)
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:2", "50.00")))
+		assert.Equal(t, invoice.StatusPartiallyPaid, inv.Status)
+	})
+	t.Run("before due date", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		assert.ErrorIs(t, inv.MarkOverdue(t.Context(), dueTime), invoice.ErrNotDue)
+	})
+	t.Run("no due date", func(t *testing.T) {
+		t.Parallel()
+		inv := draft(t)
+		inv.DueAt = time.Time{}
+		require.NoError(t, inv.Issue(t.Context(), newSequence(t), issueTime))
+		assert.ErrorIs(t, inv.MarkOverdue(t.Context(), issueTime.AddDate(1, 0, 0)), invoice.ErrNoDueDate)
+	})
+	t.Run("draft cannot go overdue", func(t *testing.T) {
+		t.Parallel()
+		inv := draft(t)
+		assert.ErrorIs(t, inv.MarkOverdue(t.Context(), dueTime.Add(time.Hour)), fsm.ErrIllegalTransition)
+	})
+}
+
+func TestVoid(t *testing.T) {
+	t.Parallel()
+
+	t.Run("draft", func(t *testing.T) {
+		t.Parallel()
+		inv := draft(t)
+		require.NoError(t, inv.Void(t.Context(), issueTime))
+		assert.Equal(t, invoice.StatusVoid, inv.Status)
+		assert.Equal(t, issueTime, inv.VoidedAt)
+	})
+	t.Run("issued without payments", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.Void(t.Context(), issueTime.Add(time.Hour)))
+		assert.Equal(t, invoice.StatusVoid, inv.Status)
+	})
+	t.Run("overdue without payments", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.MarkOverdue(t.Context(), dueTime.Add(time.Hour)))
+		require.NoError(t, inv.Void(t.Context(), dueTime.Add(2*time.Hour)))
+	})
+	t.Run("with payments the guard denies", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "19.00")))
+		err := inv.Void(t.Context(), dueTime)
+		assert.ErrorIs(t, err, fsm.ErrIllegalTransition) // no partially_paid → void edge at all
+	})
+	t.Run("overdue with payments the guard denies", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "19.00")))
+		require.NoError(t, inv.MarkOverdue(t.Context(), dueTime.Add(time.Hour)))
+		err := inv.Void(t.Context(), dueTime)
+		assert.ErrorIs(t, err, fsm.ErrGuardDenied)
+		assert.ErrorIs(t, err, invoice.ErrHasPayments)
+	})
+	t.Run("paid cannot be voided", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "119.00")))
+		assert.ErrorIs(t, inv.Void(t.Context(), dueTime), fsm.ErrIllegalTransition)
+	})
+}
+
+func TestNewCreditNote(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full credit", func(t *testing.T) {
+		t.Parallel()
+		orig := issued(t)
+		note, err := invoice.NewCreditNote(orig, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, invoice.KindCreditNote, note.Kind)
+		assert.Equal(t, invoice.StatusDraft, note.Status)
+		assert.Equal(t, orig.Number, note.Corrects)
+		assert.Equal(t, orig.Series, note.Series)
+		assert.Nil(t, note.FX, "fx snapshot is jurisdictional, never inherited")
+
+		// Copied lines are independent of the original document.
+		note.Lines[0].Description = "mutated"
+		assert.Equal(t, "test line", orig.Lines[0].Description)
+
+		require.NoError(t, note.Issue(t.Context(), newSequence(t), issueTime.AddDate(0, 0, 30)))
+		assert.Equal(t, invoice.StatusIssued, note.Status)
+		assertMoney(t, "119.00", note.Totals.Total)
+	})
+	t.Run("partial credit", func(t *testing.T) {
+		t.Parallel()
+		orig := issued(t)
+		note, err := invoice.NewCreditNote(orig, []invoice.LineItem{line(t, "1", "40.00", "0.19", money.EUR)})
+		require.NoError(t, err)
+		require.NoError(t, note.Issue(t.Context(), newSequence(t), issueTime.AddDate(0, 0, 30)))
+		assertMoney(t, "47.60", note.Totals.Total)
+	})
+	t.Run("credit of a paid original", func(t *testing.T) {
+		t.Parallel()
+		orig := issued(t)
+		require.NoError(t, orig.ApplyPayment(t.Context(), payment("ledger:1", "119.00")))
+		_, err := invoice.NewCreditNote(orig, nil)
+		assert.NoError(t, err)
+	})
+	t.Run("exceeding the original", func(t *testing.T) {
+		t.Parallel()
+		orig := issued(t)
+		_, err := invoice.NewCreditNote(orig, []invoice.LineItem{line(t, "1", "200.00", "0.19", money.EUR)})
+		assert.ErrorIs(t, err, invoice.ErrCreditExceeds)
+	})
+	t.Run("draft original", func(t *testing.T) {
+		t.Parallel()
+		_, err := invoice.NewCreditNote(draft(t), nil)
+		assert.ErrorIs(t, err, invoice.ErrNotCreditable)
+	})
+	t.Run("void original", func(t *testing.T) {
+		t.Parallel()
+		orig := issued(t)
+		require.NoError(t, orig.Void(t.Context(), issueTime))
+		_, err := invoice.NewCreditNote(orig, nil)
+		assert.ErrorIs(t, err, invoice.ErrNotCreditable)
+	})
+	t.Run("credit note original", func(t *testing.T) {
+		t.Parallel()
+		orig := issued(t)
+		note, err := invoice.NewCreditNote(orig, nil)
+		require.NoError(t, err)
+		require.NoError(t, note.Issue(t.Context(), newSequence(t), issueTime.AddDate(0, 0, 30)))
+		_, err = invoice.NewCreditNote(note, nil)
+		assert.ErrorIs(t, err, invoice.ErrNotCreditable)
+	})
+	t.Run("nil original", func(t *testing.T) {
+		t.Parallel()
+		_, err := invoice.NewCreditNote(nil, nil)
+		assert.ErrorIs(t, err, invoice.ErrNotCreditable)
+	})
+	t.Run("currency mismatch", func(t *testing.T) {
+		t.Parallel()
+		orig := issued(t)
+		_, err := invoice.NewCreditNote(orig, []invoice.LineItem{line(t, "1", "10.00", "0.19", money.USD)})
+		assert.ErrorIs(t, err, money.ErrCurrencyMismatch)
+	})
+}
+
+func TestVerify(t *testing.T) {
+	t.Parallel()
+
+	t.Run("clean document verifies", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, issued(t).Verify())
+	})
+	t.Run("tampered line", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		inv.Lines[0].UnitPrice = money.FromMinor(9999, money.EUR)
+		assert.ErrorIs(t, inv.Verify(), invoice.ErrTotalsMismatch)
+	})
+	t.Run("tampered totals", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		inv.Totals.Total = money.FromMinor(1, money.EUR)
+		assert.ErrorIs(t, inv.Verify(), invoice.ErrTotalsMismatch)
+	})
+	t.Run("tampered tax line", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		inv.Totals.TaxLines[0].Amount = money.FromMinor(1, money.EUR)
+		assert.ErrorIs(t, inv.Verify(), invoice.ErrTotalsMismatch)
+	})
+}
+
+func TestSelfBilledDirection(t *testing.T) {
+	t.Parallel()
+
+	inv := draft(t)
+	inv.Direction = invoice.DirectionSelfBilled
+	inv.Issuer = invoice.Party{Name: "Platform Inc"}     // platform issues...
+	inv.Recipient = invoice.Party{Name: "Affiliate LLC"} // ...on the supplier's behalf
+	require.NoError(t, inv.Issue(t.Context(), newSequence(t), issueTime))
+	assert.Equal(t, invoice.DirectionSelfBilled, inv.Direction)
+}

--- a/finance/invoice/invoice_test.go
+++ b/finance/invoice/invoice_test.go
@@ -30,8 +30,8 @@ func newSequence(t *testing.T, opts ...invoice.Option) *invoice.Sequence {
 func draft(t *testing.T) *invoice.Invoice {
 	t.Helper()
 	inv := invoice.New("INV-2026", money.EUR)
-	inv.Issuer = invoice.Party{Name: "Forge GmbH", TaxID: "DE123456789"}
-	inv.Recipient = invoice.Party{Name: "ACME Ltd"}
+	inv.Issuer = invoice.Party{Name: "Forge GmbH", TaxID: "DE123456789", Address: []string{"Foundry Lane 1"}}
+	inv.Recipient = invoice.Party{Name: "ACME Ltd", Address: []string{"Acme Plaza 9"}}
 	inv.Lines = []invoice.LineItem{line(t, "1", "100.00", "0.19", money.EUR)}
 	inv.DueAt = dueTime
 	return inv
@@ -151,7 +151,7 @@ func TestIssue_Validation(t *testing.T) {
 		mutate func(*invoice.Invoice)
 		want   error
 	}{
-		{"zero issue time is ErrIssueTime", nil, invoice.ErrIssueTime},
+		{"zero issue time is ErrZeroTime", nil, invoice.ErrZeroTime},
 		{"unknown kind", func(i *invoice.Invoice) { i.Kind = "receipt" }, invoice.ErrKind},
 		{"unknown direction", func(i *invoice.Invoice) { i.Direction = "sideways" }, invoice.ErrDirection},
 		{"invoice with corrects ref", func(i *invoice.Invoice) { i.Corrects = "INV-1" }, invoice.ErrCorrects},
@@ -267,6 +267,19 @@ func TestApplyPayment(t *testing.T) {
 		assert.ErrorIs(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "0")), invoice.ErrPaymentAmount)
 		assert.ErrorIs(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "-5.00")), invoice.ErrPaymentAmount)
 	})
+	t.Run("sub-minor-unit amount is rejected", func(t *testing.T) {
+		t.Parallel()
+		// Three 33.333 installments would sum to 99.999 against a rounded
+		// total and strand the document in partially_paid forever.
+		inv := issued(t)
+		err := inv.ApplyPayment(t.Context(), payment("ledger:1", "33.333"))
+		assert.ErrorIs(t, err, invoice.ErrPaymentAmount)
+		assert.Empty(t, inv.Payments)
+
+		// A scale-heavy but minor-unit-exact amount is fine.
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:2", "33.330")))
+		assert.Equal(t, invoice.StatusPartiallyPaid, inv.Status)
+	})
 	t.Run("currency mismatch", func(t *testing.T) {
 		t.Parallel()
 		inv := issued(t)
@@ -276,16 +289,23 @@ func TestApplyPayment(t *testing.T) {
 	t.Run("paying a draft is illegal", func(t *testing.T) {
 		t.Parallel()
 		inv := draft(t)
-		inv.Totals.Total = money.FromMinor(11900, money.EUR)
 		err := inv.ApplyPayment(t.Context(), payment("ledger:1", "10.00"))
 		assert.ErrorIs(t, err, fsm.ErrIllegalTransition)
 	})
-	t.Run("paying a paid document overpays", func(t *testing.T) {
+	t.Run("paying a paid document is illegal", func(t *testing.T) {
 		t.Parallel()
 		inv := issued(t)
 		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "119.00")))
 		err := inv.ApplyPayment(t.Context(), payment("ledger:2", "1.00"))
-		assert.ErrorIs(t, err, invoice.ErrOverpayment)
+		assert.ErrorIs(t, err, fsm.ErrIllegalTransition)
+	})
+	t.Run("replay on a paid document stays idempotent", func(t *testing.T) {
+		t.Parallel()
+		inv := issued(t)
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "119.00")))
+		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "119.00")))
+		assert.Len(t, inv.Payments, 1)
+		assert.Equal(t, invoice.StatusPaid, inv.Status)
 	})
 	t.Run("paying a void document is illegal", func(t *testing.T) {
 		t.Parallel()
@@ -330,6 +350,15 @@ func TestMarkOverdue(t *testing.T) {
 		require.NoError(t, inv.Issue(t.Context(), newSequence(t), issueTime))
 		assert.ErrorIs(t, inv.MarkOverdue(t.Context(), issueTime.AddDate(1, 0, 0)), invoice.ErrNoDueDate)
 	})
+	t.Run("already overdue cannot be re-marked", func(t *testing.T) {
+		t.Parallel()
+		// The caller's sweep selects by status; a naive re-sweep gets a
+		// clean illegal-transition error, not silent success.
+		inv := issued(t)
+		require.NoError(t, inv.MarkOverdue(t.Context(), dueTime.Add(time.Hour)))
+		err := inv.MarkOverdue(t.Context(), dueTime.Add(2*time.Hour))
+		assert.ErrorIs(t, err, fsm.ErrIllegalTransition)
+	})
 	t.Run("draft cannot go overdue", func(t *testing.T) {
 		t.Parallel()
 		inv := draft(t)
@@ -346,6 +375,12 @@ func TestVoid(t *testing.T) {
 		require.NoError(t, inv.Void(t.Context(), issueTime))
 		assert.Equal(t, invoice.StatusVoid, inv.Status)
 		assert.Equal(t, issueTime, inv.VoidedAt)
+	})
+	t.Run("zero timestamp", func(t *testing.T) {
+		t.Parallel()
+		inv := draft(t)
+		assert.ErrorIs(t, inv.Void(t.Context(), time.Time{}), invoice.ErrZeroTime)
+		assert.Equal(t, invoice.StatusDraft, inv.Status)
 	})
 	t.Run("issued without payments", func(t *testing.T) {
 		t.Parallel()
@@ -364,7 +399,8 @@ func TestVoid(t *testing.T) {
 		inv := issued(t)
 		require.NoError(t, inv.ApplyPayment(t.Context(), payment("ledger:1", "19.00")))
 		err := inv.Void(t.Context(), dueTime)
-		assert.ErrorIs(t, err, fsm.ErrIllegalTransition) // no partially_paid → void edge at all
+		assert.ErrorIs(t, err, fsm.ErrGuardDenied)
+		assert.ErrorIs(t, err, invoice.ErrHasPayments)
 	})
 	t.Run("overdue with payments the guard denies", func(t *testing.T) {
 		t.Parallel()
@@ -401,6 +437,13 @@ func TestNewCreditNote(t *testing.T) {
 		// Copied lines are independent of the original document.
 		note.Lines[0].Description = "mutated"
 		assert.Equal(t, "test line", orig.Lines[0].Description)
+
+		// Party address slices are cloned too: editing the draft note must
+		// never reach into the issued, immutable original.
+		note.Issuer.Address[0] = "mutated"
+		note.Recipient.Address[0] = "mutated"
+		assert.Equal(t, "Foundry Lane 1", orig.Issuer.Address[0])
+		assert.Equal(t, "Acme Plaza 9", orig.Recipient.Address[0])
 
 		require.NoError(t, note.Issue(t.Context(), newSequence(t), issueTime.AddDate(0, 0, 30)))
 		assert.Equal(t, invoice.StatusIssued, note.Status)

--- a/finance/invoice/options.go
+++ b/finance/invoice/options.go
@@ -1,0 +1,36 @@
+package invoice
+
+import "context"
+
+type sequenceConfig struct {
+	scope  func(context.Context) (string, error)
+	format func(series string, n int64) string
+	mode   NumberingMode
+}
+
+// Option configures NewSequence.
+type Option func(*sequenceConfig)
+
+// WithMode sets the numbering mode. Default Gapless.
+func WithMode(m NumberingMode) Option {
+	return func(c *sequenceConfig) { c.mode = m }
+}
+
+// WithFormat sets the display format applied to a drawn counter value, e.g.
+// yearly series "INV-2026" with the default format render "INV-2026-000042".
+// The formatter receives the caller-visible series, never the tenant-scoped
+// storage key. Default "SERIES-000042".
+func WithFormat(fn func(series string, n int64) string) Option {
+	return func(c *sequenceConfig) { c.format = fn }
+}
+
+// WithScope derives a tenant scope from the request context on every number
+// draw, so multi-tenant isolation is wired once at construction instead of at
+// every call site: each tenant gets independent per-series counters while
+// formatted numbers stay tenant-clean. The hook fails closed: an error or
+// empty scope aborts the draw with ErrScope — one tenant's series can never
+// increment another tenant's (or a global) counter. Single-tenant
+// applications omit this option.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *sequenceConfig) { c.scope = fn }
+}

--- a/finance/invoice/sequence.go
+++ b/finance/invoice/sequence.go
@@ -1,0 +1,131 @@
+package invoice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+// NumberingMode declares the jurisdictional numbering requirement of a
+// series. The mode is a construction-time contract that changes when numbers
+// may be drawn, not just documentation.
+type NumberingMode int
+
+const (
+	// Gapless is the strict transactional mode: numbers are drawn only
+	// inside Issue, never pre-assigned and never via Sequence.Next, and the
+	// store's counter increment is expected to ride the same transaction
+	// that persists the issued document (the store implementation reads the
+	// transaction from ctx), so a failed issuance rolls the number back and
+	// the series stays gapless. Required by many EU jurisdictions.
+	Gapless NumberingMode = iota
+	// WithGaps is the monotonic mode: numbers may be pre-drawn via
+	// Sequence.Next (number previews, async issuance) or pre-assigned on the
+	// draft, and a failed issuance burns the number. Sufficient wherever
+	// only uniqueness and monotonicity are required.
+	WithGaps
+)
+
+// SequenceStore is the persistence seam for per-series counters.
+// Implementations backing a Gapless sequence must perform the increment
+// inside the caller's persistence transaction carried in ctx.
+type SequenceStore interface {
+	// Next atomically increments the counter for series and returns the new
+	// value, starting at 1 for an unseen series.
+	Next(ctx context.Context, series string) (int64, error)
+}
+
+// Sequence draws document numbers from a per-series counter behind a
+// SequenceStore, formats them for display, and optionally namespaces series
+// per tenant via a scope hook.
+type Sequence struct {
+	store SequenceStore
+	cfg   sequenceConfig
+}
+
+// NewSequence builds a Sequence over store. The default mode is Gapless (the
+// strict jurisdictions' requirement — opting into gaps is the explicit
+// choice), the default format is "SERIES-000042".
+func NewSequence(store SequenceStore, opts ...Option) (*Sequence, error) {
+	if store == nil {
+		return nil, errors.New("invoice: nil sequence store")
+	}
+	cfg := sequenceConfig{mode: Gapless, format: defaultFormat}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.mode != Gapless && cfg.mode != WithGaps {
+		return nil, fmt.Errorf("invoice: unknown numbering mode %d", cfg.mode)
+	}
+	if cfg.format == nil {
+		return nil, errors.New("invoice: nil number format")
+	}
+	return &Sequence{store: store, cfg: cfg}, nil
+}
+
+// Mode returns the sequence's declared numbering mode.
+func (s *Sequence) Mode() NumberingMode { return s.cfg.mode }
+
+// Next pre-draws the next formatted number for series. It is only available
+// in WithGaps mode; a Gapless sequence returns ErrGapless because gapless
+// numbers exist only from the moment a document is issued.
+func (s *Sequence) Next(ctx context.Context, series string) (string, error) {
+	if s.cfg.mode == Gapless {
+		return "", ErrGapless
+	}
+	return s.next(ctx, series)
+}
+
+// next draws and formats the next number, applying the tenant scope to the
+// stored counter key while formatting with the caller-visible series.
+func (s *Sequence) next(ctx context.Context, series string) (string, error) {
+	key := series
+	if s.cfg.scope != nil {
+		scope, err := s.cfg.scope(ctx)
+		if err != nil {
+			return "", fmt.Errorf("%w: %w", ErrScope, err)
+		}
+		if scope == "" {
+			return "", ErrScope
+		}
+		// Length-prefix the scope so (scope, series) pairs can never
+		// collide, whatever characters they contain.
+		key = strconv.Itoa(len(scope)) + ":" + scope + ":" + series
+	}
+	n, err := s.store.Next(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	return s.cfg.format(series, n), nil
+}
+
+func defaultFormat(series string, n int64) string {
+	return fmt.Sprintf("%s-%06d", series, n)
+}
+
+// MemorySequenceStore is the in-memory SequenceStore for tests and
+// development. It cannot participate in a caller's transaction, so a Gapless
+// sequence over it is gapless only as long as every drawn number is
+// persisted; production gapless series need a transactional store.
+type MemorySequenceStore struct {
+	counters map[string]int64
+	mu       sync.Mutex
+}
+
+// NewMemorySequenceStore returns an empty in-memory counter store.
+func NewMemorySequenceStore() *MemorySequenceStore {
+	return &MemorySequenceStore{counters: make(map[string]int64)}
+}
+
+// Next implements SequenceStore.
+func (m *MemorySequenceStore) Next(ctx context.Context, series string) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.counters[series]++
+	return m.counters[series], nil
+}

--- a/finance/invoice/sequence_test.go
+++ b/finance/invoice/sequence_test.go
@@ -1,0 +1,187 @@
+package invoice_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/finance/invoice"
+)
+
+func TestNewSequence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil store", func(t *testing.T) {
+		t.Parallel()
+		_, err := invoice.NewSequence(nil)
+		assert.Error(t, err)
+	})
+	t.Run("unknown mode", func(t *testing.T) {
+		t.Parallel()
+		_, err := invoice.NewSequence(invoice.NewMemorySequenceStore(), invoice.WithMode(invoice.NumberingMode(7)))
+		assert.Error(t, err)
+	})
+	t.Run("nil format", func(t *testing.T) {
+		t.Parallel()
+		_, err := invoice.NewSequence(invoice.NewMemorySequenceStore(), invoice.WithFormat(nil))
+		assert.Error(t, err)
+	})
+	t.Run("default mode is gapless", func(t *testing.T) {
+		t.Parallel()
+		seq, err := invoice.NewSequence(invoice.NewMemorySequenceStore())
+		require.NoError(t, err)
+		assert.Equal(t, invoice.Gapless, seq.Mode())
+	})
+}
+
+func TestSequence_Next(t *testing.T) {
+	t.Parallel()
+
+	t.Run("gapless refuses pre-draw", func(t *testing.T) {
+		t.Parallel()
+		seq := newSequence(t)
+		_, err := seq.Next(t.Context(), "INV-2026")
+		assert.ErrorIs(t, err, invoice.ErrGapless)
+	})
+	t.Run("series count independently", func(t *testing.T) {
+		t.Parallel()
+		seq := newSequence(t, invoice.WithMode(invoice.WithGaps))
+		for _, want := range []string{"INV-2026-000001", "INV-2026-000002"} {
+			n, err := seq.Next(t.Context(), "INV-2026")
+			require.NoError(t, err)
+			assert.Equal(t, want, n)
+		}
+		n, err := seq.Next(t.Context(), "CN-2026")
+		require.NoError(t, err)
+		assert.Equal(t, "CN-2026-000001", n)
+	})
+	t.Run("custom format", func(t *testing.T) {
+		t.Parallel()
+		seq := newSequence(t,
+			invoice.WithMode(invoice.WithGaps),
+			invoice.WithFormat(func(series string, n int64) string {
+				return fmt.Sprintf("%s/%03d", series, n)
+			}),
+		)
+		n, err := seq.Next(t.Context(), "INV")
+		require.NoError(t, err)
+		assert.Equal(t, "INV/001", n)
+	})
+	t.Run("cancelled context", func(t *testing.T) {
+		t.Parallel()
+		seq := newSequence(t, invoice.WithMode(invoice.WithGaps))
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := seq.Next(ctx, "INV")
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestSequence_ConcurrentDrawsAreUnique(t *testing.T) {
+	t.Parallel()
+
+	seq := newSequence(t, invoice.WithMode(invoice.WithGaps))
+	const workers, draws = 8, 50
+
+	var mu sync.Mutex
+	seen := make(map[string]bool, workers*draws)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			for range draws {
+				n, err := seq.Next(context.Background(), "INV")
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				mu.Lock()
+				if seen[n] {
+					t.Errorf("duplicate number %s", n)
+				}
+				seen[n] = true
+				mu.Unlock()
+			}
+		})
+	}
+	wg.Wait()
+	assert.Len(t, seen, workers*draws)
+}
+
+type failingScopeErr struct{}
+
+func (failingScopeErr) Error() string { return "no tenant in context" }
+
+func TestSequence_Tenancy(t *testing.T) {
+	t.Parallel()
+
+	type tenantKey struct{}
+	scopeFromCtx := func(ctx context.Context) (string, error) {
+		s, _ := ctx.Value(tenantKey{}).(string)
+		if s == "" {
+			return "", failingScopeErr{}
+		}
+		return s, nil
+	}
+	tenantCtx := func(id string) context.Context {
+		return context.WithValue(context.Background(), tenantKey{}, id)
+	}
+
+	t.Run("tenants count independently with clean numbers", func(t *testing.T) {
+		t.Parallel()
+		seq := newSequence(t, invoice.WithMode(invoice.WithGaps), invoice.WithScope(scopeFromCtx))
+
+		a1, err := seq.Next(tenantCtx("tenant-a"), "INV")
+		require.NoError(t, err)
+		a2, err := seq.Next(tenantCtx("tenant-a"), "INV")
+		require.NoError(t, err)
+		b1, err := seq.Next(tenantCtx("tenant-b"), "INV")
+		require.NoError(t, err)
+
+		assert.Equal(t, "INV-000001", a1)
+		assert.Equal(t, "INV-000002", a2)
+		assert.Equal(t, "INV-000001", b1, "tenant B starts its own count; numbers never leak the scope")
+	})
+	t.Run("missing scope fails closed", func(t *testing.T) {
+		t.Parallel()
+		seq := newSequence(t, invoice.WithMode(invoice.WithGaps), invoice.WithScope(scopeFromCtx))
+		_, err := seq.Next(context.Background(), "INV")
+		assert.ErrorIs(t, err, invoice.ErrScope)
+		var cause failingScopeErr
+		assert.True(t, errors.As(err, &cause), "hook error is preserved in the chain")
+	})
+	t.Run("empty scope fails closed", func(t *testing.T) {
+		t.Parallel()
+		seq := newSequence(t, invoice.WithMode(invoice.WithGaps),
+			invoice.WithScope(func(context.Context) (string, error) { return "", nil }))
+		_, err := seq.Next(context.Background(), "INV")
+		assert.ErrorIs(t, err, invoice.ErrScope)
+	})
+	t.Run("scope and series can never collide", func(t *testing.T) {
+		t.Parallel()
+		// ("a", "b:c") vs ("a:b", "c"): naive concatenation would merge
+		// these counters; the length-prefixed key must not.
+		seq := newSequence(t, invoice.WithMode(invoice.WithGaps), invoice.WithScope(scopeFromCtx))
+		n1, err := seq.Next(tenantCtx("a"), "b:c")
+		require.NoError(t, err)
+		n2, err := seq.Next(tenantCtx("a:b"), "c")
+		require.NoError(t, err)
+		assert.Equal(t, "b:c-000001", n1)
+		assert.Equal(t, "c-000001", n2, "second pair must start at 1, not continue the first")
+	})
+	t.Run("scoped issue fails closed too", func(t *testing.T) {
+		t.Parallel()
+		seq := newSequence(t, invoice.WithScope(scopeFromCtx))
+		inv := draft(t)
+		err := inv.Issue(context.Background(), seq, issueTime)
+		assert.ErrorIs(t, err, invoice.ErrScope)
+		assert.Equal(t, invoice.StatusDraft, inv.Status)
+
+		require.NoError(t, inv.Issue(tenantCtx("tenant-a"), seq, issueTime))
+		assert.Equal(t, "INV-2026-000001", inv.Number)
+	})
+}

--- a/finance/invoice/status.go
+++ b/finance/invoice/status.go
@@ -69,6 +69,10 @@ var lifecycle = fsm.MustNew(StatusDraft,
 	def.Edge(StatusOverdue, StatusVoid, def.Guard(noPayments)),
 	def.Edge(StatusPartiallyPaid, StatusPaid),
 	def.Edge(StatusPartiallyPaid, StatusOverdue),
+	// The guard always denies here (partially paid implies payments); the
+	// edge exists so every void-with-payments path uniformly reports
+	// fsm.ErrGuardDenied wrapping ErrHasPayments.
+	def.Edge(StatusPartiallyPaid, StatusVoid, def.Guard(noPayments)),
 )
 
 func noPayments(_ context.Context, inv *Invoice, _, _ Status) error {

--- a/finance/invoice/status.go
+++ b/finance/invoice/status.go
@@ -69,10 +69,11 @@ var lifecycle = fsm.MustNew(StatusDraft,
 	def.Edge(StatusOverdue, StatusVoid, def.Guard(noPayments)),
 	def.Edge(StatusPartiallyPaid, StatusPaid),
 	def.Edge(StatusPartiallyPaid, StatusOverdue),
-	// The guard always denies here (partially paid implies payments); the
-	// edge exists so every void-with-payments path uniformly reports
+	// The guard always denies on these two (their statuses imply payments);
+	// the edges exist so every void-with-payments path uniformly reports
 	// fsm.ErrGuardDenied wrapping ErrHasPayments.
 	def.Edge(StatusPartiallyPaid, StatusVoid, def.Guard(noPayments)),
+	def.Edge(StatusPaid, StatusVoid, def.Guard(noPayments)),
 )
 
 func noPayments(_ context.Context, inv *Invoice, _, _ Status) error {

--- a/finance/invoice/status.go
+++ b/finance/invoice/status.go
@@ -1,0 +1,79 @@
+package invoice
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/core/fsm"
+)
+
+// Status is the document lifecycle state. It lives in the caller's storage
+// (a status column) and is moved exclusively by the package operations, which
+// fire the package lifecycle machine; an illegal move surfaces the fsm
+// package's sentinel errors (fsm.ErrIllegalTransition, fsm.ErrGuardDenied).
+type Status string
+
+const (
+	// StatusDraft is a mutable, unnumbered work-in-progress document.
+	StatusDraft Status = "draft"
+	// StatusIssued is a numbered, immutable document awaiting payment.
+	StatusIssued Status = "issued"
+	// StatusPartiallyPaid is an issued document with payments below total.
+	StatusPartiallyPaid Status = "partially_paid"
+	// StatusPaid is an issued document whose payments match the total.
+	StatusPaid Status = "paid"
+	// StatusOverdue is an unpaid or partially paid document past its due date.
+	StatusOverdue Status = "overdue"
+	// StatusVoid is a cancelled document. Only documents without payments can
+	// be voided; corrections to paid documents are credit notes.
+	StatusVoid Status = "void"
+)
+
+// Kind distinguishes standard invoices from credit notes.
+type Kind string
+
+const (
+	// KindInvoice is a standard invoice.
+	KindInvoice Kind = "invoice"
+	// KindCreditNote is a correction document back-referencing the invoice it
+	// corrects via Corrects (corrections post forward; issued documents are
+	// never edited).
+	KindCreditNote Kind = "credit_note"
+)
+
+// Direction records who issues the document.
+type Direction string
+
+const (
+	// DirectionStandard is the normal direction: the supplier issues to the
+	// customer.
+	DirectionStandard Direction = "standard"
+	// DirectionSelfBilled marks a self-billing invoice: the platform issues
+	// on the supplier's behalf (affiliate and agent payouts).
+	DirectionSelfBilled Direction = "self_billed"
+)
+
+var def fsm.Define[Status, *Invoice]
+
+// lifecycle is the compiled document state machine. Voiding is guarded: a
+// document that recorded payments can only be corrected forward with a credit
+// note, never voided.
+var lifecycle = fsm.MustNew(StatusDraft,
+	def.Edge(StatusDraft, StatusIssued),
+	def.Edge(StatusDraft, StatusVoid),
+	def.Edge(StatusIssued, StatusPartiallyPaid),
+	def.Edge(StatusIssued, StatusPaid),
+	def.Edge(StatusIssued, StatusOverdue),
+	def.Edge(StatusIssued, StatusVoid, def.Guard(noPayments)),
+	def.Edge(StatusOverdue, StatusPartiallyPaid),
+	def.Edge(StatusOverdue, StatusPaid),
+	def.Edge(StatusOverdue, StatusVoid, def.Guard(noPayments)),
+	def.Edge(StatusPartiallyPaid, StatusPaid),
+	def.Edge(StatusPartiallyPaid, StatusOverdue),
+)
+
+func noPayments(_ context.Context, inv *Invoice, _, _ Status) error {
+	if len(inv.Payments) > 0 {
+		return ErrHasPayments
+	}
+	return nil
+}

--- a/finance/invoice/totals.go
+++ b/finance/invoice/totals.go
@@ -1,0 +1,236 @@
+package invoice
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/core/money"
+)
+
+// RoundingPolicy selects where rounding to the currency's minor units
+// happens when totals are computed. The requirement is jurisdictional; both
+// policies use banker's rounding (decimal.HalfEven), the money package's
+// settlement default.
+type RoundingPolicy int
+
+const (
+	// RoundPerLine rounds each line net and each line's tax individually;
+	// totals are exact sums of the rounded parts. This is the default and
+	// the common retail/US sales-tax convention.
+	RoundPerLine RoundingPolicy = iota
+	// RoundPerTotal keeps line math exact, rounds the subtotal and each
+	// per-rate tax base once at the document level, and allocates the
+	// rounded subtotal back across lines penny-perfect via money.Allocate
+	// (largest-remainder), so displayed line nets always sum exactly to the
+	// subtotal. This is the common EU VAT convention.
+	RoundPerTotal
+)
+
+// LineItem is one invoice line. Quantity must be positive, UnitPrice
+// non-negative, and TaxRate a non-negative fraction (0.20 for 20%). Tax
+// rates are caller-supplied data; the package never determines them.
+type LineItem struct {
+	// Description labels the line. It is inert data, never validated.
+	Description string
+	// Quantity multiplies UnitPrice; fractional quantities (1.5 h) are exact
+	// decimals.
+	Quantity decimal.Decimal
+	// UnitPrice is the per-unit net price. Its currency fixes the line
+	// currency; all lines of a document must share one currency.
+	UnitPrice money.Money
+	// TaxRate is the tax fraction applied to the line net.
+	TaxRate decimal.Decimal
+}
+
+// TaxLine is the per-rate tax summary: every distinct TaxRate across the
+// lines produces one TaxLine, zero-rated bases included. TaxLines are sorted
+// by ascending rate.
+type TaxLine struct {
+	Rate   decimal.Decimal
+	Base   money.Money
+	Amount money.Money
+}
+
+// Totals is the computed money summary of a document. All values are rounded
+// to the currency's minor units; Subtotal + Tax = Total exactly, and
+// LineNets sum exactly to Subtotal.
+type Totals struct {
+	// Subtotal is the net total before tax.
+	Subtotal money.Money
+	// TaxLines groups tax by rate, ascending. Under RoundPerTotal the
+	// per-rate bases are rounded independently and may differ from Subtotal
+	// by a minor unit in aggregate; the tax amounts, not the bases, are the
+	// settlement values.
+	TaxLines []TaxLine
+	// Tax is the sum of all TaxLines amounts.
+	Tax money.Money
+	// Total is Subtotal + Tax.
+	Total money.Money
+	// LineNets holds the rounded net per line, index-aligned with the input
+	// lines, always summing exactly to Subtotal (allocated under
+	// RoundPerTotal).
+	LineNets []money.Money
+}
+
+// Compute derives Totals from line items under the given rounding policy.
+// It validates every line (positive quantity, non-negative price and rate,
+// one shared currency) and is a pure calculator, usable standalone for quote
+// previews; Issue calls it to freeze the document totals.
+func Compute(lines []LineItem, policy RoundingPolicy) (Totals, error) {
+	if policy != RoundPerLine && policy != RoundPerTotal {
+		return Totals{}, ErrRoundingPolicy
+	}
+	if len(lines) == 0 {
+		return Totals{}, ErrNoLines
+	}
+
+	cur := lines[0].UnitPrice.Currency()
+	exact := make([]money.Money, len(lines))
+	for i, ln := range lines {
+		if err := validateLine(i, ln, cur); err != nil {
+			return Totals{}, err
+		}
+		exact[i] = ln.UnitPrice.Mul(ln.Quantity)
+	}
+
+	if policy == RoundPerLine {
+		return computePerLine(lines, exact, cur)
+	}
+	return computePerTotal(lines, exact, cur)
+}
+
+func validateLine(i int, ln LineItem, cur money.Currency) error {
+	switch {
+	case !ln.Quantity.IsPositive():
+		return fmt.Errorf("%w: line %d: quantity must be positive", ErrInvalidLine, i)
+	case ln.UnitPrice.IsNegative():
+		return fmt.Errorf("%w: line %d: negative unit price", ErrInvalidLine, i)
+	case ln.UnitPrice.Currency().Code == "":
+		return fmt.Errorf("%w: line %d: unit price has no currency", ErrInvalidLine, i)
+	case ln.TaxRate.IsNegative():
+		return fmt.Errorf("%w: line %d: negative tax rate", ErrInvalidLine, i)
+	case ln.UnitPrice.Currency().Code != cur.Code:
+		return fmt.Errorf("invoice: line %d: %w", i, money.ErrCurrencyMismatch)
+	}
+	return nil
+}
+
+// taxGroup accumulates one distinct rate. base collects rounded line nets
+// under RoundPerLine and exact nets under RoundPerTotal.
+type taxGroup struct {
+	rate   decimal.Decimal
+	base   money.Money
+	amount money.Money // RoundPerLine only: sum of per-line rounded taxes
+}
+
+func computePerLine(lines []LineItem, exact []money.Money, cur money.Currency) (Totals, error) {
+	nets := make([]money.Money, len(lines))
+	subtotal := money.FromMinor(0, cur)
+	var groups []taxGroup
+	for i, ln := range lines {
+		nets[i] = exact[i].Round(decimal.HalfEven)
+		var err error
+		if subtotal, err = subtotal.Add(nets[i]); err != nil {
+			return Totals{}, err
+		}
+		tax := nets[i].Mul(ln.TaxRate).Round(decimal.HalfEven)
+		g := findGroup(&groups, ln.TaxRate, cur)
+		if g.base, err = g.base.Add(nets[i]); err != nil {
+			return Totals{}, err
+		}
+		if g.amount, err = g.amount.Add(tax); err != nil {
+			return Totals{}, err
+		}
+	}
+	return finish(subtotal, nets, groups)
+}
+
+func computePerTotal(lines []LineItem, exact []money.Money, cur money.Currency) (Totals, error) {
+	exactSum := money.FromMinor(0, cur)
+	var groups []taxGroup
+	for i, ln := range lines {
+		var err error
+		if exactSum, err = exactSum.Add(exact[i]); err != nil {
+			return Totals{}, err
+		}
+		g := findGroup(&groups, ln.TaxRate, cur)
+		if g.base, err = g.base.Add(exact[i]); err != nil {
+			return Totals{}, err
+		}
+	}
+	subtotal := exactSum.Round(decimal.HalfEven)
+
+	nets, err := allocateNets(subtotal, exact, cur)
+	if err != nil {
+		return Totals{}, err
+	}
+	// Round each rate group once: base and tax derive from the exact group
+	// sum, not from per-line rounded values.
+	for i := range groups {
+		groups[i].amount = groups[i].base.Mul(groups[i].rate).Round(decimal.HalfEven)
+		groups[i].base = groups[i].base.Round(decimal.HalfEven)
+	}
+	return finish(subtotal, nets, groups)
+}
+
+// allocateNets distributes the rounded subtotal across lines proportionally
+// to their exact nets so the parts sum back exactly. Lines so small that
+// every weight truncates to zero minor units fall back to equal weights.
+func allocateNets(subtotal money.Money, exact []money.Money, cur money.Currency) ([]money.Money, error) {
+	if len(exact) == 1 {
+		return []money.Money{subtotal}, nil
+	}
+	if subtotal.IsZero() {
+		nets := make([]money.Money, len(exact))
+		for i := range nets {
+			nets[i] = money.FromMinor(0, cur)
+		}
+		return nets, nil
+	}
+	weights := make([]int, len(exact))
+	anyPositive := false
+	for i, e := range exact {
+		w, ok := e.MinorOK()
+		if !ok {
+			return nil, fmt.Errorf("invoice: line %d: %w", i, money.ErrOverflow)
+		}
+		weights[i] = int(w)
+		anyPositive = anyPositive || w > 0
+	}
+	if !anyPositive {
+		for i := range weights {
+			weights[i] = 1
+		}
+	}
+	return subtotal.Allocate(weights...)
+}
+
+func findGroup(groups *[]taxGroup, rate decimal.Decimal, cur money.Currency) *taxGroup {
+	for i := range *groups {
+		if (*groups)[i].rate.Cmp(rate) == 0 {
+			return &(*groups)[i]
+		}
+	}
+	zero := money.FromMinor(0, cur)
+	*groups = append(*groups, taxGroup{rate: rate, base: zero, amount: zero})
+	return &(*groups)[len(*groups)-1]
+}
+
+func finish(subtotal money.Money, nets []money.Money, groups []taxGroup) (Totals, error) {
+	slices.SortFunc(groups, func(a, b taxGroup) int { return a.rate.Cmp(b.rate) })
+	taxLines := make([]TaxLine, len(groups))
+	tax := money.FromMinor(0, subtotal.Currency())
+	var err error
+	for i, g := range groups {
+		taxLines[i] = TaxLine{Rate: g.rate, Base: g.base, Amount: g.amount}
+		if tax, err = tax.Add(g.amount); err != nil {
+			return Totals{}, err
+		}
+	}
+	total, err := subtotal.Add(tax)
+	if err != nil {
+		return Totals{}, err
+	}
+	return Totals{Subtotal: subtotal, TaxLines: taxLines, Tax: tax, Total: total, LineNets: nets}, nil
+}

--- a/finance/invoice/totals_test.go
+++ b/finance/invoice/totals_test.go
@@ -1,0 +1,265 @@
+package invoice_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/decimal"
+	"github.com/dmitrymomot/forge/core/money"
+	"github.com/dmitrymomot/forge/finance/invoice"
+)
+
+func line(t *testing.T, qty, unit, rate string, c money.Currency) invoice.LineItem {
+	t.Helper()
+	return invoice.LineItem{
+		Description: "test line",
+		Quantity:    decimal.MustParse(qty),
+		UnitPrice:   money.New(decimal.MustParse(unit), c),
+		TaxRate:     decimal.MustParse(rate),
+	}
+}
+
+func assertMoney(t *testing.T, want string, got money.Money) {
+	t.Helper()
+	w, err := money.Parse(want, got.Currency())
+	require.NoError(t, err)
+	eq, err := w.Equal(got)
+	require.NoError(t, err)
+	assert.True(t, eq, "want %s, got %s", want, got)
+}
+
+func TestCompute_PerLineVsPerTotal(t *testing.T) {
+	t.Parallel()
+
+	// The classic VAT divergence: 3 × 33.33 at 20%.
+	lines := []invoice.LineItem{
+		line(t, "1", "33.33", "0.20", money.EUR),
+		line(t, "1", "33.33", "0.20", money.EUR),
+		line(t, "1", "33.33", "0.20", money.EUR),
+	}
+
+	perLine, err := invoice.Compute(lines, invoice.RoundPerLine)
+	require.NoError(t, err)
+	assertMoney(t, "99.99", perLine.Subtotal)
+	assertMoney(t, "20.01", perLine.Tax) // 3 × round(6.666) = 3 × 6.67
+	assertMoney(t, "120.00", perLine.Total)
+	require.Len(t, perLine.TaxLines, 1)
+	assertMoney(t, "99.99", perLine.TaxLines[0].Base)
+	assertMoney(t, "20.01", perLine.TaxLines[0].Amount)
+
+	perTotal, err := invoice.Compute(lines, invoice.RoundPerTotal)
+	require.NoError(t, err)
+	assertMoney(t, "99.99", perTotal.Subtotal)
+	assertMoney(t, "20.00", perTotal.Tax) // round(99.99 × 0.20) = round(19.998)
+	assertMoney(t, "119.99", perTotal.Total)
+}
+
+func TestCompute_PerTotalAllocatesLineNets(t *testing.T) {
+	t.Parallel()
+
+	// Each line rounds down individually (0.125 → 0.12, banker's), but the
+	// exact sum 0.25 must come back penny-perfect across the line nets.
+	lines := []invoice.LineItem{
+		line(t, "1", "0.125", "0", money.USD),
+		line(t, "1", "0.125", "0", money.USD),
+	}
+
+	perLine, err := invoice.Compute(lines, invoice.RoundPerLine)
+	require.NoError(t, err)
+	assertMoney(t, "0.24", perLine.Subtotal)
+	assertMoney(t, "0.12", perLine.LineNets[0])
+	assertMoney(t, "0.12", perLine.LineNets[1])
+
+	perTotal, err := invoice.Compute(lines, invoice.RoundPerTotal)
+	require.NoError(t, err)
+	assertMoney(t, "0.25", perTotal.Subtotal)
+	assertMoney(t, "0.13", perTotal.LineNets[0])
+	assertMoney(t, "0.12", perTotal.LineNets[1])
+}
+
+func TestCompute_TaxGroupingSortedByRate(t *testing.T) {
+	t.Parallel()
+
+	lines := []invoice.LineItem{
+		line(t, "1", "10.00", "0.20", money.EUR),
+		line(t, "1", "20.00", "0", money.EUR),
+		line(t, "1", "30.00", "0.07", money.EUR),
+		line(t, "2", "5.00", "0.20", money.EUR),
+	}
+	totals, err := invoice.Compute(lines, invoice.RoundPerLine)
+	require.NoError(t, err)
+
+	require.Len(t, totals.TaxLines, 3)
+	assert.Equal(t, 0, totals.TaxLines[0].Rate.Cmp(decimal.Zero))
+	assert.Equal(t, 0, totals.TaxLines[1].Rate.Cmp(decimal.MustParse("0.07")))
+	assert.Equal(t, 0, totals.TaxLines[2].Rate.Cmp(decimal.MustParse("0.20")))
+
+	// Zero-rated base is reported, not dropped.
+	assertMoney(t, "20.00", totals.TaxLines[0].Base)
+	assertMoney(t, "0.00", totals.TaxLines[0].Amount)
+	assertMoney(t, "30.00", totals.TaxLines[1].Base)
+	assertMoney(t, "2.10", totals.TaxLines[1].Amount)
+	assertMoney(t, "20.00", totals.TaxLines[2].Base)
+	assertMoney(t, "4.00", totals.TaxLines[2].Amount)
+	assertMoney(t, "70.00", totals.Subtotal)
+	assertMoney(t, "6.10", totals.Tax)
+	assertMoney(t, "76.10", totals.Total)
+}
+
+func TestCompute_ZeroMinorUnitCurrency(t *testing.T) {
+	t.Parallel()
+
+	lines := []invoice.LineItem{
+		line(t, "1", "100.5", "0.10", money.JPY),
+		line(t, "1", "100.5", "0.10", money.JPY),
+	}
+
+	perLine, err := invoice.Compute(lines, invoice.RoundPerLine)
+	require.NoError(t, err)
+	assertMoney(t, "200", perLine.Subtotal) // 100.5 → 100 each (banker's)
+	assertMoney(t, "20", perLine.Tax)
+
+	perTotal, err := invoice.Compute(lines, invoice.RoundPerTotal)
+	require.NoError(t, err)
+	assertMoney(t, "201", perTotal.Subtotal)
+	assertMoney(t, "20", perTotal.Tax) // round(201 × 0.10) = round(20.1)
+	assertMoney(t, "221", perTotal.Total)
+}
+
+func TestCompute_ZeroTotal(t *testing.T) {
+	t.Parallel()
+
+	lines := []invoice.LineItem{line(t, "1", "0.00", "0.20", money.USD)}
+	for _, policy := range []invoice.RoundingPolicy{invoice.RoundPerLine, invoice.RoundPerTotal} {
+		totals, err := invoice.Compute(lines, policy)
+		require.NoError(t, err)
+		assertMoney(t, "0.00", totals.Subtotal)
+		assertMoney(t, "0.00", totals.Total)
+		require.Len(t, totals.LineNets, 1)
+		assertMoney(t, "0.00", totals.LineNets[0])
+	}
+}
+
+func TestCompute_SubMinorLinesFallBackToEqualWeights(t *testing.T) {
+	t.Parallel()
+
+	// Every line net truncates to zero minor units, yet the exact sum does
+	// not — allocation falls back to equal weights instead of failing.
+	lines := []invoice.LineItem{
+		line(t, "1", "0.004", "0", money.USD),
+		line(t, "1", "0.004", "0", money.USD),
+		line(t, "1", "0.004", "0", money.USD),
+	}
+	totals, err := invoice.Compute(lines, invoice.RoundPerTotal)
+	require.NoError(t, err)
+	assertMoney(t, "0.01", totals.Subtotal)
+	sum, err := money.Sum(totals.LineNets[0], totals.LineNets[1:]...)
+	require.NoError(t, err)
+	assertMoney(t, "0.01", sum)
+}
+
+func TestCompute_Errors(t *testing.T) {
+	t.Parallel()
+
+	valid := line(t, "1", "10.00", "0.20", money.EUR)
+
+	t.Run("no lines", func(t *testing.T) {
+		t.Parallel()
+		_, err := invoice.Compute(nil, invoice.RoundPerLine)
+		assert.ErrorIs(t, err, invoice.ErrNoLines)
+	})
+	t.Run("unknown policy", func(t *testing.T) {
+		t.Parallel()
+		_, err := invoice.Compute([]invoice.LineItem{valid}, invoice.RoundingPolicy(99))
+		assert.ErrorIs(t, err, invoice.ErrRoundingPolicy)
+	})
+	t.Run("zero quantity", func(t *testing.T) {
+		t.Parallel()
+		_, err := invoice.Compute([]invoice.LineItem{line(t, "0", "10.00", "0.20", money.EUR)}, invoice.RoundPerLine)
+		assert.ErrorIs(t, err, invoice.ErrInvalidLine)
+	})
+	t.Run("negative quantity", func(t *testing.T) {
+		t.Parallel()
+		_, err := invoice.Compute([]invoice.LineItem{line(t, "-1", "10.00", "0.20", money.EUR)}, invoice.RoundPerLine)
+		assert.ErrorIs(t, err, invoice.ErrInvalidLine)
+	})
+	t.Run("negative unit price", func(t *testing.T) {
+		t.Parallel()
+		_, err := invoice.Compute([]invoice.LineItem{line(t, "1", "-10.00", "0.20", money.EUR)}, invoice.RoundPerLine)
+		assert.ErrorIs(t, err, invoice.ErrInvalidLine)
+	})
+	t.Run("negative tax rate", func(t *testing.T) {
+		t.Parallel()
+		_, err := invoice.Compute([]invoice.LineItem{line(t, "1", "10.00", "-0.20", money.EUR)}, invoice.RoundPerLine)
+		assert.ErrorIs(t, err, invoice.ErrInvalidLine)
+	})
+	t.Run("no currency", func(t *testing.T) {
+		t.Parallel()
+		bad := invoice.LineItem{Quantity: decimal.FromInt(1), TaxRate: decimal.Zero}
+		_, err := invoice.Compute([]invoice.LineItem{bad}, invoice.RoundPerLine)
+		assert.ErrorIs(t, err, invoice.ErrInvalidLine)
+	})
+	t.Run("mixed currencies", func(t *testing.T) {
+		t.Parallel()
+		mixed := []invoice.LineItem{valid, line(t, "1", "10.00", "0.20", money.USD)}
+		_, err := invoice.Compute(mixed, invoice.RoundPerLine)
+		assert.ErrorIs(t, err, money.ErrCurrencyMismatch)
+	})
+}
+
+// TestCompute_Invariants fuzzes deterministic pseudo-random documents and
+// asserts the structural money invariants both policies promise.
+func TestCompute_Invariants(t *testing.T) {
+	t.Parallel()
+
+	rng := rand.New(rand.NewSource(20260721))
+	rates := []string{"0", "0.05", "0.07", "0.19", "0.20", "0.21"}
+	quantities := []string{"1", "2", "3", "0.5", "1.5", "12"}
+
+	for range 200 {
+		n := 1 + rng.Intn(8)
+		lines := make([]invoice.LineItem, n)
+		for i := range lines {
+			lines[i] = line(t,
+				quantities[rng.Intn(len(quantities))],
+				decimal.New(int64(rng.Intn(1_000_000)), 2).String(),
+				rates[rng.Intn(len(rates))],
+				money.EUR,
+			)
+		}
+		for _, policy := range []invoice.RoundingPolicy{invoice.RoundPerLine, invoice.RoundPerTotal} {
+			totals, err := invoice.Compute(lines, policy)
+			require.NoError(t, err)
+			require.Len(t, totals.LineNets, n)
+
+			// Line nets sum exactly to the subtotal.
+			netSum, err := money.Sum(totals.LineNets[0], totals.LineNets[1:]...)
+			require.NoError(t, err)
+			eq, err := netSum.Equal(totals.Subtotal)
+			require.NoError(t, err)
+			require.True(t, eq, "line nets %v != subtotal %s", totals.LineNets, totals.Subtotal)
+
+			// Subtotal + tax = total, and tax is the sum of tax lines.
+			wantTotal, err := totals.Subtotal.Add(totals.Tax)
+			require.NoError(t, err)
+			eq, err = wantTotal.Equal(totals.Total)
+			require.NoError(t, err)
+			require.True(t, eq)
+
+			taxSum := money.FromMinor(0, money.EUR)
+			for i, tl := range totals.TaxLines {
+				taxSum, err = taxSum.Add(tl.Amount)
+				require.NoError(t, err)
+				if i > 0 {
+					require.Positive(t, tl.Rate.Cmp(totals.TaxLines[i-1].Rate), "tax lines not sorted")
+				}
+			}
+			eq, err = taxSum.Equal(totals.Tax)
+			require.NoError(t, err)
+			require.True(t, eq)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

First package in the `finance/` namespace: the invoice document model — invariants, not rendering.

- **Document model**: `Invoice` is a plain, persistable struct; invariants are enforced at the package's operation boundary (the `fsm` philosophy of caller-owned state). A draft is freely mutable; `Issue` validates, freezes totals, draws the number, and moves draft → issued; every later correction is a new credit-note document via `NewCreditNote`, back-referencing the original through `Corrects` (corrections post forward, the rule shared with the planned ledger). `Verify` recomputes totals from lines to detect drift on loaded documents.
- **Numbering**: per-series `Sequence` over a small `SequenceStore` seam with two explicit, mechanically distinct modes — the requirement is jurisdictional. `Gapless` (default) draws only inside `Issue` (inside the caller's persistence tx when the store rides ctx) and refuses pre-drawn/pre-assigned numbers; `WithGaps` allows pre-drawing via `Sequence.Next` and burns numbers on failed issuance. `Issue` draws the number last, after every other invariant passed, so a validation failure never burns one (tested). In-memory store ships for tests/dev.
- **Totals**: line items → per-rate tax lines → totals over `core/money`, with `RoundPerLine` vs `RoundPerTotal` policies (banker's rounding, money's settlement default). Per-total mode rounds once at document level and allocates the subtotal back across lines penny-perfect via `money.Allocate`; `LineNets` always sum exactly to `Subtotal` (property-tested over 200 pseudo-random documents × both policies). Tax rates are caller-supplied data per line — never determined.
- **Lifecycle**: draft → issued → partially_paid/paid/overdue/void compiled once over `core/fsm`; voiding is guarded — a document with payments can only be corrected forward with a credit note (`fsm.ErrGuardDenied` wrapping `ErrHasPayments`). Payments match by external refs (ledger posting refs): identical replays are idempotent no-ops (at-least-once feeds safe), same ref with different amount is `ErrPaymentConflict`, overpayment records nothing.
- **Self-billing** is the `Direction` field (platform issues on the supplier's behalf — affiliate/agent payouts); a non-base-currency document records its `FXSnapshot` — recorded data, never conversion math.
- **Tenancy**: optional `WithScope` hook on `NewSequence`; fails closed with `ErrScope`, per-tenant counters use a length-prefixed storage key so (scope, series) pairs can never collide (tested), formatted numbers stay tenant-clean. Single-tenant use pays zero ceremony.

Removes the shipped `finance/invoice` entry from `docs/packages.md` per the roadmap rule.

## Anti-scope

No rendering (HTML is a `render` recipe, PDF consumer-side), no tax determination, no e-invoicing formats, no dunning, no subscription/pricing logic — the billing anti-scope stands.

## Benchmarks (Apple M3 Max)

Before/after for the one measured optimization — a single-line fast path in per-total allocation (single-line documents are the common SaaS case):

| benchmark | before | after |
|---|---|---|
| Compute/per_total/1 | 663 ns/op, 944 B, 24 allocs | **312 ns/op, 544 B, 4 allocs** |

Full run after:

```
BenchmarkCompute/per_line/1-14      306.9 ns/op    544 B/op     4 allocs/op
BenchmarkCompute/per_total/1-14     311.6 ns/op    544 B/op     4 allocs/op
BenchmarkCompute/per_line/10-14     3517 ns/op    6371 B/op   111 allocs/op
BenchmarkCompute/per_total/10-14    4590 ns/op    7876 B/op   174 allocs/op
BenchmarkCompute/per_line/100-14   29445 ns/op   45891 B/op  1099 allocs/op
BenchmarkCompute/per_total/100-14  32978 ns/op   52687 B/op  1343 allocs/op
BenchmarkIssue-14                   3745 ns/op    7121 B/op   115 allocs/op
BenchmarkApplyPayment-14            186.4 ns/op    832 B/op     2 allocs/op
BenchmarkSequenceNext-14            128.2 ns/op     40 B/op     3 allocs/op
```

Remaining allocations are exact-decimal arithmetic inside `core/money`/`core/decimal`; issuance is a human-rate path, not a request hot path, so no further perf-motivated complexity.

## Testing

- `go test -race ./finance/...` — unit tests, black-box (`invoice_test`): totals known-value cases (the classic 3 × 33.33 @ 20% VAT divergence: 120.00 per-line vs 119.99 per-total), allocation penny-exactness, zero-minor-unit currency (JPY), sub-minor-unit fallback, full lifecycle matrix, numbering modes, credit notes, tenancy fail-closed + key-collision resistance, concurrent draw uniqueness, 200-document invariant fuzz.
- `just lint` — clean (golangci-lint, nilaway, betteralign, modernize, integration tags).