### PR TITLE
perf(decimal): int64 fast path for mixed-scale Cmp

### DIFF
--- a/core/decimal/compare.go
+++ b/core/decimal/compare.go
@@ -1,20 +1,31 @@
 package decimal
 
-import "math/big"
+import (
+	"cmp"
+	"math/big"
+)
 
 // Cmp compares d and e numerically, ignoring stored scale, and returns -1, 0, or
 // +1 as d < e, d == e, or d > e.
 func (d Decimal) Cmp(e Decimal) int {
-	// Fast path: both int64 and identical scale.
-	if d.big == nil && e.big == nil && d.scale == e.scale {
-		switch {
-		case d.coef < e.coef:
-			return -1
-		case d.coef > e.coef:
-			return 1
-		default:
-			return 0
+	if d.big == nil && e.big == nil {
+		// Identical scale: compare coefficients directly.
+		if d.scale == e.scale {
+			return cmp.Compare(d.coef, e.coef)
 		}
+		// Mixed scales: align both coefficients to the common scale in int64.
+		scale := max(d.scale, e.scale)
+		dc, dok := scaleInt64(d.coef, scale-d.scale)
+		ec, eok := scaleInt64(e.coef, scale-e.scale)
+		if dok && eok {
+			return cmp.Compare(dc, ec)
+		}
+	}
+	// Differing signs settle the answer without big.Int allocation; equal signs
+	// (a coefficient is big-backed, or int64 alignment overflowed) fall through
+	// to the exact big comparison.
+	if ds, es := d.Sign(), e.Sign(); ds != es {
+		return cmp.Compare(ds, es)
 	}
 	da, eb := alignBig(d, e)
 	return da.Cmp(eb)

--- a/core/decimal/compare_test.go
+++ b/core/decimal/compare_test.go
@@ -1,6 +1,7 @@
 package decimal_test
 
 import (
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,15 @@ func TestCmp_Equal_ScaleNormalized(t *testing.T) {
 		// crosses int64 during alignment
 		{"9223372036854775807.0", "9223372036854775807", 0, true},
 		{"9223372036854775808", "9223372036854775807", 1, false},
+		// mixed scales where both int64-aligned coefficients still fit
+		{"92233720368547758.07", "92233720368547758.0", 1, false},
+		{"1000", "1234.56", -1, false},
+		{"0", "0.000000", 0, true},
+		// mixed scales where aligning overflows int64 (falls back to big)
+		{"9223372036854775807", "0.01", 1, false},
+		{"0.01", "9223372036854775807", -1, false},
+		{"-9223372036854775808", "-0.5", -1, false},
+		{"-9223372036854775808", "0.5", -1, false}, // cross-sign, settled by Sign
 	}
 	for _, tc := range tests {
 		t.Run(tc.a+"_vs_"+tc.b, func(t *testing.T) {
@@ -66,4 +76,15 @@ func TestNeg_MinInt64PromotesToBig(t *testing.T) {
 	// -(-9223372036854775808) has no int64 representation, so Neg must promote.
 	d := decimal.New(-9223372036854775808, 0)
 	assert.Equal(t, "9223372036854775808", d.Neg().String())
+}
+
+func TestCmp_RatOracle(t *testing.T) {
+	// Random mixed-scale pairs (including near-int64-boundary coefficients that
+	// force the big fallback) must agree with the exact big.Rat oracle.
+	rng := rand.New(rand.NewPCG(9, 11))
+	for range 20000 {
+		a := randDecimal(rng)
+		b := randDecimal(rng)
+		assert.Equal(t, toRat(a).Cmp(toRat(b)), a.Cmp(b), "Cmp(%s, %s)", a.String(), b.String())
+	}
 }

--- a/core/decimal/decimal_bench_test.go
+++ b/core/decimal/decimal_bench_test.go
@@ -222,3 +222,12 @@ func BenchmarkScan(b *testing.B) {
 		_ = d.Scan("1234.56")
 	}
 }
+
+func BenchmarkCmpMixedScale(b *testing.B) {
+	x := decimal.MustParse("1234.56") // scale 2
+	y := decimal.MustParse("1000")    // scale 0
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = x.Cmp(y)
+	}
+}


### PR DESCRIPTION
## Summary

`decimal.Cmp` had an int64 fast path only when both operands were int64-backed **and** shared a scale; any scale mismatch fell into `alignBig` → `big.Int` allocations (`bigCoef` + `pow10Big` + `Mul`). Profiling `finance/tariff`'s `Apply` (PR #94) showed ~40 allocs/op purely from comparing scale-0 band bounds against a scale-2 base — a shape every consumer hits when comparing parsed amounts against integer literals.

## Change

- **Mixed-scale int64 fast path**: align both coefficients to the common scale with the overflow-checked `scaleInt64` helper `Add`/`Sub` already use, and compare in int64. Falls back to `alignBig` when either side is big-backed or alignment overflows.
- **Sign shortcut before the big fallback**: differing signs settle big/overflow cases without allocating; equal signs proceed to the exact big comparison. Ordered after the int64 paths so the previously-fastest identical-scale compare keeps its shape.
- **`Add`/`Sub` checked as part of this task**: they already have the mixed-scale int64 fast path via `scaleInt64` — no change needed; `Cmp` was the only alignBig-first operation.

## Benchmarks

Apple M3 Max, `go test -bench 'BenchmarkCmp' -benchmem ./core/decimal/`:

| benchmark | before | after |
|---|---|---|
| Cmp (identical scale) | 1.93 ns/op, 0 allocs | 1.88 ns/op, 0 allocs |
| CmpMixedScale (new) | 124.1 ns/op, 216 B, 8 allocs | 3.73 ns/op, 0 B, 0 allocs |
| CmpBig | 62.7 ns/op, 4 allocs | 62.8 ns/op, 4 allocs |

An intermediate version placed the sign shortcut first and regressed the identical-scale path to 3.76 ns/op; reordering (identical scale → mixed scale → signs → big) restored it.

## Testing

- New table cases in `compare_test.go`: mixed scales on the int64 path, boundary values where alignment stays in int64 (`92233720368547758.07` vs `92233720368547758.0`), overflow-forced big fallback (`MaxInt64` coef vs `0.01`, `MinInt64` vs `-0.5`), cross-sign settled by the sign shortcut, and zero-vs-scaled-zero.
- New `TestCmp_RatOracle`: 20k random mixed-scale pairs (including near-int64-boundary coefficients) must agree with the exact `big.Rat` oracle.
- `FuzzAddMulOracle` run 15–20s clean; full suite 98.2% coverage; `just lint` clean.
