### PR TITLE
docs(packages): drop shipped auth/rbac from the roadmap catalog

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -432,19 +432,6 @@ Deps: `auth/guard`.
 
 ---
 
-**auth/rbac**
-
-Role-based access control: predefined roles, role nesting/inheritance (a
-role inherits another role's permissions and adds its own),
-out-of-hierarchy standalone roles, wildcard grants; resolves subject →
-effective permission set. Implements the `access` decision seam consumed
-by `guard`/`RequirePermission` (401-vs-403 split). Subject→role
-assignment behind a storage-agnostic Store.
-
-Deps: `auth/access`.
-
----
-
 **auth/acl**
 
 Per-subject / per-resource grant and deny overrides (deny wins) layered


### PR DESCRIPTION
auth/rbac shipped in #58 (with auth/access in #57), but its catalog entry was never removed. Per the roadmap rule in docs/design.md — "the moment a package ships, delete its entry" — this removes the stale **auth/rbac** entry from docs/packages.md. The auth/access entry was already removed; the acl/abac entries stay (unbuilt) and their references to rbac now point at the shipped package's godoc.