### PR TITLE
ops/debug: internal diagnostics surface (pprof, stats, expvar) as a dedicated-port service

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -593,16 +593,6 @@ Deps: `ops/supervisor` (MCP go-sdk external, isolated).
 
 ---
 
-**ops/debug**
-
-One internal diagnostics surface: `/debug/pprof/*`, `/debug/stats`
-(runtime/GC/goroutines JSON), `/debug/vars`, with an auth guard and a
-dedicated-port `supervisor.Service`.
-
-Deps: `ops/supervisor`, `auth/guard`.
-
----
-
 **ops/auditlog**
 
 Append-only structured audit events (actor/action/resource/outcome) over a

--- a/ops/debug/bench_test.go
+++ b/ops/debug/bench_test.go
@@ -1,0 +1,38 @@
+package debug_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/debug"
+)
+
+func BenchmarkSnapshot(b *testing.B) {
+	for b.Loop() {
+		_ = debug.Snapshot()
+	}
+}
+
+func BenchmarkStatsHandler(b *testing.B) {
+	h := debug.Handler()
+	req := httptest.NewRequest(http.MethodGet, "/debug/stats", nil)
+	b.ReportAllocs()
+	for b.Loop() {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+	}
+}
+
+// BenchmarkIndexBasicAuth measures the guard + mux dispatch overhead on the
+// cheapest route, isolating it from snapshot/profile cost.
+func BenchmarkIndexBasicAuth(b *testing.B) {
+	h := debug.Handler(debug.WithBasicAuth(map[string]string{"ops": "s3cret"}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.SetBasicAuth("ops", "s3cret")
+	b.ReportAllocs()
+	for b.Loop() {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+	}
+}

--- a/ops/debug/config.go
+++ b/ops/debug/config.go
@@ -1,0 +1,46 @@
+package debug
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Config holds the serializable settings for a Server. The env struct tags are
+// inert strings — this package imports no config loader. Populate Config with any
+// loader that reads env struct tags, typically by seeding from DefaultConfig and
+// parsing the environment over it.
+type Config struct {
+	Addr              string        `env:"DEBUG_ADDR"`        // listen address; ignored when WithListener is used
+	Name              string        `env:"DEBUG_SERVER_NAME"` // empty -> "debug"
+	ReadHeaderTimeout time.Duration `env:"DEBUG_READ_HEADER_TIMEOUT"`
+	ShutdownTimeout   time.Duration `env:"DEBUG_SHUTDOWN_TIMEOUT"`
+}
+
+// DefaultConfig returns the settings NewServer starts from and is the single
+// source of truth for defaults. The default address is loopback-only, so a
+// default server needs no auth configuration.
+func DefaultConfig() Config {
+	return Config{
+		Addr:              "localhost:6060",
+		ReadHeaderTimeout: 10 * time.Second,
+		ShutdownTimeout:   5 * time.Second,
+	}
+}
+
+// Validate reports whether the field values are usable, returning an
+// ErrInvalidConfig-wrapped, single-line joined error otherwise. Run calls it
+// defensively; callers may call it after loading from env.
+func (c Config) Validate() error {
+	var errs []error
+	if c.Addr == "" {
+		errs = append(errs, fmt.Errorf("%w: Addr must not be empty", ErrInvalidConfig))
+	}
+	if c.ReadHeaderTimeout < 0 {
+		errs = append(errs, fmt.Errorf("%w: ReadHeaderTimeout must be >= 0", ErrInvalidConfig))
+	}
+	if c.ShutdownTimeout < 0 {
+		errs = append(errs, fmt.Errorf("%w: ShutdownTimeout must be >= 0", ErrInvalidConfig))
+	}
+	return errors.Join(errs...)
+}

--- a/ops/debug/doc.go
+++ b/ops/debug/doc.go
@@ -1,0 +1,34 @@
+// Package debug serves one internal diagnostics surface: /debug/pprof/*,
+// /debug/stats (runtime/GC/goroutine JSON), and /debug/vars (expvar) — guarded,
+// and off the public port.
+//
+// NewServer runs the surface on a dedicated port as a supervisor.Service. The
+// default address is loopback-only (localhost:6060), so the zero-ceremony form
+// is safe; Run refuses a non-loopback bind unless auth middleware is configured
+// (WithBasicAuth / WithMiddleware) or WithoutAuth explicitly opts out — an open
+// pprof endpoint leaks heap contents, command lines, and can stall the process
+// with profile requests:
+//
+//	users, err := guard.ParseUsers(os.Getenv("DEBUG_BASIC_USERS")) // "ops:s3cret"
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	dbg := debug.NewServer(
+//		debug.WithAddr(":6060"),
+//		debug.WithBasicAuth(users),
+//	)
+//	err = supervisor.Run(ctx,
+//		supervisor.WithService(app),
+//		supervisor.WithService(dbg),
+//	)
+//
+// Handler returns the same surface as a plain http.Handler for mounting into an
+// existing internal mux — paths are absolute, so no StripPrefix:
+//
+//	mux.Handle("/debug/", debug.Handler(debug.WithBasicAuth(users)))
+//
+// The dedicated server disables WriteTimeout because CPU profiles and traces
+// stream for the requested ?seconds=N. Importing this package (via
+// net/http/pprof) also registers the pprof handlers on http.DefaultServeMux;
+// forge never serves DefaultServeMux, but consumers that do should be aware.
+package debug

--- a/ops/debug/errors.go
+++ b/ops/debug/errors.go
@@ -1,0 +1,12 @@
+package debug
+
+import "errors"
+
+// Sentinel errors returned (often joined) by Run. Match with errors.Is.
+var (
+	// ErrInvalidConfig is returned (joined) by Run when an option or Config field has an invalid value.
+	ErrInvalidConfig = errors.New("debug: invalid config")
+	// ErrAuthRequired is returned by Run when the server would bind a non-loopback
+	// address with no auth middleware configured and no explicit WithoutAuth opt-out.
+	ErrAuthRequired = errors.New("debug: non-loopback address requires auth (WithBasicAuth/WithMiddleware) or an explicit WithoutAuth")
+)

--- a/ops/debug/example_test.go
+++ b/ops/debug/example_test.go
@@ -1,0 +1,28 @@
+package debug_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/dmitrymomot/forge/ops/debug"
+)
+
+func ExampleHandler() {
+	// Mount the surface into an existing internal mux; paths are absolute, so
+	// no StripPrefix. Gate it with debug.WithBasicAuth(users) in real wiring.
+	mux := http.NewServeMux()
+	mux.Handle("/debug/", debug.Handler())
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/debug/stats")
+	if err != nil || resp == nil {
+		fmt.Println(err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	fmt.Println(resp.StatusCode, resp.Header.Get("Content-Type"))
+	// Output: 200 application/json
+}

--- a/ops/debug/handler.go
+++ b/ops/debug/handler.go
@@ -1,0 +1,49 @@
+package debug
+
+import (
+	"expvar"
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+// Handler returns the diagnostics surface as one http.Handler:
+//
+//	/debug/pprof/*  pprof index, named profiles, cmdline, profile, symbol, trace
+//	/debug/stats    runtime/GC/goroutine snapshot as JSON (see Snapshot)
+//	/debug/vars     expvar
+//	/               plain-text index of the above
+//
+// Paths are absolute, so the handler mounts on an existing internal mux without
+// StripPrefix: mux.Handle("/debug/", debug.Handler(...)). Handler applies
+// WithBasicAuth/WithMiddleware around the whole surface and ignores the
+// server-only options (Config, listener, WithoutAuth) — exposure is the
+// caller's responsibility here; the fail-closed non-loopback check lives in
+// Server.Run.
+func Handler(opts ...Option) http.Handler {
+	c := newConfig(opts...)
+	return buildHandler(&c)
+}
+
+func buildHandler(c *config) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", index)
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux.Handle("/debug/vars", expvar.Handler())
+	mux.HandleFunc("/debug/stats", statsHandler)
+	return middleware.Wrap(mux, c.guards...)
+}
+
+func index(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = w.Write([]byte("/debug/pprof/\tprofiles (heap, goroutine, cpu, trace, ...)\n/debug/stats\truntime/GC/goroutine snapshot\n/debug/vars\texpvar\n"))
+}

--- a/ops/debug/handler.go
+++ b/ops/debug/handler.go
@@ -1,6 +1,7 @@
 package debug
 
 import (
+	"errors"
 	"expvar"
 	"net/http"
 	"net/http/pprof"
@@ -20,9 +21,14 @@ import (
 // WithBasicAuth/WithMiddleware around the whole surface and ignores the
 // server-only options (Config, listener, WithoutAuth) — exposure is the
 // caller's responsibility here; the fail-closed non-loopback check lives in
-// Server.Run.
+// Server.Run. Handler has no error return, so an invalid option value (a nil
+// middleware or listener) panics: silently dropping a broken gate would leave
+// the surface unguarded.
 func Handler(opts ...Option) http.Handler {
 	c := newConfig(opts...)
+	if err := errors.Join(c.errs...); err != nil {
+		panic(err)
+	}
 	return buildHandler(&c)
 }
 

--- a/ops/debug/handler_test.go
+++ b/ops/debug/handler_test.go
@@ -1,0 +1,179 @@
+package debug_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/debug"
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+func get(t *testing.T, h http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	return rec
+}
+
+func TestHandlerRoutes(t *testing.T) {
+	t.Parallel()
+	h := debug.Handler()
+
+	t.Run("stats", func(t *testing.T) {
+		t.Parallel()
+		rec := get(t, h, "/debug/stats")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", ct)
+		}
+		var s debug.Stats
+		if err := json.NewDecoder(rec.Body).Decode(&s); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if s.Goroutines <= 0 || s.GoVersion == "" || s.NumCPU <= 0 {
+			t.Fatalf("implausible stats: %+v", s)
+		}
+	})
+
+	t.Run("vars", func(t *testing.T) {
+		t.Parallel()
+		rec := get(t, h, "/debug/vars")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		var vars map[string]json.RawMessage
+		if err := json.NewDecoder(rec.Body).Decode(&vars); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if _, ok := vars["memstats"]; !ok {
+			t.Fatalf("expvar output missing memstats key: %v", vars)
+		}
+	})
+
+	t.Run("pprof index", func(t *testing.T) {
+		t.Parallel()
+		rec := get(t, h, "/debug/pprof/")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		body, _ := io.ReadAll(rec.Body)
+		if !strings.Contains(string(body), "goroutine") {
+			t.Fatalf("pprof index does not list goroutine profile")
+		}
+	})
+
+	t.Run("pprof named profile", func(t *testing.T) {
+		t.Parallel()
+		rec := get(t, h, "/debug/pprof/goroutine?debug=1")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+	})
+
+	t.Run("pprof cmdline", func(t *testing.T) {
+		t.Parallel()
+		if rec := get(t, h, "/debug/pprof/cmdline"); rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+	})
+
+	t.Run("root index", func(t *testing.T) {
+		t.Parallel()
+		rec := get(t, h, "/")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		body, _ := io.ReadAll(rec.Body)
+		for _, path := range []string{"/debug/pprof/", "/debug/stats", "/debug/vars"} {
+			if !strings.Contains(string(body), path) {
+				t.Fatalf("index missing %s: %s", path, body)
+			}
+		}
+	})
+
+	t.Run("unknown path", func(t *testing.T) {
+		t.Parallel()
+		if rec := get(t, h, "/nope"); rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", rec.Code)
+		}
+	})
+}
+
+func TestHandlerBasicAuth(t *testing.T) {
+	t.Parallel()
+	h := debug.Handler(debug.WithBasicAuth(map[string]string{"ops": "s3cret"}))
+
+	t.Run("no credentials", func(t *testing.T) {
+		t.Parallel()
+		rec := get(t, h, "/debug/stats")
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+		if rec.Header().Get("WWW-Authenticate") == "" {
+			t.Fatal("missing WWW-Authenticate challenge")
+		}
+	})
+
+	t.Run("wrong password", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/debug/stats", nil)
+		req.SetBasicAuth("ops", "wrong")
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+	})
+
+	t.Run("valid credentials", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/debug/stats", nil)
+		req.SetBasicAuth("ops", "s3cret")
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+	})
+}
+
+func TestWithBasicAuthEmptyUsersPanics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on empty users map")
+		}
+	}()
+	debug.Handler(debug.WithBasicAuth(nil))
+}
+
+func TestHandlerCustomMiddleware(t *testing.T) {
+	t.Parallel()
+	var mw middleware.Middleware = func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("X-Token") != "ok" {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+	h := debug.Handler(debug.WithMiddleware(mw))
+
+	if rec := get(t, h, "/debug/stats"); rec.Code != http.StatusForbidden {
+		t.Fatalf("ungated status = %d, want 403", rec.Code)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/debug/stats", nil)
+	req.Header.Set("X-Token", "ok")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("gated status = %d, want 200", rec.Code)
+	}
+}

--- a/ops/debug/handler_test.go
+++ b/ops/debug/handler_test.go
@@ -153,6 +153,16 @@ func TestWithBasicAuthEmptyUsersPanics(t *testing.T) {
 	debug.Handler(debug.WithBasicAuth(nil))
 }
 
+func TestHandlerNilMiddlewarePanics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on nil middleware — a dropped gate must not fail open")
+		}
+	}()
+	debug.Handler(debug.WithMiddleware(nil))
+}
+
 func TestHandlerCustomMiddleware(t *testing.T) {
 	t.Parallel()
 	var mw middleware.Middleware = func(next http.Handler) http.Handler {

--- a/ops/debug/options.go
+++ b/ops/debug/options.go
@@ -58,7 +58,8 @@ func WithBasicAuth(users map[string]string, opts ...guard.Option) Option {
 // chain, ipfilter, requestlog, ...). The first middleware is the outermost
 // layer. Any middleware registered this way counts as the auth guard for Run's
 // non-loopback check — pass only middleware that actually gates access when the
-// server binds beyond loopback. A nil middleware is rejected (ErrInvalidConfig).
+// server binds beyond loopback. A nil middleware is rejected
+// (ErrInvalidConfig): Run returns it, Handler panics.
 func WithMiddleware(mws ...middleware.Middleware) Option {
 	return func(c *config) {
 		for _, mw := range mws {

--- a/ops/debug/options.go
+++ b/ops/debug/options.go
@@ -1,0 +1,97 @@
+package debug
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+
+	"github.com/dmitrymomot/forge/auth/guard"
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+// config holds resolved settings. The embedded Config carries serializable
+// data; the remaining fields are non-serializable code values.
+type config struct {
+	logger   *slog.Logger
+	listener net.Listener
+	guards   []middleware.Middleware
+	errs     []error
+	Config
+	noAuth bool
+}
+
+func newConfig(opts ...Option) config {
+	c := config{Config: DefaultConfig()}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	return c
+}
+
+// Option configures Handler and NewServer. Invalid values accumulate and are
+// returned by Run.
+type Option func(*config)
+
+// WithConfig sets the whole serializable data block at once. Build the argument
+// from DefaultConfig() (or an env-parsed copy); a bare Config{} zeroes the
+// timeouts. Options apply in order — place WithConfig before any WithAddr you
+// want to take precedence. Handler ignores Config (it has no listen address).
+func WithConfig(cfg Config) Option {
+	return func(c *config) { c.Config = cfg }
+}
+
+// WithAddr sets the listen address (convenience for Config.Addr).
+func WithAddr(addr string) Option {
+	return func(c *config) { c.Addr = addr }
+}
+
+// WithBasicAuth gates the whole surface with guard.BasicAuth against a static
+// username→password map (env-sourced via guard.ParseUsers). Panics — via
+// guard.BasicAuth — on an empty map or empty username/password entries: a gate
+// with no valid credentials is a wiring bug. Accepted guard options: WithRealm,
+// WithResponder.
+func WithBasicAuth(users map[string]string, opts ...guard.Option) Option {
+	return func(c *config) { c.guards = append(c.guards, guard.BasicAuth(users, opts...)) }
+}
+
+// WithMiddleware wraps the whole surface with custom middleware (a guard.New
+// chain, ipfilter, requestlog, ...). The first middleware is the outermost
+// layer. Any middleware registered this way counts as the auth guard for Run's
+// non-loopback check — pass only middleware that actually gates access when the
+// server binds beyond loopback. A nil middleware is rejected (ErrInvalidConfig).
+func WithMiddleware(mws ...middleware.Middleware) Option {
+	return func(c *config) {
+		for _, mw := range mws {
+			if mw == nil {
+				c.errs = append(c.errs, fmt.Errorf("%w: WithMiddleware received a nil middleware", ErrInvalidConfig))
+				continue
+			}
+			c.guards = append(c.guards, mw)
+		}
+	}
+}
+
+// WithoutAuth explicitly allows serving on a non-loopback address with no auth
+// middleware — for deployments where the port is unreachable from outside the
+// private network. Without it, Run fails closed with ErrAuthRequired.
+func WithoutAuth() Option {
+	return func(c *config) { c.noAuth = true }
+}
+
+// WithLogger sets the slog.Logger for server lifecycle logging. Default: discard.
+func WithLogger(l *slog.Logger) Option {
+	return func(c *config) { c.logger = l }
+}
+
+// WithListener supplies a pre-bound listener, overriding Addr (for :0 tests,
+// socket activation). The non-loopback auth check inspects the listener's
+// address. A nil listener is rejected (ErrInvalidConfig).
+func WithListener(ln net.Listener) Option {
+	return func(c *config) {
+		if ln == nil {
+			c.errs = append(c.errs, fmt.Errorf("%w: WithListener received a nil net.Listener", ErrInvalidConfig))
+			return
+		}
+		c.listener = ln
+	}
+}

--- a/ops/debug/server.go
+++ b/ops/debug/server.go
@@ -1,0 +1,105 @@
+package debug
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"slices"
+
+	"github.com/dmitrymomot/forge/web/httpserver"
+)
+
+// Server serves the diagnostics surface on a dedicated port and satisfies
+// supervisor.Service. Each Run builds a fresh underlying HTTP server, but a
+// listener injected via WithListener is consumed by the first Run — construct a
+// fresh Server per run when using one.
+type Server struct {
+	handler http.Handler
+	cfg     config
+}
+
+// NewServer builds a Server serving Handler's surface. New does no I/O; binding
+// happens in Run. Invalid option/Config values accumulate and are returned by
+// Run — except an invalid WithBasicAuth credentials map, which panics (see
+// WithBasicAuth).
+func NewServer(opts ...Option) *Server {
+	c := newConfig(opts...)
+	return &Server{cfg: c, handler: buildHandler(&c)}
+}
+
+// Name returns the configured Name, else "debug". Satisfies supervisor.Service.
+func (s *Server) Name() string {
+	if s.cfg.Name != "" {
+		return s.cfg.Name
+	}
+	return "debug"
+}
+
+// Run serves until ctx is cancelled or serving fails, then drains gracefully
+// (delegating lifecycle to web/httpserver). It validates first and does no I/O
+// on failure; a non-loopback bind with no auth middleware and no WithoutAuth
+// fails closed with ErrAuthRequired. WriteTimeout is intentionally disabled on
+// the underlying server: CPU profiles and traces stream for ?seconds=N.
+func (s *Server) Run(ctx context.Context) error {
+	allErrs := slices.Clone(s.cfg.errs)
+	if err := s.cfg.Validate(); err != nil {
+		allErrs = append(allErrs, err)
+	}
+	if !s.cfg.noAuth && len(s.cfg.guards) == 0 && !s.loopbackBound() {
+		allErrs = append(allErrs, fmt.Errorf("%w: addr %q", ErrAuthRequired, s.bindAddr()))
+	}
+	if len(allErrs) > 0 {
+		return errors.Join(allErrs...)
+	}
+
+	cfg := httpserver.DefaultConfig()
+	cfg.Addr = s.cfg.Addr
+	cfg.Name = s.Name()
+	cfg.ReadHeaderTimeout = s.cfg.ReadHeaderTimeout
+	cfg.ShutdownTimeout = s.cfg.ShutdownTimeout
+	cfg.WriteTimeout = 0
+
+	srvOpts := []httpserver.Option{
+		httpserver.WithConfig(cfg),
+		httpserver.WithLogger(s.cfg.logger),
+	}
+	if s.cfg.listener != nil {
+		srvOpts = append(srvOpts, httpserver.WithListener(s.cfg.listener))
+	}
+	return httpserver.New(s.handler, srvOpts...).Run(ctx)
+}
+
+// bindAddr reports the address Run would bind, for error messages.
+func (s *Server) bindAddr() string {
+	if s.cfg.listener != nil {
+		return s.cfg.listener.Addr().String()
+	}
+	return s.cfg.Addr
+}
+
+// loopbackBound reports whether the server would bind a loopback-only address.
+// Only literal loopback forms pass ("localhost", 127.0.0.0/8, ::1, unix
+// sockets); hostnames that merely resolve to loopback fail closed.
+func (s *Server) loopbackBound() bool {
+	if s.cfg.listener != nil {
+		switch a := s.cfg.listener.Addr().(type) {
+		case *net.TCPAddr:
+			return a.IP.IsLoopback()
+		case *net.UnixAddr:
+			return true
+		default:
+			return false
+		}
+	}
+	host, _, err := net.SplitHostPort(s.cfg.Addr)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/ops/debug/server_test.go
+++ b/ops/debug/server_test.go
@@ -1,0 +1,186 @@
+package debug_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/ops/debug"
+)
+
+func TestServerName(t *testing.T) {
+	t.Parallel()
+	if got := debug.NewServer().Name(); got != "debug" {
+		t.Fatalf("Name() = %q, want debug", got)
+	}
+	cfg := debug.DefaultConfig()
+	cfg.Name = "diagnostics"
+	if got := debug.NewServer(debug.WithConfig(cfg)).Name(); got != "diagnostics" {
+		t.Fatalf("Name() = %q, want diagnostics", got)
+	}
+}
+
+func TestServerRunFailsClosedOnNonLoopback(t *testing.T) {
+	t.Parallel()
+	for _, addr := range []string{":6060", "0.0.0.0:6060", "example.internal:6060", "not-an-addr"} {
+		srv := debug.NewServer(debug.WithAddr(addr))
+		err := srv.Run(context.Background())
+		if !errors.Is(err, debug.ErrAuthRequired) {
+			t.Errorf("Run(addr=%q) = %v, want ErrAuthRequired", addr, err)
+		}
+	}
+}
+
+func TestServerRunNonLoopbackListenerFailsClosed(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	srv := debug.NewServer(debug.WithListener(ln))
+	if err := srv.Run(context.Background()); !errors.Is(err, debug.ErrAuthRequired) {
+		t.Fatalf("Run() = %v, want ErrAuthRequired", err)
+	}
+}
+
+func TestServerRunInvalidConfig(t *testing.T) {
+	t.Parallel()
+	srv := debug.NewServer(debug.WithConfig(debug.Config{Addr: "", ReadHeaderTimeout: -1}))
+	err := srv.Run(context.Background())
+	if !errors.Is(err, debug.ErrInvalidConfig) {
+		t.Fatalf("Run() = %v, want ErrInvalidConfig", err)
+	}
+}
+
+func TestServerRunNilListenerRejected(t *testing.T) {
+	t.Parallel()
+	srv := debug.NewServer(debug.WithListener(nil))
+	if err := srv.Run(context.Background()); !errors.Is(err, debug.ErrInvalidConfig) {
+		t.Fatalf("Run() = %v, want ErrInvalidConfig", err)
+	}
+}
+
+// runServer starts srv, waits until it accepts requests at base, and returns a
+// stop func that cancels Run and reports its error.
+func runServer(t *testing.T, srv *debug.Server) (stop func() error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+	return func() error {
+		cancel()
+		select {
+		case err := <-done:
+			return err
+		case <-time.After(5 * time.Second):
+			t.Fatal("Run did not return after cancel")
+			return nil
+		}
+	}
+}
+
+func waitReady(t *testing.T, url string) *http.Response {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		resp, err := http.Get(url) //nolint:gosec // test URL from local listener
+		if err == nil && resp != nil {
+			return resp
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("server never became ready: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestServerServesOnLoopbackWithoutAuth(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := debug.NewServer(debug.WithListener(ln))
+	stop := runServer(t, srv)
+
+	resp := waitReady(t, fmt.Sprintf("http://%s/debug/stats", ln.Addr()))
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if err := stop(); err != nil {
+		t.Fatalf("Run returned %v, want nil", err)
+	}
+}
+
+func TestServerBasicAuthEndToEnd(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := debug.NewServer(
+		debug.WithListener(ln),
+		debug.WithBasicAuth(map[string]string{"ops": "s3cret"}),
+	)
+	stop := runServer(t, srv)
+
+	url := fmt.Sprintf("http://%s/debug/stats", ln.Addr())
+	resp := waitReady(t, url)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want 401", resp.StatusCode)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.SetBasicAuth("ops", "s3cret")
+	authed, err := http.DefaultClient.Do(req)
+	if err != nil || authed == nil {
+		t.Fatalf("authenticated request: %v", err)
+	}
+	defer func() { _ = authed.Body.Close() }()
+	if authed.StatusCode != http.StatusOK {
+		t.Fatalf("authenticated status = %d, want 200", authed.StatusCode)
+	}
+	if err := stop(); err != nil {
+		t.Fatalf("Run returned %v, want nil", err)
+	}
+}
+
+func TestServerWithoutAuthAllowsNonLoopback(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := debug.NewServer(debug.WithListener(ln), debug.WithoutAuth())
+	stop := runServer(t, srv)
+	resp := waitReady(t, fmt.Sprintf("http://127.0.0.1:%d/debug/stats", ln.Addr().(*net.TCPAddr).Port))
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if err := stop(); err != nil {
+		t.Fatalf("Run returned %v, want nil", err)
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	t.Parallel()
+	if err := debug.DefaultConfig().Validate(); err != nil {
+		t.Fatalf("DefaultConfig().Validate() = %v, want nil", err)
+	}
+	bad := debug.Config{Addr: "", ReadHeaderTimeout: -1, ShutdownTimeout: -1}
+	err := bad.Validate()
+	if !errors.Is(err, debug.ErrInvalidConfig) {
+		t.Fatalf("Validate() = %v, want ErrInvalidConfig", err)
+	}
+}

--- a/ops/debug/stats.go
+++ b/ops/debug/stats.go
@@ -1,0 +1,100 @@
+package debug
+
+import (
+	"encoding/json"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+var processStart = time.Now()
+
+// Stats is one point-in-time runtime snapshot, the JSON body of /debug/stats.
+type Stats struct {
+	GoVersion     string   `json:"go_version"`
+	GC            GCStats  `json:"gc"`
+	Mem           MemStats `json:"mem"`
+	UptimeSeconds float64  `json:"uptime_seconds"`
+	Goroutines    int      `json:"goroutines"`
+	GOMAXPROCS    int      `json:"gomaxprocs"`
+	NumCPU        int      `json:"num_cpu"`
+	NumCgoCall    int64    `json:"num_cgo_call"`
+}
+
+// MemStats is the curated subset of runtime.MemStats served by /debug/stats.
+// All sizes are bytes.
+type MemStats struct {
+	Alloc        uint64 `json:"alloc"`
+	TotalAlloc   uint64 `json:"total_alloc"`
+	Sys          uint64 `json:"sys"`
+	Mallocs      uint64 `json:"mallocs"`
+	Frees        uint64 `json:"frees"`
+	HeapAlloc    uint64 `json:"heap_alloc"`
+	HeapSys      uint64 `json:"heap_sys"`
+	HeapInuse    uint64 `json:"heap_inuse"`
+	HeapIdle     uint64 `json:"heap_idle"`
+	HeapReleased uint64 `json:"heap_released"`
+	HeapObjects  uint64 `json:"heap_objects"`
+	StackInuse   uint64 `json:"stack_inuse"`
+	StackSys     uint64 `json:"stack_sys"`
+}
+
+// GCStats summarizes garbage-collector activity. LastGC/LastPauseNs are zero
+// until the first collection.
+type GCStats struct {
+	LastGC       time.Time `json:"last_gc,omitzero"`
+	NextGC       uint64    `json:"next_gc"`
+	PauseTotalNs uint64    `json:"pause_total_ns"`
+	LastPauseNs  uint64    `json:"last_pause_ns"`
+	CPUFraction  float64   `json:"cpu_fraction"`
+	NumGC        uint32    `json:"num_gc"`
+	NumForcedGC  uint32    `json:"num_forced_gc"`
+}
+
+// Snapshot collects the current runtime stats. It calls runtime.ReadMemStats,
+// which briefly stops the world — fine for a diagnostics scrape, not for a per-
+// request hot path.
+func Snapshot() Stats {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	gc := GCStats{
+		NextGC:       m.NextGC,
+		PauseTotalNs: m.PauseTotalNs,
+		CPUFraction:  m.GCCPUFraction,
+		NumGC:        m.NumGC,
+		NumForcedGC:  m.NumForcedGC,
+	}
+	if m.NumGC > 0 {
+		gc.LastGC = time.Unix(0, int64(m.LastGC))
+		gc.LastPauseNs = m.PauseNs[(m.NumGC+255)%256]
+	}
+	return Stats{
+		GoVersion:     runtime.Version(),
+		UptimeSeconds: time.Since(processStart).Seconds(),
+		Goroutines:    runtime.NumGoroutine(),
+		GOMAXPROCS:    runtime.GOMAXPROCS(0),
+		NumCPU:        runtime.NumCPU(),
+		NumCgoCall:    runtime.NumCgoCall(),
+		Mem: MemStats{
+			Alloc:        m.Alloc,
+			TotalAlloc:   m.TotalAlloc,
+			Sys:          m.Sys,
+			Mallocs:      m.Mallocs,
+			Frees:        m.Frees,
+			HeapAlloc:    m.HeapAlloc,
+			HeapSys:      m.HeapSys,
+			HeapInuse:    m.HeapInuse,
+			HeapIdle:     m.HeapIdle,
+			HeapReleased: m.HeapReleased,
+			HeapObjects:  m.HeapObjects,
+			StackInuse:   m.StackInuse,
+			StackSys:     m.StackSys,
+		},
+		GC: gc,
+	}
+}
+
+func statsHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(Snapshot())
+}

--- a/ops/debug/stats_test.go
+++ b/ops/debug/stats_test.go
@@ -1,0 +1,39 @@
+package debug_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/debug"
+)
+
+func TestSnapshot(t *testing.T) {
+	t.Parallel()
+	runtime.GC()
+	s := debug.Snapshot()
+
+	if s.GoVersion != runtime.Version() {
+		t.Errorf("GoVersion = %q, want %q", s.GoVersion, runtime.Version())
+	}
+	if s.Goroutines <= 0 {
+		t.Errorf("Goroutines = %d, want > 0", s.Goroutines)
+	}
+	if s.GOMAXPROCS <= 0 || s.NumCPU <= 0 {
+		t.Errorf("GOMAXPROCS = %d, NumCPU = %d, want > 0", s.GOMAXPROCS, s.NumCPU)
+	}
+	if s.UptimeSeconds < 0 {
+		t.Errorf("UptimeSeconds = %f, want >= 0", s.UptimeSeconds)
+	}
+	if s.Mem.Sys == 0 || s.Mem.HeapAlloc == 0 || s.Mem.Mallocs == 0 {
+		t.Errorf("implausible mem stats: %+v", s.Mem)
+	}
+	if s.GC.NumGC == 0 {
+		t.Errorf("GC.NumGC = 0 after runtime.GC()")
+	}
+	if s.GC.LastGC.IsZero() {
+		t.Errorf("GC.LastGC is zero after runtime.GC()")
+	}
+	if s.GC.NextGC == 0 {
+		t.Errorf("GC.NextGC = 0, want > 0")
+	}
+}


### PR DESCRIPTION
## Summary

Implements the `ops/debug` catalog entry: one internal diagnostics surface — `/debug/pprof/*`, `/debug/stats` (runtime/GC/goroutine JSON), `/debug/vars` (expvar) — with a guard-based auth seam and a dedicated-port `supervisor.Service`.

## API

- **`Handler(opts ...Option) http.Handler`** — one mux with the three surfaces plus a tiny plain-text `/` index. pprof handlers are registered explicitly on the package's own mux (forge never serves `http.DefaultServeMux`). Paths are absolute, so it mounts on an existing internal mux without `StripPrefix`.
- **`Snapshot() Stats`** — exported point-in-time runtime snapshot (curated `runtime.MemStats` subset + GC summary + goroutines/GOMAXPROCS/uptime), also usable outside HTTP. `last_gc`/`last_pause_ns` are zero until the first collection; `last_gc` uses `omitzero`.
- **`NewServer(opts ...Option) *Server`** — `supervisor.Service` on a dedicated port, delegating lifecycle (graceful drain, force-close, listener injection) to `web/httpserver`. `WriteTimeout` is intentionally disabled on the underlying server: CPU profiles and traces stream for the requested `?seconds=N`, which the 30s default would truncate.
- **Auth seam** — `WithBasicAuth(users, guardOpts...)` wraps `guard.BasicAuth` (env-sourced static credentials, constant-time); `WithMiddleware` accepts any custom gate (a `guard.New` chain, ipfilter, ...).

## Fail-closed exposure rule

The default bind is loopback-only (`localhost:6060`), so the zero-ceremony form is safe. `Run` refuses a non-loopback bind (including via an injected listener) when no auth middleware is configured, returning `ErrAuthRequired`, unless `WithoutAuth()` explicitly opts out. Only literal loopback forms pass — `localhost`, `127.0.0.0/8`, `::1`, unix sockets; hostnames that merely resolve to loopback fail closed. An invalid `WithBasicAuth` credentials map panics via guard (a gate with no valid credentials is a wiring bug); everything else accumulates and returns from `Run` per the httpserver idiom.

## Tenancy

N/A — this is a process-level operator surface (same class as `ops/metrics`); it exposes runtime internals of the whole process, and no tenant data flows through it. There is nothing to scope, so no scope seam is added.

## Benchmarks (Apple M3 Max)

```
BenchmarkSnapshot-14          52981    22058 ns/op       0 B/op    0 allocs/op
BenchmarkStatsHandler-14      46857    25574 ns/op    1799 B/op   11 allocs/op
BenchmarkIndexBasicAuth-14   775770     1407 ns/op    2784 B/op   30 allocs/op
```

Post-benchmark pass: `Snapshot` is already zero-alloc and dominated by `runtime.ReadMemStats` (stop-the-world, inherent). The handler's 11 allocs are the JSON encoder plus `httptest` recorder overhead. This is a diagnostics scrape path, not a request hot path — no optimization is warranted, per the readable-first rule.

## Tests

Black-box (`debug_test`): route coverage for all surfaces, BasicAuth 401/challenge/200, custom-middleware gating, empty-users panic, fail-closed matrix (wildcard/0.0.0.0/hostname/garbage addrs + non-loopback listener), invalid config, nil listener, and end-to-end runs over real loopback listeners (unauthenticated 401 → authenticated 200 → clean drain). Full `go test ./...`, `just lint`, and modernize are clean.

Catalog entry removed from `docs/packages.md` per the shipped-package rule.