### PR TITLE
feat(auth): add abac package — attribute/relationship predicates in the access decision seam

### DIFF
--- a/auth/abac/abac.go
+++ b/auth/abac/abac.go
@@ -1,0 +1,180 @@
+package abac
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+// Predicate is a registered Go function answering an attribute/relationship
+// question about a subject acting on a resource: ownership, tree membership,
+// assignment. The relationship data backing the answer stays in consumer code
+// feeding the predicate — abac never fetches anything. A non-nil error fails
+// the decision closed through the access seam. Implementations must be safe
+// for concurrent use.
+type Predicate func(ctx context.Context, s access.Subject, r access.Resource) (bool, error)
+
+// Rule binds a Predicate to the action pattern and resource type it governs.
+// Build rules with Allow and Deny; the zero Rule is rejected by New.
+type Rule struct {
+	pred     Predicate
+	name     string
+	action   string
+	resource string
+	effect   access.Effect
+}
+
+// Allow builds a rule granting action on resourceType when pred is true.
+// action is exact ("documents:read"), a noun wildcard ("documents:*"), or the
+// super pattern "*"; resourceType is an exact Resource.Type or "*" for any.
+// name labels the rule in decision reasons and errors.
+func Allow(name, action, resourceType string, pred Predicate) Rule {
+	return Rule{name: name, action: action, resource: resourceType, pred: pred, effect: access.Allow}
+}
+
+// Deny builds a veto rule: when action and resourceType match and pred is
+// true, the decision is Deny. Deny rules are evaluated before allow rules, so
+// a satisfied veto wins regardless of registration order. Patterns are as in
+// Allow.
+func Deny(name, action, resourceType string, pred Predicate) Rule {
+	return Rule{name: name, action: action, resource: resourceType, pred: pred, effect: access.Deny}
+}
+
+// action pattern kinds, classified once in New so Decide is comparisons only.
+const (
+	matchExact uint8 = iota
+	matchNoun        // "documents:*" — noun stored bare
+	matchAny         // "*"
+)
+
+// compiledRule is a Rule with its pattern classified and its decision reason
+// prebuilt, so the Decide path is allocation-free.
+type compiledRule struct {
+	pred        Predicate
+	name        string
+	action      string // exact action, or bare noun for matchNoun
+	resource    string // exact type; ignored when anyResource
+	reason      string
+	actionKind  uint8
+	anyResource bool
+}
+
+// matches reports whether the rule governs (action, resourceType). Zero-alloc:
+// strings.Cut returns substrings sharing action's backing array.
+func (cr *compiledRule) matches(action, resourceType string) bool {
+	switch cr.actionKind {
+	case matchAny:
+	case matchNoun:
+		noun, _, found := strings.Cut(action, ":")
+		if !found || noun != cr.action {
+			return false
+		}
+	default:
+		if action != cr.action {
+			return false
+		}
+	}
+	return cr.anyResource || cr.resource == resourceType
+}
+
+// Policy is an immutable, concurrent-safe set of rules; it implements
+// access.Decider and drops into a FirstDecisive/DenyOverrides chain alongside
+// rbac and acl.
+type Policy struct {
+	denies []compiledRule
+	allows []compiledRule
+}
+
+// New validates the rules and compiles them into a Policy. Errors:
+// ErrUnnamedRule, ErrDuplicateRule, ErrNilPredicate, ErrEmptyAction,
+// ErrEmptyResource.
+func New(rules ...Rule) (*Policy, error) {
+	p := &Policy{}
+	seen := make(map[string]struct{}, len(rules))
+	for _, r := range rules {
+		if r.name == "" {
+			return nil, ErrUnnamedRule
+		}
+		if _, dup := seen[r.name]; dup {
+			return nil, fmt.Errorf("%w: %q", ErrDuplicateRule, r.name)
+		}
+		seen[r.name] = struct{}{}
+		if r.pred == nil {
+			return nil, fmt.Errorf("%w: rule %q", ErrNilPredicate, r.name)
+		}
+		if r.action == "" {
+			return nil, fmt.Errorf("%w: rule %q", ErrEmptyAction, r.name)
+		}
+		if r.resource == "" {
+			return nil, fmt.Errorf("%w: rule %q", ErrEmptyResource, r.name)
+		}
+
+		cr := compiledRule{pred: r.pred, name: r.name, action: r.action, resource: r.resource}
+		switch {
+		case r.action == "*":
+			cr.actionKind = matchAny
+		case strings.HasSuffix(r.action, ":*"):
+			cr.actionKind = matchNoun
+			cr.action = r.action[:len(r.action)-2]
+		}
+		if r.resource == "*" {
+			cr.anyResource = true
+		}
+		if r.effect == access.Deny {
+			cr.reason = fmt.Sprintf("denied by rule %q", r.name)
+			p.denies = append(p.denies, cr)
+		} else {
+			cr.reason = fmt.Sprintf("allowed by rule %q", r.name)
+			p.allows = append(p.allows, cr)
+		}
+	}
+	return p, nil
+}
+
+const deciderName = "abac"
+
+// Decide implements access.Decider. Deny rules are evaluated first — the first
+// satisfied veto returns Deny — then allow rules — the first satisfied grant
+// returns Allow. With no rule matched or no predicate satisfied it abstains so
+// lower-precedence layers (rbac, scopes) can decide. A predicate error stops
+// evaluation and is returned wrapped with the rule name; the seam fails it
+// closed.
+func (p *Policy) Decide(ctx context.Context, s access.Subject, a access.Action, r access.Resource) (access.Decision, error) {
+	action := string(a)
+	matched := false
+	for i := range p.denies {
+		cr := &p.denies[i]
+		if !cr.matches(action, r.Type) {
+			continue
+		}
+		matched = true
+		ok, err := cr.pred(ctx, s, r)
+		if err != nil {
+			return access.Decision{Effect: access.Abstain, Decider: deciderName}, fmt.Errorf("abac: rule %q: %w", cr.name, err)
+		}
+		if ok {
+			return access.Decision{Effect: access.Deny, Decider: deciderName, Reason: cr.reason}, nil
+		}
+	}
+	for i := range p.allows {
+		cr := &p.allows[i]
+		if !cr.matches(action, r.Type) {
+			continue
+		}
+		matched = true
+		ok, err := cr.pred(ctx, s, r)
+		if err != nil {
+			return access.Decision{Effect: access.Abstain, Decider: deciderName}, fmt.Errorf("abac: rule %q: %w", cr.name, err)
+		}
+		if ok {
+			return access.Decision{Effect: access.Allow, Decider: deciderName, Reason: cr.reason}, nil
+		}
+	}
+	reason := "no rule matched"
+	if matched {
+		reason = "no predicate satisfied"
+	}
+	return access.Decision{Effect: access.Abstain, Decider: deciderName, Reason: reason}, nil
+}

--- a/auth/abac/abac.go
+++ b/auth/abac/abac.go
@@ -87,13 +87,17 @@ type Policy struct {
 	allows []compiledRule
 }
 
-// New validates the rules and compiles them into a Policy. Errors:
-// ErrUnnamedRule, ErrDuplicateRule, ErrNilPredicate, ErrEmptyAction,
+// New validates the rules added via WithRules and compiles them into a Policy.
+// Errors: ErrUnnamedRule, ErrDuplicateRule, ErrNilPredicate, ErrEmptyAction,
 // ErrEmptyResource.
-func New(rules ...Rule) (*Policy, error) {
+func New(opts ...Option) (*Policy, error) {
+	cfg := config{}
+	for _, o := range opts {
+		o(&cfg)
+	}
 	p := &Policy{}
-	seen := make(map[string]struct{}, len(rules))
-	for _, r := range rules {
+	seen := make(map[string]struct{}, len(cfg.rules))
+	for _, r := range cfg.rules {
 		if r.name == "" {
 			return nil, ErrUnnamedRule
 		}

--- a/auth/abac/abac_test.go
+++ b/auth/abac/abac_test.go
@@ -1,0 +1,312 @@
+package abac_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/abac"
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+func truePred(_ context.Context, _ access.Subject, _ access.Resource) (bool, error) {
+	return true, nil
+}
+
+func falsePred(_ context.Context, _ access.Subject, _ access.Resource) (bool, error) {
+	return false, nil
+}
+
+func mustPolicy(t *testing.T, rules ...abac.Rule) *abac.Policy {
+	t.Helper()
+	p, err := abac.New(rules...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return p
+}
+
+func decide(t *testing.T, p *abac.Policy, s access.Subject, a access.Action, r access.Resource) access.Decision {
+	t.Helper()
+	dec, err := p.Decide(context.Background(), s, a, r)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	return dec
+}
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		rule abac.Rule
+		want error
+	}{
+		{"zero rule", abac.Rule{}, abac.ErrUnnamedRule},
+		{"unnamed", abac.Allow("", "documents:read", "document", truePred), abac.ErrUnnamedRule},
+		{"nil predicate", abac.Allow("r", "documents:read", "document", nil), abac.ErrNilPredicate},
+		{"empty action", abac.Allow("r", "", "document", truePred), abac.ErrEmptyAction},
+		{"empty resource", abac.Allow("r", "documents:read", "", truePred), abac.ErrEmptyResource},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := abac.New(tt.rule); !errors.Is(err, tt.want) {
+				t.Fatalf("New error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+
+	t.Run("duplicate name", func(t *testing.T) {
+		t.Parallel()
+		_, err := abac.New(
+			abac.Allow("dup", "documents:read", "document", truePred),
+			abac.Deny("dup", "documents:write", "*", truePred),
+		)
+		if !errors.Is(err, abac.ErrDuplicateRule) {
+			t.Fatalf("New error = %v, want ErrDuplicateRule", err)
+		}
+	})
+
+	t.Run("empty policy is valid and abstains", func(t *testing.T) {
+		t.Parallel()
+		p := mustPolicy(t)
+		dec := decide(t, p, access.Subject{}, "documents:read", access.Resource{})
+		if dec.Effect != access.Abstain {
+			t.Fatalf("Effect = %v, want abstain", dec.Effect)
+		}
+	})
+}
+
+func TestDecideActionMatching(t *testing.T) {
+	t.Parallel()
+
+	p := mustPolicy(t,
+		abac.Allow("exact", "documents:read", "*", truePred),
+		abac.Allow("noun", "reports:*", "*", truePred),
+		abac.Allow("super", "*", "special", truePred),
+	)
+
+	tests := []struct {
+		name     string
+		action   access.Action
+		resource access.Resource
+		effect   access.Effect
+		reason   string
+	}{
+		{"exact hit", "documents:read", access.Resource{Type: "document"}, access.Allow, `allowed by rule "exact"`},
+		{"exact miss", "documents:write", access.Resource{Type: "document"}, access.Abstain, "no rule matched"},
+		{"noun wildcard hit", "reports:export", access.Resource{Type: "report"}, access.Allow, `allowed by rule "noun"`},
+		{"noun wildcard needs separator", "reports", access.Resource{Type: "report"}, access.Abstain, "no rule matched"},
+		{"noun wildcard other noun", "players:read", access.Resource{Type: "report"}, access.Abstain, "no rule matched"},
+		{"super matches anything", "anything:at:all", access.Resource{Type: "special"}, access.Allow, `allowed by rule "super"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dec := decide(t, p, access.Subject{}, tt.action, tt.resource)
+			if dec.Effect != tt.effect {
+				t.Fatalf("Effect = %v, want %v", dec.Effect, tt.effect)
+			}
+			if dec.Reason != tt.reason {
+				t.Fatalf("Reason = %q, want %q", dec.Reason, tt.reason)
+			}
+			if dec.Decider != "abac" {
+				t.Fatalf("Decider = %q, want abac", dec.Decider)
+			}
+		})
+	}
+}
+
+func TestDecideResourceMatching(t *testing.T) {
+	t.Parallel()
+
+	p := mustPolicy(t,
+		abac.Allow("typed", "documents:read", "document", truePred),
+		abac.Allow("any", "reports:read", "*", truePred),
+	)
+
+	tests := []struct {
+		name     string
+		action   access.Action
+		resource access.Resource
+		effect   access.Effect
+	}{
+		{"exact type hit", "documents:read", access.Resource{Type: "document"}, access.Allow},
+		{"type mismatch abstains", "documents:read", access.Resource{Type: "folder"}, access.Abstain},
+		{"empty type does not match exact", "documents:read", access.Resource{}, access.Abstain},
+		{"star matches any type", "reports:read", access.Resource{Type: "report"}, access.Allow},
+		{"star matches empty type", "reports:read", access.Resource{}, access.Allow},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dec := decide(t, p, access.Subject{}, tt.action, tt.resource)
+			if dec.Effect != tt.effect {
+				t.Fatalf("Effect = %v, want %v", dec.Effect, tt.effect)
+			}
+		})
+	}
+}
+
+func TestDecideDenyBeforeAllow(t *testing.T) {
+	t.Parallel()
+
+	// Deny registered AFTER the allow still vetoes: deny rules evaluate first.
+	p := mustPolicy(t,
+		abac.Allow("grant", "documents:read", "document", truePred),
+		abac.Deny("veto", "documents:*", "document", truePred),
+	)
+	dec := decide(t, p, access.Subject{}, "documents:read", access.Resource{Type: "document"})
+	if dec.Effect != access.Deny {
+		t.Fatalf("Effect = %v, want deny", dec.Effect)
+	}
+	if dec.Reason != `denied by rule "veto"` {
+		t.Fatalf("Reason = %q", dec.Reason)
+	}
+
+	// An unsatisfied deny falls through to the allow.
+	p = mustPolicy(t,
+		abac.Deny("veto", "documents:*", "document", falsePred),
+		abac.Allow("grant", "documents:read", "document", truePred),
+	)
+	dec = decide(t, p, access.Subject{}, "documents:read", access.Resource{Type: "document"})
+	if dec.Effect != access.Allow {
+		t.Fatalf("Effect = %v, want allow", dec.Effect)
+	}
+}
+
+func TestDecideFirstSatisfiedAllowWins(t *testing.T) {
+	t.Parallel()
+
+	p := mustPolicy(t,
+		abac.Allow("first", "documents:read", "*", falsePred),
+		abac.Allow("second", "documents:read", "*", truePred),
+		abac.Allow("third", "documents:read", "*", truePred),
+	)
+	dec := decide(t, p, access.Subject{}, "documents:read", access.Resource{})
+	if dec.Reason != `allowed by rule "second"` {
+		t.Fatalf("Reason = %q, want second rule", dec.Reason)
+	}
+}
+
+func TestDecideAbstainReasons(t *testing.T) {
+	t.Parallel()
+
+	p := mustPolicy(t, abac.Allow("grant", "documents:read", "document", falsePred))
+
+	dec := decide(t, p, access.Subject{}, "other:action", access.Resource{Type: "document"})
+	if dec.Effect != access.Abstain || dec.Reason != "no rule matched" {
+		t.Fatalf("got %v %q, want abstain %q", dec.Effect, dec.Reason, "no rule matched")
+	}
+
+	dec = decide(t, p, access.Subject{}, "documents:read", access.Resource{Type: "document"})
+	if dec.Effect != access.Abstain || dec.Reason != "no predicate satisfied" {
+		t.Fatalf("got %v %q, want abstain %q", dec.Effect, dec.Reason, "no predicate satisfied")
+	}
+}
+
+func TestDecidePredicateError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("relationship store down")
+	errPred := func(_ context.Context, _ access.Subject, _ access.Resource) (bool, error) {
+		return true, sentinel
+	}
+
+	for _, tt := range []struct {
+		name string
+		rule abac.Rule
+	}{
+		{"allow rule error", abac.Allow("broken", "documents:read", "*", errPred)},
+		{"deny rule error", abac.Deny("broken", "documents:read", "*", errPred)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := mustPolicy(t, tt.rule)
+			dec, err := p.Decide(context.Background(), access.Subject{}, "documents:read", access.Resource{})
+			if !errors.Is(err, sentinel) {
+				t.Fatalf("err = %v, want wrapped sentinel", err)
+			}
+			if !strings.Contains(err.Error(), `"broken"`) {
+				t.Fatalf("err %q does not name the rule", err)
+			}
+			if dec.Effect != access.Abstain {
+				t.Fatalf("Effect = %v, want abstain (seam fails it closed)", dec.Effect)
+			}
+		})
+	}
+
+	t.Run("error stops evaluation before later rules", func(t *testing.T) {
+		t.Parallel()
+		p := mustPolicy(t,
+			abac.Allow("broken", "documents:read", "*", errPred),
+			abac.Allow("grant", "documents:read", "*", truePred),
+		)
+		if _, err := p.Decide(context.Background(), access.Subject{}, "documents:read", access.Resource{}); !errors.Is(err, sentinel) {
+			t.Fatalf("err = %v, want sentinel", err)
+		}
+	})
+}
+
+func TestDecideInSeamChain(t *testing.T) {
+	t.Parallel()
+
+	policy := mustPolicy(t,
+		abac.Allow("own-document", "documents:*", "document", abac.Owner("owner_id")),
+	)
+	d := access.FirstDecisive(access.TenantMatch(), policy, access.ScopeDecider())
+
+	owned := access.Resource{Type: "document", ID: "d1", Attrs: map[string]any{"owner_id": "u1"}}
+
+	// Ownership grants without any scope.
+	dec, err := access.Authorize(context.Background(), d, access.Subject{ID: "u1"}, "documents:write", owned)
+	if err != nil || dec.Effect != access.Allow {
+		t.Fatalf("got %v %v, want allow", dec.Effect, err)
+	}
+
+	// Non-owner without a scope: abac abstains, chain closes to deny.
+	dec, err = access.Authorize(context.Background(), d, access.Subject{ID: "u2"}, "documents:write", owned)
+	if err != nil || dec.Effect != access.Deny {
+		t.Fatalf("got %v %v, want deny", dec.Effect, err)
+	}
+
+	// Cross-tenant veto beats ownership: TenantMatch sits above abac.
+	crossTenant := access.Resource{Type: "document", ID: "d1", Tenant: "t2", Attrs: map[string]any{"owner_id": "u1"}}
+	dec, err = access.Authorize(context.Background(), d, access.Subject{ID: "u1", Tenant: "t1"}, "documents:write", crossTenant)
+	if err != nil || dec.Effect != access.Deny {
+		t.Fatalf("got %v %v, want deny", dec.Effect, err)
+	}
+}
+
+func TestDecideConcurrent(t *testing.T) {
+	t.Parallel()
+
+	p := mustPolicy(t,
+		abac.Deny("veto", "documents:delete", "document", truePred),
+		abac.Allow("own-document", "documents:*", "document", abac.Owner("owner_id")),
+	)
+	res := access.Resource{Type: "document", Attrs: map[string]any{"owner_id": "u1"}}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for range 500 {
+				dec, err := p.Decide(context.Background(), access.Subject{ID: "u1"}, "documents:read", res)
+				if err != nil || dec.Effect != access.Allow {
+					t.Errorf("got %v %v, want allow", dec.Effect, err)
+					return
+				}
+				dec, err = p.Decide(context.Background(), access.Subject{ID: "u1"}, "documents:delete", res)
+				if err != nil || dec.Effect != access.Deny {
+					t.Errorf("got %v %v, want deny", dec.Effect, err)
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/auth/abac/abac_test.go
+++ b/auth/abac/abac_test.go
@@ -21,7 +21,7 @@ func falsePred(_ context.Context, _ access.Subject, _ access.Resource) (bool, er
 
 func mustPolicy(t *testing.T, rules ...abac.Rule) *abac.Policy {
 	t.Helper()
-	p, err := abac.New(rules...)
+	p, err := abac.New(abac.WithRules(rules...))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestNewValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if _, err := abac.New(tt.rule); !errors.Is(err, tt.want) {
+			if _, err := abac.New(abac.WithRules(tt.rule)); !errors.Is(err, tt.want) {
 				t.Fatalf("New error = %v, want %v", err, tt.want)
 			}
 		})
@@ -62,9 +62,10 @@ func TestNewValidation(t *testing.T) {
 
 	t.Run("duplicate name", func(t *testing.T) {
 		t.Parallel()
+		// Accumulation across WithRules calls still detects the duplicate.
 		_, err := abac.New(
-			abac.Allow("dup", "documents:read", "document", truePred),
-			abac.Deny("dup", "documents:write", "*", truePred),
+			abac.WithRules(abac.Allow("dup", "documents:read", "document", truePred)),
+			abac.WithRules(abac.Deny("dup", "documents:write", "*", truePred)),
 		)
 		if !errors.Is(err, abac.ErrDuplicateRule) {
 			t.Fatalf("New error = %v, want ErrDuplicateRule", err)

--- a/auth/abac/bench_test.go
+++ b/auth/abac/bench_test.go
@@ -1,0 +1,97 @@
+package abac_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/abac"
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+func benchPolicy(b *testing.B) *abac.Policy {
+	b.Helper()
+	p, err := abac.New(
+		abac.Deny("archived-write", "documents:write", "document",
+			func(_ context.Context, _ access.Subject, r access.Resource) (bool, error) {
+				archived, _ := abac.Attr[bool](r.Attrs, "archived")
+				return archived, nil
+			}),
+		abac.Allow("own-document", "documents:*", "document", abac.Owner("owner_id")),
+		abac.Allow("public-read", "documents:read", "document",
+			func(_ context.Context, _ access.Subject, r access.Resource) (bool, error) {
+				public, _ := abac.Attr[bool](r.Attrs, "public")
+				return public, nil
+			}),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return p
+}
+
+func BenchmarkDecideAllow(b *testing.B) {
+	p := benchPolicy(b)
+	ctx := context.Background()
+	sub := access.Subject{ID: "u1"}
+	res := access.Resource{Type: "document", ID: "d1", Attrs: map[string]any{"owner_id": "u1"}}
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = p.Decide(ctx, sub, "documents:read", res)
+	}
+}
+
+func BenchmarkDecideDeny(b *testing.B) {
+	p := benchPolicy(b)
+	ctx := context.Background()
+	sub := access.Subject{ID: "u1"}
+	res := access.Resource{Type: "document", ID: "d1", Attrs: map[string]any{"owner_id": "u1", "archived": true}}
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = p.Decide(ctx, sub, "documents:write", res)
+	}
+}
+
+func BenchmarkDecideAbstain(b *testing.B) {
+	p := benchPolicy(b)
+	ctx := context.Background()
+	sub := access.Subject{ID: "u1"}
+	res := access.Resource{Type: "report", ID: "r1"}
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = p.Decide(ctx, sub, "reports:read", res)
+	}
+}
+
+// BenchmarkDecideWidePolicy is the worst case for the linear rule scan: 60
+// rules across 20 resource types, deciding an action only the last rule
+// matches.
+func BenchmarkDecideWidePolicy(b *testing.B) {
+	rules := make([]abac.Rule, 0, 60)
+	for i := range 60 {
+		typ := "type" + string(rune('a'+i%20))
+		rules = append(rules, abac.Allow(fmt.Sprintf("rule-%d", i), fmt.Sprintf("noun%d:read", i), typ, truePredBench))
+	}
+	p, err := abac.New(rules...)
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	sub := access.Subject{ID: "u1"}
+	res := access.Resource{Type: "type" + string(rune('a'+59%20))}
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = p.Decide(ctx, sub, "noun59:read", res)
+	}
+}
+
+func truePredBench(_ context.Context, _ access.Subject, _ access.Resource) (bool, error) {
+	return true, nil
+}
+
+func BenchmarkNew(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = benchPolicy(b)
+	}
+}

--- a/auth/abac/bench_test.go
+++ b/auth/abac/bench_test.go
@@ -11,7 +11,7 @@ import (
 
 func benchPolicy(b *testing.B) *abac.Policy {
 	b.Helper()
-	p, err := abac.New(
+	p, err := abac.New(abac.WithRules(
 		abac.Deny("archived-write", "documents:write", "document",
 			func(_ context.Context, _ access.Subject, r access.Resource) (bool, error) {
 				archived, _ := abac.Attr[bool](r.Attrs, "archived")
@@ -23,7 +23,7 @@ func benchPolicy(b *testing.B) *abac.Policy {
 				public, _ := abac.Attr[bool](r.Attrs, "public")
 				return public, nil
 			}),
-	)
+	))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func BenchmarkDecideWidePolicy(b *testing.B) {
 		typ := "type" + string(rune('a'+i%20))
 		rules = append(rules, abac.Allow(fmt.Sprintf("rule-%d", i), fmt.Sprintf("noun%d:read", i), typ, truePredBench))
 	}
-	p, err := abac.New(rules...)
+	p, err := abac.New(abac.WithRules(rules...))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/auth/abac/doc.go
+++ b/auth/abac/doc.go
@@ -20,14 +20,14 @@
 //
 // Wiring (composed with rbac under the documented precedence):
 //
-//	policy, err := abac.New(
+//	policy, err := abac.New(abac.WithRules(
 //		abac.Allow("own-document", "documents:*", "document", abac.Owner("owner_id")),
 //		abac.Deny("archived-write", "documents:write", "document",
 //			func(ctx context.Context, s access.Subject, r access.Resource) (bool, error) {
 //				archived, _ := abac.Attr[bool](r.Attrs, "archived")
 //				return archived, nil
 //			}),
-//	)
+//	))
 //	if err != nil { ... }
 //	decider := access.FirstDecisive(access.TenantMatch(), policy, rbacDecider)
 //	mux.Handle("PUT /docs/{id}", authn(docs.Handle(decider, "documents:write", updateDoc)))

--- a/auth/abac/doc.go
+++ b/auth/abac/doc.go
@@ -1,0 +1,34 @@
+// Package abac evaluates attribute/relationship predicates — registered Go
+// functions — as one layer in the auth/access decision seam: "agent sees own
+// subtree but not subagents' player details". There is no policy DSL and no
+// storage: the relationship data (trees, assignments, ownership) stays in
+// consumer code feeding the predicate, and rules are plain Go registered at
+// startup.
+//
+// A Policy is an immutable, concurrent-safe set of named rules built by New.
+// Each rule binds a Predicate to the action pattern (exact "documents:read",
+// noun wildcard "documents:*", or super "*") and resource type (exact or "*")
+// it governs. Deciding evaluates deny rules before allow rules — a satisfied
+// deny vetoes regardless of registration order — and abstains when nothing
+// matched, so rbac/acl layers below can speak. A predicate error fails the
+// decision closed through the seam.
+//
+// Tenancy is a passed value: predicates receive Subject.Tenant and
+// Resource.Tenant on their arguments, and access.TenantMatch placed first in
+// the chain vetoes cross-tenant access by construction. Single-tenant apps
+// leave both empty.
+//
+// Wiring (composed with rbac under the documented precedence):
+//
+//	policy, err := abac.New(
+//		abac.Allow("own-document", "documents:*", "document", abac.Owner("owner_id")),
+//		abac.Deny("archived-write", "documents:write", "document",
+//			func(ctx context.Context, s access.Subject, r access.Resource) (bool, error) {
+//				archived, _ := abac.Attr[bool](r.Attrs, "archived")
+//				return archived, nil
+//			}),
+//	)
+//	if err != nil { ... }
+//	decider := access.FirstDecisive(access.TenantMatch(), policy, rbacDecider)
+//	mux.Handle("PUT /docs/{id}", authn(docs.Handle(decider, "documents:write", updateDoc)))
+package abac

--- a/auth/abac/errors.go
+++ b/auth/abac/errors.go
@@ -1,0 +1,23 @@
+package abac
+
+import "errors"
+
+var (
+	// ErrUnnamedRule is returned by New for a rule with an empty name (including
+	// the zero Rule). Names label decisions in the explanation record.
+	ErrUnnamedRule = errors.New("abac: rule has no name")
+
+	// ErrDuplicateRule is returned by New when two rules share a name — names
+	// must be unique so an explanation points at exactly one rule.
+	ErrDuplicateRule = errors.New("abac: duplicate rule name")
+
+	// ErrNilPredicate is returned by New for a rule with a nil predicate.
+	ErrNilPredicate = errors.New("abac: nil predicate")
+
+	// ErrEmptyAction is returned by New for a rule with an empty action pattern.
+	ErrEmptyAction = errors.New("abac: rule has no action pattern")
+
+	// ErrEmptyResource is returned by New for a rule with an empty resource
+	// type. Matching any resource type must be the explicit "*".
+	ErrEmptyResource = errors.New("abac: rule has no resource type")
+)

--- a/auth/abac/example_test.go
+++ b/auth/abac/example_test.go
@@ -23,7 +23,7 @@ func Example() {
 		return false
 	}
 
-	policy, err := abac.New(
+	policy, err := abac.New(abac.WithRules(
 		abac.Allow("own-subtree", "agents:read", "agent",
 			func(_ context.Context, s access.Subject, r access.Resource) (bool, error) {
 				return inSubtree(s.ID, r.ID), nil
@@ -33,7 +33,7 @@ func Example() {
 				agentID, _ := abac.Attr[string](r.Attrs, "agent_id")
 				return agentID != s.ID && inSubtree(s.ID, agentID), nil
 			}),
-	)
+	))
 	if err != nil {
 		panic(err)
 	}

--- a/auth/abac/example_test.go
+++ b/auth/abac/example_test.go
@@ -1,0 +1,54 @@
+package abac_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/auth/abac"
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+// The catalog scenario: an agent sees agents in its own subtree but not its
+// subagents' player details. The relationship data (the agent tree) stays in
+// consumer code feeding the predicates.
+func Example() {
+	parent := map[string]string{"sub1": "agent1", "sub2": "sub1"}
+	inSubtree := func(root, node string) bool {
+		for node != "" {
+			if node == root {
+				return true
+			}
+			node = parent[node]
+		}
+		return false
+	}
+
+	policy, err := abac.New(
+		abac.Allow("own-subtree", "agents:read", "agent",
+			func(_ context.Context, s access.Subject, r access.Resource) (bool, error) {
+				return inSubtree(s.ID, r.ID), nil
+			}),
+		abac.Deny("subagent-player-details", "players:read", "player",
+			func(_ context.Context, s access.Subject, r access.Resource) (bool, error) {
+				agentID, _ := abac.Attr[string](r.Attrs, "agent_id")
+				return agentID != s.ID && inSubtree(s.ID, agentID), nil
+			}),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	agent := access.Subject{ID: "agent1"}
+
+	dec, _ := access.Authorize(context.Background(), policy, agent,
+		"agents:read", access.Resource{Type: "agent", ID: "sub2"})
+	fmt.Println(dec.Effect, "—", dec.Reason)
+
+	dec, _ = access.Authorize(context.Background(), policy, agent,
+		"players:read", access.Resource{Type: "player", ID: "p1", Attrs: map[string]any{"agent_id": "sub1"}})
+	fmt.Println(dec.Effect, "—", dec.Reason)
+
+	// Output:
+	// allow — allowed by rule "own-subtree"
+	// deny — denied by rule "subagent-player-details"
+}

--- a/auth/abac/options.go
+++ b/auth/abac/options.go
@@ -1,0 +1,15 @@
+package abac
+
+type config struct {
+	rules []Rule
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithRules adds rules to the policy. Accumulates across calls, so rule sets
+// can be assembled from multiple call sites (feature modules registering their
+// own predicates).
+func WithRules(rules ...Rule) Option {
+	return func(c *config) { c.rules = append(c.rules, rules...) }
+}

--- a/auth/abac/predicates.go
+++ b/auth/abac/predicates.go
@@ -1,0 +1,93 @@
+package abac
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+// Attr reads a typed attribute from a Subject/Resource attribute bag. Nil-safe;
+// ok is false when the key is absent or the value is not a T.
+func Attr[T any](attrs map[string]any, key string) (T, bool) {
+	v, ok := attrs[key]
+	if !ok {
+		var zero T
+		return zero, false
+	}
+	t, ok := v.(T)
+	return t, ok
+}
+
+// Owner is the most common relationship predicate: true when the resource's
+// attrKey string attribute equals the subject ID and both are non-empty.
+// Consumers populate the attribute when describing the resource
+// (Attrs: map[string]any{"owner_id": doc.OwnerID}).
+func Owner(attrKey string) Predicate {
+	return func(_ context.Context, s access.Subject, r access.Resource) (bool, error) {
+		owner, ok := Attr[string](r.Attrs, attrKey)
+		return ok && owner != "" && owner == s.ID, nil
+	}
+}
+
+// And is true when every predicate is true; it short-circuits on the first
+// false. With no predicates it is false (fail closed — an empty conjunction
+// must not grant). An error stops evaluation and propagates. Nil predicates
+// panic here at wiring time rather than at request time.
+func And(preds ...Predicate) Predicate {
+	requireNonNil("And", preds)
+	return func(ctx context.Context, s access.Subject, r access.Resource) (bool, error) {
+		if len(preds) == 0 {
+			return false, nil
+		}
+		for _, p := range preds {
+			ok, err := p(ctx, s, r)
+			if err != nil || !ok {
+				return false, err
+			}
+		}
+		return true, nil
+	}
+}
+
+// Or is true when any predicate is true; it short-circuits on the first true.
+// With no predicates it is false. An error stops evaluation and propagates
+// (fail closed) even if a later predicate would have been true. Nil predicates
+// panic here at wiring time rather than at request time.
+func Or(preds ...Predicate) Predicate {
+	requireNonNil("Or", preds)
+	return func(ctx context.Context, s access.Subject, r access.Resource) (bool, error) {
+		for _, p := range preds {
+			ok, err := p(ctx, s, r)
+			if err != nil {
+				return false, err
+			}
+			if ok {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+}
+
+// Not inverts pred. An error propagates with a false result (fail closed), not
+// an inverted one. A nil pred panics here at wiring time.
+func Not(pred Predicate) Predicate {
+	if pred == nil {
+		panic("abac: Not requires a non-nil predicate")
+	}
+	return func(ctx context.Context, s access.Subject, r access.Resource) (bool, error) {
+		ok, err := pred(ctx, s, r)
+		if err != nil {
+			return false, err
+		}
+		return !ok, nil
+	}
+}
+
+func requireNonNil(combinator string, preds []Predicate) {
+	for _, p := range preds {
+		if p == nil {
+			panic("abac: " + combinator + " requires non-nil predicates")
+		}
+	}
+}

--- a/auth/abac/predicates_test.go
+++ b/auth/abac/predicates_test.go
@@ -1,0 +1,158 @@
+package abac_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/abac"
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+func evalPred(t *testing.T, p abac.Predicate, s access.Subject, r access.Resource) (bool, error) {
+	t.Helper()
+	return p(context.Background(), s, r)
+}
+
+func TestAttr(t *testing.T) {
+	t.Parallel()
+
+	attrs := map[string]any{"owner_id": "u1", "count": 3, "archived": true}
+
+	if v, ok := abac.Attr[string](attrs, "owner_id"); !ok || v != "u1" {
+		t.Fatalf("string attr = %q %v", v, ok)
+	}
+	if v, ok := abac.Attr[int](attrs, "count"); !ok || v != 3 {
+		t.Fatalf("int attr = %d %v", v, ok)
+	}
+	if _, ok := abac.Attr[string](attrs, "count"); ok {
+		t.Fatal("wrong type must not match")
+	}
+	if _, ok := abac.Attr[string](attrs, "missing"); ok {
+		t.Fatal("missing key must not match")
+	}
+	if _, ok := abac.Attr[string](nil, "owner_id"); ok {
+		t.Fatal("nil map must not match")
+	}
+}
+
+func TestOwner(t *testing.T) {
+	t.Parallel()
+
+	pred := abac.Owner("owner_id")
+	owned := access.Resource{Attrs: map[string]any{"owner_id": "u1"}}
+
+	tests := []struct {
+		name     string
+		subject  access.Subject
+		resource access.Resource
+		want     bool
+	}{
+		{"owner matches", access.Subject{ID: "u1"}, owned, true},
+		{"other subject", access.Subject{ID: "u2"}, owned, false},
+		{"missing attr", access.Subject{ID: "u1"}, access.Resource{}, false},
+		{"non-string attr", access.Subject{ID: "u1"}, access.Resource{Attrs: map[string]any{"owner_id": 7}}, false},
+		{"empty owner and empty subject", access.Subject{}, access.Resource{Attrs: map[string]any{"owner_id": ""}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := evalPred(t, pred, tt.subject, tt.resource)
+			if err != nil || got != tt.want {
+				t.Fatalf("Owner = %v %v, want %v", got, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestAnd(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	errPred := abac.Predicate(func(_ context.Context, _ access.Subject, _ access.Resource) (bool, error) {
+		return true, sentinel
+	})
+	panicPred := abac.Predicate(func(_ context.Context, _ access.Subject, _ access.Resource) (bool, error) {
+		panic("must not be evaluated")
+	})
+
+	if ok, err := evalPred(t, abac.And(truePred, truePred), access.Subject{}, access.Resource{}); err != nil || !ok {
+		t.Fatalf("all true = %v %v", ok, err)
+	}
+	if ok, err := evalPred(t, abac.And(falsePred, panicPred), access.Subject{}, access.Resource{}); err != nil || ok {
+		t.Fatalf("short-circuit on false = %v %v", ok, err)
+	}
+	if ok, err := evalPred(t, abac.And(errPred, panicPred), access.Subject{}, access.Resource{}); !errors.Is(err, sentinel) || ok {
+		t.Fatalf("error propagation = %v %v", ok, err)
+	}
+	if ok, err := evalPred(t, abac.And(), access.Subject{}, access.Resource{}); err != nil || ok {
+		t.Fatalf("empty And must be false (fail closed) = %v %v", ok, err)
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("nil predicate must panic at wiring time")
+		}
+	}()
+	abac.And(truePred, nil)
+}
+
+func TestOr(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	errPred := abac.Predicate(func(_ context.Context, _ access.Subject, _ access.Resource) (bool, error) {
+		return false, sentinel
+	})
+	panicPred := abac.Predicate(func(_ context.Context, _ access.Subject, _ access.Resource) (bool, error) {
+		panic("must not be evaluated")
+	})
+
+	if ok, err := evalPred(t, abac.Or(truePred, panicPred), access.Subject{}, access.Resource{}); err != nil || !ok {
+		t.Fatalf("short-circuit on true = %v %v", ok, err)
+	}
+	if ok, err := evalPred(t, abac.Or(falsePred, falsePred), access.Subject{}, access.Resource{}); err != nil || ok {
+		t.Fatalf("all false = %v %v", ok, err)
+	}
+	// Fail closed: an error wins over a later true.
+	if ok, err := evalPred(t, abac.Or(errPred, truePred), access.Subject{}, access.Resource{}); !errors.Is(err, sentinel) || ok {
+		t.Fatalf("error propagation = %v %v", ok, err)
+	}
+	if ok, err := evalPred(t, abac.Or(), access.Subject{}, access.Resource{}); err != nil || ok {
+		t.Fatalf("empty Or must be false = %v %v", ok, err)
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("nil predicate must panic at wiring time")
+		}
+	}()
+	abac.Or(nil)
+}
+
+func TestNot(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	errPred := abac.Predicate(func(_ context.Context, _ access.Subject, _ access.Resource) (bool, error) {
+		return true, sentinel
+	})
+
+	if ok, err := evalPred(t, abac.Not(falsePred), access.Subject{}, access.Resource{}); err != nil || !ok {
+		t.Fatalf("Not(false) = %v %v", ok, err)
+	}
+	if ok, err := evalPred(t, abac.Not(truePred), access.Subject{}, access.Resource{}); err != nil || ok {
+		t.Fatalf("Not(true) = %v %v", ok, err)
+	}
+	// Fail closed: an error is not inverted into a grant.
+	if ok, err := evalPred(t, abac.Not(errPred), access.Subject{}, access.Resource{}); !errors.Is(err, sentinel) || ok {
+		t.Fatalf("Not(error) = %v %v", ok, err)
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("nil predicate must panic at wiring time")
+		}
+	}()
+	abac.Not(nil)
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -456,17 +456,6 @@ Deps: `auth/access`.
 
 ---
 
-**auth/abac**
-
-Attribute/relationship predicates as registered Go functions — "agent sees
-own subtree but not subagents' player details" — evaluated in the
-`access` decision seam alongside rbac/acl. The relationship data (trees,
-assignments) stays consumer code feeding the predicate; no policy DSL.
-
-Deps: `auth/access`.
-
----
-
 **auth/webauthn**
 
 Passkey registration and assertion over isolated `go-webauthn` (CBOR/COSE


### PR DESCRIPTION
## Summary

New `auth/abac` package: attribute/relationship predicates as registered Go functions, evaluated as one layer in the `auth/access` decision seam — "agent sees own subtree but not subagents' player details". No policy DSL, no storage: the relationship data (trees, assignments, ownership) stays in consumer code feeding the predicates.

## Design

- **`Policy`** — immutable, concurrent-safe set of named rules built by `New(rules ...Rule)`; implements `access.Decider` directly, so it drops into `access.FirstDecisive(access.TenantMatch(), policy, rbacDecider)` under the documented precedence.
- **Rules** — `abac.Allow(name, action, resourceType, pred)` / `abac.Deny(...)`. Action patterns mirror rbac's grant forms (exact `documents:read`, noun wildcard `documents:*`, super `*`); resource type is exact or `*` (empty type only matches `*` — matching "any" is always explicit).
- **Deny before allow** — deny rules evaluate first, so a satisfied veto wins regardless of registration order; within an effect, first satisfied rule wins. Nothing matched / nothing satisfied → Abstain (never Deny), so rbac/scopes below can speak — same contract as `rbac.Decider`.
- **Fail closed** — a predicate error stops evaluation and returns wrapped with the rule name; the seam turns it into Deny. `And`/`Or`/`Not` propagate errors (an error is never inverted or out-voted); empty `And()`/`Or()` are false; nil predicates panic at wiring time (the `access.NewModel` precedent).
- **Explainability** — every decision carries `Decider: "abac"` and a precomputed reason naming the rule (`allowed by rule "own-document"`), distinguishing "no rule matched" from "no predicate satisfied" on the abstain path.
- **Helpers** — `Owner(attrKey)` (the ownership predicate), `Attr[T](attrs, key)` typed bag reader, `And`/`Or`/`Not` combinators.
- **Tenancy** — passed value, not a seam: predicates receive `Subject.Tenant`/`Resource.Tenant`, and `access.TenantMatch` placed above vetoes cross-tenant access by construction; single-tenant apps leave both empty (zero ceremony).

Validation errors are `errors.Is`-matchable sentinels: `ErrUnnamedRule`, `ErrDuplicateRule`, `ErrNilPredicate`, `ErrEmptyAction`, `ErrEmptyResource`.

Catalog entry removed from `docs/packages.md` (shipped packages leave the roadmap).

## Benchmarks (Apple M3 Max)

```
BenchmarkDecideAllow-14         108835334   22.01 ns/op   0 B/op   0 allocs/op
BenchmarkDecideDeny-14          165945456   14.53 ns/op   0 B/op   0 allocs/op
BenchmarkDecideAbstain-14       147695935   16.19 ns/op   0 B/op   0 allocs/op
BenchmarkDecideWidePolicy-14     14020348  171.1  ns/op   0 B/op   0 allocs/op
BenchmarkNew-14                   2598775  801.5  ns/op  536 B/op  11 allocs/op
```

Post-benchmark optimization pass: decision reasons and pattern classification are precomputed in `New`, making every `Decide` path zero-alloc out of the gate (matching uses `strings.Cut` substrings, no map lookups needed). The worst case — a 60-rule policy where only the last rule matches — is a 171ns linear scan with zero allocs; indexing rules by action would add complexity for a sub-200ns win on unrealistically wide policies, so per the perf meta-rule (readable first) it stays a linear scan.

## Testing

- 100% statement coverage, black-box (`abac_test`), race-clean; concurrent-decide test exercises the immutable policy under `-race`.
- Runnable `Example` reproduces the catalog scenario (own-subtree allow + subagent-player deny).
- Seam integration test composes the policy under `FirstDecisive` with `TenantMatch` and `ScopeDecider` and checks the fail-closed `Authorize` contract.
- `just lint` clean (vet, golangci-lint, nilaway, betteralign, modernize, integration tier).
