### PR TITLE
feat(acl): per-subject/per-resource grant-deny override layer

### DIFF
--- a/auth/acl/acl.go
+++ b/auth/acl/acl.go
@@ -1,0 +1,30 @@
+package acl
+
+import "github.com/dmitrymomot/forge/auth/access"
+
+// Entry is one ACL override: Subject may (Effect Allow) or may not (Effect
+// Deny) perform Action on the addressed resource. ResourceID "" makes the
+// entry type-wide — it matches every resource of ResourceType, collection
+// checks included. Action is the exact action string, or "*" for every action
+// on the resource. Any other Effect (including the zero value Abstain) never
+// matches, so a zero Entry grants nothing.
+type Entry struct {
+	Subject      string
+	ResourceType string
+	ResourceID   string
+	Action       string
+	Effect       access.Effect
+}
+
+// matches reports whether the entry applies to (resourceType, resourceID,
+// action). The Decider re-filters with it so an over-returning Store can
+// never widen a grant onto the wrong resource.
+func (e Entry) matches(resourceType, resourceID string, action access.Action) bool {
+	if e.ResourceType != resourceType {
+		return false
+	}
+	if e.ResourceID != "" && e.ResourceID != resourceID {
+		return false
+	}
+	return e.Action == "*" || e.Action == string(action)
+}

--- a/auth/acl/bench_test.go
+++ b/auth/acl/bench_test.go
@@ -1,0 +1,70 @@
+package acl_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/auth/acl"
+)
+
+// benchStore holds a subject with n specific grants plus one type-wide deny —
+// the "manager sees exactly these assigned agents" shape.
+func benchStore(b *testing.B, n int) acl.Store {
+	b.Helper()
+	store := acl.NewMemoryStore()
+	m := acl.NewManager(store)
+	ctx := context.Background()
+	for i := range n {
+		if err := m.Grant(ctx, "mgr", "agent", strconv.Itoa(i), "agents:read"); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := m.Deny(ctx, "mgr", "report", "", "reports:export"); err != nil {
+		b.Fatal(err)
+	}
+	return store
+}
+
+func BenchmarkDeciderGrant(b *testing.B) {
+	d := acl.Decider(benchStore(b, 100))
+	ctx := context.Background()
+	sub := access.Subject{ID: "mgr"}
+	res := access.Resource{Type: "agent", ID: "42"}
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = d.Decide(ctx, sub, "agents:read", res)
+	}
+}
+
+func BenchmarkDeciderDeny(b *testing.B) {
+	d := acl.Decider(benchStore(b, 100))
+	ctx := context.Background()
+	sub := access.Subject{ID: "mgr"}
+	res := access.Resource{Type: "report", ID: "7"}
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = d.Decide(ctx, sub, "reports:export", res)
+	}
+}
+
+func BenchmarkDeciderAbstain(b *testing.B) {
+	d := acl.Decider(benchStore(b, 100))
+	ctx := context.Background()
+	sub := access.Subject{ID: "nobody"}
+	res := access.Resource{Type: "agent", ID: "42"}
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = d.Decide(ctx, sub, "agents:read", res)
+	}
+}
+
+func BenchmarkMemoryEntriesFor(b *testing.B) {
+	store := benchStore(b, 100)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = store.EntriesFor(ctx, "", "mgr", "agent", "42")
+	}
+}

--- a/auth/acl/decider.go
+++ b/auth/acl/decider.go
@@ -1,0 +1,38 @@
+package acl
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+// Decider adapts the entry Store to the access seam. It fetches the subject's
+// entries on (Resource.Type, Resource.ID) — type-wide entries included — and
+// applies deny-wins: any matching Deny entry → Deny, else any matching Allow
+// entry → Allow, else Abstain (rbac or another layer may still grant). The
+// tenant is Subject.Tenant, so entries never cross tenants. A Store error
+// abstains and returns the error so combinators fail the chain closed.
+func Decider(store Store) access.Decider {
+	return access.DeciderFunc(func(ctx context.Context, s access.Subject, a access.Action, r access.Resource) (access.Decision, error) {
+		entries, err := store.EntriesFor(ctx, s.Tenant, s.ID, r.Type, r.ID)
+		if err != nil {
+			return access.Decision{Effect: access.Abstain, Decider: "acl"}, err
+		}
+		allowed := false
+		for _, e := range entries {
+			if !e.matches(r.Type, r.ID, a) {
+				continue
+			}
+			switch e.Effect {
+			case access.Deny:
+				return access.Decision{Effect: access.Deny, Decider: "acl", Reason: "explicit deny"}, nil
+			case access.Allow:
+				allowed = true
+			}
+		}
+		if allowed {
+			return access.Decision{Effect: access.Allow, Decider: "acl", Reason: "explicit grant"}, nil
+		}
+		return access.Decision{Effect: access.Abstain, Decider: "acl", Reason: "no matching entry"}, nil
+	})
+}

--- a/auth/acl/decider_test.go
+++ b/auth/acl/decider_test.go
@@ -1,0 +1,154 @@
+package acl_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/auth/acl"
+)
+
+// fakeStore returns canned entries and records the EntriesFor arguments.
+type fakeStore struct {
+	err     error
+	entries []acl.Entry
+	got     [4]string // tenant, subject, resourceType, resourceID
+}
+
+func (f *fakeStore) EntriesFor(_ context.Context, tenant, subject, resourceType, resourceID string) ([]acl.Entry, error) {
+	f.got = [4]string{tenant, subject, resourceType, resourceID}
+	return f.entries, f.err
+}
+
+func (f *fakeStore) ListFor(context.Context, string, string) ([]acl.Entry, error) { return nil, nil }
+func (f *fakeStore) Put(context.Context, string, []acl.Entry) error               { return nil }
+func (f *fakeStore) Delete(context.Context, string, string, string, string, []string) error {
+	return nil
+}
+
+func decide(t *testing.T, store acl.Store, sub access.Subject, action access.Action, res access.Resource) access.Decision {
+	t.Helper()
+	dec, err := acl.Decider(store).Decide(context.Background(), sub, action, res)
+	require.NoError(t, err)
+	return dec
+}
+
+func TestDeciderGrantDenyAbstain(t *testing.T) {
+	ctx := context.Background()
+	store := acl.NewMemoryStore()
+	m := acl.NewManager(store)
+	require.NoError(t, m.Grant(ctx, "mgr-7", "agent", "42", "agents:read"))
+	require.NoError(t, m.Deny(ctx, "mgr-7", "agent", "13", "agents:read"))
+
+	sub := access.Subject{ID: "mgr-7"}
+
+	dec := decide(t, store, sub, "agents:read", access.Resource{Type: "agent", ID: "42"})
+	assert.Equal(t, access.Allow, dec.Effect)
+	assert.Equal(t, "acl", dec.Decider)
+
+	dec = decide(t, store, sub, "agents:read", access.Resource{Type: "agent", ID: "13"})
+	assert.Equal(t, access.Deny, dec.Effect)
+
+	// unlisted resource, unlisted action, unlisted subject: no opinion
+	assert.Equal(t, access.Abstain, decide(t, store, sub, "agents:read", access.Resource{Type: "agent", ID: "99"}).Effect)
+	assert.Equal(t, access.Abstain, decide(t, store, sub, "agents:write", access.Resource{Type: "agent", ID: "42"}).Effect)
+	assert.Equal(t, access.Abstain, decide(t, store, access.Subject{ID: "other"}, "agents:read", access.Resource{Type: "agent", ID: "42"}).Effect)
+}
+
+func TestDeciderDenyWinsOverGrant(t *testing.T) {
+	ctx := context.Background()
+	store := acl.NewMemoryStore()
+	m := acl.NewManager(store)
+	// type-wide suspension beats a specific grant regardless of entry order
+	require.NoError(t, m.Grant(ctx, "u1", "document", "7", "documents:read"))
+	require.NoError(t, m.Deny(ctx, "u1", "document", "", "documents:read"))
+
+	dec := decide(t, store, access.Subject{ID: "u1"}, "documents:read", access.Resource{Type: "document", ID: "7"})
+	assert.Equal(t, access.Deny, dec.Effect)
+}
+
+func TestDeciderActionWildcard(t *testing.T) {
+	ctx := context.Background()
+	store := acl.NewMemoryStore()
+	m := acl.NewManager(store)
+	require.NoError(t, m.Grant(ctx, "u1", "agent", "42", "*"))
+
+	sub := access.Subject{ID: "u1"}
+	assert.Equal(t, access.Allow, decide(t, store, sub, "agents:read", access.Resource{Type: "agent", ID: "42"}).Effect)
+	assert.Equal(t, access.Allow, decide(t, store, sub, "agents:delete", access.Resource{Type: "agent", ID: "42"}).Effect)
+	assert.Equal(t, access.Abstain, decide(t, store, sub, "agents:read", access.Resource{Type: "agent", ID: "43"}).Effect)
+}
+
+func TestDeciderCollectionCheck(t *testing.T) {
+	ctx := context.Background()
+	store := acl.NewMemoryStore()
+	m := acl.NewManager(store)
+	require.NoError(t, m.Grant(ctx, "u1", "agent", "42", "agents:read")) // specific
+	require.NoError(t, m.Grant(ctx, "u1", "report", "", "reports:read")) // type-wide
+
+	sub := access.Subject{ID: "u1"}
+	// a collection check (ID "") is matched only by type-wide entries
+	assert.Equal(t, access.Abstain, decide(t, store, sub, "agents:read", access.Resource{Type: "agent"}).Effect)
+	assert.Equal(t, access.Allow, decide(t, store, sub, "reports:read", access.Resource{Type: "report"}).Effect)
+}
+
+func TestDeciderRefiltersOverReturningStore(t *testing.T) {
+	// A loose Store may over-return; grants must not leak onto other resources,
+	// types, or actions.
+	store := &fakeStore{entries: []acl.Entry{
+		{Subject: "u1", ResourceType: "agent", ResourceID: "42", Action: "agents:read", Effect: access.Allow},
+		{Subject: "u1", ResourceType: "report", ResourceID: "1", Action: "reports:read", Effect: access.Allow},
+	}}
+	sub := access.Subject{ID: "u1"}
+
+	assert.Equal(t, access.Abstain, decide(t, store, sub, "agents:read", access.Resource{Type: "agent", ID: "13"}).Effect)
+	assert.Equal(t, access.Abstain, decide(t, store, sub, "reports:read", access.Resource{Type: "agent", ID: "42"}).Effect)
+	assert.Equal(t, access.Allow, decide(t, store, sub, "agents:read", access.Resource{Type: "agent", ID: "42"}).Effect)
+}
+
+func TestDeciderSkipsNonDecisiveEffects(t *testing.T) {
+	store := &fakeStore{entries: []acl.Entry{
+		{Subject: "u1", ResourceType: "agent", ResourceID: "42", Action: "agents:read"}, // zero Effect (Abstain)
+	}}
+	dec := decide(t, store, access.Subject{ID: "u1"}, "agents:read", access.Resource{Type: "agent", ID: "42"})
+	assert.Equal(t, access.Abstain, dec.Effect)
+}
+
+func TestDeciderStoreErrorFailsClosed(t *testing.T) {
+	boom := errors.New("boom")
+	store := &fakeStore{err: boom}
+	d := acl.Decider(store)
+
+	dec, err := d.Decide(context.Background(), access.Subject{ID: "u1"}, "agents:read", access.Resource{Type: "agent", ID: "42"})
+	require.ErrorIs(t, err, boom)
+	assert.Equal(t, access.Abstain, dec.Effect)
+
+	// Authorize closes it: error → Deny
+	dec, err = access.Authorize(context.Background(), d, access.Subject{ID: "u1"}, "agents:read", access.Resource{Type: "agent", ID: "42"})
+	require.ErrorIs(t, err, boom)
+	assert.Equal(t, access.Deny, dec.Effect)
+}
+
+func TestDeciderPassesSubjectTenant(t *testing.T) {
+	store := &fakeStore{}
+	sub := access.Subject{ID: "u1", Tenant: "acme"}
+	_ = decide(t, store, sub, "agents:read", access.Resource{Type: "agent", ID: "42", Tenant: "acme"})
+	assert.Equal(t, [4]string{"acme", "u1", "agent", "42"}, store.got)
+}
+
+func TestDeciderTenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	store := acl.NewMemoryStore()
+	tenant := "acme"
+	m := acl.NewManager(store, acl.WithScope(func(context.Context) (string, error) { return tenant, nil }))
+	require.NoError(t, m.Grant(ctx, "u1", "agent", "42", "agents:read"))
+
+	res := access.Resource{Type: "agent", ID: "42"}
+	assert.Equal(t, access.Allow, decide(t, store, access.Subject{ID: "u1", Tenant: "acme"}, "agents:read", res).Effect)
+	assert.Equal(t, access.Abstain, decide(t, store, access.Subject{ID: "u1", Tenant: "other"}, "agents:read", res).Effect)
+	assert.Equal(t, access.Abstain, decide(t, store, access.Subject{ID: "u1"}, "agents:read", res).Effect)
+}

--- a/auth/acl/doc.go
+++ b/auth/acl/doc.go
@@ -1,0 +1,29 @@
+// Package acl is the runtime-data override layer of authorization: explicit
+// per-subject, per-resource grant and deny entries — "this manager sees
+// exactly these assigned agents" — layered onto rbac's role decisions, with
+// deny winning. Entries live behind a storage-agnostic Store (in-memory built
+// in; acl/pgstore for Postgres), administered through a Manager scoped by an
+// optional WithScope tenancy hook that fails closed.
+//
+// The Decider plugs into the auth/access seam: a matching deny entry → Deny,
+// a matching grant → Allow, otherwise Abstain — so placed before rbac in a
+// chain an ACL deny vetoes what a role allows, and an ACL grant opens exactly
+// the listed resources without widening the role. An entry with ResourceID ""
+// is type-wide (every resource of the type, collection checks included); an
+// entry with Action "*" covers every action on the resource. Grant and deny
+// share one key (subject, resource, action) — writing one overwrites the
+// other, so contradictory pairs cannot exist.
+//
+// Wiring (see access for the middleware surface):
+//
+//	store := acl.NewMemoryStore()
+//	admin := acl.NewManager(store)
+//	_ = admin.Grant(ctx, "mgr-7", "agent", "42", "*")            // full access to agent 42
+//	_ = admin.Deny(ctx, "mgr-7", "report", "", "reports:export") // no export on any report
+//
+//	decider := access.FirstDecisive(
+//		access.TenantMatch(),
+//		acl.Decider(store),
+//		rbac.Decider(rs, rbac.FromSubject()),
+//	)
+package acl

--- a/auth/acl/errors.go
+++ b/auth/acl/errors.go
@@ -1,0 +1,13 @@
+package acl
+
+import "errors"
+
+var (
+	// ErrScope fails a Manager operation closed when the WithScope hook errors
+	// or yields an empty tenant.
+	ErrScope = errors.New("acl: scope hook failed")
+
+	// ErrInvalidEntry rejects a write with an empty subject, resource type, or
+	// action, or an entry whose Effect is neither Allow nor Deny.
+	ErrInvalidEntry = errors.New("acl: invalid entry")
+)

--- a/auth/acl/example_test.go
+++ b/auth/acl/example_test.go
@@ -1,0 +1,52 @@
+package acl_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/auth/acl"
+	"github.com/dmitrymomot/forge/auth/rbac"
+)
+
+func Example() {
+	ctx := context.Background()
+	store := acl.NewMemoryStore()
+	admin := acl.NewManager(store)
+	_ = admin.Grant(ctx, "mgr-7", "agent", "42", "agents:read")
+	_ = admin.Deny(ctx, "mgr-7", "agent", "13", "agents:read")
+
+	d := acl.Decider(store)
+	for _, id := range []string{"42", "13", "99"} {
+		dec, _ := d.Decide(ctx, access.Subject{ID: "mgr-7"}, "agents:read", access.Resource{Type: "agent", ID: id})
+		fmt.Println(id, dec.Effect, "—", dec.Reason)
+	}
+	// Output:
+	// 42 allow — explicit grant
+	// 13 deny — explicit deny
+	// 99 abstain — no matching entry
+}
+
+// An ACL deny placed before rbac vetoes what the role would allow.
+func Example_vetoRoleGrant() {
+	ctx := context.Background()
+	rs, _ := rbac.NewRoleSet(rbac.WithRoles(rbac.Role("viewer", "documents:read")))
+
+	store := acl.NewMemoryStore()
+	_ = acl.NewManager(store).Deny(ctx, "u1", "document", "13", "documents:read")
+
+	decider := access.FirstDecisive(
+		access.TenantMatch(),
+		acl.Decider(store),
+		rbac.Decider(rs, rbac.FromSubject()),
+	)
+
+	sub := access.Subject{ID: "u1", Roles: []string{"viewer"}}
+	for _, id := range []string{"7", "13"} {
+		dec, _ := access.Authorize(ctx, decider, sub, "documents:read", access.Resource{Type: "document", ID: id})
+		fmt.Println(id, dec.Effect, "by", dec.Decider)
+	}
+	// Output:
+	// 7 allow by rbac
+	// 13 deny by acl
+}

--- a/auth/acl/memory.go
+++ b/auth/acl/memory.go
@@ -1,0 +1,115 @@
+package acl
+
+import (
+	"context"
+	"sync"
+
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+type (
+	actionEffects   map[string]access.Effect // action -> effect
+	resourceEntries map[string]actionEffects // resource id ("" = type-wide) -> actions
+	typeEntries     map[string]resourceEntries
+)
+
+// memoryStore buckets entries by (tenant+subject) -> type -> id -> action, so
+// EntriesFor touches only the addressed resource's bucket and the type-wide
+// one — a subject with thousands of grants pays for two bucket reads, not a
+// full scan.
+type memoryStore struct {
+	m  map[string]typeEntries // key(tenant,subject) -> entries
+	mu sync.RWMutex
+}
+
+// NewMemoryStore returns an in-memory Store for tests and single-node dev use.
+func NewMemoryStore() Store {
+	return &memoryStore{m: map[string]typeEntries{}}
+}
+
+func memKey(tenant, subject string) string { return tenant + "\x00" + subject }
+
+func appendEntries(dst []Entry, subject, resourceType, resourceID string, actions actionEffects) []Entry {
+	for a, eff := range actions {
+		dst = append(dst, Entry{Subject: subject, ResourceType: resourceType, ResourceID: resourceID, Action: a, Effect: eff})
+	}
+	return dst
+}
+
+func (s *memoryStore) EntriesFor(_ context.Context, tenant, subject, resourceType, resourceID string) ([]Entry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	resources := s.m[memKey(tenant, subject)][resourceType]
+	exact, wide := resources[resourceID], resources[""]
+	if resourceID == "" { // a collection check: exact IS the type-wide bucket
+		exact = nil
+	}
+	n := len(exact) + len(wide)
+	if n == 0 {
+		return nil, nil
+	}
+	entries := make([]Entry, 0, n)
+	entries = appendEntries(entries, subject, resourceType, resourceID, exact)
+	entries = appendEntries(entries, subject, resourceType, "", wide)
+	return entries, nil
+}
+
+func (s *memoryStore) ListFor(_ context.Context, tenant, subject string) ([]Entry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var entries []Entry
+	for resourceType, resources := range s.m[memKey(tenant, subject)] {
+		for resourceID, actions := range resources {
+			entries = appendEntries(entries, subject, resourceType, resourceID, actions)
+		}
+	}
+	return entries, nil
+}
+
+func (s *memoryStore) Put(_ context.Context, tenant string, entries []Entry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range entries {
+		k := memKey(tenant, e.Subject)
+		types := s.m[k]
+		if types == nil {
+			types = typeEntries{}
+			s.m[k] = types
+		}
+		resources := types[e.ResourceType]
+		if resources == nil {
+			resources = resourceEntries{}
+			types[e.ResourceType] = resources
+		}
+		actions := resources[e.ResourceID]
+		if actions == nil {
+			actions = actionEffects{}
+			resources[e.ResourceID] = actions
+		}
+		actions[e.Action] = e.Effect
+	}
+	return nil
+}
+
+func (s *memoryStore) Delete(_ context.Context, tenant, subject, resourceType, resourceID string, actionNames []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := memKey(tenant, subject)
+	types := s.m[k]
+	resources := types[resourceType]
+	actions := resources[resourceID]
+	for _, a := range actionNames {
+		delete(actions, a)
+	}
+	// reclaim emptied buckets bottom-up
+	if len(actions) == 0 {
+		delete(resources, resourceID)
+	}
+	if len(resources) == 0 {
+		delete(types, resourceType)
+	}
+	if len(types) == 0 {
+		delete(s.m, k)
+	}
+	return nil
+}

--- a/auth/acl/memory.go
+++ b/auth/acl/memory.go
@@ -2,6 +2,7 @@ package acl
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/dmitrymomot/forge/auth/access"
@@ -67,6 +68,14 @@ func (s *memoryStore) ListFor(_ context.Context, tenant, subject string) ([]Entr
 }
 
 func (s *memoryStore) Put(_ context.Context, tenant string, entries []Entry) error {
+	// validate before writing anything so a bad entry can't leave a partial
+	// batch behind — pgstore's implicit batch transaction gives the same
+	// all-or-nothing behavior
+	for _, e := range entries {
+		if e.Effect != access.Allow && e.Effect != access.Deny {
+			return fmt.Errorf("%w: effect %v", ErrInvalidEntry, e.Effect)
+		}
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, e := range entries {

--- a/auth/acl/memory_test.go
+++ b/auth/acl/memory_test.go
@@ -1,0 +1,60 @@
+package acl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/auth/acl"
+)
+
+func TestMemoryEntriesForFiltering(t *testing.T) {
+	s := acl.NewMemoryStore()
+	ctx := context.Background()
+	require.NoError(t, s.Put(ctx, "", []acl.Entry{
+		{Subject: "u1", ResourceType: "agent", ResourceID: "42", Action: "agents:read", Effect: access.Allow},
+		{Subject: "u1", ResourceType: "agent", ResourceID: "13", Action: "agents:read", Effect: access.Deny},
+		{Subject: "u1", ResourceType: "agent", ResourceID: "", Action: "agents:list", Effect: access.Allow},
+		{Subject: "u1", ResourceType: "report", ResourceID: "42", Action: "reports:read", Effect: access.Allow},
+	}))
+
+	// exact id + type-wide, same type only
+	entries, err := s.EntriesFor(ctx, "", "u1", "agent", "42")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []acl.Entry{
+		{Subject: "u1", ResourceType: "agent", ResourceID: "42", Action: "agents:read", Effect: access.Allow},
+		{Subject: "u1", ResourceType: "agent", ResourceID: "", Action: "agents:list", Effect: access.Allow},
+	}, entries)
+
+	// collection check: only type-wide entries
+	entries, err = s.EntriesFor(ctx, "", "u1", "agent", "")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []acl.Entry{
+		{Subject: "u1", ResourceType: "agent", ResourceID: "", Action: "agents:list", Effect: access.Allow},
+	}, entries)
+
+	// unknown subject / tenant: empty
+	entries, err = s.EntriesFor(ctx, "", "other", "agent", "42")
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+	entries, err = s.EntriesFor(ctx, "acme", "u1", "agent", "42")
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestMemoryDeleteReclaims(t *testing.T) {
+	s := acl.NewMemoryStore()
+	ctx := context.Background()
+	require.NoError(t, s.Put(ctx, "", []acl.Entry{
+		{Subject: "u1", ResourceType: "agent", ResourceID: "42", Action: "agents:read", Effect: access.Allow},
+	}))
+	require.NoError(t, s.Delete(ctx, "", "u1", "agent", "42", []string{"agents:read"}))
+	require.NoError(t, s.Delete(ctx, "", "u1", "agent", "42", []string{"agents:read"})) // missing keys: not an error
+
+	entries, err := s.ListFor(ctx, "", "u1")
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}

--- a/auth/acl/memory_test.go
+++ b/auth/acl/memory_test.go
@@ -45,6 +45,21 @@ func TestMemoryEntriesForFiltering(t *testing.T) {
 	assert.Empty(t, entries)
 }
 
+func TestMemoryPutRejectsInvalidEffect(t *testing.T) {
+	s := acl.NewMemoryStore()
+	ctx := context.Background()
+	err := s.Put(ctx, "", []acl.Entry{
+		{Subject: "u1", ResourceType: "agent", ResourceID: "42", Action: "agents:read", Effect: access.Allow},
+		{Subject: "u1", ResourceType: "agent", ResourceID: "13", Action: "agents:read"}, // zero Effect
+	})
+	assert.ErrorIs(t, err, acl.ErrInvalidEntry)
+
+	// nothing written — validation happens before the first write
+	entries, err := s.ListFor(ctx, "", "u1")
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
 func TestMemoryDeleteReclaims(t *testing.T) {
 	s := acl.NewMemoryStore()
 	ctx := context.Background()

--- a/auth/acl/pgstore/doc.go
+++ b/auth/acl/pgstore/doc.go
@@ -1,0 +1,6 @@
+// Package pgstore is the Postgres driver for acl.Store: per-subject,
+// per-resource grant/deny entries in forge_acl_entries, scoped by tenant.
+// Apply Migrations (under its own version table) before use; the pool's
+// lifecycle is the caller's. See auth/acl for the engine and the
+// access.Decider adapter.
+package pgstore

--- a/auth/acl/pgstore/migrations/00001_create_forge_acl_entries.sql
+++ b/auth/acl/pgstore/migrations/00001_create_forge_acl_entries.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+CREATE TABLE forge_acl_entries (
+    tenant        text NOT NULL DEFAULT '',
+    subject       text NOT NULL,
+    resource_type text NOT NULL,
+    resource_id   text NOT NULL DEFAULT '',
+    action        text NOT NULL,
+    effect        text NOT NULL CHECK (effect IN ('allow', 'deny')),
+    PRIMARY KEY (tenant, subject, resource_type, resource_id, action)
+);
+
+-- +goose Down
+DROP TABLE forge_acl_entries;

--- a/auth/acl/pgstore/pgstore.go
+++ b/auth/acl/pgstore/pgstore.go
@@ -1,0 +1,152 @@
+package pgstore
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io/fs"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/auth/acl"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_acl_entries, rooted so
+// its .sql files sit at fsys root (data/migration.New globs the root). Apply
+// via data/migration under its own version table ("forge_acl_schema").
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// Store is the Postgres implementation of acl.Store. The pool's lifecycle is
+// the caller's.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+var _ acl.Store = (*Store)(nil)
+
+// New builds a Postgres ACL entry Store. Apply Migrations first.
+func New(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
+
+func effectText(e access.Effect) (string, error) {
+	switch e {
+	case access.Allow:
+		return "allow", nil
+	case access.Deny:
+		return "deny", nil
+	default:
+		return "", fmt.Errorf("%w: effect %v", acl.ErrInvalidEntry, e)
+	}
+}
+
+func textEffect(s string) (access.Effect, error) {
+	switch s {
+	case "allow":
+		return access.Allow, nil
+	case "deny":
+		return access.Deny, nil
+	default: // unreachable behind the CHECK constraint
+		return access.Abstain, fmt.Errorf("%w: effect %q", acl.ErrInvalidEntry, s)
+	}
+}
+
+func scanEntries(rows pgx.Rows, subject string) ([]acl.Entry, error) {
+	defer rows.Close()
+	var entries []acl.Entry
+	for rows.Next() {
+		var e acl.Entry
+		var effect string
+		if err := rows.Scan(&e.ResourceType, &e.ResourceID, &e.Action, &effect); err != nil {
+			return nil, err
+		}
+		eff, err := textEffect(effect)
+		if err != nil {
+			return nil, err
+		}
+		e.Subject = subject
+		e.Effect = eff
+		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// EntriesFor returns subject's entries on (resourceType, resourceID) plus the
+// type-wide entries (empty resource_id), in one primary-key-indexed query.
+func (s *Store) EntriesFor(ctx context.Context, tenant, subject, resourceType, resourceID string) ([]acl.Entry, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT resource_type, resource_id, action, effect FROM forge_acl_entries
+		 WHERE tenant = $1 AND subject = $2 AND resource_type = $3 AND resource_id IN ($4, '')`,
+		tenant, subject, resourceType, resourceID)
+	if err != nil {
+		return nil, err
+	}
+	return scanEntries(rows, subject)
+}
+
+// ListFor returns all of subject's entries within tenant.
+func (s *Store) ListFor(ctx context.Context, tenant, subject string) ([]acl.Entry, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT resource_type, resource_id, action, effect FROM forge_acl_entries
+		 WHERE tenant = $1 AND subject = $2`,
+		tenant, subject)
+	if err != nil {
+		return nil, err
+	}
+	return scanEntries(rows, subject)
+}
+
+// Put upserts entries by key, batched in one round-trip; a conflicting key
+// has its effect overwritten (grant↔deny flips in place).
+func (s *Store) Put(ctx context.Context, tenant string, entries []acl.Entry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	batch := &pgx.Batch{}
+	for _, e := range entries {
+		effect, err := effectText(e.Effect)
+		if err != nil {
+			return err
+		}
+		batch.Queue(
+			`INSERT INTO forge_acl_entries (tenant, subject, resource_type, resource_id, action, effect)
+			 VALUES ($1, $2, $3, $4, $5, $6)
+			 ON CONFLICT (tenant, subject, resource_type, resource_id, action)
+			 DO UPDATE SET effect = EXCLUDED.effect`,
+			tenant, e.Subject, e.ResourceType, e.ResourceID, e.Action, effect)
+	}
+	br := s.pool.SendBatch(ctx, batch)
+	for range entries {
+		if _, err := br.Exec(); err != nil {
+			_ = br.Close()
+			return err
+		}
+	}
+	return br.Close()
+}
+
+// Delete removes subject's entries on the resource for the given actions.
+func (s *Store) Delete(ctx context.Context, tenant, subject, resourceType, resourceID string, actions []string) error {
+	if len(actions) == 0 {
+		return nil
+	}
+	_, err := s.pool.Exec(ctx,
+		`DELETE FROM forge_acl_entries
+		 WHERE tenant = $1 AND subject = $2 AND resource_type = $3 AND resource_id = $4 AND action = ANY($5)`,
+		tenant, subject, resourceType, resourceID, actions)
+	return err
+}

--- a/auth/acl/pgstore/pgstore_test.go
+++ b/auth/acl/pgstore/pgstore_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/auth/acl"
+	"github.com/dmitrymomot/forge/auth/acl/pgstore"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+)
+
+var _ acl.Store = (*pgstore.Store)(nil)
+
+func newStore(t *testing.T) *pgstore.Store {
+	t.Helper()
+	cfg := postgres.DefaultConfig()
+	cfg.URL = pgtest.DSN(t)
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgstore.Migrations, migration.WithTable("forge_acl_schema")).Up(context.Background(), db))
+	return pgstore.New(pool)
+}
+
+func TestPgPutEntriesForDelete(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	subject := id.NewUUID().String() // unique per run; table persists
+	tenant := "acme"
+
+	entries := []acl.Entry{
+		{Subject: subject, ResourceType: "agent", ResourceID: "42", Action: "agents:read", Effect: access.Allow},
+		{Subject: subject, ResourceType: "agent", ResourceID: "13", Action: "agents:read", Effect: access.Deny},
+		{Subject: subject, ResourceType: "agent", ResourceID: "", Action: "agents:list", Effect: access.Allow},
+		{Subject: subject, ResourceType: "report", ResourceID: "42", Action: "reports:read", Effect: access.Allow},
+	}
+	require.NoError(t, s.Put(ctx, tenant, entries))
+	require.NoError(t, s.Put(ctx, tenant, entries[:1])) // idempotent
+
+	// exact id + type-wide, same type only
+	got, err := s.EntriesFor(ctx, tenant, subject, "agent", "42")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []acl.Entry{entries[0], entries[2]}, got)
+
+	// collection check: only type-wide entries
+	got, err = s.EntriesFor(ctx, tenant, subject, "agent", "")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []acl.Entry{entries[2]}, got)
+
+	// tenant isolation
+	got, err = s.EntriesFor(ctx, "other", subject, "agent", "42")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	all, err := s.ListFor(ctx, tenant, subject)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, entries, all)
+
+	require.NoError(t, s.Delete(ctx, tenant, subject, "agent", "42", []string{"agents:read"}))
+	require.NoError(t, s.Delete(ctx, tenant, subject, "agent", "42", []string{"agents:read"})) // missing: not an error
+	all, err = s.ListFor(ctx, tenant, subject)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []acl.Entry{entries[1], entries[2], entries[3]}, all)
+}
+
+func TestPgPutFlipsEffect(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	subject := id.NewUUID().String()
+
+	grant := acl.Entry{Subject: subject, ResourceType: "agent", ResourceID: "42", Action: "agents:read", Effect: access.Allow}
+	deny := grant
+	deny.Effect = access.Deny
+
+	require.NoError(t, s.Put(ctx, "", []acl.Entry{grant}))
+	require.NoError(t, s.Put(ctx, "", []acl.Entry{deny}))
+
+	got, err := s.ListFor(ctx, "", subject)
+	require.NoError(t, err)
+	require.Len(t, got, 1) // one key — the effect flipped in place
+	assert.Equal(t, access.Deny, got[0].Effect)
+}
+
+func TestPgPutRejectsInvalidEffect(t *testing.T) {
+	s := newStore(t)
+	err := s.Put(context.Background(), "", []acl.Entry{
+		{Subject: id.NewUUID().String(), ResourceType: "agent", ResourceID: "42", Action: "agents:read"}, // zero Effect
+	})
+	assert.ErrorIs(t, err, acl.ErrInvalidEntry)
+}

--- a/auth/acl/store.go
+++ b/auth/acl/store.go
@@ -21,7 +21,9 @@ type Store interface {
 	// ListFor returns all of subject's entries within tenant — the admin
 	// "what exactly can this subject touch" surface.
 	ListFor(ctx context.Context, tenant, subject string) ([]Entry, error)
-	// Put upserts entries by key (idempotent).
+	// Put upserts entries by key (idempotent). It rejects an entry whose
+	// Effect is neither Allow nor Deny (ErrInvalidEntry) without writing
+	// anything.
 	Put(ctx context.Context, tenant string, entries []Entry) error
 	// Delete removes subject's entries on the resource for the given actions,
 	// whatever their effect. Missing keys are not an error.

--- a/auth/acl/store.go
+++ b/auth/acl/store.go
@@ -1,0 +1,139 @@
+package acl
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+// Store persists ACL entries. Tenant is explicit at the boundary
+// (single-tenant callers pass ""). The entry key is (tenant, subject,
+// resource type, resource id, action); Put upserts by that key, so
+// re-granting a denied key (or vice versa) flips its effect in place.
+// EntriesFor may over-return (any superset of the matching entries is legal —
+// the Decider re-filters); it must never omit a matching entry.
+// Implementations must be safe for concurrent use.
+type Store interface {
+	// EntriesFor returns subject's entries on (resourceType, resourceID),
+	// including the type-wide entries (ResourceID "").
+	EntriesFor(ctx context.Context, tenant, subject, resourceType, resourceID string) ([]Entry, error)
+	// ListFor returns all of subject's entries within tenant — the admin
+	// "what exactly can this subject touch" surface.
+	ListFor(ctx context.Context, tenant, subject string) ([]Entry, error)
+	// Put upserts entries by key (idempotent).
+	Put(ctx context.Context, tenant string, entries []Entry) error
+	// Delete removes subject's entries on the resource for the given actions,
+	// whatever their effect. Missing keys are not an error.
+	Delete(ctx context.Context, tenant, subject, resourceType, resourceID string, actions []string) error
+}
+
+type managerConfig struct {
+	scope func(context.Context) (string, error)
+}
+
+// Option configures a Manager.
+type Option func(*managerConfig)
+
+// WithScope derives the tenant from context for every Manager operation and
+// fails closed (ErrScope) when the hook errors or yields an empty tenant. A nil
+// fn (or no WithScope) leaves the Manager single-tenant, operating on "".
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *managerConfig) { c.scope = fn }
+}
+
+// Manager is the tenant-scoped admin surface over a Store: grant, deny,
+// revoke, and list a subject's entries.
+type Manager struct {
+	store Store
+	cfg   managerConfig
+}
+
+// NewManager wraps store with the given options.
+func NewManager(store Store, opts ...Option) *Manager {
+	var cfg managerConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return &Manager{store: store, cfg: cfg}
+}
+
+// tenant resolves the scope for this operation. No hook -> "" (single-tenant).
+func (m *Manager) tenant(ctx context.Context) (string, error) {
+	if m.cfg.scope == nil {
+		return "", nil
+	}
+	t, err := m.cfg.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrScope, err)
+	}
+	if t == "" {
+		return "", fmt.Errorf("%w: empty tenant", ErrScope)
+	}
+	return t, nil
+}
+
+// Grant writes Allow entries: subject may perform each action on the resource
+// (resourceID "" = type-wide, action "*" = every action). Overwrites a deny
+// on the same key.
+func (m *Manager) Grant(ctx context.Context, subject, resourceType, resourceID string, actions ...string) error {
+	return m.put(ctx, access.Allow, subject, resourceType, resourceID, actions)
+}
+
+// Deny writes Deny entries: subject may not perform each action on the
+// resource, vetoing any role grant. Overwrites a grant on the same key.
+func (m *Manager) Deny(ctx context.Context, subject, resourceType, resourceID string, actions ...string) error {
+	return m.put(ctx, access.Deny, subject, resourceType, resourceID, actions)
+}
+
+func (m *Manager) put(ctx context.Context, effect access.Effect, subject, resourceType, resourceID string, actions []string) error {
+	if len(actions) == 0 {
+		return nil
+	}
+	if subject == "" {
+		return fmt.Errorf("%w: empty subject", ErrInvalidEntry)
+	}
+	if resourceType == "" {
+		return fmt.Errorf("%w: empty resource type", ErrInvalidEntry)
+	}
+	entries := make([]Entry, 0, len(actions))
+	for _, a := range actions {
+		if a == "" {
+			return fmt.Errorf("%w: empty action", ErrInvalidEntry)
+		}
+		entries = append(entries, Entry{
+			Subject:      subject,
+			ResourceType: resourceType,
+			ResourceID:   resourceID,
+			Action:       a,
+			Effect:       effect,
+		})
+	}
+	t, err := m.tenant(ctx)
+	if err != nil {
+		return err
+	}
+	return m.store.Put(ctx, t, entries)
+}
+
+// Revoke removes subject's entries on the resource for the given actions,
+// grants and denies alike — the resource falls back to role decisions.
+func (m *Manager) Revoke(ctx context.Context, subject, resourceType, resourceID string, actions ...string) error {
+	if len(actions) == 0 {
+		return nil
+	}
+	t, err := m.tenant(ctx)
+	if err != nil {
+		return err
+	}
+	return m.store.Delete(ctx, t, subject, resourceType, resourceID, actions)
+}
+
+// ListFor returns all of subject's entries within the resolved tenant.
+func (m *Manager) ListFor(ctx context.Context, subject string) ([]Entry, error) {
+	t, err := m.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return m.store.ListFor(ctx, t, subject)
+}

--- a/auth/acl/store_test.go
+++ b/auth/acl/store_test.go
@@ -1,0 +1,109 @@
+package acl_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/auth/acl"
+)
+
+func TestManagerGrantListRevoke(t *testing.T) {
+	m := acl.NewManager(acl.NewMemoryStore())
+	ctx := context.Background()
+
+	require.NoError(t, m.Grant(ctx, "u1", "agent", "42", "agents:read", "agents:write"))
+	require.NoError(t, m.Grant(ctx, "u1", "agent", "42", "agents:read")) // idempotent
+	require.NoError(t, m.Deny(ctx, "u1", "report", "", "reports:export"))
+
+	entries, err := m.ListFor(ctx, "u1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []acl.Entry{
+		{Subject: "u1", ResourceType: "agent", ResourceID: "42", Action: "agents:read", Effect: access.Allow},
+		{Subject: "u1", ResourceType: "agent", ResourceID: "42", Action: "agents:write", Effect: access.Allow},
+		{Subject: "u1", ResourceType: "report", ResourceID: "", Action: "reports:export", Effect: access.Deny},
+	}, entries)
+
+	// Revoke removes grants and denies alike
+	require.NoError(t, m.Revoke(ctx, "u1", "agent", "42", "agents:write"))
+	require.NoError(t, m.Revoke(ctx, "u1", "report", "", "reports:export"))
+	entries, err = m.ListFor(ctx, "u1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []acl.Entry{
+		{Subject: "u1", ResourceType: "agent", ResourceID: "42", Action: "agents:read", Effect: access.Allow},
+	}, entries)
+}
+
+func TestManagerGrantDenyFlipsInPlace(t *testing.T) {
+	m := acl.NewManager(acl.NewMemoryStore())
+	ctx := context.Background()
+
+	require.NoError(t, m.Grant(ctx, "u1", "agent", "42", "agents:read"))
+	require.NoError(t, m.Deny(ctx, "u1", "agent", "42", "agents:read"))
+
+	entries, err := m.ListFor(ctx, "u1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1) // one key — no contradictory grant+deny pair
+	assert.Equal(t, access.Deny, entries[0].Effect)
+
+	require.NoError(t, m.Grant(ctx, "u1", "agent", "42", "agents:read"))
+	entries, err = m.ListFor(ctx, "u1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, access.Allow, entries[0].Effect)
+}
+
+func TestManagerValidation(t *testing.T) {
+	m := acl.NewManager(acl.NewMemoryStore())
+	ctx := context.Background()
+
+	assert.ErrorIs(t, m.Grant(ctx, "", "agent", "42", "agents:read"), acl.ErrInvalidEntry)
+	assert.ErrorIs(t, m.Grant(ctx, "u1", "", "42", "agents:read"), acl.ErrInvalidEntry)
+	assert.ErrorIs(t, m.Deny(ctx, "u1", "agent", "42", ""), acl.ErrInvalidEntry)
+
+	// zero actions: no-op, nothing written
+	require.NoError(t, m.Grant(ctx, "u1", "agent", "42"))
+	require.NoError(t, m.Revoke(ctx, "u1", "agent", "42"))
+	entries, err := m.ListFor(ctx, "u1")
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestManagerScopeIsolation(t *testing.T) {
+	store := acl.NewMemoryStore()
+	tenant := "acme"
+	m := acl.NewManager(store, acl.WithScope(func(context.Context) (string, error) {
+		return tenant, nil
+	}))
+	ctx := context.Background()
+	require.NoError(t, m.Grant(ctx, "u1", "agent", "42", "agents:read"))
+
+	// another tenant sees nothing
+	tenant = "other"
+	entries, err := m.ListFor(ctx, "u1")
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestManagerScopeFailClosed(t *testing.T) {
+	boom := errors.New("boom")
+	for name, hook := range map[string]func(context.Context) (string, error){
+		"hook error":   func(context.Context) (string, error) { return "", boom },
+		"empty tenant": func(context.Context) (string, error) { return "", nil },
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := acl.NewManager(acl.NewMemoryStore(), acl.WithScope(hook))
+			ctx := context.Background()
+
+			assert.ErrorIs(t, m.Grant(ctx, "u1", "agent", "42", "agents:read"), acl.ErrScope)
+			assert.ErrorIs(t, m.Deny(ctx, "u1", "agent", "42", "agents:read"), acl.ErrScope)
+			assert.ErrorIs(t, m.Revoke(ctx, "u1", "agent", "42", "agents:read"), acl.ErrScope)
+			_, err := m.ListFor(ctx, "u1")
+			assert.ErrorIs(t, err, acl.ErrScope)
+		})
+	}
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -432,30 +432,6 @@ Deps: `auth/guard`.
 
 ---
 
-**auth/rbac**
-
-Role-based access control: predefined roles, role nesting/inheritance (a
-role inherits another role's permissions and adds its own),
-out-of-hierarchy standalone roles, wildcard grants; resolves subject →
-effective permission set. Implements the `access` decision seam consumed
-by `guard`/`RequirePermission` (401-vs-403 split). Subject→role
-assignment behind a storage-agnostic Store.
-
-Deps: `auth/access`.
-
----
-
-**auth/acl**
-
-Per-subject / per-resource grant and deny overrides (deny wins) layered
-onto rbac decisions — "this manager sees exactly these assigned agents".
-The runtime-data authorization layer: storage-agnostic Store with drivers;
-composes into the `access` decision seam.
-
-Deps: `auth/access`.
-
----
-
 **auth/abac**
 
 Attribute/relationship predicates as registered Go functions — "agent sees


### PR DESCRIPTION
## Summary

Implements **auth/acl** — the runtime-data override layer of authorization: explicit per-subject, per-resource grant and deny entries ("this manager sees exactly these assigned agents") layered onto rbac's role decisions, with deny winning.

- **Entry model**: key is (tenant, subject, resource type, resource id, action) with an `access.Effect` value. `ResourceID ""` = type-wide (matches every resource of the type, collection checks included); `Action "*"` = every action on the resource. Grant and deny share one key — `Put` upserts, so re-granting a denied key flips it in place and contradictory grant+deny pairs cannot exist.
- **Decider** (`acl.Decider(store)`): plugs into the `auth/access` seam. Matching deny → `Deny`, matching grant → `Allow`, else `Abstain` (rbac may still grant). Placed before rbac in `FirstDecisive`/`DenyOverrides`, an ACL deny vetoes a role grant. The decider **re-filters** entries with exact match rules, so an over-returning consumer Store can never widen a grant onto the wrong resource; a Store error abstains + returns the error so the chain fails closed. Tenant comes from `Subject.Tenant` (mirrors `rbac.FromStore`).
- **Manager**: tenant-scoped admin surface (`Grant`/`Deny`/`Revoke`/`ListFor`) with the standard optional `WithScope` hook that fails closed (`ErrScope`); single-tenant use passes zero ceremony. Writes validate subject/type/actions (`ErrInvalidEntry`).
- **Stores**: in-memory (bucketed by type→id→action, see benchmarks) and `acl/pgstore` — `forge_acl_entries` with a composite PK that fully covers the decision query (`tenant, subject, resource_type, resource_id` prefix), batched upserts, `effect` CHECK-constrained; goose migration under its own `forge_acl_schema` version table.

Also deletes the shipped `auth/rbac` and `auth/acl` entries from `docs/packages.md` (the roadmap lists only unbuilt packages; rbac's entry was stale).

## Benchmarks (Apple M3 Max, subject with 100 grants + 1 type-wide deny)

Post-benchmark optimization: the first memory store was a flat per-subject map, so every decision scanned all of the subject's entries. Re-bucketing by resource type → id → action makes a decision two bucket reads, independent of grant count:

| Benchmark | flat map | bucketed | |
|---|---|---|---|
| DeciderGrant | 1009 ns/op, 80 B, 1 alloc | 116 ns/op, 80 B, 1 alloc | 8.7× |
| DeciderDeny | 579 ns/op, 80 B, 1 alloc | 114 ns/op, 80 B, 1 alloc | 5.1× |
| DeciderAbstain | 31.8 ns/op, 0 B, 0 allocs | 31.5 ns/op, 0 B, 0 allocs | — |
| MemoryEntriesFor | 949 ns/op, 80 B, 1 alloc | 99 ns/op, 80 B, 1 alloc | 9.6× |

The single alloc on decisive paths is the exact-sized result slice from the store.

## Testing

- Black-box unit tests: decider semantics (deny-wins, wildcards, collection checks, over-returning-store re-filtering, fail-closed store errors, tenant threading), Manager (upsert flip, validation, scope isolation + fail-closed), memory store filtering/reclaim, runnable examples incl. acl-vetoes-rbac.
- Integration (testcontainers): pgstore put/list/filter/delete, effect flip in place, tenant isolation, invalid-effect rejection. Passing locally: `just test-integration ./auth/acl/pgstore/` → ok, 80% coverage.
- `just lint` clean (vet, golangci-lint, nilaway, betteralign, modernize, integration tier).