### PR TITLE
ops/tracing: Tracer seam, W3C trace-context middleware, otel driver

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -638,15 +638,6 @@ Deps: none (stdlib only).
 
 ---
 
-**ops/tracing**
-
-`Tracer` seam, W3C traceparent middleware, trace_id log extractor;
-`tracing/otel` driver isolated. Pairs with httpclient propagation.
-
-Deps: none forge-internal (otel external, isolated).
-
----
-
 **ops/secretsource**
 
 Hot-reloadable secrets behind a `Provider` seam, exposing `redact.Secret`

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,9 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.43.0
 	go.mongodb.org/mongo-driver/v2 v2.7.0
+	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
+	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/text v0.38.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -309,9 +312,7 @@ require (
 	go.augendre.info/fatcontext v0.9.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/ops/tracing/bench_test.go
+++ b/ops/tracing/bench_test.go
@@ -1,0 +1,88 @@
+package tracing_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/tracing"
+)
+
+func BenchmarkParseTraceparent(b *testing.B) {
+	for b.Loop() {
+		if _, err := tracing.ParseTraceparent(sampleTraceparent); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTraceparent(b *testing.B) {
+	sc, err := tracing.ParseTraceparent(sampleTraceparent)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for b.Loop() {
+		if sc.Traceparent() == "" {
+			b.Fatal("empty")
+		}
+	}
+}
+
+func BenchmarkStartChild(b *testing.B) {
+	tr := tracing.New()
+	ctx, parent := tr.Start(b.Context(), "parent")
+	defer parent.End()
+	b.ResetTimer()
+	for b.Loop() {
+		_, span := tr.Start(ctx, "child")
+		span.End()
+	}
+}
+
+func BenchmarkSpanContextFromContext(b *testing.B) {
+	tr := tracing.New()
+	ctx, span := tr.Start(b.Context(), "s")
+	defer span.End()
+	b.ResetTimer()
+	for b.Loop() {
+		if !tracing.SpanContextFromContext(ctx).IsValid() {
+			b.Fatal("invalid")
+		}
+	}
+}
+
+func BenchmarkLogExtractor(b *testing.B) {
+	tr := tracing.New()
+	ctx, span := tr.Start(b.Context(), "s")
+	defer span.End()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, ok := tracing.LogExtractor(ctx); !ok {
+			b.Fatal("missing")
+		}
+	}
+}
+
+func BenchmarkPropagationHeaders(b *testing.B) {
+	tr := tracing.New()
+	ctx, span := tr.Start(b.Context(), "s")
+	defer span.End()
+	b.ResetTimer()
+	for b.Loop() {
+		if tracing.PropagationHeaders(ctx) == nil {
+			b.Fatal("nil")
+		}
+	}
+}
+
+func BenchmarkMiddleware(b *testing.B) {
+	h := tracing.NewMiddleware(tracing.New())(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.Header.Set("traceparent", sampleTraceparent)
+	w := httptest.NewRecorder()
+	b.ResetTimer()
+	for b.Loop() {
+		h.ServeHTTP(w, r)
+	}
+}

--- a/ops/tracing/context.go
+++ b/ops/tracing/context.go
@@ -1,0 +1,75 @@
+package tracing
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/dmitrymomot/forge/core/ctxkey"
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+var (
+	spanKey   = ctxkey.New[Span]("tracing.span")
+	remoteKey = ctxkey.New[SpanContext]("tracing.remote")
+)
+
+// ContextWithSpan returns ctx carrying s as the current span. Tracer
+// implementations call it from Start; consumers rarely need it directly.
+func ContextWithSpan(ctx context.Context, s Span) context.Context {
+	return spanKey.With(ctx, s)
+}
+
+// SpanFromContext returns the current span, or a no-op span when none is
+// present, so call sites add attributes and events without nil checks.
+func SpanFromContext(ctx context.Context) Span {
+	if s, ok := spanKey.From(ctx); ok {
+		return s
+	}
+	return noopSpan{}
+}
+
+// ContextWithRemote returns ctx carrying a remote parent span context — one
+// parsed from an inbound traceparent header (NewMiddleware does this) or
+// restored from a queue message. Tracers adopt it as the parent when no live
+// span is in ctx, and SpanContextFromContext falls back to it, so trace
+// correlation works even before (or without) a local span.
+func ContextWithRemote(ctx context.Context, sc SpanContext) context.Context {
+	return remoteKey.With(ctx, sc)
+}
+
+// SpanContextFromContext returns the identity of the current span when one is
+// in ctx, else the remote parent stored by ContextWithRemote, else the zero
+// SpanContext. LogExtractor and header propagation read through this.
+func SpanContextFromContext(ctx context.Context) SpanContext {
+	if s, ok := spanKey.From(ctx); ok {
+		if sc := s.Context(); sc.IsValid() {
+			return sc
+		}
+	}
+	if sc, ok := remoteKey.From(ctx); ok {
+		return sc
+	}
+	return SpanContext{}
+}
+
+// LogExtractor adds a "trace_id" attribute when ctx carries a span or a remote
+// parent. Register with logger.WithContextExtractors to correlate every log
+// line with its trace.
+var LogExtractor logger.ContextExtractor = func(ctx context.Context) (slog.Attr, bool) {
+	sc := SpanContextFromContext(ctx)
+	if !sc.TraceID.IsValid() {
+		return slog.Attr{}, false
+	}
+	return slog.String("trace_id", sc.TraceID.String()), true
+}
+
+type noopSpan struct{}
+
+func (noopSpan) Context() SpanContext          { return SpanContext{} }
+func (noopSpan) IsRecording() bool             { return false }
+func (noopSpan) SetName(string)                {}
+func (noopSpan) SetAttributes(...slog.Attr)    {}
+func (noopSpan) AddEvent(string, ...slog.Attr) {}
+func (noopSpan) RecordError(error)             {}
+func (noopSpan) SetStatus(Status, string)      {}
+func (noopSpan) End()                          {}

--- a/ops/tracing/context_test.go
+++ b/ops/tracing/context_test.go
@@ -1,0 +1,64 @@
+package tracing_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/tracing"
+)
+
+func TestSpanFromContextReturnsNoopWhenAbsent(t *testing.T) {
+	span := tracing.SpanFromContext(t.Context())
+	require.NotNil(t, span)
+	assert.False(t, span.IsRecording())
+	assert.False(t, span.Context().IsValid())
+	span.AddEvent("safe") // must not panic
+	span.End()
+}
+
+func TestSpanFromContextReturnsCurrentSpan(t *testing.T) {
+	tr := tracing.New()
+	ctx, span := tr.Start(t.Context(), "s")
+	defer span.End()
+
+	assert.Equal(t, span.Context(), tracing.SpanFromContext(ctx).Context())
+}
+
+func TestSpanContextFromContextPrecedence(t *testing.T) {
+	remote, err := tracing.ParseTraceparent(sampleTraceparent)
+	require.NoError(t, err)
+	ctx := tracing.ContextWithRemote(t.Context(), remote)
+	assert.Equal(t, remote, tracing.SpanContextFromContext(ctx))
+
+	tr := tracing.New()
+	ctx, span := tr.Start(ctx, "s")
+	defer span.End()
+	assert.Equal(t, span.Context(), tracing.SpanContextFromContext(ctx), "live span outranks remote")
+
+	assert.Equal(t, tracing.SpanContext{}, tracing.SpanContextFromContext(t.Context()))
+}
+
+func TestLogExtractor(t *testing.T) {
+	_, ok := tracing.LogExtractor(t.Context())
+	assert.False(t, ok)
+
+	remote, err := tracing.ParseTraceparent(sampleTraceparent)
+	require.NoError(t, err)
+	ctx := tracing.ContextWithRemote(t.Context(), remote)
+	attr, ok := tracing.LogExtractor(ctx)
+	require.True(t, ok)
+	assert.Equal(t, "trace_id", attr.Key)
+	assert.Equal(t, sampleTraceHex, attr.Value.String())
+
+	tr := tracing.New()
+	ctx, span := tr.Start(context.Background(), "s")
+	defer span.End()
+	attr, ok = tracing.LogExtractor(ctx)
+	require.True(t, ok)
+	assert.Equal(t, slog.KindString, attr.Value.Kind())
+	assert.Equal(t, span.Context().TraceID.String(), attr.Value.String())
+}

--- a/ops/tracing/doc.go
+++ b/ops/tracing/doc.go
@@ -1,0 +1,77 @@
+// Package tracing is a minimal distributed-tracing facade: a Tracer/Span
+// seam, W3C trace-context middleware, a trace_id log extractor, and header
+// propagation for outbound calls. Application and forge packages start spans
+// against the Tracer seam; swapping the backend (tracing/otel is the only
+// driver) changes wiring, never call sites. Attributes are plain slog.Attr —
+// the same vocabulary as logging.
+//
+// # Zero-dependency default
+//
+// New returns a propagation-only tracer: it continues the inbound trace (or
+// mints a new one) and gives every span a fresh id, but records nothing — the
+// full correlation story with no exporter and no dependencies:
+//
+//	tr := tracing.New()
+//
+//	log, err := logger.New(logger.WithContextExtractors(tracing.LogExtractor))
+//
+//	mux := http.NewServeMux()
+//	mux.Handle("GET /users/{id}", getUser)
+//	handler := middleware.Wrap(mux,
+//		tracing.NewMiddleware(tr, tracing.WithSkip(func(r *http.Request) bool {
+//			return r.URL.Path == "/livez"
+//		})),
+//		recoverer.New(), // inside tracing: panicking requests still end their span
+//	)
+//
+// The middleware parses an inbound traceparent into a remote parent, wraps the
+// handler in a KindServer span named "GET /users/{id}" (the matched r.Pattern;
+// WithPathFunc is the hook for non-ServeMux routers), and marks 5xx responses
+// StatusError. Every log line through the extractor carries trace_id.
+//
+// # Outbound propagation
+//
+// Pair with httpclient so outbound calls join the trace:
+//
+//	client := httpclient.New(httpclient.WithContextHeaders(tracing.PropagationHeaders))
+//
+// For non-httpclient transports, Inject(ctx, header) writes the same headers.
+// Cross-queue hand-off works the same way: carry SpanContextFromContext(ctx)
+// in the message (its Traceparent() string) and restore it on the consumer
+// side with ParseTraceparent + ContextWithRemote.
+//
+// # Instrumenting code
+//
+//	ctx, span := tr.Start(ctx, "sync invoices", tracing.WithAttributes(slog.Int("batch", n)))
+//	defer span.End()
+//	...
+//	if err != nil {
+//		span.RecordError(err)
+//		span.SetStatus(tracing.StatusError, "sync failed")
+//	}
+//
+// SpanFromContext(ctx) returns the current span (a no-op span when absent) so
+// helpers deep in the call stack can add events without plumbing.
+//
+// # Multi-tenant scoping
+//
+// WithContextAttr is the construction-time tenancy seam; single-tenant apps
+// skip it and pay nothing:
+//
+//	tracing.NewMiddleware(tr,
+//		tracing.WithContextAttr("tenant", func(ctx context.Context) string {
+//			id, _ := tenant.FromContext(ctx)
+//			return id // "" records as "unknown" (fail-closed)
+//		}),
+//	)
+//
+// # OpenTelemetry
+//
+// tracing/otel adapts any otel TracerProvider (sampling and export stay SDK
+// concerns, wired in the consumer's main):
+//
+//	tr := otel.New(sdktrace.NewTracerProvider(sdktrace.WithBatcher(exporter)))
+//
+// Packages that emit spans take a Tracer option defaulting to NewNoop, which
+// still passes an inbound trace through to logs and outbound headers.
+package tracing

--- a/ops/tracing/errors.go
+++ b/ops/tracing/errors.go
@@ -1,0 +1,6 @@
+package tracing
+
+import "errors"
+
+// ErrInvalidTraceparent reports a malformed W3C traceparent header value.
+var ErrInvalidTraceparent = errors.New("tracing: invalid traceparent")

--- a/ops/tracing/middleware.go
+++ b/ops/tracing/middleware.go
@@ -112,13 +112,17 @@ func NewMiddleware(tr Tracer, opts ...MiddlewareOption) middleware.Middleware {
 				}
 			}
 			method := normalizeMethod(r.Method)
-			ctx, span := tr.Start(ctx, method,
-				WithKind(KindServer),
-				WithAttributes(
-					slog.String("http.request.method", method),
-					slog.String("url.path", r.URL.Path),
-				),
+			startAttrs := make([]slog.Attr, 0, 3)
+			startAttrs = append(startAttrs,
+				slog.String("http.request.method", method),
+				slog.String("url.path", r.URL.Path),
 			)
+			if method != r.Method {
+				// Cardinality control folded the verb to "OTHER"; keep the raw
+				// method debuggable per OTel semconv.
+				startAttrs = append(startAttrs, slog.String("http.request.method_original", r.Method))
+			}
+			ctx, span := tr.Start(ctx, method, WithKind(KindServer), WithAttributes(startAttrs...))
 			defer span.End()
 
 			rw := middleware.WrapWriter(w)

--- a/ops/tracing/middleware.go
+++ b/ops/tracing/middleware.go
@@ -1,0 +1,173 @@
+package tracing
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+// W3C Trace Context header names, in canonical MIME form so they can be used
+// as direct http.Header map keys.
+const (
+	TraceparentHeader = "Traceparent"
+	TracestateHeader  = "Tracestate"
+)
+
+// maxTracestate caps the combined inbound tracestate forwarded downstream (the
+// spec recommends vendors keep the list under 512 characters). An oversized
+// value is dropped whole rather than truncated mid-member.
+const maxTracestate = 512
+
+type middlewareConfig struct {
+	skip         func(*http.Request) bool
+	pathFunc     func(*http.Request) string
+	attrNames    []string
+	attrFuncs    []func(context.Context) string
+	trustInbound bool
+}
+
+// MiddlewareOption configures NewMiddleware.
+type MiddlewareOption func(*middlewareConfig)
+
+// WithSkip skips tracing for requests where pred returns true (e.g. health
+// checks). A nil pred is ignored.
+func WithSkip(pred func(*http.Request) bool) MiddlewareOption {
+	return func(c *middlewareConfig) {
+		if pred != nil {
+			c.skip = pred
+		}
+	}
+}
+
+// WithPathFunc overrides how the route is derived for the span name and
+// http.route attribute. The default uses r.Pattern — the matched ServeMux
+// route with the method prefix stripped ("/users/{id}", never the raw URL
+// path) — and "" when no pattern matched, which leaves the span named after
+// the method alone. Routers that don't populate r.Pattern (chi, gorilla) need
+// this hook to expose their route template. A nil fn is ignored.
+func WithPathFunc(fn func(*http.Request) string) MiddlewareOption {
+	return func(c *middlewareConfig) {
+		if fn != nil {
+			c.pathFunc = fn
+		}
+	}
+}
+
+// WithTrustInbound controls whether inbound traceparent/tracestate headers are
+// honored (default true). Disable on public edges where an arbitrary client
+// must not steer trace ids or downstream sampling decisions.
+func WithTrustInbound(trust bool) MiddlewareOption {
+	return func(c *middlewareConfig) { c.trustInbound = trust }
+}
+
+// WithContextAttr adds a span attribute whose value is derived from the
+// request context — the tenancy seam: pair it with a tenant-from-context
+// lookup to scope request spans per tenant. fn sees the context as this
+// middleware received it, so mount the tracing middleware INSIDE whatever
+// middleware populates the value. Fail-closed: when fn returns "" the value is
+// recorded as "unknown", never attributed elsewhere. Panics on an empty key or
+// nil fn: a misconfigured scope hook must not silently drop scoping.
+func WithContextAttr(key string, fn func(context.Context) string) MiddlewareOption {
+	if key == "" || fn == nil {
+		panic("tracing: WithContextAttr requires a key and a non-nil fn")
+	}
+	return func(c *middlewareConfig) {
+		c.attrNames = append(c.attrNames, key)
+		c.attrFuncs = append(c.attrFuncs, fn)
+	}
+}
+
+// NewMiddleware returns middleware that parses the inbound W3C traceparent
+// into a remote parent, starts a KindServer span around the handler, and ends
+// it when the handler returns. The span starts named after the method and is
+// renamed "GET /users/{id}" once the matched route is known; it carries
+// http.request.method, url.path, http.route, http.response.status_code, and
+// any WithContextAttr additions, with 5xx responses marked StatusError. Place
+// it OUTSIDE the recoverer so panicking requests still close their span (as
+// the 500 the recoverer writes). Panics on a nil Tracer.
+func NewMiddleware(tr Tracer, opts ...MiddlewareOption) middleware.Middleware {
+	if tr == nil {
+		panic("tracing: NewMiddleware requires a Tracer")
+	}
+	c := middlewareConfig{pathFunc: patternPath, trustInbound: true}
+	for _, o := range opts {
+		o(&c)
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if c.skip != nil && c.skip(r) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			ctx := r.Context()
+			if c.trustInbound {
+				if sc, err := ParseTraceparent(r.Header.Get(TraceparentHeader)); err == nil {
+					if ts := strings.Join(r.Header.Values(TracestateHeader), ","); ts != "" && len(ts) <= maxTracestate {
+						sc.TraceState = ts
+					}
+					ctx = ContextWithRemote(ctx, sc)
+				}
+			}
+			method := normalizeMethod(r.Method)
+			ctx, span := tr.Start(ctx, method,
+				WithKind(KindServer),
+				WithAttributes(
+					slog.String("http.request.method", method),
+					slog.String("url.path", r.URL.Path),
+				),
+			)
+			defer span.End()
+
+			rw := middleware.WrapWriter(w)
+			// Serve via the context-carrying copy and read the matched pattern
+			// off that same copy: ServeMux sets Pattern on the request it
+			// receives, not on this middleware's original.
+			r = r.WithContext(ctx)
+			next.ServeHTTP(rw, r)
+
+			if route := c.pathFunc(r); route != "" {
+				span.SetName(method + " " + route)
+				span.SetAttributes(slog.String("http.route", route))
+			}
+			status := rw.Status()
+			if status == 0 {
+				status = http.StatusOK
+			}
+			attrs := make([]slog.Attr, 0, 1+len(c.attrFuncs))
+			attrs = append(attrs, slog.Int("http.response.status_code", status))
+			for i, fn := range c.attrFuncs {
+				v := fn(ctx)
+				if v == "" {
+					v = "unknown"
+				}
+				attrs = append(attrs, slog.String(c.attrNames[i], v))
+			}
+			span.SetAttributes(attrs...)
+			if status >= 500 {
+				span.SetStatus(StatusError, http.StatusText(status))
+			}
+		})
+	}
+}
+
+// normalizeMethod caps span-name cardinality: anything outside the nine
+// standard HTTP methods (arbitrary strings are valid on the wire) is "OTHER".
+func normalizeMethod(m string) string {
+	switch m {
+	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete,
+		http.MethodHead, http.MethodOptions, http.MethodConnect, http.MethodTrace:
+		return m
+	}
+	return "OTHER"
+}
+
+func patternPath(r *http.Request) string {
+	p := r.Pattern
+	if i := strings.IndexByte(p, ' '); i >= 0 {
+		p = p[i+1:]
+	}
+	return p
+}

--- a/ops/tracing/middleware_test.go
+++ b/ops/tracing/middleware_test.go
@@ -1,0 +1,309 @@
+package tracing_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/ctxkey"
+	"github.com/dmitrymomot/forge/ops/tracing"
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+// recordingTracer is a test double capturing everything the middleware does to
+// its spans, layered on the real propagation tracer for identity handling.
+type recordingTracer struct {
+	mu    sync.Mutex
+	spans []*recordedSpan
+}
+
+type recordedSpan struct {
+	mu       sync.Mutex
+	sc       tracing.SpanContext
+	name     string
+	kind     tracing.SpanKind
+	attrs    []slog.Attr
+	events   []string
+	errs     []error
+	status   tracing.Status
+	statusD  string
+	endCalls int
+}
+
+func (t *recordingTracer) Start(ctx context.Context, name string, opts ...tracing.StartOption) (context.Context, tracing.Span) {
+	cfg := tracing.NewStartConfig(opts...)
+	ctx, id := tracing.New().Start(ctx, name, opts...)
+	s := &recordedSpan{sc: id.Context(), name: name, kind: cfg.Kind, attrs: cfg.Attrs}
+	t.mu.Lock()
+	t.spans = append(t.spans, s)
+	t.mu.Unlock()
+	return tracing.ContextWithSpan(ctx, s), s
+}
+
+func (t *recordingTracer) last(tb testing.TB) *recordedSpan {
+	tb.Helper()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	require.NotEmpty(tb, t.spans)
+	return t.spans[len(t.spans)-1]
+}
+
+func (s *recordedSpan) Context() tracing.SpanContext { return s.sc }
+func (s *recordedSpan) IsRecording() bool            { return true }
+
+func (s *recordedSpan) SetName(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.name = name
+}
+
+func (s *recordedSpan) SetAttributes(attrs ...slog.Attr) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.attrs = append(s.attrs, attrs...)
+}
+
+func (s *recordedSpan) AddEvent(name string, _ ...slog.Attr) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, name)
+}
+
+func (s *recordedSpan) RecordError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.errs = append(s.errs, err)
+}
+
+func (s *recordedSpan) SetStatus(code tracing.Status, description string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status, s.statusD = code, description
+}
+
+func (s *recordedSpan) End() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.endCalls++
+}
+
+func (s *recordedSpan) attr(tb testing.TB, key string) slog.Value {
+	tb.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, a := range s.attrs {
+		if a.Key == key {
+			return a.Value
+		}
+	}
+	tb.Fatalf("attribute %q not recorded", key)
+	return slog.Value{}
+}
+
+func serve(h http.Handler, r *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w
+}
+
+func TestMiddlewareStartsServerSpanWithRouteName(t *testing.T) {
+	tr := &recordingTracer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /users/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	h := middleware.Wrap(mux, tracing.NewMiddleware(tr))
+
+	serve(h, httptest.NewRequest(http.MethodGet, "/users/42", nil))
+
+	span := tr.last(t)
+	assert.Equal(t, "GET /users/{id}", span.name)
+	assert.Equal(t, tracing.KindServer, span.kind)
+	assert.Equal(t, 1, span.endCalls)
+	assert.Equal(t, "GET", span.attr(t, "http.request.method").String())
+	assert.Equal(t, "/users/42", span.attr(t, "url.path").String())
+	assert.Equal(t, "/users/{id}", span.attr(t, "http.route").String())
+	assert.Equal(t, int64(http.StatusCreated), span.attr(t, "http.response.status_code").Int64())
+	assert.Equal(t, tracing.StatusUnset, span.status)
+}
+
+func TestMiddlewareUnmatchedRouteKeepsMethodName(t *testing.T) {
+	tr := &recordingTracer{}
+	h := tracing.NewMiddleware(tr)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	serve(h, httptest.NewRequest(http.MethodGet, "/whatever", nil))
+
+	span := tr.last(t)
+	assert.Equal(t, "GET", span.name)
+	assert.Equal(t, int64(http.StatusOK), span.attr(t, "http.response.status_code").Int64(), "implicit 200")
+}
+
+func TestMiddlewareNonStandardMethodNormalized(t *testing.T) {
+	tr := &recordingTracer{}
+	h := tracing.NewMiddleware(tr)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	serve(h, httptest.NewRequest("PROPFIND", "/x", nil))
+
+	assert.Equal(t, "OTHER", tr.last(t).name)
+}
+
+func TestMiddlewareContinuesInboundTrace(t *testing.T) {
+	tr := &recordingTracer{}
+	h := tracing.NewMiddleware(tr)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.Header.Set("traceparent", sampleTraceparent)
+	r.Header.Set("tracestate", "vendor=a")
+	r.Header.Add("tracestate", "other=b")
+	serve(h, r)
+
+	sc := tr.last(t).sc
+	assert.Equal(t, sampleTraceHex, sc.TraceID.String())
+	assert.NotEqual(t, sampleSpanHex, sc.SpanID.String())
+	assert.Equal(t, "vendor=a,other=b", sc.TraceState)
+}
+
+func TestMiddlewareIgnoresInvalidTraceparent(t *testing.T) {
+	tr := &recordingTracer{}
+	h := tracing.NewMiddleware(tr)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.Header.Set("traceparent", "00-garbage-garbage-01")
+	serve(h, r)
+
+	sc := tr.last(t).sc
+	assert.True(t, sc.IsValid())
+	assert.NotEqual(t, sampleTraceHex, sc.TraceID.String())
+}
+
+func TestMiddlewareDropsOversizedTracestate(t *testing.T) {
+	tr := &recordingTracer{}
+	h := tracing.NewMiddleware(tr)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.Header.Set("traceparent", sampleTraceparent)
+	r.Header.Set("tracestate", "v="+strings.Repeat("x", 600))
+	serve(h, r)
+
+	assert.Empty(t, tr.last(t).sc.TraceState)
+}
+
+func TestMiddlewareTrustInboundDisabled(t *testing.T) {
+	tr := &recordingTracer{}
+	h := tracing.NewMiddleware(tr, tracing.WithTrustInbound(false))(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.Header.Set("traceparent", sampleTraceparent)
+	serve(h, r)
+
+	assert.NotEqual(t, sampleTraceHex, tr.last(t).sc.TraceID.String())
+}
+
+func TestMiddlewareFiveHundredMarksError(t *testing.T) {
+	tr := &recordingTracer{}
+	h := tracing.NewMiddleware(tr)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+
+	serve(h, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	span := tr.last(t)
+	assert.Equal(t, tracing.StatusError, span.status)
+	assert.Equal(t, http.StatusText(http.StatusBadGateway), span.statusD)
+}
+
+func TestMiddlewareFourHundredStaysUnset(t *testing.T) {
+	tr := &recordingTracer{}
+	h := tracing.NewMiddleware(tr)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	serve(h, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	assert.Equal(t, tracing.StatusUnset, tr.last(t).status)
+}
+
+func TestMiddlewareSkip(t *testing.T) {
+	tr := &recordingTracer{}
+	h := tracing.NewMiddleware(tr, tracing.WithSkip(func(r *http.Request) bool {
+		return r.URL.Path == "/livez"
+	}))(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	serve(h, httptest.NewRequest(http.MethodGet, "/livez", nil))
+	assert.Empty(t, tr.spans)
+
+	serve(h, httptest.NewRequest(http.MethodGet, "/real", nil))
+	assert.Len(t, tr.spans, 1)
+}
+
+func TestMiddlewareHandlerSeesSpanContext(t *testing.T) {
+	tr := &recordingTracer{}
+	var got tracing.SpanContext
+	h := tracing.NewMiddleware(tr)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got = tracing.SpanContextFromContext(r.Context())
+	}))
+
+	serve(h, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	assert.Equal(t, tr.last(t).sc, got)
+}
+
+func TestMiddlewareEndsSpanOnPanic(t *testing.T) {
+	tr := &recordingTracer{}
+	h := tracing.NewMiddleware(tr)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	}))
+
+	assert.Panics(t, func() {
+		serve(h, httptest.NewRequest(http.MethodGet, "/x", nil))
+	})
+	assert.Equal(t, 1, tr.last(t).endCalls)
+}
+
+var tenantKey = ctxkey.New[string]("tenant")
+
+func TestMiddlewareContextAttr(t *testing.T) {
+	tr := &recordingTracer{}
+	mw := tracing.NewMiddleware(tr, tracing.WithContextAttr("tenant", func(ctx context.Context) string {
+		v, _ := tenantKey.From(ctx)
+		return v
+	}))
+	h := mw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	serve(h, r.WithContext(tenantKey.With(r.Context(), "acme")))
+	assert.Equal(t, "acme", tr.last(t).attr(t, "tenant").String())
+
+	serve(h, httptest.NewRequest(http.MethodGet, "/x", nil))
+	assert.Equal(t, "unknown", tr.last(t).attr(t, "tenant").String(), "missing scope fails closed")
+}
+
+func TestMiddlewareContextAttrPanicsOnBadConfig(t *testing.T) {
+	assert.Panics(t, func() { tracing.WithContextAttr("", func(context.Context) string { return "" }) })
+	assert.Panics(t, func() { tracing.WithContextAttr("tenant", nil) })
+}
+
+func TestNewMiddlewarePanicsOnNilTracer(t *testing.T) {
+	assert.Panics(t, func() { tracing.NewMiddleware(nil) })
+}
+
+func TestMiddlewareWithPathFunc(t *testing.T) {
+	tr := &recordingTracer{}
+	h := tracing.NewMiddleware(tr, tracing.WithPathFunc(func(*http.Request) string {
+		return "/custom/:id"
+	}))(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	serve(h, httptest.NewRequest(http.MethodGet, "/custom/7", nil))
+
+	span := tr.last(t)
+	assert.Equal(t, "GET /custom/:id", span.name)
+	assert.Equal(t, "/custom/:id", span.attr(t, "http.route").String())
+}

--- a/ops/tracing/middleware_test.go
+++ b/ops/tracing/middleware_test.go
@@ -151,7 +151,21 @@ func TestMiddlewareNonStandardMethodNormalized(t *testing.T) {
 
 	serve(h, httptest.NewRequest("PROPFIND", "/x", nil))
 
-	assert.Equal(t, "OTHER", tr.last(t).name)
+	span := tr.last(t)
+	assert.Equal(t, "OTHER", span.name)
+	assert.Equal(t, "OTHER", span.attr(t, "http.request.method").String())
+	assert.Equal(t, "PROPFIND", span.attr(t, "http.request.method_original").String(), "raw verb stays debuggable")
+}
+
+func TestMiddlewareStandardMethodNoOriginalAttr(t *testing.T) {
+	tr := &recordingTracer{}
+	h := tracing.NewMiddleware(tr)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	serve(h, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	for _, a := range tr.last(t).attrs {
+		assert.NotEqual(t, "http.request.method_original", a.Key)
+	}
 }
 
 func TestMiddlewareContinuesInboundTrace(t *testing.T) {

--- a/ops/tracing/otel/bench_test.go
+++ b/ops/tracing/otel/bench_test.go
@@ -1,0 +1,40 @@
+package otel_test
+
+import (
+	"log/slog"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/dmitrymomot/forge/ops/tracing/otel"
+)
+
+func BenchmarkStartEnd(b *testing.B) {
+	tp := sdktrace.NewTracerProvider() // no exporter: measures the adapter + SDK span path
+	b.Cleanup(func() { _ = tp.Shutdown(b.Context()) })
+	tr := otel.New(tp)
+	ctx, parent := tr.Start(b.Context(), "parent")
+	defer parent.End()
+	b.ResetTimer()
+	for b.Loop() {
+		_, span := tr.Start(ctx, "child")
+		span.End()
+	}
+}
+
+func BenchmarkSetAttributes(b *testing.B) {
+	tp := sdktrace.NewTracerProvider()
+	b.Cleanup(func() { _ = tp.Shutdown(b.Context()) })
+	tr := otel.New(tp)
+	_, span := tr.Start(b.Context(), "s")
+	defer span.End()
+	attrs := []slog.Attr{
+		slog.String("http.request.method", "GET"),
+		slog.Int("http.response.status_code", 200),
+		slog.Group("g", slog.String("inner", "x")),
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		span.SetAttributes(attrs...)
+	}
+}

--- a/ops/tracing/otel/otel.go
+++ b/ops/tracing/otel/otel.go
@@ -1,0 +1,213 @@
+// Package otel adapts the OpenTelemetry trace API to the tracing.Tracer seam.
+// Sampling, resources, and exporters remain OTel SDK concerns wired in the
+// consumer's main; this driver only translates the seam's vocabulary.
+package otel
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/dmitrymomot/forge/ops/tracing"
+)
+
+type config struct {
+	name string
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithTracerName sets the OTel instrumentation-scope name (default the import
+// path of this package). An empty name is ignored.
+func WithTracerName(name string) Option {
+	return func(c *config) {
+		if name != "" {
+			c.name = name
+		}
+	}
+}
+
+// New returns a tracing.Tracer backed by tp — typically the OTel SDK's
+// sdktrace.NewTracerProvider with the consumer's sampler and exporter. Panics
+// on a nil provider.
+func New(tp oteltrace.TracerProvider, opts ...Option) *Tracer {
+	if tp == nil {
+		panic("otel: New requires a TracerProvider")
+	}
+	c := config{name: "github.com/dmitrymomot/forge/ops/tracing/otel"}
+	for _, o := range opts {
+		o(&c)
+	}
+	return &Tracer{tr: tp.Tracer(c.name)}
+}
+
+// Tracer implements tracing.Tracer over an OpenTelemetry tracer. Spans it
+// starts live in both the forge and the OTel context slots, so third-party
+// OTel instrumentation parents onto them and vice versa.
+type Tracer struct {
+	tr oteltrace.Tracer
+}
+
+var _ tracing.Tracer = (*Tracer)(nil)
+
+func (t *Tracer) Start(ctx context.Context, name string, opts ...tracing.StartOption) (context.Context, tracing.Span) {
+	cfg := tracing.NewStartConfig(opts...)
+	// A remote parent stored by the tracing middleware (or a queue consumer)
+	// only exists in the forge context slot; seed it into the OTel slot so the
+	// SDK parents and samples off it. A live OTel span in ctx always wins.
+	if !oteltrace.SpanContextFromContext(ctx).IsValid() {
+		if sc := tracing.SpanContextFromContext(ctx); sc.IsValid() {
+			ctx = oteltrace.ContextWithRemoteSpanContext(ctx, toOtelSpanContext(sc))
+		}
+	}
+	startOpts := make([]oteltrace.SpanStartOption, 0, 3)
+	startOpts = append(startOpts, oteltrace.WithSpanKind(toOtelKind(cfg.Kind)))
+	if len(cfg.Attrs) > 0 {
+		startOpts = append(startOpts, oteltrace.WithAttributes(convertAttrs(cfg.Attrs)...))
+	}
+	if cfg.NewRoot {
+		startOpts = append(startOpts, oteltrace.WithNewRoot())
+	}
+	ctx, s := t.tr.Start(ctx, name, startOpts...)
+	sp := span{s: s}
+	return tracing.ContextWithSpan(ctx, sp), sp
+}
+
+type span struct{ s oteltrace.Span }
+
+func (sp span) Context() tracing.SpanContext {
+	sc := sp.s.SpanContext()
+	out := tracing.SpanContext{
+		TraceID: tracing.TraceID(sc.TraceID()),
+		SpanID:  tracing.SpanID(sc.SpanID()),
+		Sampled: sc.IsSampled(),
+	}
+	if ts := sc.TraceState(); ts.Len() > 0 {
+		out.TraceState = ts.String()
+	}
+	return out
+}
+
+func (sp span) IsRecording() bool { return sp.s.IsRecording() }
+
+func (sp span) SetName(name string) { sp.s.SetName(name) }
+
+func (sp span) SetAttributes(attrs ...slog.Attr) {
+	sp.s.SetAttributes(convertAttrs(attrs)...)
+}
+
+func (sp span) AddEvent(name string, attrs ...slog.Attr) {
+	if len(attrs) == 0 {
+		sp.s.AddEvent(name)
+		return
+	}
+	sp.s.AddEvent(name, oteltrace.WithAttributes(convertAttrs(attrs)...))
+}
+
+func (sp span) RecordError(err error) {
+	if err != nil {
+		sp.s.RecordError(err)
+	}
+}
+
+func (sp span) SetStatus(code tracing.Status, description string) {
+	switch code {
+	case tracing.StatusOK:
+		sp.s.SetStatus(codes.Ok, description)
+	case tracing.StatusError:
+		sp.s.SetStatus(codes.Error, description)
+	default:
+		sp.s.SetStatus(codes.Unset, description)
+	}
+}
+
+func (sp span) End() { sp.s.End() }
+
+func toOtelSpanContext(sc tracing.SpanContext) oteltrace.SpanContext {
+	cfg := oteltrace.SpanContextConfig{
+		TraceID: oteltrace.TraceID(sc.TraceID),
+		SpanID:  oteltrace.SpanID(sc.SpanID),
+		Remote:  true,
+	}
+	if sc.Sampled {
+		cfg.TraceFlags = oteltrace.FlagsSampled
+	}
+	if sc.TraceState != "" {
+		if ts, err := oteltrace.ParseTraceState(sc.TraceState); err == nil {
+			cfg.TraceState = ts
+		}
+	}
+	return oteltrace.NewSpanContext(cfg)
+}
+
+func toOtelKind(k tracing.SpanKind) oteltrace.SpanKind {
+	switch k {
+	case tracing.KindServer:
+		return oteltrace.SpanKindServer
+	case tracing.KindClient:
+		return oteltrace.SpanKindClient
+	case tracing.KindProducer:
+		return oteltrace.SpanKindProducer
+	case tracing.KindConsumer:
+		return oteltrace.SpanKindConsumer
+	default:
+		return oteltrace.SpanKindInternal
+	}
+}
+
+func convertAttrs(attrs []slog.Attr) []attribute.KeyValue {
+	out := make([]attribute.KeyValue, 0, len(attrs))
+	for _, a := range attrs {
+		out = appendAttr(out, "", a)
+	}
+	return out
+}
+
+// appendAttr maps one slog.Attr onto OTel attributes: scalar kinds map
+// directly, groups flatten to dotted keys (slog's empty-key groups inline, as
+// in logging), LogValuers resolve first, and anything without a native OTel
+// type is stringified.
+func appendAttr(dst []attribute.KeyValue, prefix string, a slog.Attr) []attribute.KeyValue {
+	v := a.Value.Resolve()
+	key := a.Key
+	if prefix != "" {
+		if key == "" {
+			key = prefix
+		} else {
+			key = prefix + "." + key
+		}
+	}
+	switch v.Kind() {
+	case slog.KindGroup:
+		for _, ga := range v.Group() {
+			dst = appendAttr(dst, key, ga)
+		}
+		return dst
+	case slog.KindString:
+		return append(dst, attribute.String(key, v.String()))
+	case slog.KindInt64:
+		return append(dst, attribute.Int64(key, v.Int64()))
+	case slog.KindUint64:
+		if u := v.Uint64(); u <= math.MaxInt64 {
+			return append(dst, attribute.Int64(key, int64(u)))
+		}
+		return append(dst, attribute.String(key, strconv.FormatUint(v.Uint64(), 10)))
+	case slog.KindFloat64:
+		return append(dst, attribute.Float64(key, v.Float64()))
+	case slog.KindBool:
+		return append(dst, attribute.Bool(key, v.Bool()))
+	case slog.KindDuration:
+		return append(dst, attribute.String(key, v.Duration().String()))
+	case slog.KindTime:
+		return append(dst, attribute.String(key, v.Time().Format(time.RFC3339Nano)))
+	default:
+		return append(dst, attribute.String(key, v.String()))
+	}
+}

--- a/ops/tracing/otel/otel_test.go
+++ b/ops/tracing/otel/otel_test.go
@@ -1,0 +1,234 @@
+package otel_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/dmitrymomot/forge/ops/tracing"
+	"github.com/dmitrymomot/forge/ops/tracing/otel"
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+const sampleTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+func newTracer(t *testing.T) (*otel.Tracer, *tracetest.InMemoryExporter) {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return otel.New(tp), exp
+}
+
+func exported(t *testing.T, exp *tracetest.InMemoryExporter) tracetest.SpanStub {
+	t.Helper()
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	return spans[0]
+}
+
+func attrValue(t *testing.T, stub tracetest.SpanStub, key string) attribute.Value {
+	t.Helper()
+	for _, kv := range stub.Attributes {
+		if string(kv.Key) == key {
+			return kv.Value
+		}
+	}
+	t.Fatalf("attribute %q not exported", key)
+	return attribute.Value{}
+}
+
+func TestNewPanicsOnNilProvider(t *testing.T) {
+	assert.Panics(t, func() { otel.New(nil) })
+}
+
+func TestStartExportsSpan(t *testing.T) {
+	tr, exp := newTracer(t)
+	ctx, span := tr.Start(t.Context(), "work",
+		tracing.WithKind(tracing.KindClient),
+		tracing.WithAttributes(slog.String("k", "v")),
+	)
+	assert.True(t, span.IsRecording())
+	assert.True(t, span.Context().IsValid())
+	assert.Equal(t, span.Context(), tracing.SpanContextFromContext(ctx))
+	span.End()
+
+	stub := exported(t, exp)
+	assert.Equal(t, "work", stub.Name)
+	assert.Equal(t, oteltrace.SpanKindClient, stub.SpanKind)
+	assert.Equal(t, "v", attrValue(t, stub, "k").AsString())
+}
+
+func TestStartAdoptsForgeRemoteParent(t *testing.T) {
+	remote, err := tracing.ParseTraceparent(sampleTraceparent)
+	require.NoError(t, err)
+	remote.TraceState = "vendor=state"
+
+	tr, exp := newTracer(t)
+	ctx := tracing.ContextWithRemote(t.Context(), remote)
+	_, span := tr.Start(ctx, "server")
+	span.End()
+
+	stub := exported(t, exp)
+	assert.Equal(t, remote.TraceID.String(), stub.SpanContext.TraceID().String())
+	assert.Equal(t, remote.SpanID.String(), stub.Parent.SpanID().String())
+	assert.True(t, stub.Parent.IsRemote())
+	assert.Equal(t, "vendor=state", span.Context().TraceState)
+}
+
+func TestChildSpansNest(t *testing.T) {
+	tr, exp := newTracer(t)
+	ctx, parent := tr.Start(t.Context(), "parent")
+	_, child := tr.Start(ctx, "child")
+	child.End()
+	parent.End()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 2)
+	assert.Equal(t, parent.Context().SpanID.String(), spans[0].Parent.SpanID().String())
+	assert.Equal(t, parent.Context().TraceID, child.Context().TraceID)
+}
+
+func TestWithNewRootDetaches(t *testing.T) {
+	tr, exp := newTracer(t)
+	ctx, parent := tr.Start(t.Context(), "parent")
+	_, detached := tr.Start(ctx, "detached", tracing.WithNewRoot())
+	detached.End()
+	parent.End()
+
+	assert.NotEqual(t, parent.Context().TraceID, detached.Context().TraceID)
+	require.Len(t, exp.GetSpans(), 2)
+}
+
+func TestSpanMutators(t *testing.T) {
+	tr, exp := newTracer(t)
+	_, span := tr.Start(t.Context(), "before")
+	span.SetName("after")
+	span.SetAttributes(slog.Int("n", 7))
+	span.AddEvent("checkpoint", slog.Bool("ok", true))
+	span.AddEvent("bare")
+	span.RecordError(errors.New("boom"))
+	span.RecordError(nil)
+	span.SetStatus(tracing.StatusError, "failed")
+	span.End()
+
+	stub := exported(t, exp)
+	assert.Equal(t, "after", stub.Name)
+	assert.Equal(t, int64(7), attrValue(t, stub, "n").AsInt64())
+	require.Len(t, stub.Events, 3) // checkpoint + bare + exception
+	assert.Equal(t, "checkpoint", stub.Events[0].Name)
+	assert.Equal(t, "exception", stub.Events[2].Name)
+	assert.Equal(t, codes.Error, stub.Status.Code)
+	assert.Equal(t, "failed", stub.Status.Description)
+}
+
+func TestStatusOKMapping(t *testing.T) {
+	tr, exp := newTracer(t)
+	_, span := tr.Start(t.Context(), "s")
+	span.SetStatus(tracing.StatusOK, "")
+	span.End()
+
+	assert.Equal(t, codes.Ok, exported(t, exp).Status.Code)
+}
+
+func TestAttrConversion(t *testing.T) {
+	tr, exp := newTracer(t)
+	ts := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	_, span := tr.Start(t.Context(), "s")
+	span.SetAttributes(
+		slog.String("s", "v"),
+		slog.Int64("i", -5),
+		slog.Uint64("u", 12),
+		slog.Uint64("big", 1<<63),
+		slog.Float64("f", 1.5),
+		slog.Bool("b", true),
+		slog.Duration("d", 1500*time.Millisecond),
+		slog.Time("t", ts),
+		slog.Group("g", slog.String("inner", "x"), slog.Group("gg", slog.Int("deep", 1))),
+		slog.Any("any", struct{ X int }{X: 1}),
+	)
+	span.End()
+
+	stub := exported(t, exp)
+	assert.Equal(t, "v", attrValue(t, stub, "s").AsString())
+	assert.Equal(t, int64(-5), attrValue(t, stub, "i").AsInt64())
+	assert.Equal(t, int64(12), attrValue(t, stub, "u").AsInt64())
+	assert.Equal(t, "9223372036854775808", attrValue(t, stub, "big").AsString(), "uint64 overflow stringified")
+	assert.InDelta(t, 1.5, attrValue(t, stub, "f").AsFloat64(), 1e-9)
+	assert.True(t, attrValue(t, stub, "b").AsBool())
+	assert.Equal(t, "1.5s", attrValue(t, stub, "d").AsString())
+	assert.Equal(t, "2026-07-21T10:00:00Z", attrValue(t, stub, "t").AsString())
+	assert.Equal(t, "x", attrValue(t, stub, "g.inner").AsString())
+	assert.Equal(t, int64(1), attrValue(t, stub, "g.gg.deep").AsInt64())
+	assert.Equal(t, "{1}", attrValue(t, stub, "any").AsString())
+}
+
+func TestUnsampledParentNotRecorded(t *testing.T) {
+	remote, err := tracing.ParseTraceparent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00")
+	require.NoError(t, err)
+
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp),
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.AlwaysSample())),
+	)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	tr := otel.New(tp)
+
+	ctx := tracing.ContextWithRemote(t.Context(), remote)
+	_, span := tr.Start(ctx, "s")
+	assert.False(t, span.IsRecording(), "parent-based sampler honors the inbound unsampled flag")
+	assert.False(t, span.Context().Sampled)
+	span.End()
+	assert.Empty(t, exp.GetSpans())
+}
+
+func TestWithTracerName(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	tr := otel.New(tp, otel.WithTracerName("custom-scope"))
+	_, span := tr.Start(t.Context(), "s")
+	span.End()
+
+	assert.Equal(t, "custom-scope", exported(t, exp).InstrumentationScope.Name)
+}
+
+// TestMiddlewareIntegration wires the core middleware to the otel driver and
+// verifies a full server span export with trace continuation.
+func TestMiddlewareIntegration(t *testing.T) {
+	tr, exp := newTracer(t)
+	mux := http.NewServeMux()
+	var inHandler tracing.SpanContext
+	mux.HandleFunc("GET /users/{id}", func(w http.ResponseWriter, r *http.Request) {
+		inHandler = tracing.SpanContextFromContext(r.Context())
+		w.WriteHeader(http.StatusTeapot)
+	})
+	h := middleware.Wrap(mux, tracing.NewMiddleware(tr))
+
+	r := httptest.NewRequest(http.MethodGet, "/users/42", nil)
+	r.Header.Set("traceparent", sampleTraceparent)
+	h.ServeHTTP(httptest.NewRecorder(), r)
+
+	stub := exported(t, exp)
+	assert.Equal(t, "GET /users/{id}", stub.Name)
+	assert.Equal(t, oteltrace.SpanKindServer, stub.SpanKind)
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", stub.SpanContext.TraceID().String())
+	assert.Equal(t, "00f067aa0ba902b7", stub.Parent.SpanID().String())
+	assert.Equal(t, int64(http.StatusTeapot), attrValue(t, stub, "http.response.status_code").AsInt64())
+	assert.True(t, inHandler.IsValid())
+	assert.Equal(t, stub.SpanContext.SpanID().String(), inHandler.SpanID.String())
+}

--- a/ops/tracing/propagation.go
+++ b/ops/tracing/propagation.go
@@ -1,0 +1,40 @@
+package tracing
+
+import (
+	"context"
+	"net/http"
+)
+
+// Inject writes the trace context from ctx onto h as W3C traceparent (and
+// tracestate, when present) headers. It is a no-op when ctx carries no valid
+// span context, so it is always safe to call.
+func Inject(ctx context.Context, h http.Header) {
+	sc := SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		return
+	}
+	h.Set(TraceparentHeader, sc.Traceparent())
+	if sc.TraceState != "" {
+		h.Set(TracestateHeader, sc.TraceState)
+	}
+}
+
+// PropagationHeaders returns the W3C trace context headers for ctx — nil when
+// none — shaped for httpclient's context-header seam:
+//
+//	client := httpclient.New(httpclient.WithContextHeaders(tracing.PropagationHeaders))
+//
+// Every request made with a span (or remote parent) in its context then joins
+// the trace downstream.
+func PropagationHeaders(ctx context.Context) http.Header {
+	sc := SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		return nil
+	}
+	h := make(http.Header, 2)
+	h[TraceparentHeader] = []string{sc.Traceparent()}
+	if sc.TraceState != "" {
+		h[TracestateHeader] = []string{sc.TraceState}
+	}
+	return h
+}

--- a/ops/tracing/propagation.go
+++ b/ops/tracing/propagation.go
@@ -6,11 +6,11 @@ import (
 )
 
 // Inject writes the trace context from ctx onto h as W3C traceparent (and
-// tracestate, when present) headers. It is a no-op when ctx carries no valid
-// span context, so it is always safe to call.
+// tracestate, when present) headers. It is a no-op when h is nil or ctx
+// carries no valid span context, so it is always safe to call.
 func Inject(ctx context.Context, h http.Header) {
 	sc := SpanContextFromContext(ctx)
-	if !sc.IsValid() {
+	if h == nil || !sc.IsValid() {
 		return
 	}
 	h.Set(TraceparentHeader, sc.Traceparent())

--- a/ops/tracing/propagation_test.go
+++ b/ops/tracing/propagation_test.go
@@ -1,0 +1,75 @@
+package tracing_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/tracing"
+)
+
+func TestPropagationHeadersEmptyContext(t *testing.T) {
+	assert.Nil(t, tracing.PropagationHeaders(t.Context()))
+}
+
+func TestPropagationHeadersFromSpan(t *testing.T) {
+	tr := tracing.New()
+	ctx, span := tr.Start(t.Context(), "s")
+	defer span.End()
+
+	h := tracing.PropagationHeaders(ctx)
+	require.NotNil(t, h)
+	assert.Equal(t, span.Context().Traceparent(), h.Get("Traceparent"))
+	assert.Empty(t, h.Get("Tracestate"))
+}
+
+func TestPropagationHeadersCarryTracestate(t *testing.T) {
+	remote, err := tracing.ParseTraceparent(sampleTraceparent)
+	require.NoError(t, err)
+	remote.TraceState = "vendor=state"
+	ctx := tracing.ContextWithRemote(t.Context(), remote)
+
+	h := tracing.PropagationHeaders(ctx)
+	require.NotNil(t, h)
+	assert.Equal(t, sampleTraceparent, h.Get("Traceparent"))
+	assert.Equal(t, "vendor=state", h.Get("Tracestate"))
+}
+
+func TestInject(t *testing.T) {
+	h := http.Header{}
+	tracing.Inject(t.Context(), h)
+	assert.Empty(t, h)
+
+	remote, err := tracing.ParseTraceparent(sampleTraceparent)
+	require.NoError(t, err)
+	remote.TraceState = "vendor=state"
+	tracing.Inject(tracing.ContextWithRemote(t.Context(), remote), h)
+	assert.Equal(t, sampleTraceparent, h.Get("Traceparent"))
+	assert.Equal(t, "vendor=state", h.Get("Tracestate"))
+}
+
+// TestEndToEndPropagation proves the full hop: middleware continues an inbound
+// trace and PropagationHeaders forwards the server span downstream.
+func TestEndToEndPropagation(t *testing.T) {
+	tr := tracing.New()
+	var outbound http.Header
+	h := tracing.NewMiddleware(tr)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		outbound = tracing.PropagationHeaders(r.Context())
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.Header.Set("traceparent", sampleTraceparent)
+	r.Header.Set("tracestate", "vendor=state")
+	h.ServeHTTP(httptest.NewRecorder(), r)
+
+	require.NotNil(t, outbound)
+	forwarded, err := tracing.ParseTraceparent(outbound.Get("Traceparent"))
+	require.NoError(t, err)
+	assert.Equal(t, sampleTraceHex, forwarded.TraceID.String(), "same trace continues downstream")
+	assert.NotEqual(t, sampleSpanHex, forwarded.SpanID.String(), "parent id is this hop's span")
+	assert.True(t, forwarded.Sampled)
+	assert.Equal(t, "vendor=state", outbound.Get("Tracestate"))
+}

--- a/ops/tracing/propagation_test.go
+++ b/ops/tracing/propagation_test.go
@@ -43,6 +43,11 @@ func TestInject(t *testing.T) {
 	tracing.Inject(t.Context(), h)
 	assert.Empty(t, h)
 
+	tr := tracing.New()
+	ctx, span := tr.Start(t.Context(), "s")
+	defer span.End()
+	assert.NotPanics(t, func() { tracing.Inject(ctx, nil) }, "nil header is a no-op")
+
 	remote, err := tracing.ParseTraceparent(sampleTraceparent)
 	require.NoError(t, err)
 	remote.TraceState = "vendor=state"

--- a/ops/tracing/spancontext.go
+++ b/ops/tracing/spancontext.go
@@ -1,0 +1,127 @@
+package tracing
+
+// TraceID is the 16-byte W3C trace id shared by every span in a trace. The
+// zero value is invalid per the spec.
+type TraceID [16]byte
+
+// IsValid reports whether the id is non-zero.
+func (id TraceID) IsValid() bool { return id != TraceID{} }
+
+// String returns the id as 32 lowercase hex characters.
+func (id TraceID) String() string { return string(appendHex(make([]byte, 0, 32), id[:])) }
+
+// SpanID is the 8-byte W3C span id (parent-id in traceparent terms). The zero
+// value is invalid per the spec.
+type SpanID [8]byte
+
+// IsValid reports whether the id is non-zero.
+func (id SpanID) IsValid() bool { return id != SpanID{} }
+
+// String returns the id as 16 lowercase hex characters.
+func (id SpanID) String() string { return string(appendHex(make([]byte, 0, 16), id[:])) }
+
+// SpanContext is the propagatable identity of a span: what travels in the W3C
+// traceparent/tracestate headers. TraceState is the raw tracestate value
+// carried through unmodified (vendor key=value pairs, opaque to forge).
+type SpanContext struct {
+	TraceState string
+	TraceID    TraceID
+	SpanID     SpanID
+	Sampled    bool
+}
+
+// IsValid reports whether both ids are non-zero.
+func (sc SpanContext) IsValid() bool { return sc.TraceID.IsValid() && sc.SpanID.IsValid() }
+
+// Traceparent renders the W3C header value
+// "00-<trace-id>-<parent-id>-<trace-flags>", or "" when sc is invalid.
+func (sc SpanContext) Traceparent() string {
+	if !sc.IsValid() {
+		return ""
+	}
+	b := make([]byte, 0, traceparentLen)
+	b = append(b, "00-"...)
+	b = appendHex(b, sc.TraceID[:])
+	b = append(b, '-')
+	b = appendHex(b, sc.SpanID[:])
+	if sc.Sampled {
+		b = append(b, "-01"...)
+	} else {
+		b = append(b, "-00"...)
+	}
+	return string(b)
+}
+
+// traceparentLen is the exact length of a version-00 traceparent value:
+// "xx-<32 hex>-<16 hex>-xx".
+const traceparentLen = 55
+
+// ParseTraceparent parses a W3C traceparent header value. It enforces the
+// spec: lowercase hex only, non-zero trace and parent ids, version ff
+// rejected, and unknown future versions accepted as long as the version-00
+// prefix parses (extra "-..." fields are ignored). The returned SpanContext
+// has an empty TraceState — tracestate travels in its own header.
+func ParseTraceparent(s string) (SpanContext, error) {
+	if len(s) < traceparentLen || s[2] != '-' || s[35] != '-' || s[52] != '-' {
+		return SpanContext{}, ErrInvalidTraceparent
+	}
+	version, ok := parseHexByte(s[0], s[1])
+	if !ok || version == 0xff {
+		return SpanContext{}, ErrInvalidTraceparent
+	}
+	// Version 00 is exactly 55 chars; future versions may append "-<field>"s.
+	if len(s) > traceparentLen && (version == 0 || s[traceparentLen] != '-') {
+		return SpanContext{}, ErrInvalidTraceparent
+	}
+	var sc SpanContext
+	if !parseHex(sc.TraceID[:], s[3:35]) || !parseHex(sc.SpanID[:], s[36:52]) {
+		return SpanContext{}, ErrInvalidTraceparent
+	}
+	if !sc.IsValid() {
+		return SpanContext{}, ErrInvalidTraceparent
+	}
+	flags, ok := parseHexByte(s[53], s[54])
+	if !ok {
+		return SpanContext{}, ErrInvalidTraceparent
+	}
+	sc.Sampled = flags&0x01 != 0
+	return sc, nil
+}
+
+const hexDigits = "0123456789abcdef"
+
+func appendHex(dst, src []byte) []byte {
+	for _, v := range src {
+		dst = append(dst, hexDigits[v>>4], hexDigits[v&0x0f])
+	}
+	return dst
+}
+
+// parseHex decodes exactly len(dst)*2 lowercase hex characters (the W3C spec
+// forbids uppercase, so encoding/hex would be too lenient).
+func parseHex(dst []byte, s string) bool {
+	for i := range dst {
+		b, ok := parseHexByte(s[2*i], s[2*i+1])
+		if !ok {
+			return false
+		}
+		dst[i] = b
+	}
+	return true
+}
+
+func parseHexByte(hi, lo byte) (byte, bool) {
+	h, ok1 := hexNibble(hi)
+	l, ok2 := hexNibble(lo)
+	return h<<4 | l, ok1 && ok2
+}
+
+func hexNibble(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	}
+	return 0, false
+}

--- a/ops/tracing/spancontext_test.go
+++ b/ops/tracing/spancontext_test.go
@@ -1,0 +1,111 @@
+package tracing_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/tracing"
+)
+
+const (
+	sampleTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	sampleTraceHex    = "4bf92f3577b34da6a3ce929d0e0e4736"
+	sampleSpanHex     = "00f067aa0ba902b7"
+)
+
+func TestParseTraceparentValid(t *testing.T) {
+	sc, err := tracing.ParseTraceparent(sampleTraceparent)
+	require.NoError(t, err)
+	assert.True(t, sc.IsValid())
+	assert.Equal(t, sampleTraceHex, sc.TraceID.String())
+	assert.Equal(t, sampleSpanHex, sc.SpanID.String())
+	assert.True(t, sc.Sampled)
+	assert.Empty(t, sc.TraceState)
+}
+
+func TestParseTraceparentNotSampled(t *testing.T) {
+	sc, err := tracing.ParseTraceparent("00-" + sampleTraceHex + "-" + sampleSpanHex + "-00")
+	require.NoError(t, err)
+	assert.False(t, sc.Sampled)
+}
+
+func TestParseTraceparentOnlySampledBitRead(t *testing.T) {
+	sc, err := tracing.ParseTraceparent("00-" + sampleTraceHex + "-" + sampleSpanHex + "-fd")
+	require.NoError(t, err)
+	assert.True(t, sc.Sampled)
+
+	sc, err = tracing.ParseTraceparent("00-" + sampleTraceHex + "-" + sampleSpanHex + "-fe")
+	require.NoError(t, err)
+	assert.False(t, sc.Sampled)
+}
+
+func TestParseTraceparentFutureVersion(t *testing.T) {
+	// A future version may append extra dash-separated fields.
+	sc, err := tracing.ParseTraceparent("cc-" + sampleTraceHex + "-" + sampleSpanHex + "-01-extra-stuff")
+	require.NoError(t, err)
+	assert.Equal(t, sampleTraceHex, sc.TraceID.String())
+
+	sc, err = tracing.ParseTraceparent("cc-" + sampleTraceHex + "-" + sampleSpanHex + "-01")
+	require.NoError(t, err)
+	assert.True(t, sc.Sampled)
+}
+
+func TestParseTraceparentInvalid(t *testing.T) {
+	cases := map[string]string{
+		"empty":              "",
+		"too short":          "00-abc-def-01",
+		"wrong separator":    "00_" + sampleTraceHex + "_" + sampleSpanHex + "_01",
+		"uppercase trace id": "00-" + strings.ToUpper(sampleTraceHex) + "-" + sampleSpanHex + "-01",
+		"uppercase span id":  "00-" + sampleTraceHex + "-" + strings.ToUpper(sampleSpanHex) + "-01",
+		"non-hex trace id":   "00-" + strings.Repeat("zz", 16) + "-" + sampleSpanHex + "-01",
+		"zero trace id":      "00-" + strings.Repeat("0", 32) + "-" + sampleSpanHex + "-01",
+		"zero span id":       "00-" + sampleTraceHex + "-" + strings.Repeat("0", 16) + "-01",
+		"version ff":         "ff-" + sampleTraceHex + "-" + sampleSpanHex + "-01",
+		"bad version":        "0x-" + sampleTraceHex + "-" + sampleSpanHex + "-01",
+		"bad flags":          "00-" + sampleTraceHex + "-" + sampleSpanHex + "-0x",
+		"v00 trailing data":  sampleTraceparent + "-extra",
+		"v00 trailing junk":  sampleTraceparent + "x",
+		"future no dash":     "cc-" + sampleTraceHex + "-" + sampleSpanHex + "-01x",
+		"missing flags":      "00-" + sampleTraceHex + "-" + sampleSpanHex,
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := tracing.ParseTraceparent(in)
+			require.ErrorIs(t, err, tracing.ErrInvalidTraceparent)
+		})
+	}
+}
+
+func TestTraceparentRoundTrip(t *testing.T) {
+	sc, err := tracing.ParseTraceparent(sampleTraceparent)
+	require.NoError(t, err)
+	assert.Equal(t, sampleTraceparent, sc.Traceparent())
+
+	sc.Sampled = false
+	out, err := tracing.ParseTraceparent(sc.Traceparent())
+	require.NoError(t, err)
+	assert.Equal(t, sc, out)
+}
+
+func TestTraceparentInvalidContextEmpty(t *testing.T) {
+	assert.Empty(t, tracing.SpanContext{}.Traceparent())
+	assert.Empty(t, tracing.SpanContext{TraceID: tracing.TraceID{1}}.Traceparent())
+	assert.Empty(t, tracing.SpanContext{SpanID: tracing.SpanID{1}}.Traceparent())
+}
+
+func TestIDValidityAndString(t *testing.T) {
+	assert.False(t, tracing.TraceID{}.IsValid())
+	assert.False(t, tracing.SpanID{}.IsValid())
+	assert.Equal(t, strings.Repeat("0", 32), tracing.TraceID{}.String())
+
+	id := tracing.TraceID{0x01, 0xab}
+	assert.True(t, id.IsValid())
+	assert.Equal(t, "01ab"+strings.Repeat("0", 28), id.String())
+
+	sid := tracing.SpanID{0xff}
+	assert.True(t, sid.IsValid())
+	assert.Equal(t, "ff"+strings.Repeat("0", 14), sid.String())
+}

--- a/ops/tracing/tracer.go
+++ b/ops/tracing/tracer.go
@@ -1,0 +1,84 @@
+package tracing
+
+import (
+	"context"
+	"encoding/binary"
+	"log/slog"
+	"math/rand/v2"
+)
+
+// New returns the zero-dependency default Tracer: propagation-only. It manages
+// trace identity — continuing the inbound trace or minting a new one, with a
+// fresh span id per span — but records nothing, so trace_id log correlation
+// and downstream header propagation work without any exporter. New roots are
+// marked sampled: this tracer makes no sampling decision of its own, and an
+// unsampled flag would tell parent-based samplers downstream to drop the
+// trace. Swap in tracing/otel for real span export without touching call
+// sites.
+func New() Tracer { return idTracer{} }
+
+type idTracer struct{}
+
+func (idTracer) Start(ctx context.Context, _ string, opts ...StartOption) (context.Context, Span) {
+	cfg := NewStartConfig(opts...)
+	var sc SpanContext
+	if parent := SpanContextFromContext(ctx); !cfg.NewRoot && parent.TraceID.IsValid() {
+		sc.TraceID = parent.TraceID
+		sc.Sampled = parent.Sampled
+		sc.TraceState = parent.TraceState
+	} else {
+		sc.TraceID = newTraceID()
+		sc.Sampled = true
+	}
+	sc.SpanID = newSpanID()
+	s := idSpan{sc: sc}
+	return ContextWithSpan(ctx, s), s
+}
+
+// idSpan carries identity only; every mutator is a no-op.
+type idSpan struct{ sc SpanContext }
+
+func (s idSpan) Context() SpanContext        { return s.sc }
+func (idSpan) IsRecording() bool             { return false }
+func (idSpan) SetName(string)                {}
+func (idSpan) SetAttributes(...slog.Attr)    {}
+func (idSpan) AddEvent(string, ...slog.Attr) {}
+func (idSpan) RecordError(error)             {}
+func (idSpan) SetStatus(Status, string)      {}
+func (idSpan) End()                          {}
+
+// NewNoop returns a Tracer that does nothing at all: Start returns ctx
+// unchanged and a span with no identity. Because ctx is untouched, a remote
+// parent stored by the middleware stays visible to LogExtractor and
+// propagation — a service with tracing disabled still logs and forwards the
+// trace it received. Use as the safe default when tracing is an optional
+// dependency.
+func NewNoop() Tracer { return noopTracer{} }
+
+type noopTracer struct{}
+
+func (noopTracer) Start(ctx context.Context, _ string, _ ...StartOption) (context.Context, Span) {
+	return ctx, noopSpan{}
+}
+
+// Trace ids need uniqueness, not secrecy: math/rand/v2's global generator
+// (ChaCha8, crypto-seeded, per-P states) avoids a crypto/rand read per span.
+// The loops re-draw the astronomically unlikely all-zero value, which the W3C
+// spec declares invalid.
+
+func newTraceID() TraceID {
+	var id TraceID
+	for id == (TraceID{}) {
+		binary.BigEndian.PutUint64(id[:8], rand.Uint64())
+		binary.BigEndian.PutUint64(id[8:], rand.Uint64())
+	}
+	return id
+}
+
+func newSpanID() SpanID {
+	var id SpanID
+	for id == (SpanID{}) {
+		binary.BigEndian.PutUint64(id[:], rand.Uint64())
+	}
+	return id
+}

--- a/ops/tracing/tracer_test.go
+++ b/ops/tracing/tracer_test.go
@@ -1,0 +1,115 @@
+package tracing_test
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/tracing"
+)
+
+func TestNewStartsRootSpan(t *testing.T) {
+	tr := tracing.New()
+	ctx, span := tr.Start(t.Context(), "root")
+	defer span.End()
+
+	sc := span.Context()
+	assert.True(t, sc.IsValid())
+	assert.True(t, sc.Sampled, "propagation-only roots must not suppress downstream sampling")
+	assert.False(t, span.IsRecording())
+	assert.Equal(t, sc, tracing.SpanContextFromContext(ctx))
+}
+
+func TestNewChildInheritsTraceID(t *testing.T) {
+	tr := tracing.New()
+	ctx, parent := tr.Start(t.Context(), "parent")
+	defer parent.End()
+	_, child := tr.Start(ctx, "child")
+	defer child.End()
+
+	assert.Equal(t, parent.Context().TraceID, child.Context().TraceID)
+	assert.NotEqual(t, parent.Context().SpanID, child.Context().SpanID)
+}
+
+func TestNewAdoptsRemoteParent(t *testing.T) {
+	remote, err := tracing.ParseTraceparent("00-" + sampleTraceHex + "-" + sampleSpanHex + "-00")
+	require.NoError(t, err)
+	remote.TraceState = "vendor=state"
+
+	tr := tracing.New()
+	ctx := tracing.ContextWithRemote(t.Context(), remote)
+	_, span := tr.Start(ctx, "server")
+	defer span.End()
+
+	sc := span.Context()
+	assert.Equal(t, remote.TraceID, sc.TraceID)
+	assert.NotEqual(t, remote.SpanID, sc.SpanID, "each hop gets its own span id")
+	assert.False(t, sc.Sampled, "inbound sampling decision is inherited")
+	assert.Equal(t, "vendor=state", sc.TraceState)
+}
+
+func TestNewWithNewRootIgnoresParent(t *testing.T) {
+	tr := tracing.New()
+	ctx, parent := tr.Start(t.Context(), "parent")
+	defer parent.End()
+	_, span := tr.Start(ctx, "detached", tracing.WithNewRoot())
+	defer span.End()
+
+	assert.NotEqual(t, parent.Context().TraceID, span.Context().TraceID)
+	assert.True(t, span.Context().Sampled)
+}
+
+func TestNewSpanMutatorsAreNoops(t *testing.T) {
+	tr := tracing.New()
+	_, span := tr.Start(t.Context(), "s", tracing.WithKind(tracing.KindServer),
+		tracing.WithAttributes(slog.String("k", "v")))
+
+	// Nothing to observe — just prove none of these panic on the id-only span.
+	span.SetName("renamed")
+	span.SetAttributes(slog.Int("n", 1))
+	span.AddEvent("event", slog.Bool("ok", true))
+	span.RecordError(errors.New("boom"))
+	span.SetStatus(tracing.StatusError, "bad")
+	span.End()
+	span.End()
+	assert.True(t, span.Context().IsValid())
+}
+
+func TestNewUniqueIDs(t *testing.T) {
+	tr := tracing.New()
+	seen := make(map[tracing.SpanID]bool)
+	_, root := tr.Start(t.Context(), "root")
+	traceID := root.Context().TraceID
+	for range 100 {
+		_, s := tr.Start(t.Context(), "s")
+		assert.NotEqual(t, traceID, s.Context().TraceID)
+		require.False(t, seen[s.Context().SpanID])
+		seen[s.Context().SpanID] = true
+	}
+}
+
+func TestNoopStartReturnsContextUnchanged(t *testing.T) {
+	tr := tracing.NewNoop()
+	ctx, span := tr.Start(t.Context(), "ignored")
+	defer span.End()
+
+	assert.Equal(t, t.Context(), ctx)
+	assert.False(t, span.Context().IsValid())
+	assert.False(t, span.IsRecording())
+}
+
+func TestNoopPassesRemoteThrough(t *testing.T) {
+	remote, err := tracing.ParseTraceparent(sampleTraceparent)
+	require.NoError(t, err)
+
+	tr := tracing.NewNoop()
+	ctx := tracing.ContextWithRemote(t.Context(), remote)
+	ctx, span := tr.Start(ctx, "ignored")
+	defer span.End()
+
+	// A disabled service still logs and forwards the trace it received.
+	assert.Equal(t, remote, tracing.SpanContextFromContext(ctx))
+}

--- a/ops/tracing/tracing.go
+++ b/ops/tracing/tracing.go
@@ -1,0 +1,110 @@
+package tracing
+
+import (
+	"context"
+	"log/slog"
+)
+
+// SpanKind describes a span's role in a trace, mirroring the OpenTelemetry
+// vocabulary so drivers map it one-to-one.
+type SpanKind uint8
+
+const (
+	// KindInternal is an operation internal to the service (the default).
+	KindInternal SpanKind = iota
+	// KindServer is the handling of an inbound request.
+	KindServer
+	// KindClient is an outbound synchronous call.
+	KindClient
+	// KindProducer is the enqueue side of an async hand-off.
+	KindProducer
+	// KindConsumer is the processing side of an async hand-off.
+	KindConsumer
+)
+
+// Status is a span's outcome. StatusUnset (the default) means the backend
+// derives the outcome itself; only mark StatusError for genuine failures.
+type Status uint8
+
+const (
+	StatusUnset Status = iota
+	StatusOK
+	StatusError
+)
+
+// Tracer starts spans. Implementations are safe for concurrent use. Packages
+// that emit spans take a Tracer option defaulting to NewNoop; swapping the
+// implementation (New, tracing/otel) changes wiring, never call sites.
+type Tracer interface {
+	// Start begins a span named name as a child of the span in ctx — or of a
+	// remote parent stored by ContextWithRemote when no live span is present —
+	// and returns a context carrying the new span. The caller must call End on
+	// the returned span.
+	Start(ctx context.Context, name string, opts ...StartOption) (context.Context, Span)
+}
+
+// Span is a live span. Mutators are no-ops after End and on non-recording
+// spans; guard genuinely expensive attribute computation with IsRecording.
+// RecordError only attaches the error as an event — a span that failed should
+// also SetStatus(StatusError, ...).
+type Span interface {
+	// Context returns the span's propagatable identity.
+	Context() SpanContext
+	// IsRecording reports whether attributes and events are being captured.
+	IsRecording() bool
+	// SetName renames the span (e.g. once the route pattern is known).
+	SetName(name string)
+	// SetAttributes adds attributes. Scalar slog kinds map directly; groups
+	// flatten to dotted keys; anything else is stringified.
+	SetAttributes(attrs ...slog.Attr)
+	// AddEvent adds a timestamped event.
+	AddEvent(name string, attrs ...slog.Attr)
+	// RecordError attaches err as an exception event. A nil err is ignored.
+	RecordError(err error)
+	// SetStatus sets the span outcome; description is only meaningful for
+	// StatusError.
+	SetStatus(code Status, description string)
+	// End completes the span. Only the first call has an effect.
+	End()
+}
+
+// StartConfig is the resolved set of Start options. It is exported so Tracer
+// implementations outside this package can apply StartOptions via
+// NewStartConfig; consumers never construct it directly.
+type StartConfig struct {
+	Attrs   []slog.Attr
+	Kind    SpanKind
+	NewRoot bool
+}
+
+// StartOption configures Start.
+type StartOption func(*StartConfig)
+
+// NewStartConfig applies opts (nil entries are ignored) and returns the
+// resolved config. Tracer implementations call this first in Start.
+func NewStartConfig(opts ...StartOption) StartConfig {
+	var c StartConfig
+	for _, o := range opts {
+		if o != nil {
+			o(&c)
+		}
+	}
+	return c
+}
+
+// WithKind sets the span kind (default KindInternal).
+func WithKind(k SpanKind) StartOption {
+	return func(c *StartConfig) { c.Kind = k }
+}
+
+// WithAttributes adds attributes present from the span's start (visible to
+// samplers, unlike SetAttributes).
+func WithAttributes(attrs ...slog.Attr) StartOption {
+	return func(c *StartConfig) { c.Attrs = append(c.Attrs, attrs...) }
+}
+
+// WithNewRoot starts a new trace even when ctx carries a parent — e.g. a
+// background job triggered by, but not part of, a request.
+func WithNewRoot() StartOption {
+	return func(c *StartConfig) { c.NewRoot = true }
+}


### PR DESCRIPTION
Implements the `ops/tracing` catalog entry: a minimal distributed-tracing facade with a `Tracer`/`Span` seam, W3C trace-context middleware, a `trace_id` log extractor, outbound header propagation pairing with `httpclient`, and an isolated `tracing/otel` driver. The entry is removed from `docs/packages.md` per the shipped-package rule.

## Design

- **Seam** (`tracing.go`): `Tracer.Start` + `Span` interfaces using plain `slog.Attr` for attributes — same vocabulary as logging, no new KV type. `StartConfig`/`NewStartConfig` are exported so out-of-tree drivers can apply `StartOption`s. Kinds and statuses mirror the OTel vocabulary for one-to-one driver mapping.
- **W3C trace context** (`spancontext.go`): zero-alloc `ParseTraceparent` enforcing the spec (lowercase hex only, non-zero ids, version `ff` rejected, future versions tolerated), `SpanContext.Traceparent()` formatter, opaque `TraceState` pass-through.
- **Zero-dependency default** (`tracer.go`): `New()` is propagation-only — continues the inbound trace (or mints a new one) with a fresh span id per hop but records nothing, so `trace_id` log correlation and downstream propagation work with no exporter. New roots are marked sampled so parent-based samplers downstream aren't suppressed. `NewNoop()` returns ctx unchanged, which keeps an inbound remote parent visible to logs and propagation — a disabled service still forwards the trace it received.
- **Middleware** (`middleware.go`): parses inbound `traceparent`/`tracestate` into a remote parent (`WithTrustInbound(false)` for public edges), wraps the handler in a `KindServer` span named after the matched `r.Pattern` (`WithPathFunc` hook for other routers), records `http.request.method`, `url.path`, `http.route`, `http.response.status_code`, marks 5xx `StatusError`, and ends the span even on panic. `WithContextAttr` is the construction-time tenancy seam (fail-closed `"unknown"`, mirrors `metrics.WithContextLabel`); single-tenant apps skip it and pay nothing.
- **Log + outbound pairing** (`context.go`, `propagation.go`): `LogExtractor` adds `trace_id` from the live span or remote parent; `PropagationHeaders` is shaped for `httpclient.WithContextHeaders`, `Inject` covers other transports and queue hand-off.
- **otel driver** (`tracing/otel`): adapts any `trace.TracerProvider`; seeds a forge remote parent into the OTel context slot only when no live OTel span exists (third-party OTel instrumentation composes both ways), flattens slog groups to dotted keys, resolves `LogValuer`s, stringifies uint64 overflow. The OTel SDK is a test-only dependency; `go.opentelemetry.io/otel`+`/trace` move from indirect to direct.

## Benchmarks (Apple M-series, `-benchmem`)

```
BenchmarkParseTraceparent-14          64.98 ns/op     0 B/op   0 allocs/op
BenchmarkTraceparent-14               30.70 ns/op    64 B/op   1 allocs/op
BenchmarkStartChild-14                80.22 ns/op   176 B/op   4 allocs/op
BenchmarkSpanContextFromContext-14    13.15 ns/op     0 B/op   0 allocs/op
BenchmarkLogExtractor-14              31.08 ns/op    32 B/op   1 allocs/op
BenchmarkPropagationHeaders-14       139.3  ns/op   480 B/op   4 allocs/op
BenchmarkMiddleware-14               389.0  ns/op   912 B/op  14 allocs/op
otel: BenchmarkStartEnd-14           381.4  ns/op   704 B/op   8 allocs/op
otel: BenchmarkSetAttributes-14      169.6  ns/op   356 B/op   2 allocs/op
```

Post-benchmark pass: the hot parse path is already zero-alloc and the remaining allocations are irreducible boxing/context/string costs (span interface value, `context.WithValue`, hex string, header map), so no perf-motivated complexity was added — numbers above are the shipped baseline.

## Testing

Black-box tests throughout: spec-negative parser matrix (uppercase hex, zero ids, version `ff`, future-version tolerance), identity inheritance/remote adoption/new-root, noop pass-through, middleware (route naming, inbound trust on/off, oversized-tracestate drop, 5xx status, panic still ends span, tenancy attr fail-closed), end-to-end hop propagation, and otel driver tests against the SDK's in-memory exporter (remote parent seeding, parent-based sampling of unsampled inbound, attribute conversion incl. nested groups and uint64 overflow, middleware integration). `just lint` clean; full `go test -race ./...` green.
