### PR TITLE
ops/auditlog: append-only audit events with tamper-evident hash chaining

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    # nilaway's whole-repo analysis started getting OOM-killed ("signal:
+    # killed") on the 16 GB runner as the repo grew. A soft memory limit
+    # plus a more aggressive GC keeps its RSS under the kernel OOM
+    # threshold — slower, but it completes.
+    env:
+      GOMEMLIMIT: 12GiB
+      GOGC: 50
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -148,7 +148,7 @@ Named retention policies run as batched delete/anonymize sweeps via
 audit events. Handles the two-sided GDPR constraint — minimum retention
 and erasure deadlines — as declared policy, not cron scripts.
 
-Deps: `async/scheduler`, `async/queue`, `ops/auditlog` (planned).
+Deps: `async/scheduler`, `async/queue`, `ops/auditlog`.
 
 ---
 
@@ -414,8 +414,8 @@ events on start/end and every action, optional `ops/approval` gate.
 Composes `session` and the `access` decision seam — the hand-rolled
 version is where privilege escalation lives.
 
-Deps: `auth/access`; `auth/session`, `ops/auditlog`, `ops/approval` (all
-planned).
+Deps: `auth/access`; `auth/session`, `ops/approval` (both planned);
+`ops/auditlog`.
 
 ---
 
@@ -603,19 +603,6 @@ Deps: `ops/supervisor`, `auth/guard`.
 
 ---
 
-**ops/auditlog**
-
-Append-only structured audit events (actor/action/resource/outcome) over a
-`Sink` seam; slog + JSONL sinks built in; `auditlog/pgsink` adds the
-insert plus tenant-isolated, keyset-paginated queries — the audit trail
-every B2B SaaS shows in its UI. Optional per-stream hash chaining
-(prev-hash + a verify pass) makes the trail tamper-evident for
-compliance-grade audits.
-
-Deps: `ops/logger`, `data/postgres`.
-
----
-
 **ops/approval**
 
 Maker-checker dual control: typed approval requests (action + payload) a
@@ -624,7 +611,7 @@ emit `auditlog` events and approver eligibility rides the `auth/access`
 decision seam. The two-person rule for payouts, limit overrides, and
 config changes.
 
-Deps: `auth/access`; `ops/auditlog` (planned).
+Deps: `auth/access`; `ops/auditlog`.
 
 ---
 

--- a/ops/auditlog/bench_test.go
+++ b/ops/auditlog/bench_test.go
@@ -1,0 +1,50 @@
+package auditlog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/auditlog"
+)
+
+// discardSink accepts and drops every event, isolating recorder overhead.
+type discardSink struct{}
+
+func (discardSink) Write(context.Context, auditlog.Event) error { return nil }
+
+var benchEvent = auditlog.Event{
+	Tenant: "org_1", Actor: "user_42", Action: "member.invite",
+	Resource: "member:bob@example.com", Outcome: auditlog.OutcomeSuccess,
+	Meta: map[string]string{"role": "admin", "request_id": "req_123"},
+}
+
+func BenchmarkRecord(b *testing.B) {
+	rec := auditlog.New(discardSink{})
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := rec.Record(ctx, benchEvent); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRecordChained(b *testing.B) {
+	rec := auditlog.New(discardSink{}, auditlog.WithChain())
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := rec.Record(ctx, benchEvent); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkComputeHash(b *testing.B) {
+	e := benchEvent
+	e.PrevHash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = auditlog.ComputeHash(e)
+	}
+}

--- a/ops/auditlog/chain.go
+++ b/ops/auditlog/chain.go
@@ -19,7 +19,7 @@ import (
 // hashed with sha256.Sum256 — 1.7x faster and 33 -> 8 allocs versus the
 // streaming sha256.New form (see BenchmarkComputeHash).
 func ComputeHash(e Event) string {
-	size := 9*8 + 8 + // nine length prefixes + the meta pair count
+	size := 8*8 + 8 + // eight field length prefixes + the meta pair count
 		len(e.PrevHash) + len(e.ID) + 8 + // 8 = encoded Time
 		len(e.Tenant) + len(e.Actor) + len(e.Action) + len(e.Resource) + len(e.Outcome)
 	for k, v := range e.Meta {

--- a/ops/auditlog/chain.go
+++ b/ops/auditlog/chain.go
@@ -1,0 +1,73 @@
+package auditlog
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// ComputeHash returns the hex SHA-256 chain hash of e: a deterministic
+// digest of PrevHash and every payload field (ID, Time, Tenant, Actor,
+// Action, Resource, Outcome, sorted Meta). Every field is length-prefixed
+// so no two distinct events can collide by field concatenation. Nil and
+// empty Meta hash identically.
+//
+// The canonical message is assembled in one exactly-sized buffer and
+// hashed with sha256.Sum256 — 1.7x faster and 33 -> 8 allocs versus the
+// streaming sha256.New form (see BenchmarkComputeHash).
+func ComputeHash(e Event) string {
+	size := 9*8 + 8 + // nine length prefixes + the meta pair count
+		len(e.PrevHash) + len(e.ID) + 8 + // 8 = encoded Time
+		len(e.Tenant) + len(e.Actor) + len(e.Action) + len(e.Resource) + len(e.Outcome)
+	for k, v := range e.Meta {
+		size += 2*8 + len(k) + len(v)
+	}
+	buf := make([]byte, 0, size)
+	buf = appendField(buf, e.PrevHash)
+	buf = binary.BigEndian.AppendUint64(buf, uint64(len(e.ID)))
+	buf = append(buf, e.ID[:]...)
+	buf = binary.BigEndian.AppendUint64(buf, 8)
+	buf = binary.BigEndian.AppendUint64(buf, uint64(e.Time.UTC().UnixMicro()))
+	buf = appendField(buf, e.Tenant)
+	buf = appendField(buf, e.Actor)
+	buf = appendField(buf, e.Action)
+	buf = appendField(buf, e.Resource)
+	buf = appendField(buf, string(e.Outcome))
+	buf = binary.BigEndian.AppendUint64(buf, uint64(len(e.Meta)))
+	for _, k := range slices.Sorted(maps.Keys(e.Meta)) {
+		buf = appendField(buf, k)
+		buf = appendField(buf, e.Meta[k])
+	}
+	sum := sha256.Sum256(buf)
+	return hex.EncodeToString(sum[:])
+}
+
+// appendField appends s with a fixed-width length prefix, making the
+// overall message injective over field sequences.
+func appendField(b []byte, s string) []byte {
+	b = binary.BigEndian.AppendUint64(b, uint64(len(s)))
+	return append(b, s...)
+}
+
+// VerifyChain checks that events, in order, extend the chain whose head
+// hash is prev (use "" when verifying from the genesis of a stream) and
+// returns the new head. It fails with ErrChainBroken at the first event
+// whose PrevHash does not match the running head or whose Hash does not
+// match its recomputed value. Verifying a large trail in batches is just
+// threading the returned head into the next call.
+func VerifyChain(prev string, events []Event) (string, error) {
+	for i := range events {
+		e := &events[i]
+		if e.PrevHash != prev {
+			return prev, fmt.Errorf("%w: event %s: prev hash mismatch", ErrChainBroken, e.ID)
+		}
+		if ComputeHash(*e) != e.Hash {
+			return prev, fmt.Errorf("%w: event %s: hash mismatch", ErrChainBroken, e.ID)
+		}
+		prev = e.Hash
+	}
+	return prev, nil
+}

--- a/ops/auditlog/chain_test.go
+++ b/ops/auditlog/chain_test.go
@@ -1,0 +1,212 @@
+package auditlog_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/auditlog"
+)
+
+func recordN(t *testing.T, rec *auditlog.Recorder, n int, e auditlog.Event) {
+	t.Helper()
+	for range n {
+		_, err := rec.Record(context.Background(), e)
+		require.NoError(t, err)
+	}
+}
+
+func TestChain_LinksAndVerifies(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	rec := auditlog.New(sink, auditlog.WithChain())
+	recordN(t, rec, 5, auditlog.Event{Actor: "u", Action: "doc.edit", Outcome: "ok"})
+
+	events := sink.Events()
+	require.Len(t, events, 5)
+	assert.Empty(t, events[0].PrevHash, "genesis event has no prev hash")
+	for i := 1; i < len(events); i++ {
+		assert.Equal(t, events[i-1].Hash, events[i].PrevHash)
+	}
+
+	head, err := auditlog.VerifyChain("", events)
+	require.NoError(t, err)
+	assert.Equal(t, events[4].Hash, head)
+}
+
+func TestChain_BatchedVerifyThreadsHead(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	rec := auditlog.New(sink, auditlog.WithChain())
+	recordN(t, rec, 6, auditlog.Event{Action: "a", Outcome: "ok"})
+
+	events := sink.Events()
+	head, err := auditlog.VerifyChain("", events[:3])
+	require.NoError(t, err)
+	head, err = auditlog.VerifyChain(head, events[3:])
+	require.NoError(t, err)
+	assert.Equal(t, events[5].Hash, head)
+}
+
+func TestChain_DetectsTampering(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	rec := auditlog.New(sink, auditlog.WithChain())
+	recordN(t, rec, 3, auditlog.Event{Actor: "u", Action: "a", Outcome: "ok"})
+	events := sink.Events()
+
+	tests := []struct {
+		name   string
+		mutate func([]auditlog.Event) []auditlog.Event
+	}{
+		{"payload rewritten", func(ev []auditlog.Event) []auditlog.Event { ev[1].Actor = "attacker"; return ev }},
+		{"meta injected", func(ev []auditlog.Event) []auditlog.Event { ev[1].Meta = map[string]string{"x": "y"}; return ev }},
+		{"outcome flipped", func(ev []auditlog.Event) []auditlog.Event { ev[1].Outcome = "denied"; return ev }},
+		{"event deleted", func(ev []auditlog.Event) []auditlog.Event { return append(ev[:1], ev[2:]...) }},
+		{"events reordered", func(ev []auditlog.Event) []auditlog.Event { ev[0], ev[1] = ev[1], ev[0]; return ev }},
+		{"hash forged", func(ev []auditlog.Event) []auditlog.Event { ev[2].Hash = ev[1].Hash; return ev }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tampered := tt.mutate(slices.Clone(events))
+			_, err := auditlog.VerifyChain("", tampered)
+			assert.ErrorIs(t, err, auditlog.ErrChainBroken)
+		})
+	}
+}
+
+func TestChain_PerStreamChains(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	tenant := "org_a"
+	rec := auditlog.New(sink,
+		auditlog.WithChain(),
+		auditlog.WithScope(func(context.Context) (string, error) { return tenant, nil }),
+	)
+	recordN(t, rec, 3, auditlog.Event{Action: "a", Outcome: "ok"})
+	tenant = "org_b"
+	recordN(t, rec, 2, auditlog.Event{Action: "a", Outcome: "ok"})
+	tenant = "org_a"
+	recordN(t, rec, 1, auditlog.Event{Action: "a", Outcome: "ok"})
+
+	byTenant := map[string][]auditlog.Event{}
+	for _, e := range sink.Events() {
+		byTenant[e.Tenant] = append(byTenant[e.Tenant], e)
+	}
+	require.Len(t, byTenant["org_a"], 4)
+	require.Len(t, byTenant["org_b"], 2)
+	for _, stream := range byTenant {
+		_, err := auditlog.VerifyChain("", stream)
+		assert.NoError(t, err, "each tenant stream verifies independently")
+	}
+}
+
+func TestChain_ResumesFromChainHead(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	rec := auditlog.New(sink, auditlog.WithChain())
+	recordN(t, rec, 2, auditlog.Event{Action: "a", Outcome: "ok"})
+
+	// A new recorder (process restart) resumes the chain from the sink.
+	rec2 := auditlog.New(sink, auditlog.WithChain())
+	recordN(t, rec2, 2, auditlog.Event{Action: "a", Outcome: "ok"})
+
+	_, err := auditlog.VerifyChain("", sink.Events())
+	assert.NoError(t, err, "chain continues across recorder restarts")
+}
+
+func TestChain_SinkFailureDoesNotAdvanceHead(t *testing.T) {
+	t.Parallel()
+	sink := newFailSink()
+	rec := auditlog.New(sink, auditlog.WithChain())
+	recordN(t, rec, 1, auditlog.Event{Action: "a", Outcome: "ok"})
+
+	sink.setFail(true)
+	_, err := rec.Record(context.Background(), auditlog.Event{Action: "a", Outcome: "ok"})
+	require.Error(t, err)
+
+	sink.setFail(false)
+	recordN(t, rec, 1, auditlog.Event{Action: "a", Outcome: "ok"})
+
+	_, err = auditlog.VerifyChain("", sink.inner.Events())
+	assert.NoError(t, err, "failed write leaves no gap in the chain")
+}
+
+// ambiguousSink persists the event but still reports an error — the
+// canceled-after-commit edge of a real database sink.
+type ambiguousSink struct {
+	inner *auditlog.MemorySink
+	fail  bool
+}
+
+func (s *ambiguousSink) Write(ctx context.Context, e auditlog.Event) error {
+	if err := s.inner.Write(ctx, e); err != nil {
+		return err
+	}
+	if s.fail {
+		s.fail = false
+		return errors.New("context canceled")
+	}
+	return nil
+}
+
+func (s *ambiguousSink) ChainHead(ctx context.Context, stream string) (string, error) {
+	return s.inner.ChainHead(ctx, stream)
+}
+
+func TestChain_AmbiguousWriteDoesNotForkChain(t *testing.T) {
+	t.Parallel()
+	sink := &ambiguousSink{inner: auditlog.NewMemorySink()}
+	rec := auditlog.New(sink, auditlog.WithChain())
+	recordN(t, rec, 1, auditlog.Event{Action: "a", Outcome: "ok"})
+
+	sink.fail = true
+	_, err := rec.Record(context.Background(), auditlog.Event{Action: "a", Outcome: "ok"})
+	require.Error(t, err, "the write persisted but was reported failed")
+
+	recordN(t, rec, 1, auditlog.Event{Action: "a", Outcome: "ok"})
+
+	events := sink.inner.Events()
+	require.Len(t, events, 3)
+	_, err = auditlog.VerifyChain("", events)
+	assert.NoError(t, err, "recorder re-seeds from the persisted head instead of forking")
+}
+
+func TestChain_ConcurrentRecordStaysVerifiable(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	rec := auditlog.New(sink, auditlog.WithChain())
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for range 25 {
+				_, err := rec.Record(context.Background(), auditlog.Event{Action: "a", Outcome: "ok"})
+				assert.NoError(t, err)
+			}
+		})
+	}
+	wg.Wait()
+
+	events := sink.Events()
+	require.Len(t, events, 200)
+	_, err := auditlog.VerifyChain("", events)
+	assert.NoError(t, err, "write order equals chain order under concurrency")
+}
+
+func TestComputeHash_FieldBoundariesAreUnambiguous(t *testing.T) {
+	t.Parallel()
+	a := auditlog.Event{Actor: "ab", Action: "c", Outcome: "ok"}
+	b := auditlog.Event{Actor: "a", Action: "bc", Outcome: "ok"}
+	assert.NotEqual(t, auditlog.ComputeHash(a), auditlog.ComputeHash(b), "length prefixes prevent concatenation collisions")
+
+	nilMeta := auditlog.Event{Action: "a", Outcome: "ok"}
+	emptyMeta := auditlog.Event{Action: "a", Outcome: "ok", Meta: map[string]string{}}
+	assert.Equal(t, auditlog.ComputeHash(nilMeta), auditlog.ComputeHash(emptyMeta), "nil and empty meta hash identically")
+}

--- a/ops/auditlog/config.go
+++ b/ops/auditlog/config.go
@@ -1,0 +1,17 @@
+package auditlog
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type config struct {
+	scope func(context.Context) (string, error)
+	clock clock.Clock
+	chain bool
+}
+
+func defaultConfig() config {
+	return config{clock: clock.System()}
+}

--- a/ops/auditlog/doc.go
+++ b/ops/auditlog/doc.go
@@ -1,0 +1,40 @@
+// Package auditlog records append-only structured audit events — who
+// (Actor) did what (Action) to which target (Resource) with what result
+// (Outcome) — through a pluggable Sink. SlogSink (observability) and
+// JSONLSink (file trail) ship here; auditlog/pgsink persists events to
+// Postgres and adds the tenant-isolated, keyset-paginated queries an
+// audit-trail UI needs.
+//
+//	sink := auditlog.NewMemorySink() // pgsink.New(pool) in production
+//	rec := auditlog.New(sink)
+//
+//	e, err := rec.Record(ctx, auditlog.Event{
+//		Actor:    "user_42",
+//		Action:   "member.invite",
+//		Resource: "member:bob@example.com",
+//		Outcome:  auditlog.OutcomeSuccess,
+//		Meta:     map[string]string{"role": "admin"},
+//	})
+//	// e.ID is the audit reference to surface to the user.
+//
+// Record stamps a time-ordered UUIDv7 ID and the current time, then
+// writes synchronously: a sink error is the caller's error, never a
+// silent drop. Multi-tenant applications stamp the tenant with the
+// fail-closed WithScope hook:
+//
+//	rec := auditlog.New(sink, auditlog.WithScope(func(ctx context.Context) (string, error) {
+//		return tenantFromCtx(ctx), nil // empty or error aborts Record
+//	}))
+//
+// # Tamper evidence
+//
+// WithChain links each event to its predecessor within a stream (stream =
+// tenant): Hash = SHA-256(PrevHash, payload). Rewriting, deleting, or
+// reordering any persisted event breaks every hash after it, which
+// VerifyChain (or pgsink's Verify) detects. Chained writes serialize per
+// stream and require a single writer per stream; sinks implementing
+// ChainHead (pgsink, MemorySink) let the chain resume across restarts.
+//
+//	rec := auditlog.New(sink, auditlog.WithChain())
+//	head, err := auditlog.VerifyChain("", events) // events in id-ascending order
+package auditlog

--- a/ops/auditlog/doc.go
+++ b/ops/auditlog/doc.go
@@ -31,9 +31,12 @@
 // WithChain links each event to its predecessor within a stream (stream =
 // tenant): Hash = SHA-256(PrevHash, payload). Rewriting, deleting, or
 // reordering any persisted event breaks every hash after it, which
-// VerifyChain (or pgsink's Verify) detects. Chained writes serialize per
-// stream and require a single writer per stream; sinks implementing
-// ChainHead (pgsink, MemorySink) let the chain resume across restarts.
+// VerifyChain (or pgsink's Verify) detects. The chain is unkeyed, so an
+// attacker who can rewrite the entire suffix after an edit — or truncate
+// the tail — defeats it; anchoring the verified head outside the database
+// closes that gap. Chained writes serialize per stream and require a
+// single writer per stream; sinks implementing ChainHead (pgsink,
+// MemorySink) let the chain resume across restarts.
 //
 //	rec := auditlog.New(sink, auditlog.WithChain())
 //	head, err := auditlog.VerifyChain("", events) // events in id-ascending order

--- a/ops/auditlog/errors.go
+++ b/ops/auditlog/errors.go
@@ -1,0 +1,22 @@
+package auditlog
+
+import "errors"
+
+var (
+	// ErrInvalidEvent rejects Record calls with an empty Action or Outcome —
+	// an audit record must state what happened and how it ended.
+	ErrInvalidEvent = errors.New("auditlog: invalid event")
+
+	// ErrScope fails Record closed when the WithScope hook errors or
+	// yields an empty tenant.
+	ErrScope = errors.New("auditlog: tenant scope unavailable")
+
+	// ErrTenantMismatch rejects events whose explicit Tenant conflicts
+	// with the WithScope-derived tenant.
+	ErrTenantMismatch = errors.New("auditlog: tenant mismatch")
+
+	// ErrChainBroken reports a tampered or gapped hash chain: an event
+	// whose PrevHash does not extend the chain head or whose Hash does not
+	// match its recomputed value.
+	ErrChainBroken = errors.New("auditlog: chain broken")
+)

--- a/ops/auditlog/event.go
+++ b/ops/auditlog/event.go
@@ -1,0 +1,53 @@
+package auditlog
+
+import (
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Outcome classifies how an audited action ended. The constants cover the
+// common cases; free-form values are allowed for domain-specific outcomes.
+type Outcome string
+
+// Common outcomes.
+const (
+	OutcomeSuccess Outcome = "success"
+	OutcomeFailure Outcome = "failure"
+	OutcomeDenied  Outcome = "denied"
+)
+
+// Event is one append-only audit record: who (Actor) did what (Action) to
+// which target (Resource) with what result (Outcome). Action and Outcome
+// are required; everything else is optional context.
+//
+// ID and Time are assigned by Recorder.Record — ID is always a fresh
+// time-ordered UUIDv7, and Time defaults to the recorder's clock when zero
+// (both truncated to microseconds so records survive a Postgres
+// round-trip). PrevHash and Hash are populated only by a WithChain
+// recorder and link each event to the previous one in its stream.
+type Event struct {
+	// Time is when the action occurred, UTC, microsecond precision.
+	Time time.Time `json:"time"`
+	// Meta carries free-form context (request id, changed fields, reason).
+	Meta map[string]string `json:"meta,omitempty"`
+	// Tenant is the owning tenant; empty in single-tenant applications.
+	Tenant string `json:"tenant,omitempty"`
+	// Actor is the principal that performed the action (user id, API key
+	// id, or a service name for system actions).
+	Actor string `json:"actor,omitempty"`
+	// Action names what happened, dot-scoped by convention ("user.invite").
+	Action string `json:"action"`
+	// Resource identifies the target ("user:42", "invoice:2024-001").
+	Resource string `json:"resource,omitempty"`
+	// Outcome is the result of the action.
+	Outcome Outcome `json:"outcome"`
+	// PrevHash is the Hash of the previous event in this stream ("" for
+	// the first event). Set by a WithChain recorder.
+	PrevHash string `json:"prev_hash,omitempty"`
+	// Hash is the SHA-256 chain hash of this event. Set by a WithChain
+	// recorder.
+	Hash string `json:"hash,omitempty"`
+	// ID is a time-ordered UUIDv7 assigned by Record.
+	ID id.UUID `json:"id"`
+}

--- a/ops/auditlog/memory.go
+++ b/ops/auditlog/memory.go
@@ -1,0 +1,54 @@
+package auditlog
+
+import (
+	"context"
+	"sync"
+)
+
+// MemorySink is an in-memory Sink for tests and development: it retains
+// every event unboundedly and implements ChainHead, so chained recorders
+// behave exactly as they do against pgsink. Not for production.
+type MemorySink struct {
+	heads  map[string]string
+	events []Event
+	mu     sync.Mutex
+}
+
+var (
+	_ Sink      = (*MemorySink)(nil)
+	_ ChainHead = (*MemorySink)(nil)
+)
+
+// NewMemorySink returns an empty MemorySink.
+func NewMemorySink() *MemorySink {
+	return &MemorySink{heads: map[string]string{}}
+}
+
+// Write appends e.
+func (s *MemorySink) Write(_ context.Context, e Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, e)
+	if e.Hash != "" {
+		s.heads[e.Tenant] = e.Hash
+	}
+	return nil
+}
+
+// ChainHead returns the hash of the last chained event written for
+// stream, or "" when none exists.
+func (s *MemorySink) ChainHead(_ context.Context, stream string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.heads[stream], nil
+}
+
+// Events returns a copy of every event written, in write order (non-nil
+// even when empty).
+func (s *MemorySink) Events() []Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Event, len(s.events))
+	copy(out, s.events)
+	return out
+}

--- a/ops/auditlog/options.go
+++ b/ops/auditlog/options.go
@@ -1,0 +1,52 @@
+package auditlog
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type config struct {
+	scope func(context.Context) (string, error)
+	clock clock.Clock
+	chain bool
+}
+
+func defaultConfig() config {
+	return config{clock: clock.System()}
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithScope derives the tenant from context for every Record call and
+// stamps it onto the event. Fail-closed: a hook error or empty tenant
+// fails Record with ErrScope, and an event whose explicit Tenant
+// disagrees with the hook fails with ErrTenantMismatch. A nil fn leaves
+// the recorder unscoped — single-tenant applications pay no ceremony, and
+// multi-tenant callers may still set Event.Tenant by hand.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) { c.scope = fn }
+}
+
+// WithChain enables per-stream hash chaining: each event's Hash is a
+// SHA-256 over its payload and the previous event's Hash, making the
+// trail tamper-evident (stream = tenant; "" is the single-tenant stream).
+// Chained writes serialize per stream, and the recorder must be the only
+// writer of its streams — run one chained Recorder per stream, not one
+// per replica. If the Sink implements ChainHead, the chain resumes from
+// the persisted head on first write; otherwise every process restart
+// starts a new chain.
+func WithChain() Option {
+	return func(c *config) { c.chain = true }
+}
+
+// WithClock sets the time source used to stamp Event.Time and generate
+// IDs (default the system clock). A nil clock is ignored.
+func WithClock(clk clock.Clock) Option {
+	return func(c *config) {
+		if clk != nil {
+			c.clock = clk
+		}
+	}
+}

--- a/ops/auditlog/options.go
+++ b/ops/auditlog/options.go
@@ -6,16 +6,6 @@ import (
 	"github.com/dmitrymomot/forge/core/clock"
 )
 
-type config struct {
-	scope func(context.Context) (string, error)
-	clock clock.Clock
-	chain bool
-}
-
-func defaultConfig() config {
-	return config{clock: clock.System()}
-}
-
 // Option configures New.
 type Option func(*config)
 
@@ -34,9 +24,16 @@ func WithScope(fn func(context.Context) (string, error)) Option {
 // trail tamper-evident (stream = tenant; "" is the single-tenant stream).
 // Chained writes serialize per stream, and the recorder must be the only
 // writer of its streams — run one chained Recorder per stream, not one
-// per replica. If the Sink implements ChainHead, the chain resumes from
-// the persisted head on first write; otherwise every process restart
-// starts a new chain.
+// per replica. A stream must be chained from its very first event and
+// stay chained: an unchained event in the middle both breaks
+// verification and resets ChainHead seeding. If the Sink implements
+// ChainHead, the chain resumes from the persisted head on first write;
+// otherwise every process restart starts a new chain.
+//
+// The chain is unkeyed, so it detects tampering by anyone who cannot
+// rewrite every later event — to also catch a full suffix rewrite or
+// tail truncation, periodically anchor the head (pgsink Verify returns
+// it) outside the database.
 func WithChain() Option {
 	return func(c *config) { c.chain = true }
 }

--- a/ops/auditlog/pgsink/doc.go
+++ b/ops/auditlog/pgsink/doc.go
@@ -1,0 +1,32 @@
+// Package pgsink persists auditlog events to Postgres and serves the
+// read side of the trail: the append-only insert, tenant-isolated
+// keyset-paginated List (the query behind a B2B audit-trail UI), and the
+// chain Verify pass for tamper-evident streams. It implements
+// auditlog.Sink and auditlog.ChainHead, so a WithChain recorder resumes
+// its per-stream hash chain across process restarts.
+//
+// Apply Migrations before first use (its own goose version table keeps it
+// independent of application migrations):
+//
+//	err := migration.New(pgsink.Migrations, migration.WithTable("forge_auditlog_schema")).Up(ctx, db)
+//
+//	sink := pgsink.New(pool)
+//	rec := auditlog.New(sink, auditlog.WithChain())
+//
+// The audit-trail page is one List call — keyset pagination over the
+// time-ordered UUIDv7 id, so deep pages cost the same as the first:
+//
+//	page, next, err := sink.List(ctx, pgsink.Filter{Tenant: "org_7", Limit: 50})
+//	more, _, err := sink.List(ctx, pgsink.Filter{Tenant: "org_7", Cursor: next})
+//
+// Multi-tenant applications confine reads with the same fail-closed hook
+// the recorder uses:
+//
+//	sink := pgsink.New(pool, pgsink.WithScope(func(ctx context.Context) (string, error) {
+//		return tenantFromCtx(ctx), nil // empty or error aborts the read
+//	}))
+//
+// A compliance audit is one Verify call per stream:
+//
+//	n, err := sink.Verify(ctx, "org_7") // ErrChainBroken names the first bad event
+package pgsink

--- a/ops/auditlog/pgsink/doc.go
+++ b/ops/auditlog/pgsink/doc.go
@@ -26,7 +26,9 @@
 //		return tenantFromCtx(ctx), nil // empty or error aborts the read
 //	}))
 //
-// A compliance audit is one Verify call per stream:
+// A compliance audit is one Verify call per stream; compare the returned
+// head against an externally anchored copy to also catch tail truncation
+// and full-suffix rewrites:
 //
-//	n, err := sink.Verify(ctx, "org_7") // ErrChainBroken names the first bad event
+//	n, head, err := sink.Verify(ctx, "org_7") // ErrChainBroken names the first bad event
 package pgsink

--- a/ops/auditlog/pgsink/migrations/00001_create_forge_audit_events.sql
+++ b/ops/auditlog/pgsink/migrations/00001_create_forge_audit_events.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+CREATE TABLE forge_audit_events (
+    id          uuid PRIMARY KEY,
+    tenant      text NOT NULL DEFAULT '',
+    actor       text NOT NULL DEFAULT '',
+    action      text NOT NULL,
+    resource    text NOT NULL DEFAULT '',
+    outcome     text NOT NULL,
+    meta        jsonb NOT NULL DEFAULT '{}'::jsonb,
+    prev_hash   text NOT NULL DEFAULT '',
+    hash        text NOT NULL DEFAULT '',
+    occurred_at timestamptz NOT NULL
+);
+
+-- Serves tenant-isolated keyset pagination (id is a time-ordered UUIDv7)
+-- and the chain-head/verify scans, which walk the same (tenant, id) order.
+CREATE INDEX forge_audit_events_list_idx ON forge_audit_events (tenant, id DESC);
+
+-- +goose Down
+DROP TABLE forge_audit_events;

--- a/ops/auditlog/pgsink/options.go
+++ b/ops/auditlog/pgsink/options.go
@@ -1,0 +1,17 @@
+package pgsink
+
+import "context"
+
+// Option configures New.
+type Option func(*Sink)
+
+// WithScope derives the tenant from context for every read (List,
+// Verify), confining queries to that tenant. Fail-closed: a hook error or
+// empty tenant fails the call with auditlog.ErrScope, and an explicit
+// tenant that disagrees with the hook fails with
+// auditlog.ErrTenantMismatch. Writes are unaffected — the recorder's own
+// WithScope stamps the tenant onto each event before it reaches the sink.
+// A nil fn leaves reads unscoped.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(s *Sink) { s.scope = fn }
+}

--- a/ops/auditlog/pgsink/options.go
+++ b/ops/auditlog/pgsink/options.go
@@ -5,13 +5,15 @@ import "context"
 // Option configures New.
 type Option func(*Sink)
 
-// WithScope derives the tenant from context for every read (List,
-// Verify), confining queries to that tenant. Fail-closed: a hook error or
-// empty tenant fails the call with auditlog.ErrScope, and an explicit
+// WithScope derives the tenant from context for every read (List, Verify,
+// ChainHead), confining queries to that tenant. Fail-closed: a hook error
+// or empty tenant fails the call with auditlog.ErrScope, and an explicit
 // tenant that disagrees with the hook fails with
-// auditlog.ErrTenantMismatch. Writes are unaffected — the recorder's own
-// WithScope stamps the tenant onto each event before it reaches the sink.
-// A nil fn leaves reads unscoped.
+// auditlog.ErrTenantMismatch. Write is unaffected — the recorder's own
+// WithScope stamps the tenant onto each event before it reaches the sink;
+// a chained recorder over a scoped sink must therefore use the same hook,
+// since its chain seeding reads ChainHead. A nil fn leaves reads
+// unscoped.
 func WithScope(fn func(context.Context) (string, error)) Option {
 	return func(s *Sink) { s.scope = fn }
 }

--- a/ops/auditlog/pgsink/pgsink.go
+++ b/ops/auditlog/pgsink/pgsink.go
@@ -1,0 +1,253 @@
+package pgsink
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/auditlog"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_audit_events, rooted
+// so its .sql files sit at fsys root (data/migration.New globs fsys's
+// root, not subdirectories). Apply via data/migration under its own
+// version table ("forge_auditlog_schema").
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// ErrInvalidCursor rejects List cursors that are not an event id from a
+// previous page.
+var ErrInvalidCursor = errors.New("pgsink: invalid cursor")
+
+// Sink persists audit events to Postgres and serves the read side of the
+// trail: tenant-isolated keyset-paginated List and the chain Verify pass.
+// It implements auditlog.Sink and auditlog.ChainHead. The table is
+// append-only — no update or delete path exists. The pool's lifecycle is
+// the caller's.
+type Sink struct {
+	pool  *pgxpool.Pool
+	scope func(context.Context) (string, error)
+}
+
+var (
+	_ auditlog.Sink      = (*Sink)(nil)
+	_ auditlog.ChainHead = (*Sink)(nil)
+)
+
+// New builds a Postgres Sink. Apply Migrations first. It panics on a nil
+// pool — a wiring bug caught at startup.
+func New(pool *pgxpool.Pool, opts ...Option) *Sink {
+	if pool == nil {
+		panic("pgsink: nil pool")
+	}
+	s := &Sink{pool: pool}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+const cols = `id, tenant, actor, action, resource, outcome, meta, prev_hash, hash, occurred_at`
+
+// Write inserts e.
+func (s *Sink) Write(ctx context.Context, e auditlog.Event) error {
+	meta := e.Meta
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	_, err := s.pool.Exec(ctx, `INSERT INTO forge_audit_events (`+cols+`)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		e.ID, e.Tenant, e.Actor, e.Action, e.Resource, string(e.Outcome), meta,
+		e.PrevHash, e.Hash, e.Time)
+	return err
+}
+
+// ChainHead returns the hash of the newest event in stream, or "" for an
+// empty stream, letting a chained Recorder resume across restarts.
+func (s *Sink) ChainHead(ctx context.Context, stream string) (string, error) {
+	var hash string
+	err := s.pool.QueryRow(ctx,
+		`SELECT hash FROM forge_audit_events WHERE tenant = $1 ORDER BY id DESC LIMIT 1`,
+		stream).Scan(&hash)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", nil
+	}
+	return hash, err
+}
+
+// Filter narrows List. Zero-value fields do not filter; a zero Limit
+// defaults to 50 (capped at 500). Cursor is the NextCursor of the
+// previous page.
+type Filter struct {
+	From     time.Time
+	To       time.Time
+	Tenant   string
+	Actor    string
+	Action   string
+	Resource string
+	Outcome  auditlog.Outcome
+	Cursor   string
+	Limit    int
+}
+
+// List returns events matching f, newest first, plus the cursor of the
+// next page ("" on the last page). Under WithScope the hook's tenant
+// confines the query — a hook error or empty tenant fails closed with
+// auditlog.ErrScope, and a conflicting f.Tenant fails with
+// auditlog.ErrTenantMismatch. Unscoped, f.Tenant filters explicitly and
+// "" spans all tenants (the single-tenant case).
+func (s *Sink) List(ctx context.Context, f Filter) ([]auditlog.Event, string, error) {
+	tenant, err := s.scoped(ctx, f.Tenant)
+	if err != nil {
+		return nil, "", err
+	}
+	limit := f.Limit
+	switch {
+	case limit <= 0:
+		limit = 50
+	case limit > 500:
+		limit = 500
+	}
+	var cursor any
+	if f.Cursor != "" {
+		u, err := id.ParseUUID(f.Cursor)
+		if err != nil {
+			return nil, "", fmt.Errorf("%w: %w", ErrInvalidCursor, err)
+		}
+		cursor = u
+	}
+	rows, err := s.pool.Query(ctx, `SELECT `+cols+` FROM forge_audit_events
+		WHERE ($1 = '' OR tenant = $1)
+		  AND ($2 = '' OR actor = $2)
+		  AND ($3 = '' OR action = $3)
+		  AND ($4 = '' OR resource = $4)
+		  AND ($5 = '' OR outcome = $5)
+		  AND ($6::timestamptz IS NULL OR occurred_at >= $6)
+		  AND ($7::timestamptz IS NULL OR occurred_at <= $7)
+		  AND ($8::uuid IS NULL OR id < $8)
+		ORDER BY id DESC
+		LIMIT $9`,
+		tenant, f.Actor, f.Action, f.Resource, string(f.Outcome),
+		nullTime(f.From), nullTime(f.To), cursor, limit+1)
+	if err != nil {
+		return nil, "", err
+	}
+	events, err := scanEvents(rows, limit+1)
+	if err != nil {
+		return nil, "", err
+	}
+	next := ""
+	if len(events) > limit {
+		events = events[:limit]
+		next = events[limit-1].ID.String()
+	}
+	return events, next, nil
+}
+
+// verifyBatch is the page size of Verify's ascending scan.
+const verifyBatch = 500
+
+// Verify walks stream's events in id-ascending (chain) order and checks
+// the hash chain from its genesis, returning the number of events
+// verified. A tampered, deleted, or reordered event fails with
+// auditlog.ErrChainBroken naming the first bad event. Under WithScope the
+// hook's tenant selects the stream, failing closed like List.
+func (s *Sink) Verify(ctx context.Context, stream string) (int, error) {
+	tenant, err := s.scoped(ctx, stream)
+	if err != nil {
+		return 0, err
+	}
+	var (
+		prev  string
+		after any
+		count int
+	)
+	for {
+		rows, err := s.pool.Query(ctx, `SELECT `+cols+` FROM forge_audit_events
+			WHERE tenant = $1 AND ($2::uuid IS NULL OR id > $2)
+			ORDER BY id ASC
+			LIMIT $3`, tenant, after, verifyBatch)
+		if err != nil {
+			return count, err
+		}
+		events, err := scanEvents(rows, verifyBatch)
+		if err != nil {
+			return count, err
+		}
+		if len(events) == 0 {
+			return count, nil
+		}
+		if prev, err = auditlog.VerifyChain(prev, events); err != nil {
+			return count, err
+		}
+		count += len(events)
+		after = events[len(events)-1].ID
+		if len(events) < verifyBatch {
+			return count, nil
+		}
+	}
+}
+
+// scoped resolves the effective tenant: the WithScope hook when
+// configured (fail-closed, must agree with any explicit tenant), the
+// explicit value otherwise.
+func (s *Sink) scoped(ctx context.Context, explicit string) (string, error) {
+	if s.scope == nil {
+		return explicit, nil
+	}
+	tenant, err := s.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", auditlog.ErrScope, err)
+	}
+	if tenant == "" {
+		return "", auditlog.ErrScope
+	}
+	if explicit != "" && explicit != tenant {
+		return "", auditlog.ErrTenantMismatch
+	}
+	return tenant, nil
+}
+
+func scanEvents(rows pgx.Rows, capacity int) ([]auditlog.Event, error) {
+	defer rows.Close()
+	events := make([]auditlog.Event, 0, capacity)
+	for rows.Next() {
+		var (
+			e       auditlog.Event
+			outcome string
+		)
+		if err := rows.Scan(&e.ID, &e.Tenant, &e.Actor, &e.Action, &e.Resource,
+			&outcome, &e.Meta, &e.PrevHash, &e.Hash, &e.Time); err != nil {
+			return nil, err
+		}
+		e.Outcome = auditlog.Outcome(outcome)
+		e.Time = e.Time.UTC()
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}
+
+// nullTime maps the zero time to SQL NULL.
+func nullTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}

--- a/ops/auditlog/pgsink/pgsink.go
+++ b/ops/auditlog/pgsink/pgsink.go
@@ -80,12 +80,18 @@ func (s *Sink) Write(ctx context.Context, e auditlog.Event) error {
 }
 
 // ChainHead returns the hash of the newest event in stream, or "" for an
-// empty stream, letting a chained Recorder resume across restarts.
+// empty stream, letting a chained Recorder resume across restarts. Like
+// every read it honors WithScope: the hook's tenant selects the stream,
+// failing closed.
 func (s *Sink) ChainHead(ctx context.Context, stream string) (string, error) {
+	tenant, err := s.scoped(ctx, stream)
+	if err != nil {
+		return "", err
+	}
 	var hash string
-	err := s.pool.QueryRow(ctx,
+	err = s.pool.QueryRow(ctx,
 		`SELECT hash FROM forge_audit_events WHERE tenant = $1 ORDER BY id DESC LIMIT 1`,
-		stream).Scan(&hash)
+		tenant).Scan(&hash)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", nil
 	}
@@ -93,8 +99,12 @@ func (s *Sink) ChainHead(ctx context.Context, stream string) (string, error) {
 }
 
 // Filter narrows List. Zero-value fields do not filter; a zero Limit
-// defaults to 50 (capped at 500). Cursor is the NextCursor of the
-// previous page.
+// defaults to 50 (capped at 500). Cursor is the next-page cursor returned
+// by the previous List call. Only (tenant, id) is indexed — the
+// actor/action/resource/outcome/time filters scan within the tenant's
+// history, which is fine for a paged UI but not for hot-path lookups; add
+// a purpose-built index in the consumer schema if a filtered query
+// becomes hot.
 type Filter struct {
 	From     time.Time
 	To       time.Time
@@ -166,13 +176,21 @@ const verifyBatch = 500
 
 // Verify walks stream's events in id-ascending (chain) order and checks
 // the hash chain from its genesis, returning the number of events
-// verified. A tampered, deleted, or reordered event fails with
-// auditlog.ErrChainBroken naming the first bad event. Under WithScope the
-// hook's tenant selects the stream, failing closed like List.
-func (s *Sink) Verify(ctx context.Context, stream string) (int, error) {
+// verified and the final head hash. A tampered, deleted, or reordered
+// event fails with auditlog.ErrChainBroken naming the first bad event.
+// Under WithScope the hook's tenant selects the stream, failing closed
+// like List.
+//
+// An intact chain proves no one modified the middle of the trail, but an
+// attacker who can rewrite rows can also recompute every hash after the
+// edit, and truncating the tail leaves a shorter chain that still
+// verifies. Compare the returned head (and count) against a copy anchored
+// outside the database — exported after each backup, or shipped to
+// another system — to detect those.
+func (s *Sink) Verify(ctx context.Context, stream string) (int, string, error) {
 	tenant, err := s.scoped(ctx, stream)
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 	var (
 		prev  string
@@ -185,22 +203,22 @@ func (s *Sink) Verify(ctx context.Context, stream string) (int, error) {
 			ORDER BY id ASC
 			LIMIT $3`, tenant, after, verifyBatch)
 		if err != nil {
-			return count, err
+			return count, prev, err
 		}
 		events, err := scanEvents(rows, verifyBatch)
 		if err != nil {
-			return count, err
+			return count, prev, err
 		}
 		if len(events) == 0 {
-			return count, nil
+			return count, prev, nil
 		}
 		if prev, err = auditlog.VerifyChain(prev, events); err != nil {
-			return count, err
+			return count, prev, err
 		}
 		count += len(events)
 		after = events[len(events)-1].ID
 		if len(events) < verifyBatch {
-			return count, nil
+			return count, prev, nil
 		}
 	}
 }

--- a/ops/auditlog/pgsink/pgsink_test.go
+++ b/ops/auditlog/pgsink/pgsink_test.go
@@ -181,8 +181,10 @@ func TestPg_ScopedReads(t *testing.T) {
 	_, _, err = failing.List(context.Background(), pgsink.Filter{})
 	assert.ErrorIs(t, err, auditlog.ErrScope)
 	assert.ErrorIs(t, err, hookErr)
-	_, err = failing.Verify(context.Background(), "")
+	_, _, err = failing.Verify(context.Background(), "")
 	assert.ErrorIs(t, err, auditlog.ErrScope, "Verify fails closed too")
+	_, err = failing.ChainHead(context.Background(), "")
+	assert.ErrorIs(t, err, auditlog.ErrScope, "ChainHead fails closed too")
 }
 
 func TestPg_ChainHeadAndResume(t *testing.T) {
@@ -204,9 +206,35 @@ func TestPg_ChainHeadAndResume(t *testing.T) {
 	rec2 := auditlog.New(sink, auditlog.WithChain())
 	record(t, rec2, tenant, 2)
 
-	n, err := sink.Verify(context.Background(), tenant)
+	n, verifiedHead, err := sink.Verify(context.Background(), tenant)
 	require.NoError(t, err)
 	assert.Equal(t, 4, n, "chain verifies across recorder restarts")
+
+	head, err = sink.ChainHead(context.Background(), tenant)
+	require.NoError(t, err)
+	assert.Equal(t, head, verifiedHead, "Verify returns the anchorable head")
+}
+
+func TestPg_TailTruncationCaughtByAnchoredHead(t *testing.T) {
+	pool := newPool(t)
+	sink := pgsink.New(pool)
+	tenant := tenantFor(t)
+	events := record(t, auditlog.New(sink, auditlog.WithChain()), tenant, 3)
+
+	_, anchored, err := sink.Verify(context.Background(), tenant)
+	require.NoError(t, err)
+
+	// An attacker deletes the newest event: the shorter chain still
+	// verifies — only the externally anchored head exposes the loss.
+	_, err = pool.Exec(context.Background(),
+		`DELETE FROM forge_audit_events WHERE id = $1`, events[2].ID)
+	require.NoError(t, err)
+
+	n, head, err := sink.Verify(context.Background(), tenant)
+	require.NoError(t, err, "truncation is invisible to chain verification alone")
+	assert.Equal(t, 2, n)
+	assert.NotEqual(t, anchored, head, "anchored-head comparison detects the truncation")
+	assert.Equal(t, events[1].Hash, head)
 }
 
 func TestPg_VerifyDetectsTampering(t *testing.T) {
@@ -215,7 +243,7 @@ func TestPg_VerifyDetectsTampering(t *testing.T) {
 	tenant := tenantFor(t)
 	events := record(t, auditlog.New(sink, auditlog.WithChain()), tenant, 3)
 
-	n, err := sink.Verify(context.Background(), tenant)
+	n, _, err := sink.Verify(context.Background(), tenant)
 	require.NoError(t, err)
 	require.Equal(t, 3, n)
 
@@ -224,7 +252,7 @@ func TestPg_VerifyDetectsTampering(t *testing.T) {
 		`UPDATE forge_audit_events SET actor = 'attacker' WHERE id = $1`, events[1].ID)
 	require.NoError(t, err)
 
-	_, err = sink.Verify(context.Background(), tenant)
+	_, _, err = sink.Verify(context.Background(), tenant)
 	assert.ErrorIs(t, err, auditlog.ErrChainBroken)
 	assert.ErrorContains(t, err, events[1].ID.String(), "names the first bad event")
 
@@ -236,7 +264,7 @@ func TestPg_VerifyDetectsTampering(t *testing.T) {
 	_, err = pool.Exec(context.Background(),
 		`DELETE FROM forge_audit_events WHERE id = $1`, events[0].ID)
 	require.NoError(t, err)
-	_, err = sink.Verify(context.Background(), tenant)
+	_, _, err = sink.Verify(context.Background(), tenant)
 	assert.ErrorIs(t, err, auditlog.ErrChainBroken)
 }
 
@@ -247,14 +275,16 @@ func TestPg_VerifyCrossesBatchBoundary(t *testing.T) {
 	// across batches.
 	record(t, auditlog.New(sink, auditlog.WithChain()), tenant, 501)
 
-	n, err := sink.Verify(context.Background(), tenant)
+	n, head, err := sink.Verify(context.Background(), tenant)
 	require.NoError(t, err)
 	assert.Equal(t, 501, n)
+	assert.NotEmpty(t, head)
 }
 
 func TestPg_VerifyEmptyStream(t *testing.T) {
 	sink := pgsink.New(newPool(t))
-	n, err := sink.Verify(context.Background(), tenantFor(t))
+	n, head, err := sink.Verify(context.Background(), tenantFor(t))
 	require.NoError(t, err)
 	assert.Zero(t, n)
+	assert.Empty(t, head)
 }

--- a/ops/auditlog/pgsink/pgsink_test.go
+++ b/ops/auditlog/pgsink/pgsink_test.go
@@ -1,0 +1,260 @@
+//go:build integration
+
+package pgsink_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+	"github.com/dmitrymomot/forge/ops/auditlog"
+	"github.com/dmitrymomot/forge/ops/auditlog/pgsink"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+)
+
+func newPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	cfg := postgres.DefaultConfig()
+	cfg.URL = pgtest.DSN(t)
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgsink.Migrations, migration.WithTable("forge_auditlog_schema")).Up(context.Background(), db))
+	return pool
+}
+
+// tenantFor returns a unique tenant per test: the table persists across
+// test runs, so a fixed tenant would inflate List counts on re-runs.
+func tenantFor(t *testing.T) string {
+	t.Helper()
+	return "tenant-" + id.NewUUID().String()
+}
+
+func record(t *testing.T, rec *auditlog.Recorder, tenant string, n int) []auditlog.Event {
+	t.Helper()
+	out := make([]auditlog.Event, 0, n)
+	for range n {
+		e, err := rec.Record(context.Background(), auditlog.Event{
+			Tenant: tenant, Actor: "user_1", Action: "doc.edit", Resource: "doc:1",
+			Outcome: auditlog.OutcomeSuccess, Meta: map[string]string{"k": "v"},
+		})
+		require.NoError(t, err)
+		out = append(out, e)
+	}
+	return out
+}
+
+func TestPg_WriteListRoundTrip(t *testing.T) {
+	sink := pgsink.New(newPool(t))
+	tenant := tenantFor(t)
+	rec := auditlog.New(sink, auditlog.WithChain())
+
+	at := time.Date(2026, 7, 21, 10, 30, 0, 123456789, time.UTC)
+	want, err := rec.Record(context.Background(), auditlog.Event{
+		Tenant: tenant, Actor: "user_9", Action: "invoice.void", Resource: "invoice:77",
+		Outcome: auditlog.OutcomeDenied, Meta: map[string]string{"reason": "already paid"}, Time: at,
+	})
+	require.NoError(t, err)
+
+	events, next, err := sink.List(context.Background(), pgsink.Filter{Tenant: tenant})
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Empty(t, next)
+	assert.Equal(t, want, events[0], "event round-trips bit-identically (microsecond time)")
+}
+
+func TestPg_ListFiltersAndPaginates(t *testing.T) {
+	sink := pgsink.New(newPool(t))
+	tenant := tenantFor(t)
+	rec := auditlog.New(sink)
+	record(t, rec, tenant, 5)
+	otherTenant := tenantFor(t)
+	record(t, rec, otherTenant, 3)
+
+	// Tenant isolation.
+	events, _, err := sink.List(context.Background(), pgsink.Filter{Tenant: tenant})
+	require.NoError(t, err)
+	require.Len(t, events, 5)
+	for _, e := range events {
+		assert.Equal(t, tenant, e.Tenant)
+	}
+
+	// Newest first.
+	for i := 1; i < len(events); i++ {
+		assert.True(t, events[i-1].Time.After(events[i].Time) || events[i-1].Time.Equal(events[i].Time))
+	}
+
+	// Keyset pagination walks the full set without overlap.
+	var (
+		seen   []id.UUID
+		cursor string
+	)
+	for {
+		page, next, err := sink.List(context.Background(), pgsink.Filter{Tenant: tenant, Limit: 2, Cursor: cursor})
+		require.NoError(t, err)
+		for _, e := range page {
+			seen = append(seen, e.ID)
+		}
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+	require.Len(t, seen, 5)
+	for i, e := range events {
+		assert.Equal(t, e.ID, seen[i], "paged walk equals unpaged order")
+	}
+
+	// Field filters.
+	byActor, _, err := sink.List(context.Background(), pgsink.Filter{Tenant: tenant, Actor: "nobody"})
+	require.NoError(t, err)
+	assert.Empty(t, byActor)
+	byAction, _, err := sink.List(context.Background(), pgsink.Filter{Tenant: tenant, Action: "doc.edit", Outcome: auditlog.OutcomeSuccess})
+	require.NoError(t, err)
+	assert.Len(t, byAction, 5)
+
+	// Time range.
+	mid := events[2].Time
+	ranged, _, err := sink.List(context.Background(), pgsink.Filter{Tenant: tenant, From: mid})
+	require.NoError(t, err)
+	assert.Len(t, ranged, 3, "From is inclusive")
+	ranged, _, err = sink.List(context.Background(), pgsink.Filter{Tenant: tenant, To: mid})
+	require.NoError(t, err)
+	assert.Len(t, ranged, 3, "To is inclusive")
+}
+
+func TestPg_ListExactPageBoundary(t *testing.T) {
+	sink := pgsink.New(newPool(t))
+	tenant := tenantFor(t)
+	record(t, auditlog.New(sink), tenant, 4)
+
+	page, next, err := sink.List(context.Background(), pgsink.Filter{Tenant: tenant, Limit: 4})
+	require.NoError(t, err)
+	require.Len(t, page, 4)
+	assert.Empty(t, next, "exact fit is the last page")
+}
+
+func TestPg_InvalidCursor(t *testing.T) {
+	sink := pgsink.New(newPool(t))
+	_, _, err := sink.List(context.Background(), pgsink.Filter{Cursor: "not-a-uuid"})
+	assert.ErrorIs(t, err, pgsink.ErrInvalidCursor)
+}
+
+func TestPg_ScopedReads(t *testing.T) {
+	pool := newPool(t)
+	tenant := tenantFor(t)
+	record(t, auditlog.New(pgsink.New(pool)), tenant, 2)
+	otherTenant := tenantFor(t)
+	record(t, auditlog.New(pgsink.New(pool)), otherTenant, 1)
+
+	current := tenant
+	scoped := pgsink.New(pool, pgsink.WithScope(func(context.Context) (string, error) {
+		return current, nil
+	}))
+
+	events, _, err := scoped.List(context.Background(), pgsink.Filter{})
+	require.NoError(t, err)
+	assert.Len(t, events, 2, "scope confines the query")
+
+	_, _, err = scoped.List(context.Background(), pgsink.Filter{Tenant: otherTenant})
+	assert.ErrorIs(t, err, auditlog.ErrTenantMismatch)
+
+	current = ""
+	_, _, err = scoped.List(context.Background(), pgsink.Filter{})
+	assert.ErrorIs(t, err, auditlog.ErrScope, "empty tenant fails closed")
+
+	hookErr := errors.New("no session")
+	failing := pgsink.New(pool, pgsink.WithScope(func(context.Context) (string, error) {
+		return "", hookErr
+	}))
+	_, _, err = failing.List(context.Background(), pgsink.Filter{})
+	assert.ErrorIs(t, err, auditlog.ErrScope)
+	assert.ErrorIs(t, err, hookErr)
+	_, err = failing.Verify(context.Background(), "")
+	assert.ErrorIs(t, err, auditlog.ErrScope, "Verify fails closed too")
+}
+
+func TestPg_ChainHeadAndResume(t *testing.T) {
+	sink := pgsink.New(newPool(t))
+	tenant := tenantFor(t)
+
+	head, err := sink.ChainHead(context.Background(), tenant)
+	require.NoError(t, err)
+	assert.Empty(t, head, "empty stream has no head")
+
+	rec := auditlog.New(sink, auditlog.WithChain())
+	events := record(t, rec, tenant, 2)
+
+	head, err = sink.ChainHead(context.Background(), tenant)
+	require.NoError(t, err)
+	assert.Equal(t, events[1].Hash, head)
+
+	// A fresh recorder (process restart) resumes the persisted chain.
+	rec2 := auditlog.New(sink, auditlog.WithChain())
+	record(t, rec2, tenant, 2)
+
+	n, err := sink.Verify(context.Background(), tenant)
+	require.NoError(t, err)
+	assert.Equal(t, 4, n, "chain verifies across recorder restarts")
+}
+
+func TestPg_VerifyDetectsTampering(t *testing.T) {
+	pool := newPool(t)
+	sink := pgsink.New(pool)
+	tenant := tenantFor(t)
+	events := record(t, auditlog.New(sink, auditlog.WithChain()), tenant, 3)
+
+	n, err := sink.Verify(context.Background(), tenant)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+
+	// A DBA rewrites one event's payload behind the application's back.
+	_, err = pool.Exec(context.Background(),
+		`UPDATE forge_audit_events SET actor = 'attacker' WHERE id = $1`, events[1].ID)
+	require.NoError(t, err)
+
+	_, err = sink.Verify(context.Background(), tenant)
+	assert.ErrorIs(t, err, auditlog.ErrChainBroken)
+	assert.ErrorContains(t, err, events[1].ID.String(), "names the first bad event")
+
+	// Deleting an event breaks the chain at its successor (restore the
+	// actor first so the deletion is the only damage).
+	_, err = pool.Exec(context.Background(),
+		`UPDATE forge_audit_events SET actor = 'user_1' WHERE id = $1`, events[1].ID)
+	require.NoError(t, err)
+	_, err = pool.Exec(context.Background(),
+		`DELETE FROM forge_audit_events WHERE id = $1`, events[0].ID)
+	require.NoError(t, err)
+	_, err = sink.Verify(context.Background(), tenant)
+	assert.ErrorIs(t, err, auditlog.ErrChainBroken)
+}
+
+func TestPg_VerifyCrossesBatchBoundary(t *testing.T) {
+	sink := pgsink.New(newPool(t))
+	tenant := tenantFor(t)
+	// More events than one verify batch (500) forces head threading
+	// across batches.
+	record(t, auditlog.New(sink, auditlog.WithChain()), tenant, 501)
+
+	n, err := sink.Verify(context.Background(), tenant)
+	require.NoError(t, err)
+	assert.Equal(t, 501, n)
+}
+
+func TestPg_VerifyEmptyStream(t *testing.T) {
+	sink := pgsink.New(newPool(t))
+	n, err := sink.Verify(context.Background(), tenantFor(t))
+	require.NoError(t, err)
+	assert.Zero(t, n)
+}

--- a/ops/auditlog/recorder.go
+++ b/ops/auditlog/recorder.go
@@ -62,9 +62,6 @@ func (r *Recorder) Record(ctx context.Context, e Event) (Event, error) {
 	if e.Action == "" || e.Outcome == "" {
 		return Event{}, fmt.Errorf("%w: action and outcome are required", ErrInvalidEvent)
 	}
-	if err := checkNUL(e); err != nil {
-		return Event{}, err
-	}
 	if r.cfg.scope != nil {
 		tenant, err := r.cfg.scope(ctx)
 		if err != nil {
@@ -77,6 +74,10 @@ func (r *Recorder) Record(ctx context.Context, e Event) (Event, error) {
 			return Event{}, ErrTenantMismatch
 		}
 		e.Tenant = tenant
+	}
+	// After the scope hook, so a hook-derived tenant is validated too.
+	if err := checkNUL(e); err != nil {
+		return Event{}, err
 	}
 	if e.Time.IsZero() {
 		e.Time = r.cfg.clock.Now()

--- a/ops/auditlog/recorder.go
+++ b/ops/auditlog/recorder.go
@@ -3,6 +3,7 @@ package auditlog
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -60,6 +61,9 @@ func New(sink Sink, opts ...Option) *Recorder {
 func (r *Recorder) Record(ctx context.Context, e Event) (Event, error) {
 	if e.Action == "" || e.Outcome == "" {
 		return Event{}, fmt.Errorf("%w: action and outcome are required", ErrInvalidEvent)
+	}
+	if err := checkNUL(e); err != nil {
+		return Event{}, err
 	}
 	if r.cfg.scope != nil {
 		tenant, err := r.cfg.scope(ctx)
@@ -122,6 +126,26 @@ func (r *Recorder) recordChained(ctx context.Context, e Event) (Event, error) {
 	}
 	head.hash = e.Hash
 	return e, nil
+}
+
+// checkNUL rejects events carrying NUL bytes: Postgres text and jsonb
+// cannot store them, and silently stripping them after hashing would make
+// the persisted event fail verification. Rejecting up front keeps the
+// failure at the audit point instead of an opaque driver error —
+// consumers must sanitize untrusted input before putting it in an event.
+func checkNUL(e Event) error {
+	fields := [...]string{e.Tenant, e.Actor, e.Action, e.Resource, string(e.Outcome)}
+	for _, f := range fields {
+		if strings.ContainsRune(f, 0) {
+			return fmt.Errorf("%w: NUL byte in field", ErrInvalidEvent)
+		}
+	}
+	for k, v := range e.Meta {
+		if strings.ContainsRune(k, 0) || strings.ContainsRune(v, 0) {
+			return fmt.Errorf("%w: NUL byte in meta", ErrInvalidEvent)
+		}
+	}
+	return nil
 }
 
 // head returns the chain state for stream, creating it on first use. The

--- a/ops/auditlog/recorder.go
+++ b/ops/auditlog/recorder.go
@@ -1,0 +1,138 @@
+package auditlog
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Recorder stamps and appends audit events to a Sink. Safe for concurrent
+// use. Without WithChain, Record is lock-free apart from the monotonic ID
+// generator; with it, writes serialize per stream (see WithChain).
+type Recorder struct {
+	sink  Sink
+	gen   *id.Generator
+	heads map[string]*chainHead
+	cfg   config
+	mu    sync.Mutex // guards heads
+}
+
+// chainHead is the running chain state of one stream. Its mutex serializes
+// appends to the stream: hash(n) depends on hash(n-1), so two concurrent
+// writers cannot both extend the same head. It is intentionally held
+// across the Sink write — releasing earlier would let a second event chain
+// onto a hash that may never persist.
+type chainHead struct {
+	hash   string
+	mu     sync.Mutex
+	seeded bool
+}
+
+// New builds a Recorder over sink. It panics on a nil sink — a wiring bug
+// caught at startup.
+func New(sink Sink, opts ...Option) *Recorder {
+	if sink == nil {
+		panic("auditlog: nil sink")
+	}
+	cfg := defaultConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return &Recorder{
+		sink:  sink,
+		gen:   id.NewGenerator(id.WithClock(cfg.clock), id.WithMonotonic()),
+		cfg:   cfg,
+		heads: map[string]*chainHead{},
+	}
+}
+
+// Record validates, stamps, and writes e, returning the finalized event
+// (assigned ID, defaulted Time, resolved Tenant, chain hashes when
+// enabled). An empty Action or Outcome fails with ErrInvalidEvent. Under
+// WithScope the hook's tenant is stamped onto the event; a hook error or
+// empty tenant fails closed with ErrScope, and an explicit e.Tenant that
+// disagrees with the hook fails with ErrTenantMismatch. A Sink error is
+// returned as-is and, under WithChain, leaves the stream head unchanged so
+// the chain never references an event that was not persisted.
+func (r *Recorder) Record(ctx context.Context, e Event) (Event, error) {
+	if e.Action == "" || e.Outcome == "" {
+		return Event{}, fmt.Errorf("%w: action and outcome are required", ErrInvalidEvent)
+	}
+	if r.cfg.scope != nil {
+		tenant, err := r.cfg.scope(ctx)
+		if err != nil {
+			return Event{}, fmt.Errorf("%w: %w", ErrScope, err)
+		}
+		if tenant == "" {
+			return Event{}, ErrScope
+		}
+		if e.Tenant != "" && e.Tenant != tenant {
+			return Event{}, ErrTenantMismatch
+		}
+		e.Tenant = tenant
+	}
+	if e.Time.IsZero() {
+		e.Time = r.cfg.clock.Now()
+	}
+	// Microsecond precision survives a Postgres timestamptz round-trip, so
+	// chain hashes recompute identically after a read-back.
+	e.Time = e.Time.UTC().Truncate(time.Microsecond)
+
+	if !r.cfg.chain {
+		e.ID = r.gen.UUID()
+		e.PrevHash, e.Hash = "", ""
+		if err := r.sink.Write(ctx, e); err != nil {
+			return Event{}, err
+		}
+		return e, nil
+	}
+	return r.recordChained(ctx, e)
+}
+
+func (r *Recorder) recordChained(ctx context.Context, e Event) (Event, error) {
+	head := r.head(e.Tenant)
+	head.mu.Lock()
+	defer head.mu.Unlock()
+	if !head.seeded {
+		if ch, ok := r.sink.(ChainHead); ok {
+			hash, err := ch.ChainHead(ctx, e.Tenant)
+			if err != nil {
+				return Event{}, fmt.Errorf("auditlog: seed chain head: %w", err)
+			}
+			head.hash = hash
+		}
+		head.seeded = true
+	}
+	// The ID is generated under the stream lock: the generator is
+	// monotonic, so id order matches chain order and a verify pass can
+	// walk the stream by id ascending.
+	e.ID = r.gen.UUID()
+	e.PrevHash = head.hash
+	e.Hash = ComputeHash(e)
+	if err := r.sink.Write(ctx, e); err != nil {
+		// The write is ambiguous — it may have persisted despite the error
+		// (e.g. context canceled after the insert committed). Re-seed from
+		// the sink on the next Record so the chain continues from whatever
+		// head actually persisted instead of forking.
+		head.seeded = false
+		return Event{}, err
+	}
+	head.hash = e.Hash
+	return e, nil
+}
+
+// head returns the chain state for stream, creating it on first use. The
+// map is bounded by the number of distinct tenants.
+func (r *Recorder) head(stream string) *chainHead {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	h, ok := r.heads[stream]
+	if !ok {
+		h = &chainHead{}
+		r.heads[stream] = h
+	}
+	return h
+}

--- a/ops/auditlog/recorder_test.go
+++ b/ops/auditlog/recorder_test.go
@@ -80,6 +80,15 @@ func TestRecord_RejectsNULBytes(t *testing.T) {
 		assert.ErrorIs(t, err, auditlog.ErrInvalidEvent, "NUL bytes cannot be stored by Postgres and must fail at the audit point")
 	}
 	assert.Empty(t, sink.Events())
+
+	// A NUL smuggled in by the scope hook is caught too — validation runs
+	// after the hook stamps the tenant.
+	scoped := auditlog.New(sink, auditlog.WithScope(func(context.Context) (string, error) {
+		return "org\x007", nil
+	}))
+	_, err := scoped.Record(context.Background(), auditlog.Event{Action: "a", Outcome: "ok"})
+	assert.ErrorIs(t, err, auditlog.ErrInvalidEvent)
+	assert.Empty(t, sink.Events())
 }
 
 func TestRecord_IDsAreTimeOrdered(t *testing.T) {

--- a/ops/auditlog/recorder_test.go
+++ b/ops/auditlog/recorder_test.go
@@ -1,0 +1,181 @@
+package auditlog_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/auditlog"
+)
+
+func TestRecord_StampsIDAndTime(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	now := time.Date(2026, 7, 21, 12, 0, 0, 123456789, time.UTC)
+	rec := auditlog.New(sink, auditlog.WithClock(clock.NewMock(now)))
+
+	e, err := rec.Record(context.Background(), auditlog.Event{
+		Actor:   "user_1",
+		Action:  "user.login",
+		Outcome: auditlog.OutcomeSuccess,
+	})
+	require.NoError(t, err)
+	assert.False(t, e.ID.IsZero())
+	assert.Equal(t, now.Truncate(time.Microsecond), e.Time, "time is stamped and truncated to microseconds")
+	assert.Empty(t, e.Hash, "no chain hash without WithChain")
+
+	events := sink.Events()
+	require.Len(t, events, 1)
+	assert.Equal(t, e, events[0], "sink receives the finalized event")
+}
+
+func TestRecord_KeepsCallerTime(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	rec := auditlog.New(sink)
+	at := time.Date(2025, 1, 2, 3, 4, 5, 678901234, time.FixedZone("X", 3600))
+
+	e, err := rec.Record(context.Background(), auditlog.Event{
+		Action:  "import.backfill",
+		Outcome: auditlog.OutcomeSuccess,
+		Time:    at,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, at.UTC().Truncate(time.Microsecond), e.Time, "caller time normalized to UTC microseconds")
+}
+
+func TestRecord_InvalidEvent(t *testing.T) {
+	t.Parallel()
+	rec := auditlog.New(auditlog.NewMemorySink())
+
+	_, err := rec.Record(context.Background(), auditlog.Event{Outcome: auditlog.OutcomeSuccess})
+	assert.ErrorIs(t, err, auditlog.ErrInvalidEvent, "missing action")
+
+	_, err = rec.Record(context.Background(), auditlog.Event{Action: "user.login"})
+	assert.ErrorIs(t, err, auditlog.ErrInvalidEvent, "missing outcome")
+}
+
+func TestRecord_IDsAreTimeOrdered(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	rec := auditlog.New(sink)
+	for range 100 {
+		_, err := rec.Record(context.Background(), auditlog.Event{Action: "a", Outcome: "ok"})
+		require.NoError(t, err)
+	}
+	events := sink.Events()
+	for i := 1; i < len(events); i++ {
+		assert.Equal(t, -1, compareIDs(events[i-1].ID[:], events[i].ID[:]), "monotonic ids")
+	}
+}
+
+func compareIDs(a, b []byte) int {
+	for i := range a {
+		switch {
+		case a[i] < b[i]:
+			return -1
+		case a[i] > b[i]:
+			return 1
+		}
+	}
+	return 0
+}
+
+func TestRecord_ScopeStampsTenant(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	rec := auditlog.New(sink, auditlog.WithScope(func(context.Context) (string, error) {
+		return "org_7", nil
+	}))
+
+	e, err := rec.Record(context.Background(), auditlog.Event{Action: "a", Outcome: "ok"})
+	require.NoError(t, err)
+	assert.Equal(t, "org_7", e.Tenant)
+
+	// Matching explicit tenant is accepted.
+	e, err = rec.Record(context.Background(), auditlog.Event{Action: "a", Outcome: "ok", Tenant: "org_7"})
+	require.NoError(t, err)
+	assert.Equal(t, "org_7", e.Tenant)
+
+	// Conflicting explicit tenant fails.
+	_, err = rec.Record(context.Background(), auditlog.Event{Action: "a", Outcome: "ok", Tenant: "org_9"})
+	assert.ErrorIs(t, err, auditlog.ErrTenantMismatch)
+}
+
+func TestRecord_ScopeFailsClosed(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+
+	rec := auditlog.New(sink, auditlog.WithScope(func(context.Context) (string, error) {
+		return "", nil
+	}))
+	_, err := rec.Record(context.Background(), auditlog.Event{Action: "a", Outcome: "ok"})
+	assert.ErrorIs(t, err, auditlog.ErrScope, "empty tenant fails closed")
+
+	hookErr := errors.New("boom")
+	rec = auditlog.New(sink, auditlog.WithScope(func(context.Context) (string, error) {
+		return "", hookErr
+	}))
+	_, err = rec.Record(context.Background(), auditlog.Event{Action: "a", Outcome: "ok"})
+	assert.ErrorIs(t, err, auditlog.ErrScope)
+	assert.ErrorIs(t, err, hookErr, "hook error preserved for errors.Is")
+
+	assert.Empty(t, sink.Events(), "nothing reaches the sink on scope failure")
+}
+
+func TestRecord_UnscopedKeepsExplicitTenant(t *testing.T) {
+	t.Parallel()
+	rec := auditlog.New(auditlog.NewMemorySink())
+	e, err := rec.Record(context.Background(), auditlog.Event{Action: "a", Outcome: "ok", Tenant: "org_1"})
+	require.NoError(t, err)
+	assert.Equal(t, "org_1", e.Tenant)
+}
+
+// failSink wraps a MemorySink and fails every write until healed.
+type failSink struct {
+	inner *auditlog.MemorySink
+	mu    sync.Mutex
+	fail  bool
+}
+
+func newFailSink() *failSink { return &failSink{inner: auditlog.NewMemorySink()} }
+
+func (s *failSink) Write(ctx context.Context, e auditlog.Event) error {
+	s.mu.Lock()
+	fail := s.fail
+	s.mu.Unlock()
+	if fail {
+		return errors.New("sink down")
+	}
+	return s.inner.Write(ctx, e)
+}
+
+func (s *failSink) ChainHead(ctx context.Context, stream string) (string, error) {
+	return s.inner.ChainHead(ctx, stream)
+}
+
+func (s *failSink) setFail(v bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.fail = v
+}
+
+func TestRecord_SinkErrorPropagates(t *testing.T) {
+	t.Parallel()
+	sink := newFailSink()
+	sink.setFail(true)
+	rec := auditlog.New(sink)
+	_, err := rec.Record(context.Background(), auditlog.Event{Action: "a", Outcome: "ok"})
+	assert.ErrorContains(t, err, "sink down")
+}
+
+func TestNew_NilSinkPanics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { auditlog.New(nil) })
+}

--- a/ops/auditlog/recorder_test.go
+++ b/ops/auditlog/recorder_test.go
@@ -61,6 +61,27 @@ func TestRecord_InvalidEvent(t *testing.T) {
 	assert.ErrorIs(t, err, auditlog.ErrInvalidEvent, "missing outcome")
 }
 
+func TestRecord_RejectsNULBytes(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	rec := auditlog.New(sink)
+
+	events := []auditlog.Event{
+		{Action: "a\x00b", Outcome: "ok"},
+		{Action: "a", Outcome: "ok", Actor: "u\x00"},
+		{Action: "a", Outcome: "ok", Tenant: "t\x00"},
+		{Action: "a", Outcome: "ok", Resource: "r\x00"},
+		{Action: "a", Outcome: auditlog.Outcome("o\x00k")},
+		{Action: "a", Outcome: "ok", Meta: map[string]string{"k\x00": "v"}},
+		{Action: "a", Outcome: "ok", Meta: map[string]string{"k": "v\x00"}},
+	}
+	for _, e := range events {
+		_, err := rec.Record(context.Background(), e)
+		assert.ErrorIs(t, err, auditlog.ErrInvalidEvent, "NUL bytes cannot be stored by Postgres and must fail at the audit point")
+	}
+	assert.Empty(t, sink.Events())
+}
+
 func TestRecord_IDsAreTimeOrdered(t *testing.T) {
 	t.Parallel()
 	sink := auditlog.NewMemorySink()

--- a/ops/auditlog/sink.go
+++ b/ops/auditlog/sink.go
@@ -1,0 +1,96 @@
+package auditlog
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"sync"
+
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+// Sink receives finalized audit events. Implementations must be safe for
+// concurrent use and must persist (or durably hand off) the event before
+// returning nil — Record reports the sink's error to the caller, and a
+// chained recorder advances the stream head only on success.
+type Sink interface {
+	Write(ctx context.Context, e Event) error
+}
+
+// ChainHead is optionally implemented by a Sink that can report the last
+// persisted chain hash of a stream ("" when the stream is empty). A
+// WithChain recorder uses it to resume a stream's chain across process
+// restarts instead of starting a new one.
+type ChainHead interface {
+	ChainHead(ctx context.Context, stream string) (string, error)
+}
+
+// SlogSink writes audit events to a slog.Logger as level-Info "audit"
+// records with structured attributes. It is an observability sink — logs
+// are typically rotated and unqueryable per tenant — so pair it with a
+// durable sink (pgsink, JSONL) when the trail must be retained.
+type SlogSink struct {
+	log *slog.Logger
+}
+
+// NewSlogSink builds a SlogSink over l; a nil l discards events
+// (logger.NewNope).
+func NewSlogSink(l *slog.Logger) *SlogSink {
+	if l == nil {
+		l = logger.NewNope()
+	}
+	return &SlogSink{log: l}
+}
+
+// Write logs e. It never fails.
+func (s *SlogSink) Write(ctx context.Context, e Event) error {
+	attrs := make([]slog.Attr, 0, 10)
+	attrs = append(attrs,
+		slog.String("event_id", e.ID.String()),
+		slog.Time("occurred_at", e.Time),
+		slog.String("action", e.Action),
+		slog.String("outcome", string(e.Outcome)),
+	)
+	if e.Tenant != "" {
+		attrs = append(attrs, slog.String("tenant", e.Tenant))
+	}
+	if e.Actor != "" {
+		attrs = append(attrs, slog.String("actor", e.Actor))
+	}
+	if e.Resource != "" {
+		attrs = append(attrs, slog.String("resource", e.Resource))
+	}
+	if len(e.Meta) > 0 {
+		attrs = append(attrs, slog.Any("meta", e.Meta))
+	}
+	if e.Hash != "" {
+		attrs = append(attrs, slog.String("prev_hash", e.PrevHash), slog.String("hash", e.Hash))
+	}
+	s.log.LogAttrs(ctx, slog.LevelInfo, "audit", attrs...)
+	return nil
+}
+
+// JSONLSink appends one JSON object per line to w — a file-backed audit
+// trail. Writes are serialized so lines never interleave; the caller owns
+// w's lifecycle (open with O_APPEND, close after the recorder stops).
+type JSONLSink struct {
+	enc *json.Encoder
+	mu  sync.Mutex
+}
+
+// NewJSONLSink builds a JSONLSink over w. It panics on a nil w — a wiring
+// bug caught at startup.
+func NewJSONLSink(w io.Writer) *JSONLSink {
+	if w == nil {
+		panic("auditlog: nil writer")
+	}
+	return &JSONLSink{enc: json.NewEncoder(w)}
+}
+
+// Write appends e as one JSON line.
+func (s *JSONLSink) Write(_ context.Context, e Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.enc.Encode(e)
+}

--- a/ops/auditlog/sink.go
+++ b/ops/auditlog/sink.go
@@ -29,7 +29,8 @@ type ChainHead interface {
 // SlogSink writes audit events to a slog.Logger as level-Info "audit"
 // records with structured attributes. It is an observability sink — logs
 // are typically rotated and unqueryable per tenant — so pair it with a
-// durable sink (pgsink, JSONL) when the trail must be retained.
+// durable sink when the trail must be retained: pgsink, or JSONLSink for
+// unchained trails (see its restart caveat).
 type SlogSink struct {
 	log *slog.Logger
 }

--- a/ops/auditlog/sink.go
+++ b/ops/auditlog/sink.go
@@ -73,7 +73,11 @@ func (s *SlogSink) Write(ctx context.Context, e Event) error {
 
 // JSONLSink appends one JSON object per line to w — a file-backed audit
 // trail. Writes are serialized so lines never interleave; the caller owns
-// w's lifecycle (open with O_APPEND, close after the recorder stops).
+// w's lifecycle (open with O_APPEND, close after the recorder stops). It
+// does not implement ChainHead, so a chained recorder restarted onto an
+// existing file starts a new chain and a whole-file VerifyChain will
+// report ErrChainBroken at the restart boundary — chaining across
+// restarts needs a ChainHead-capable sink (pgsink).
 type JSONLSink struct {
 	enc *json.Encoder
 	mu  sync.Mutex

--- a/ops/auditlog/sink_test.go
+++ b/ops/auditlog/sink_test.go
@@ -1,0 +1,99 @@
+package auditlog_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/auditlog"
+)
+
+func TestJSONLSink_RoundTripsAndVerifies(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	rec := auditlog.New(auditlog.NewJSONLSink(&buf), auditlog.WithChain())
+	recordN(t, rec, 3, auditlog.Event{
+		Actor: "user_1", Action: "doc.edit", Resource: "doc:9",
+		Outcome: auditlog.OutcomeSuccess, Meta: map[string]string{"field": "title"},
+	})
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 3)
+
+	events := make([]auditlog.Event, 0, len(lines))
+	for _, line := range lines {
+		var e auditlog.Event
+		require.NoError(t, json.Unmarshal([]byte(line), &e))
+		events = append(events, e)
+	}
+	assert.Equal(t, "user_1", events[0].Actor)
+	assert.Equal(t, map[string]string{"field": "title"}, events[0].Meta)
+
+	_, err := auditlog.VerifyChain("", events)
+	assert.NoError(t, err, "a decoded JSONL trail verifies offline")
+}
+
+func TestNewJSONLSink_NilWriterPanics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { auditlog.NewJSONLSink(nil) })
+}
+
+func TestSlogSink_EmitsStructuredRecord(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	sink := auditlog.NewSlogSink(slog.New(slog.NewJSONHandler(&buf, nil)))
+	rec := auditlog.New(sink, auditlog.WithChain())
+
+	e, err := rec.Record(context.Background(), auditlog.Event{
+		Tenant: "org_1", Actor: "user_1", Action: "member.remove",
+		Resource: "member:2", Outcome: auditlog.OutcomeDenied,
+		Meta: map[string]string{"reason": "last admin"},
+	})
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+	assert.Equal(t, "audit", out["msg"])
+	assert.Equal(t, e.ID.String(), out["event_id"])
+	assert.Equal(t, "member.remove", out["action"])
+	assert.Equal(t, "denied", out["outcome"])
+	assert.Equal(t, "org_1", out["tenant"])
+	assert.Equal(t, "user_1", out["actor"])
+	assert.Equal(t, "member:2", out["resource"])
+	assert.Equal(t, e.Hash, out["hash"])
+	assert.Equal(t, map[string]any{"reason": "last admin"}, out["meta"])
+}
+
+func TestSlogSink_SkipsEmptyFields(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	sink := auditlog.NewSlogSink(slog.New(slog.NewJSONHandler(&buf, nil)))
+	require.NoError(t, sink.Write(context.Background(), auditlog.Event{Action: "a", Outcome: "ok"}))
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+	for _, absent := range []string{"tenant", "actor", "resource", "meta", "hash", "prev_hash"} {
+		assert.NotContains(t, out, absent)
+	}
+}
+
+func TestSlogSink_NilLoggerDiscards(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewSlogSink(nil)
+	assert.NoError(t, sink.Write(context.Background(), auditlog.Event{Action: "a", Outcome: "ok"}))
+}
+
+func TestMemorySink_EventsReturnsCopy(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	require.NoError(t, sink.Write(context.Background(), auditlog.Event{Action: "a", Outcome: "ok"}))
+	events := sink.Events()
+	events[0].Action = "mutated"
+	assert.Equal(t, "a", sink.Events()[0].Action)
+}


### PR DESCRIPTION
## Summary

Implements the **ops/auditlog** catalog entry: append-only structured audit events (actor/action/resource/outcome) over a `Sink` seam, with slog + JSONL sinks built in, and **auditlog/pgsink** adding the Postgres insert plus tenant-isolated keyset-paginated queries. Optional per-stream hash chaining (prev-hash + a verify pass) makes the trail tamper-evident for compliance-grade audits.

### Core (`ops/auditlog`)

- `Event` — actor/action/resource/outcome + tenant, free-form `Meta`, microsecond-precision `Time` (survives a Postgres timestamptz round-trip bit-identically, so chain hashes recompute after read-back), and a time-ordered UUIDv7 `ID`.
- `Recorder` — `New(sink, ...Option)`; `Record` validates (Action + Outcome required), stamps ID/Time, and writes synchronously: a sink error is the caller's error, never a silent drop.
- **Tenancy**: fail-closed `WithScope` seam per the repo rule — hook error or empty tenant fails with `ErrScope`, conflicting explicit tenant fails with `ErrTenantMismatch`, single-tenant use pays zero ceremony.
- **Chaining** (`WithChain`): `Hash = SHA-256(PrevHash, length-prefixed payload)` per stream (stream = tenant). IDs are generated under the per-stream lock from a monotonic generator, so id order equals chain order and a verify pass can walk streams by id ascending. Sink failures leave the head unchanged; ambiguous failures (persisted-but-errored) drop the seed so the next write re-reads the persisted head via `ChainHead` instead of forking the chain.
- Sinks: `SlogSink` (structured attrs, skips empties), `JSONLSink` (serialized JSON lines; a decoded trail verifies offline), `MemorySink` (tests/dev, implements `ChainHead`).
- `VerifyChain(prev, events)` — stateless incremental verification; batching = threading the returned head.

### Postgres (`ops/auditlog/pgsink`)

- Implements `auditlog.Sink` + `auditlog.ChainHead`; append-only table (no update/delete path), goose migration under its own version table (`forge_auditlog_schema`).
- `List` — tenant-isolated keyset pagination over the UUIDv7 id (deep pages cost the same as page one), filters on actor/action/resource/outcome/time-range, limit clamped to 1..500, `ErrInvalidCursor` on bad cursors.
- `Verify` — batched ascending walk of a stream's chain; `ErrChainBroken` names the first bad event. Integration test tampers via direct `UPDATE`/`DELETE` and checks detection.
- Same fail-closed `WithScope` hook confines reads.

### Benchmarks (M3 Max)

| benchmark | ns/op | allocs |
|---|---|---|
| Record | 155.6 | 0 |
| RecordChained | 554.8 | 8 |
| ComputeHash | 379.6 | 8 |

Post-bench optimization: `ComputeHash` assembles the canonical message in one exactly-sized buffer and uses `sha256.Sum256` instead of streaming `sha256.New` — **643 → 380 ns, 33 → 8 allocs**. Record includes NUL-byte validation (rejected up front because Postgres text/jsonb cannot store NUL and stripping after hashing would break verification) — still zero-alloc.

### Tests

- Unit (race-clean): validation, scope fail-closed paths, tamper-detection table (rewrite/inject/flip/delete/reorder/forge), per-stream chains, restart resume via ChainHead, failed and ambiguous writes, 8-goroutine concurrent chained recording, JSONL/slog round-trips, hash injectivity.
- Integration (`-tags=integration`, testcontainers): round-trip fidelity, tenant isolation, keyset walk vs unpaged order, page boundaries, scoped reads, chain resume, tamper detection via SQL, 501-event verify crossing the batch boundary.

Catalog entry removed from docs/packages.md; dependent entries un-planned per the roadmap rule.
