### PR TITLE
web/risk: generic anti-fraud gate with scorer strategies and probability threshold

### DIFF
--- a/docs/superpowers/specs/2026-07-21-web-risk-design.md
+++ b/docs/superpowers/specs/2026-07-21-web-risk-design.md
@@ -1,0 +1,132 @@
+# web/risk — Design
+
+**Date:** 2026-07-21
+**Status:** Approved
+
+## Purpose
+
+Generic anti-fraud gate: consumer-supplied scorer functions each return a fraud probability for an input, a pluggable strategy combines them, and a threshold gate decides whether the call proceeds, trips a fraud handler, or errors. Mechanism only — the package owns combining, gating, and error flow; all fraud *logic* (useragent checks, fingerprint mismatch, velocity, geo rules) lives in consumer scorers. Fills the consumer-side "fraud diversion / bot filtering" seam that `web/smartlink` explicitly leaves to callers, and is equally usable mid-handler (signup, deposit, bonus claim) or off-request (queue consumers).
+
+Not `auth/abac` (boolean predicate policy → allow/deny): `risk` is graded scoring with a threshold and an action hook. Not `web/ipfilter` (static list gate). If a consumer only needs boolean rules, they should use `abac`, not this.
+
+## Decisions (from brainstorming Q&A)
+
+1. **Multiple scorers + combining strategy**, not a single function. Default strategy `Max` — fraud signals are not additive; one 0.9 signal must not be diluted by innocent 0.1s in an average. `Mean` and `Weighted` ship as alternatives.
+2. **Generic transport-free core + thin `net/http` middleware adapter in the same package** (option b from Q&A). Core never imports `net/http`; the adapter follows the `web/tenant` / `auth/guard` middleware pattern.
+3. **Fraud handler decides the outcome.** On gate trip with an `OnFraud` handler set, the handler runs and its return value controls flow: `nil` → proceed (shadow mode / divert-and-allow), error → blocked with that error. No handler → blocked with `ErrFraud`.
+4. **Fail closed, no fail-open option in v1.** Scorer error, NaN, or out-of-range score fails the check. Consumers wanting lenient scorers wrap their own recover-to-zero.
+5. **Name `web/risk`** — short, mechanism-named like `fingerprint`/`ipfilter`/`lockout`.
+
+## Core API
+
+```go
+package risk
+
+type Scorer[T any] func(ctx context.Context, input T) (float64, error)
+
+type Strategy func(scores []float64) float64 // Max (default), Mean; weighted average via WithWeights
+
+type Engine[T any] struct{ /* unexported */ }
+
+func New[T any](opts ...Option[T]) (*Engine[T], error)
+
+// Options
+func WithScorer[T any](s Scorer[T]) Option[T]          // repeatable; New errors with zero scorers
+func WithGate[T any](threshold float64) Option[T]      // required; must be in (0,1]
+func WithStrategy[T any](st Strategy) Option[T]        // default Max; mutually exclusive with WithWeights
+func WithWeights[T any](weights ...float64) Option[T]  // weighted-average strategy; arity validated in New
+func OnFraud[T any](h func(ctx context.Context, input T, score Score) error) Option[T]
+
+// Methods
+func (e *Engine[T]) Check(ctx context.Context, input T) error          // nil = proceed
+func (e *Engine[T]) Score(ctx context.Context, input T) (Score, error) // combined score, no gating — telemetry / shadow use
+```
+
+`Score` carries the combined value plus attribution:
+
+```go
+type Score struct {
+    Value    float64   // combined score
+    Peak     float64   // highest individual scorer value
+    PeakIdx  int       // index (registration order) of the peaking scorer
+    Scores   []float64 // per-scorer values, registration order
+}
+```
+
+`ErrFraud` is an `errors.As`-able type wrapping the `Score`, so callers and the middleware can log which scorer tripped the gate:
+
+```go
+type FraudError struct{ Score Score }
+func (e *FraudError) Error() string
+func (e *FraudError) Is(target error) bool // true for ErrFraud
+
+var ErrFraud = errors.New("risk: fraud detected") // errors.Is(err, ErrFraud) matches any *FraudError
+```
+
+## Semantics
+
+**Check flow:** run all scorers in registration order → validate each result (see Edge handling) → combine via strategy → compare against gate. `score >= gate` trips (boundary inclusive: a scorer returning exactly the gate value is fraud). Below gate → `Check` returns nil.
+
+**On trip:** no `OnFraud` → return `*FraudError` (matches `errors.Is(err, ErrFraud)`). With `OnFraud` → call it with input and `Score`; return its error verbatim (nil proceeds). The handler's error is NOT wrapped in `FraudError` — the handler owns the contract with its caller; it can return a `FraudError` itself if it wants that shape.
+
+**Scorers run sequentially, all of them, even under `Max`.** No short-circuit on first score ≥ gate: `Score.Scores` attribution must be complete, and scorers are consumer code whose side effects (metric increments) should not silently vary with registration order. Scorer count is small (units, not hundreds); if a proven-hot path needs short-circuiting later, that is a measured optimization behind the same API.
+
+**Strategies:**
+
+- `Max` — highest score wins. Default.
+- `Mean` — arithmetic mean.
+- `WithWeights(w ...float64)` — a weighted average configured as an option rather than a `Strategy` value, because a plain `func([]float64) float64` cannot expose its weight arity for `New`-time validation. Weight count must equal scorer count, weights must be non-negative and sum > 0; normalized internally so `WithWeights(1, 3)` means 25%/75%. Mutually exclusive with `WithStrategy`.
+- Custom: any `func([]float64) float64`. Output is validated like a scorer output (NaN / out-of-range from a custom strategy → error).
+
+## Edge handling (fail closed)
+
+- Scorer returns error → `Check`/`Score` return that error wrapped with scorer index context. No skip, no zero-substitute.
+- Scorer returns NaN, ±Inf, or a value outside [0,1] → error, not clamp. A NaN comparing false against the gate is the `auth/lockout` NaN hole; silent clamping hides broken scorers.
+- Strategy output NaN / out-of-range → error (covers custom strategies).
+- `New` validation errors: zero scorers, gate outside (0,1], nil scorer, nil strategy, `Weighted` arity/negative/zero-sum violations.
+- `ctx` cancellation: scorers receive ctx and are expected to honor it; the engine checks `ctx.Err()` between scorers and aborts with the ctx error.
+
+## Middleware adapter
+
+```go
+func Middleware[T any](e *Engine[T], buildInput func(*http.Request) T, opts ...MiddlewareOption) func(http.Handler) http.Handler
+
+func WithRejectHandler(h func(w http.ResponseWriter, r *http.Request, err error)) MiddlewareOption
+func WithLogger(l *slog.Logger) MiddlewareOption // default logger.NewNope()
+```
+
+- `Check` nil → `next.ServeHTTP`.
+- `Check` returns any error (fraud or scorer infrastructure failure) → reject: default plain `403 Forbidden` response; `WithRejectHandler` overrides (consumer can emit `web/problem`, redirect to a decoy, etc.). Fail closed on infrastructure errors — same as fraud.
+- Rejections and scorer errors are logged at Warn/Error respectively via the optional logger, single-line slog attrs (score value, peak index, path); never the error text in the response body beyond the status line.
+- `OnFraud`-returns-nil surfaces as `Check` nil → request proceeds; the middleware never knows the gate tripped. Shadow mode works unchanged under the middleware.
+
+## Tenancy
+
+Pure compute, no storage, no I/O → tenancy is a passed value, not a seam (`core/phone` precedent). Tenant identity travels inside `T` for scorers to read, or the consumer constructs per-tenant engines (construction is cheap and allocation-free after `New`). No `WithScope`; the package doc states this explicitly.
+
+## Dependencies
+
+Core: stdlib only. Middleware: `net/http`, `log/slog`, `ops/logger` (for `NewNope` default). No storage, no drivers.
+
+## Anti-scope
+
+- No built-in scorers — fingerprint/geoip/useragent/velocity checks are consumer functions wired from existing packages.
+- No velocity/counter storage — a velocity scorer backs itself with `resilience/cache` or `ratelimit.Store` on the consumer side.
+- No ML, no model loading, no feature extraction.
+- No verdict persistence or case management — audit is the consumer's `ops/auditlog` call inside `OnFraud`.
+- No challenge/step-up flows (captcha, OTP) — an `OnFraud` handler or reject handler can redirect to one.
+- No async/batch scoring API.
+
+## Testing (black-box, `risk_test`)
+
+- Strategy math: `Max`, `Mean`, `Weighted` normalization, custom strategy.
+- Gate boundary: `score == gate` trips; `gate - ε` passes.
+- Handler semantics: nil-proceeds, error-blocks-verbatim, no-handler → `ErrFraud` with correct `Score` attribution (Peak/PeakIdx/Scores order).
+- Fail-closed: scorer error, NaN, +Inf, -0.1, 1.1, strategy-output violations; ctx cancellation between scorers.
+- `New` validation matrix.
+- Middleware: pass → next reached; fraud → 403 default; `WithRejectHandler` override; infrastructure error → 403; shadow (OnFraud nil) → next reached.
+- Fuzz: `Weighted` normalization over random weight/score vectors — output always in [0,1], no NaN.
+
+## Benchmarks
+
+`bench_test.go` per repo rule: `Check` pass path (target zero allocs — `Score.Scores` slice must not escape on the nil-return path; reuse via stack or pool if measurement demands), `Check` trip path, 1/4/16 scorers, each built-in strategy. Post-benchmark optimization pass with before/after numbers in the PR.

--- a/web/risk/bench_test.go
+++ b/web/risk/bench_test.go
@@ -1,0 +1,105 @@
+package risk_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/risk"
+)
+
+func benchEngine(b *testing.B, n int, opts ...risk.Option[string]) *risk.Engine[string] {
+	b.Helper()
+	all := make([]risk.Option[string], 0, n+2)
+	for range n {
+		all = append(all, risk.WithScorer(constScorer(0.1)))
+	}
+	all = append(all, risk.WithGate[string](0.8))
+	all = append(all, opts...)
+	e, err := risk.New(all...)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return e
+}
+
+func BenchmarkCheckPass(b *testing.B) {
+	ctx := context.Background()
+	for _, n := range []int{1, 4, 16} {
+		b.Run(map[int]string{1: "1scorer", 4: "4scorers", 16: "16scorers"}[n], func(b *testing.B) {
+			e := benchEngine(b, n)
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := e.Check(ctx, "visit"); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCheckPassMean(b *testing.B) {
+	ctx := context.Background()
+	e := benchEngine(b, 4, risk.WithStrategy[string](risk.Mean))
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := e.Check(ctx, "visit"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCheckPassWeighted(b *testing.B) {
+	ctx := context.Background()
+	e := benchEngine(b, 4, risk.WithWeights[string](1, 2, 3, 4))
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := e.Check(ctx, "visit"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCheckTrip(b *testing.B) {
+	ctx := context.Background()
+	e, err := risk.New(
+		risk.WithScorer(constScorer(0.9)),
+		risk.WithScorer(constScorer(0.1)),
+		risk.WithScorer(constScorer(0.2)),
+		risk.WithScorer(constScorer(0.3)),
+		risk.WithGate[string](0.8),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if e.Check(ctx, "visit") == nil {
+			b.Fatal("expected trip")
+		}
+	}
+}
+
+func BenchmarkScore(b *testing.B) {
+	ctx := context.Background()
+	e := benchEngine(b, 4)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := e.Score(ctx, "visit"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMiddlewarePass(b *testing.B) {
+	e := benchEngine(b, 4)
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+	h := risk.Middleware(e, func(r *http.Request) string { return r.URL.Path })(next)
+	req := httptest.NewRequest(http.MethodGet, "/click", nil)
+	rec := httptest.NewRecorder()
+	b.ReportAllocs()
+	for b.Loop() {
+		h.ServeHTTP(rec, req)
+	}
+}

--- a/web/risk/doc.go
+++ b/web/risk/doc.go
@@ -1,0 +1,42 @@
+// Package risk is a generic anti-fraud gate: consumer-supplied scorer
+// functions each return a fraud probability in [0, 1] for an input, a
+// combining strategy folds them into one score, and a threshold gate decides
+// whether the call proceeds. The package owns combining, gating, and error
+// flow only — all fraud logic (useragent checks, fingerprint mismatch,
+// velocity, geo rules) lives in consumer scorers, typically wired from
+// web/useragent, web/fingerprint, web/geoip, and web/clientip.
+//
+// An Engine is built once with New and is immutable and concurrent-safe.
+// Check runs every scorer in registration order, combines the scores
+// (default strategy Max — fraud signals are not additive, one strong signal
+// must not be diluted by weak ones), and trips when the combined score
+// reaches the gate (score >= gate). On trip without an OnFraud handler,
+// Check returns a *FraudError matching errors.Is(err, ErrFraud) and carrying
+// per-scorer attribution. With a handler, the handler's return decides:
+// nil proceeds (shadow mode, divert-and-allow), an error blocks with that
+// error verbatim.
+//
+// Everything fails closed: a scorer error, a NaN, or a score outside [0, 1]
+// fails the check — no silent skips, no clamping of broken scorers. Score
+// computes the combined score without gating, for telemetry and for tuning
+// the gate in shadow mode before enforcing.
+//
+//	engine, err := risk.New[Visit](
+//		risk.WithScorer(botUserAgent),     // func(ctx, Visit) (float64, error)
+//		risk.WithScorer(fingerprintMismatch),
+//		risk.WithGate(0.8),
+//	)
+//	if err != nil { ... }
+//	if err := engine.Check(ctx, visit); err != nil { ... } // gate tripped
+//
+// Middleware adapts an Engine to net/http: buildInput assembles the scorer
+// input from the request, gate trips and scorer failures alike reject with
+// 403 (override with WithRejectHandler to divert to a decoy or render a
+// problem response). Off-request use — queue consumers, smartlink decision
+// decorators (a Decider wrapper calling Check and returning a decoy
+// Decision on fraud), OnHit shadow scoring — calls Check or Score directly.
+//
+// Tenancy is a passed value, not a seam: the engine is pure compute with no
+// storage, so tenant identity travels inside the input type T for scorers to
+// read, or the consumer builds one engine per tenant.
+package risk

--- a/web/risk/errors.go
+++ b/web/risk/errors.go
@@ -1,0 +1,55 @@
+package risk
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrFraud matches (via errors.Is) the *FraudError returned by Check when
+	// the combined score reaches the gate and no OnFraud handler is set.
+	ErrFraud = errors.New("risk: fraud detected")
+
+	// ErrNoScorers is returned by New when no WithScorer option was given.
+	ErrNoScorers = errors.New("risk: no scorers")
+
+	// ErrNilScorer is returned by New for a nil scorer.
+	ErrNilScorer = errors.New("risk: nil scorer")
+
+	// ErrInvalidGate is returned by New when the gate is missing or outside
+	// (0, 1]. A gate of 0 would trip on every input.
+	ErrInvalidGate = errors.New("risk: gate must be in (0, 1]")
+
+	// ErrNilStrategy is returned by New for WithStrategy(nil).
+	ErrNilStrategy = errors.New("risk: nil strategy")
+
+	// ErrInvalidWeights is returned by New when WithWeights arity does not
+	// match the scorer count, a weight is negative or NaN, or all weights are
+	// zero.
+	ErrInvalidWeights = errors.New("risk: invalid weights")
+
+	// ErrStrategyConflict is returned by New when both WithStrategy and
+	// WithWeights are set.
+	ErrStrategyConflict = errors.New("risk: WithStrategy and WithWeights are mutually exclusive")
+
+	// ErrInvalidScore is returned by Check and Score when a scorer or a custom
+	// strategy produces NaN, an infinity, or a value outside [0, 1]. Broken
+	// scorers fail closed instead of being clamped.
+	ErrInvalidScore = errors.New("risk: score outside [0, 1]")
+)
+
+// FraudError is returned by Check on a gate trip with no OnFraud handler. It
+// matches errors.Is(err, ErrFraud) and carries the full Score attribution so
+// callers can log which scorer peaked.
+type FraudError struct {
+	Score Score
+}
+
+// Error implements error.
+func (e *FraudError) Error() string {
+	return fmt.Sprintf("risk: fraud detected: score %.4g, peak %.4g from scorer %d", e.Score.Value, e.Score.Peak, e.Score.PeakIdx)
+}
+
+// Is reports true for ErrFraud, so errors.Is(err, ErrFraud) matches any
+// *FraudError.
+func (e *FraudError) Is(target error) bool { return target == ErrFraud }

--- a/web/risk/example_test.go
+++ b/web/risk/example_test.go
@@ -1,0 +1,54 @@
+package risk_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/dmitrymomot/forge/web/risk"
+)
+
+// Visit is the consumer's own input type — the engine is generic over it.
+type Visit struct {
+	UserAgent   string
+	Fingerprint string
+}
+
+func Example() {
+	// Scorers hold the fraud logic; the engine owns combining and gating.
+	botUA := func(_ context.Context, v Visit) (float64, error) {
+		if strings.Contains(strings.ToLower(v.UserAgent), "headless") {
+			return 0.9, nil
+		}
+		return 0.1, nil
+	}
+	noFingerprint := func(_ context.Context, v Visit) (float64, error) {
+		if v.Fingerprint == "" {
+			return 0.6, nil
+		}
+		return 0, nil
+	}
+
+	engine, err := risk.New(
+		risk.WithScorer(botUA),
+		risk.WithScorer(noFingerprint),
+		risk.WithGate[Visit](0.8), // default strategy Max: one strong signal trips
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	fmt.Println(engine.Check(ctx, Visit{UserAgent: "Mozilla/5.0", Fingerprint: "abc"}))
+
+	err = engine.Check(ctx, Visit{UserAgent: "HeadlessChrome"})
+	fmt.Println(errors.Is(err, risk.ErrFraud))
+	if fraud, ok := errors.AsType[*risk.FraudError](err); ok {
+		fmt.Printf("score %.1f from scorer %d\n", fraud.Score.Value, fraud.Score.PeakIdx)
+	}
+	// Output:
+	// <nil>
+	// true
+	// score 0.9 from scorer 0
+}

--- a/web/risk/fuzz_test.go
+++ b/web/risk/fuzz_test.go
@@ -1,0 +1,44 @@
+package risk_test
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/risk"
+)
+
+// FuzzWeights pins the weighted-average invariant: for any weight vector New
+// accepts and any valid scores, the combined value stays in [0, 1] with no
+// error and no NaN.
+func FuzzWeights(f *testing.F) {
+	f.Add(1.0, 3.0, 0.0, 0.4, 0.8, 1.0)
+	f.Add(0.001, 1000.0, 5.0, 0.0, 1.0, 0.5)
+	f.Add(1.0, 1.0, 1.0, 0.3333, 0.6667, 0.9999)
+	f.Fuzz(func(t *testing.T, w1, w2, w3, s1, s2, s3 float64) {
+		valid := func(v float64) bool { return v >= 0 && v <= 1 }
+		for _, s := range []float64{s1, s2, s3} {
+			if !valid(s) {
+				t.Skip()
+			}
+		}
+		scores := []float64{s1, s2, s3}
+		e, err := risk.New(
+			risk.WithScorer(func(context.Context, int) (float64, error) { return scores[0], nil }),
+			risk.WithScorer(func(context.Context, int) (float64, error) { return scores[1], nil }),
+			risk.WithScorer(func(context.Context, int) (float64, error) { return scores[2], nil }),
+			risk.WithGate[int](1),
+			risk.WithWeights[int](w1, w2, w3),
+		)
+		if err != nil {
+			t.Skip() // New rejected the weights — rejection is its own tested contract
+		}
+		sc, err := e.Score(context.Background(), 0)
+		if err != nil {
+			t.Fatalf("Score() = %v for weights %v scores %v", err, []float64{w1, w2, w3}, scores)
+		}
+		if math.IsNaN(sc.Value) || sc.Value < 0 || sc.Value > 1 {
+			t.Fatalf("combined value %v out of [0,1] for weights %v scores %v", sc.Value, []float64{w1, w2, w3}, scores)
+		}
+	})
+}

--- a/web/risk/middleware.go
+++ b/web/risk/middleware.go
@@ -26,9 +26,13 @@ func WithRejectHandler(h func(w http.ResponseWriter, r *http.Request, err error)
 }
 
 // WithLogger sets the logger for rejection and scorer-failure records.
-// Defaults to logger.NewNope.
+// Defaults to logger.NewNope; nil is ignored.
 func WithLogger(l *slog.Logger) MiddlewareOption {
-	return func(c *middlewareConfig) { c.log = l }
+	return func(c *middlewareConfig) {
+		if l != nil {
+			c.log = l
+		}
+	}
 }
 
 // Middleware gates requests through e. buildInput assembles the scorer input

--- a/web/risk/middleware.go
+++ b/web/risk/middleware.go
@@ -1,0 +1,79 @@
+package risk
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/dmitrymomot/forge/ops/logger"
+	"github.com/dmitrymomot/forge/web/middleware"
+)
+
+type middlewareConfig struct {
+	log    *slog.Logger
+	reject func(w http.ResponseWriter, r *http.Request, err error)
+}
+
+// MiddlewareOption configures Middleware.
+type MiddlewareOption func(*middlewareConfig)
+
+// WithRejectHandler replaces the default plain 403 written on any Check
+// failure — gate trip or scorer error alike. Use it to divert to a decoy
+// destination or render a problem response. err is the Check error; a gate
+// trip matches errors.Is(err, ErrFraud).
+func WithRejectHandler(h func(w http.ResponseWriter, r *http.Request, err error)) MiddlewareOption {
+	return func(c *middlewareConfig) { c.reject = h }
+}
+
+// WithLogger sets the logger for rejection and scorer-failure records.
+// Defaults to logger.NewNope.
+func WithLogger(l *slog.Logger) MiddlewareOption {
+	return func(c *middlewareConfig) { c.log = l }
+}
+
+// Middleware gates requests through e. buildInput assembles the scorer input
+// from the request — the raw *http.Request is richer than any digested visit
+// context, so scorers here can read headers, fingerprints, and client IPs
+// directly. Check nil proceeds to next (an OnFraud handler returning nil
+// lands here — shadow mode is invisible to the middleware). Any Check error
+// — fraud or scorer infrastructure failure — rejects fail-closed: a gate
+// trip logs at Warn with score attribution, an infrastructure error at
+// Error, then the reject handler writes the response (default: plain 403,
+// no error detail in the body). Panics on a nil engine or buildInput.
+func Middleware[T any](e *Engine[T], buildInput func(*http.Request) T, opts ...MiddlewareOption) middleware.Middleware {
+	if e == nil {
+		panic("risk: Middleware requires a non-nil Engine")
+	}
+	if buildInput == nil {
+		panic("risk: Middleware requires a non-nil buildInput")
+	}
+	cfg := middlewareConfig{log: logger.NewNope(), reject: defaultReject}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err := e.Check(r.Context(), buildInput(r))
+			if err == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if fraud, ok := errors.AsType[*FraudError](err); ok {
+				cfg.log.WarnContext(r.Context(), "request rejected as fraud",
+					slog.Float64("score", fraud.Score.Value),
+					slog.Float64("peak", fraud.Score.Peak),
+					slog.Int("peak_scorer", fraud.Score.PeakIdx),
+					slog.String("path", r.URL.Path))
+			} else {
+				cfg.log.ErrorContext(r.Context(), "risk check failed",
+					slog.Any("error", err),
+					slog.String("path", r.URL.Path))
+			}
+			cfg.reject(w, r, err)
+		})
+	}
+}
+
+func defaultReject(w http.ResponseWriter, _ *http.Request, _ error) {
+	http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+}

--- a/web/risk/middleware_test.go
+++ b/web/risk/middleware_test.go
@@ -3,6 +3,7 @@ package risk_test
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -100,6 +101,72 @@ func TestMiddlewareShadowModeProceeds(t *testing.T) {
 	}
 	if !handlerRan {
 		t.Fatal("OnFraud handler did not run in shadow mode")
+	}
+}
+
+// recordHandler captures slog records for assertions.
+type recordHandler struct {
+	records *[]slog.Record
+}
+
+func (h recordHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h recordHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.records = append(*h.records, r)
+	return nil
+}
+func (h recordHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h recordHandler) WithGroup(string) slog.Handler      { return h }
+
+func TestMiddlewareLogsFraudAtWarnWithAttrs(t *testing.T) {
+	t.Parallel()
+	var records []slog.Record
+	log := slog.New(recordHandler{records: &records})
+	var nextCalled bool
+	serve(risk.Middleware(mwEngine(t, 0.9), buildInput, risk.WithLogger(log)), &nextCalled)
+	if len(records) != 1 || records[0].Level != slog.LevelWarn {
+		t.Fatalf("records = %d, want 1 Warn record; got %+v", len(records), records)
+	}
+	attrs := map[string]slog.Value{}
+	records[0].Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value
+		return true
+	})
+	if got := attrs["score"].Float64(); got != 0.9 {
+		t.Errorf("score attr = %v, want 0.9", got)
+	}
+	if got := attrs["peak_scorer"].Int64(); got != 0 {
+		t.Errorf("peak_scorer attr = %v, want 0", got)
+	}
+	if got := attrs["path"].String(); got != "/click" {
+		t.Errorf("path attr = %q, want /click", got)
+	}
+}
+
+func TestMiddlewareLogsInfraErrorAtError(t *testing.T) {
+	t.Parallel()
+	e, err := risk.New(
+		risk.WithScorer(func(context.Context, string) (float64, error) { return 0, errors.New("lookup down") }),
+		risk.WithGate[string](0.8),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var records []slog.Record
+	log := slog.New(recordHandler{records: &records})
+	var nextCalled bool
+	serve(risk.Middleware(e, buildInput, risk.WithLogger(log)), &nextCalled)
+	if len(records) != 1 || records[0].Level != slog.LevelError {
+		t.Fatalf("records = %d, want 1 Error record; got %+v", len(records), records)
+	}
+}
+
+func TestMiddlewareWithLoggerNilKeepsDefault(t *testing.T) {
+	t.Parallel()
+	var nextCalled bool
+	// Must not panic: nil is ignored and the NewNope default stays.
+	rec := serve(risk.Middleware(mwEngine(t, 0.9), buildInput, risk.WithLogger(nil)), &nextCalled)
+	if nextCalled || rec.Code != http.StatusForbidden {
+		t.Fatalf("nil-logger path: nextCalled=%v code=%d, want false/403", nextCalled, rec.Code)
 	}
 }
 

--- a/web/risk/middleware_test.go
+++ b/web/risk/middleware_test.go
@@ -1,0 +1,118 @@
+package risk_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/risk"
+)
+
+func mwEngine(t *testing.T, score float64, opts ...risk.Option[string]) *risk.Engine[string] {
+	t.Helper()
+	e, err := risk.New(append([]risk.Option[string]{
+		risk.WithScorer(constScorer(score)),
+		risk.WithGate[string](0.8),
+	}, opts...)...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+func buildInput(r *http.Request) string { return r.URL.Path }
+
+func serve(mw func(http.Handler) http.Handler, nextCalled *bool) *httptest.ResponseRecorder {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		*nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/click", nil))
+	return rec
+}
+
+func TestMiddlewarePass(t *testing.T) {
+	t.Parallel()
+	var nextCalled bool
+	rec := serve(risk.Middleware(mwEngine(t, 0.2), buildInput), &nextCalled)
+	if !nextCalled || rec.Code != http.StatusOK {
+		t.Fatalf("pass path: nextCalled=%v code=%d, want true/200", nextCalled, rec.Code)
+	}
+}
+
+func TestMiddlewareFraudDefault403(t *testing.T) {
+	t.Parallel()
+	var nextCalled bool
+	rec := serve(risk.Middleware(mwEngine(t, 0.9), buildInput), &nextCalled)
+	if nextCalled || rec.Code != http.StatusForbidden {
+		t.Fatalf("fraud path: nextCalled=%v code=%d, want false/403", nextCalled, rec.Code)
+	}
+}
+
+func TestMiddlewareScorerErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+	e, err := risk.New(
+		risk.WithScorer(func(context.Context, string) (float64, error) { return 0, errors.New("lookup down") }),
+		risk.WithGate[string](0.8),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var nextCalled bool
+	rec := serve(risk.Middleware(e, buildInput), &nextCalled)
+	if nextCalled || rec.Code != http.StatusForbidden {
+		t.Fatalf("infra error path: nextCalled=%v code=%d, want false/403", nextCalled, rec.Code)
+	}
+}
+
+func TestMiddlewareRejectHandlerOverride(t *testing.T) {
+	t.Parallel()
+	var gotErr error
+	mw := risk.Middleware(mwEngine(t, 0.9), buildInput,
+		risk.WithRejectHandler(func(w http.ResponseWriter, r *http.Request, err error) {
+			gotErr = err
+			http.Redirect(w, r, "https://decoy.example", http.StatusFound)
+		}))
+	var nextCalled bool
+	rec := serve(mw, &nextCalled)
+	if nextCalled || rec.Code != http.StatusFound {
+		t.Fatalf("override path: nextCalled=%v code=%d, want false/302", nextCalled, rec.Code)
+	}
+	if !errors.Is(gotErr, risk.ErrFraud) {
+		t.Fatalf("reject handler err = %v, want ErrFraud match", gotErr)
+	}
+}
+
+func TestMiddlewareShadowModeProceeds(t *testing.T) {
+	t.Parallel()
+	handlerRan := false
+	e := mwEngine(t, 0.9, risk.OnFraud(func(context.Context, string, risk.Score) error {
+		handlerRan = true
+		return nil
+	}))
+	var nextCalled bool
+	rec := serve(risk.Middleware(e, buildInput), &nextCalled)
+	if !nextCalled || rec.Code != http.StatusOK {
+		t.Fatalf("shadow path: nextCalled=%v code=%d, want true/200", nextCalled, rec.Code)
+	}
+	if !handlerRan {
+		t.Fatal("OnFraud handler did not run in shadow mode")
+	}
+}
+
+func TestMiddlewareNilArgsPanic(t *testing.T) {
+	t.Parallel()
+	assertPanics := func(name string, fn func()) {
+		defer func() {
+			if recover() == nil {
+				t.Errorf("%s: expected panic", name)
+			}
+		}()
+		fn()
+	}
+	assertPanics("nil engine", func() { risk.Middleware(nil, buildInput) })
+	assertPanics("nil buildInput", func() { risk.Middleware(mwEngine(t, 0.1), nil) })
+}

--- a/web/risk/options.go
+++ b/web/risk/options.go
@@ -1,0 +1,58 @@
+package risk
+
+import (
+	"context"
+	"slices"
+)
+
+type config[T any] struct {
+	onFraud     func(ctx context.Context, input T, score Score) error
+	strategy    Strategy
+	scorers     []Scorer[T]
+	weights     []float64
+	gate        float64
+	strategySet bool
+	weightsSet  bool
+}
+
+// Option configures New.
+type Option[T any] func(*config[T])
+
+// WithScorer adds a scorer. Repeatable; scorers run in registration order and
+// New requires at least one.
+func WithScorer[T any](s Scorer[T]) Option[T] {
+	return func(c *config[T]) { c.scorers = append(c.scorers, s) }
+}
+
+// WithGate sets the trip threshold. Required; must be in (0, 1]. A combined
+// score >= threshold trips the gate (boundary inclusive).
+func WithGate[T any](threshold float64) Option[T] {
+	return func(c *config[T]) { c.gate = threshold }
+}
+
+// WithStrategy replaces the default Max combining strategy with Mean or a
+// custom Strategy. Mutually exclusive with WithWeights.
+func WithStrategy[T any](st Strategy) Option[T] {
+	return func(c *config[T]) {
+		c.strategy = st
+		c.strategySet = true
+	}
+}
+
+// WithWeights configures a weighted-average strategy. Weight count must equal
+// the scorer count (positional, validated by New), weights must be
+// non-negative with a positive sum, and are normalized internally so
+// WithWeights(1, 3) means 25%/75%. Mutually exclusive with WithStrategy.
+func WithWeights[T any](weights ...float64) Option[T] {
+	return func(c *config[T]) {
+		c.weights = slices.Clone(weights)
+		c.weightsSet = true
+	}
+}
+
+// OnFraud sets the handler run on a gate trip in place of returning
+// *FraudError. Its return decides the outcome: nil proceeds (shadow mode,
+// divert-and-allow), an error blocks Check with that error verbatim.
+func OnFraud[T any](h func(ctx context.Context, input T, score Score) error) Option[T] {
+	return func(c *config[T]) { c.onFraud = h }
+}

--- a/web/risk/risk.go
+++ b/web/risk/risk.go
@@ -1,0 +1,161 @@
+package risk
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+)
+
+// Scorer returns the fraud probability of input in [0, 1]. A non-nil error or
+// an out-of-range value fails the check closed. Implementations must be safe
+// for concurrent use.
+type Scorer[T any] func(ctx context.Context, input T) (float64, error)
+
+// Score is the combined result of one evaluation, with per-scorer
+// attribution. Indexes refer to scorer registration order.
+type Score struct {
+	// Scores holds every scorer's value in registration order.
+	Scores []float64
+	// Value is the strategy-combined score compared against the gate.
+	Value float64
+	// Peak is the highest individual scorer value.
+	Peak float64
+	// PeakIdx is the index of the scorer that produced Peak.
+	PeakIdx int
+}
+
+// Engine gates inputs on their combined fraud score. Build with New;
+// immutable and concurrent-safe afterwards.
+type Engine[T any] struct {
+	// scratch pools the per-Check scores buffer so the pass path — every
+	// legitimate request — allocates nothing; attribution is copied out only
+	// on a trip (see bench_test.go).
+	scratch  sync.Pool
+	onFraud  func(ctx context.Context, input T, score Score) error
+	strategy Strategy
+	scorers  []Scorer[T]
+	weights  []float64 // normalized; nil unless WithWeights
+	gate     float64
+}
+
+// New validates the options and builds an Engine. At least one WithScorer and
+// a WithGate in (0, 1] are required. Errors: ErrNoScorers, ErrNilScorer,
+// ErrInvalidGate, ErrNilStrategy, ErrInvalidWeights, ErrStrategyConflict.
+func New[T any](opts ...Option[T]) (*Engine[T], error) {
+	var cfg config[T]
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if len(cfg.scorers) == 0 {
+		return nil, ErrNoScorers
+	}
+	for i, s := range cfg.scorers {
+		if s == nil {
+			return nil, fmt.Errorf("%w: index %d", ErrNilScorer, i)
+		}
+	}
+	if !(cfg.gate > 0 && cfg.gate <= 1) { // NaN fails both comparisons
+		return nil, fmt.Errorf("%w: got %v", ErrInvalidGate, cfg.gate)
+	}
+	if cfg.strategySet && cfg.weightsSet {
+		return nil, ErrStrategyConflict
+	}
+	if cfg.strategySet && cfg.strategy == nil {
+		return nil, ErrNilStrategy
+	}
+	n := len(cfg.scorers)
+	e := &Engine[T]{
+		onFraud:  cfg.onFraud,
+		strategy: cfg.strategy,
+		scorers:  cfg.scorers,
+		gate:     cfg.gate,
+		scratch: sync.Pool{New: func() any {
+			s := make([]float64, n)
+			return &s
+		}},
+	}
+	if cfg.weightsSet {
+		w, err := normalizeWeights(cfg.weights, len(cfg.scorers))
+		if err != nil {
+			return nil, err
+		}
+		e.weights = w
+	}
+	if e.strategy == nil && e.weights == nil {
+		e.strategy = Max
+	}
+	return e, nil
+}
+
+// Check evaluates input and gates the combined score. It returns nil to
+// proceed. On score >= gate: with no OnFraud handler it returns a *FraudError
+// (errors.Is-matchable against ErrFraud); with a handler it returns the
+// handler's result verbatim — nil proceeds (shadow mode), an error blocks.
+// Scorer errors, invalid scores, and context cancellation fail closed with
+// the underlying error.
+func (e *Engine[T]) Check(ctx context.Context, input T) error {
+	buf := e.scratch.Get().(*[]float64)
+	sc, err := e.evaluate(ctx, input, *buf)
+	if err != nil || sc.Value < e.gate {
+		e.scratch.Put(buf)
+		return err
+	}
+	sc.Scores = slices.Clone(sc.Scores) // detach attribution from the pooled buffer
+	e.scratch.Put(buf)
+	if e.onFraud != nil {
+		return e.onFraud(ctx, input, sc)
+	}
+	return &FraudError{Score: sc}
+}
+
+// Score evaluates input and returns the combined score without gating — for
+// telemetry, hit tagging, and tuning the gate in shadow mode.
+func (e *Engine[T]) Score(ctx context.Context, input T) (Score, error) {
+	return e.evaluate(ctx, input, make([]float64, len(e.scorers)))
+}
+
+// evaluate runs every scorer in registration order — all of them, no
+// short-circuit, so attribution is complete and consumer scorer side effects
+// do not vary with registration order — and combines the results into scores,
+// which the returned Score aliases.
+func (e *Engine[T]) evaluate(ctx context.Context, input T, scores []float64) (Score, error) {
+	peak, peakIdx := -1.0, 0
+	for i, s := range e.scorers {
+		if err := ctx.Err(); err != nil {
+			return Score{}, err
+		}
+		v, err := s(ctx, input)
+		if err != nil {
+			return Score{}, fmt.Errorf("risk: scorer %d: %w", i, err)
+		}
+		if !validScore(v) {
+			return Score{}, fmt.Errorf("%w: scorer %d returned %v", ErrInvalidScore, i, v)
+		}
+		scores[i] = v
+		if v > peak {
+			peak, peakIdx = v, i
+		}
+	}
+	var value float64
+	if e.weights != nil {
+		for i, v := range scores {
+			value += e.weights[i] * v
+		}
+		value = clamp01(value) // float rounding only; inputs are validated
+	} else {
+		value = e.strategy(scores)
+		if !validScore(value) {
+			return Score{}, fmt.Errorf("%w: strategy returned %v", ErrInvalidScore, value)
+		}
+	}
+	return Score{Scores: scores, Value: value, Peak: peak, PeakIdx: peakIdx}, nil
+}
+
+// validScore reports whether v is a usable probability. NaN and infinities
+// fail both comparisons.
+func validScore(v float64) bool { return v >= 0 && v <= 1 }
+
+func clamp01(v float64) float64 {
+	return min(1, max(0, v))
+}

--- a/web/risk/risk_test.go
+++ b/web/risk/risk_test.go
@@ -1,0 +1,387 @@
+package risk_test
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/dmitrymomot/forge/web/risk"
+)
+
+// constScorer returns v unconditionally.
+func constScorer(v float64) risk.Scorer[string] {
+	return func(context.Context, string) (float64, error) { return v, nil }
+}
+
+func TestNewValidation(t *testing.T) {
+	t.Parallel()
+
+	scorer := constScorer(0.5)
+
+	tests := []struct {
+		name string
+		opts []risk.Option[string]
+		want error
+	}{
+		{"no scorers", []risk.Option[string]{risk.WithGate[string](0.8)}, risk.ErrNoScorers},
+		{"nil scorer", []risk.Option[string]{risk.WithScorer[string](nil), risk.WithGate[string](0.8)}, risk.ErrNilScorer},
+		{"missing gate", []risk.Option[string]{risk.WithScorer(scorer)}, risk.ErrInvalidGate},
+		{"gate zero", []risk.Option[string]{risk.WithScorer(scorer), risk.WithGate[string](0)}, risk.ErrInvalidGate},
+		{"gate negative", []risk.Option[string]{risk.WithScorer(scorer), risk.WithGate[string](-0.1)}, risk.ErrInvalidGate},
+		{"gate above one", []risk.Option[string]{risk.WithScorer(scorer), risk.WithGate[string](1.1)}, risk.ErrInvalidGate},
+		{"gate NaN", []risk.Option[string]{risk.WithScorer(scorer), risk.WithGate[string](math.NaN())}, risk.ErrInvalidGate},
+		{"nil strategy", []risk.Option[string]{risk.WithScorer(scorer), risk.WithGate[string](0.8), risk.WithStrategy[string](nil)}, risk.ErrNilStrategy},
+		{"strategy conflict", []risk.Option[string]{risk.WithScorer(scorer), risk.WithGate[string](0.8), risk.WithStrategy[string](risk.Mean), risk.WithWeights[string](1)}, risk.ErrStrategyConflict},
+		{"weights arity", []risk.Option[string]{risk.WithScorer(scorer), risk.WithGate[string](0.8), risk.WithWeights[string](1, 2)}, risk.ErrInvalidWeights},
+		{"weight negative", []risk.Option[string]{risk.WithScorer(scorer), risk.WithGate[string](0.8), risk.WithWeights[string](-1)}, risk.ErrInvalidWeights},
+		{"weight NaN", []risk.Option[string]{risk.WithScorer(scorer), risk.WithGate[string](0.8), risk.WithWeights[string](math.NaN())}, risk.ErrInvalidWeights},
+		{"weights zero sum", []risk.Option[string]{risk.WithScorer(scorer), risk.WithScorer(scorer), risk.WithGate[string](0.8), risk.WithWeights[string](0, 0)}, risk.ErrInvalidWeights},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := risk.New(tt.opts...)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("New() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		e, err := risk.New(risk.WithScorer(scorer), risk.WithGate[string](1))
+		if err != nil || e == nil {
+			t.Fatalf("New() = %v, %v; want engine, nil", e, err)
+		}
+	})
+}
+
+func TestCheckPass(t *testing.T) {
+	t.Parallel()
+	e, err := risk.New(
+		risk.WithScorer(constScorer(0.1)),
+		risk.WithScorer(constScorer(0.79)),
+		risk.WithGate[string](0.8),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Check(context.Background(), "visit"); err != nil {
+		t.Fatalf("Check() = %v, want nil", err)
+	}
+}
+
+func TestCheckTripNoHandler(t *testing.T) {
+	t.Parallel()
+	e, err := risk.New(
+		risk.WithScorer(constScorer(0.2)),
+		risk.WithScorer(constScorer(0.9)),
+		risk.WithScorer(constScorer(0.5)),
+		risk.WithGate[string](0.8),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = e.Check(context.Background(), "visit")
+	if !errors.Is(err, risk.ErrFraud) {
+		t.Fatalf("Check() = %v, want ErrFraud match", err)
+	}
+	fraud, ok := errors.AsType[*risk.FraudError](err)
+	if !ok {
+		t.Fatalf("Check() = %T, want *FraudError", err)
+	}
+	sc := fraud.Score
+	if sc.Value != 0.9 || sc.Peak != 0.9 || sc.PeakIdx != 1 {
+		t.Errorf("Score = %+v, want Value 0.9, Peak 0.9, PeakIdx 1", sc)
+	}
+	want := []float64{0.2, 0.9, 0.5}
+	if len(sc.Scores) != len(want) {
+		t.Fatalf("Scores = %v, want %v", sc.Scores, want)
+	}
+	for i, v := range want {
+		if sc.Scores[i] != v {
+			t.Errorf("Scores[%d] = %v, want %v", i, sc.Scores[i], v)
+		}
+	}
+}
+
+func TestCheckGateBoundaryInclusive(t *testing.T) {
+	t.Parallel()
+	e, err := risk.New(risk.WithScorer(constScorer(0.8)), risk.WithGate[string](0.8))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Check(context.Background(), "visit"); !errors.Is(err, risk.ErrFraud) {
+		t.Fatalf("Check() at score == gate = %v, want ErrFraud match", err)
+	}
+}
+
+func TestOnFraudNilProceeds(t *testing.T) {
+	t.Parallel()
+	called := false
+	e, err := risk.New(
+		risk.WithScorer(constScorer(0.9)),
+		risk.WithGate[string](0.8),
+		risk.OnFraud(func(_ context.Context, input string, sc risk.Score) error {
+			called = true
+			if input != "visit" {
+				t.Errorf("handler input = %q, want %q", input, "visit")
+			}
+			if sc.Value != 0.9 {
+				t.Errorf("handler score = %v, want 0.9", sc.Value)
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Check(context.Background(), "visit"); err != nil {
+		t.Fatalf("Check() with nil-returning handler = %v, want nil", err)
+	}
+	if !called {
+		t.Fatal("OnFraud handler was not called")
+	}
+}
+
+func TestOnFraudErrorBlocksVerbatim(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("diverted")
+	e, err := risk.New(
+		risk.WithScorer(constScorer(0.9)),
+		risk.WithGate[string](0.8),
+		risk.OnFraud(func(context.Context, string, risk.Score) error { return sentinel }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = e.Check(context.Background(), "visit")
+	if err != sentinel { //nolint:errorlint // verbatim identity is the contract
+		t.Fatalf("Check() = %v, want handler error verbatim", err)
+	}
+	if errors.Is(err, risk.ErrFraud) {
+		t.Fatal("handler error must not be wrapped in FraudError")
+	}
+}
+
+func TestOnFraudNotCalledBelowGate(t *testing.T) {
+	t.Parallel()
+	e, err := risk.New(
+		risk.WithScorer(constScorer(0.5)),
+		risk.WithGate[string](0.8),
+		risk.OnFraud(func(context.Context, string, risk.Score) error {
+			t.Error("OnFraud called below gate")
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Check(context.Background(), "visit"); err != nil {
+		t.Fatalf("Check() = %v, want nil", err)
+	}
+}
+
+func TestAllScorersRunNoShortCircuit(t *testing.T) {
+	t.Parallel()
+	var order []int
+	scorer := func(i int, v float64) risk.Scorer[string] {
+		return func(context.Context, string) (float64, error) {
+			order = append(order, i)
+			return v, nil
+		}
+	}
+	e, err := risk.New(
+		risk.WithScorer(scorer(0, 0.95)), // already >= gate
+		risk.WithScorer(scorer(1, 0.1)),
+		risk.WithScorer(scorer(2, 0.2)),
+		risk.WithGate[string](0.8),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Check(context.Background(), "visit"); !errors.Is(err, risk.ErrFraud) {
+		t.Fatalf("Check() = %v, want ErrFraud match", err)
+	}
+	if len(order) != 3 || order[0] != 0 || order[1] != 1 || order[2] != 2 {
+		t.Fatalf("scorer call order = %v, want [0 1 2]", order)
+	}
+}
+
+func TestScorerErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("lookup down")
+	e, err := risk.New(
+		risk.WithScorer(constScorer(0.1)),
+		risk.WithScorer(func(context.Context, string) (float64, error) { return 0, boom }),
+		risk.WithGate[string](0.8),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = e.Check(context.Background(), "visit")
+	if !errors.Is(err, boom) {
+		t.Fatalf("Check() = %v, want wrapped scorer error", err)
+	}
+	if errors.Is(err, risk.ErrFraud) {
+		t.Fatal("scorer error must not match ErrFraud")
+	}
+}
+
+func TestInvalidScorerOutputFailsClosed(t *testing.T) {
+	t.Parallel()
+	for _, bad := range []float64{math.NaN(), math.Inf(1), math.Inf(-1), -0.1, 1.1} {
+		e, err := risk.New(risk.WithScorer(constScorer(bad)), risk.WithGate[string](0.8))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := e.Check(context.Background(), "visit"); !errors.Is(err, risk.ErrInvalidScore) {
+			t.Errorf("Check() with scorer output %v = %v, want ErrInvalidScore", bad, err)
+		}
+	}
+}
+
+func TestInvalidCustomStrategyOutputFailsClosed(t *testing.T) {
+	t.Parallel()
+	e, err := risk.New(
+		risk.WithScorer(constScorer(0.5)),
+		risk.WithGate[string](0.8),
+		risk.WithStrategy[string](func([]float64) float64 { return math.NaN() }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Check(context.Background(), "visit"); !errors.Is(err, risk.ErrInvalidScore) {
+		t.Fatalf("Check() with NaN strategy = %v, want ErrInvalidScore", err)
+	}
+}
+
+func TestContextCancellationBetweenScorers(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	secondRan := false
+	e, err := risk.New(
+		risk.WithScorer(func(context.Context, string) (float64, error) {
+			cancel()
+			return 0.1, nil
+		}),
+		risk.WithScorer(func(context.Context, string) (float64, error) {
+			secondRan = true
+			return 0.1, nil
+		}),
+		risk.WithGate[string](0.8),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Check(ctx, "visit"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Check() = %v, want context.Canceled", err)
+	}
+	if secondRan {
+		t.Fatal("second scorer ran after cancellation")
+	}
+}
+
+func TestScoreNoGating(t *testing.T) {
+	t.Parallel()
+	e, err := risk.New(
+		risk.WithScorer(constScorer(0.95)), // above gate — Score must not care
+		risk.WithScorer(constScorer(0.3)),
+		risk.WithGate[string](0.8),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc, err := e.Score(context.Background(), "visit")
+	if err != nil {
+		t.Fatalf("Score() = %v, want nil", err)
+	}
+	if sc.Value != 0.95 || sc.Peak != 0.95 || sc.PeakIdx != 0 {
+		t.Errorf("Score = %+v, want Value 0.95, Peak 0.95, PeakIdx 0", sc)
+	}
+}
+
+func TestStrategies(t *testing.T) {
+	t.Parallel()
+
+	t.Run("max default", func(t *testing.T) {
+		t.Parallel()
+		e, err := risk.New(
+			risk.WithScorer(constScorer(0.3)),
+			risk.WithScorer(constScorer(0.6)),
+			risk.WithGate[string](0.5),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sc, err := e.Score(context.Background(), "v")
+		if err != nil || sc.Value != 0.6 {
+			t.Fatalf("Score() = %+v, %v; want Value 0.6 (Max default)", sc, err)
+		}
+	})
+
+	t.Run("mean", func(t *testing.T) {
+		t.Parallel()
+		e, err := risk.New(
+			risk.WithScorer(constScorer(0.2)),
+			risk.WithScorer(constScorer(0.6)),
+			risk.WithGate[string](0.5),
+			risk.WithStrategy[string](risk.Mean),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sc, err := e.Score(context.Background(), "v")
+		if err != nil || math.Abs(sc.Value-0.4) > 1e-12 {
+			t.Fatalf("Score() = %+v, %v; want Value 0.4 (Mean)", sc, err)
+		}
+	})
+
+	t.Run("weights normalized", func(t *testing.T) {
+		t.Parallel()
+		// Weights 1,3 normalize to 0.25/0.75: 0.25*0.4 + 0.75*0.8 = 0.7.
+		e, err := risk.New(
+			risk.WithScorer(constScorer(0.4)),
+			risk.WithScorer(constScorer(0.8)),
+			risk.WithGate[string](0.9),
+			risk.WithWeights[string](1, 3),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sc, err := e.Score(context.Background(), "v")
+		if err != nil || math.Abs(sc.Value-0.7) > 1e-12 {
+			t.Fatalf("Score() = %+v, %v; want Value 0.7", sc, err)
+		}
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		t.Parallel()
+		e, err := risk.New(
+			risk.WithScorer(constScorer(0.3)),
+			risk.WithScorer(constScorer(0.5)),
+			risk.WithGate[string](0.5),
+			risk.WithStrategy[string](func(scores []float64) float64 { return scores[0] }),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sc, err := e.Score(context.Background(), "v")
+		if err != nil || sc.Value != 0.3 {
+			t.Fatalf("Score() = %+v, %v; want Value 0.3 (custom)", sc, err)
+		}
+	})
+}
+
+func TestFraudErrorMessage(t *testing.T) {
+	t.Parallel()
+	e, err := risk.New(risk.WithScorer(constScorer(0.9)), risk.WithGate[string](0.8))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = e.Check(context.Background(), "visit")
+	if err == nil || err.Error() == "" {
+		t.Fatalf("FraudError message empty, err = %v", err)
+	}
+}

--- a/web/risk/strategies.go
+++ b/web/risk/strategies.go
@@ -1,0 +1,57 @@
+package risk
+
+import (
+	"fmt"
+	"math"
+)
+
+// Strategy combines per-scorer scores into one value in [0, 1]. New
+// guarantees at least one score. Built-ins: Max (default) and Mean; a
+// weighted average is configured with WithWeights, not a Strategy, so its
+// arity is validated in New. A custom Strategy returning NaN or a value
+// outside [0, 1] fails the check closed.
+type Strategy func(scores []float64) float64
+
+// Max returns the highest score — the default strategy. Fraud signals are
+// not additive: one strong signal must not be diluted by weak ones.
+func Max(scores []float64) float64 {
+	peak := scores[0]
+	for _, v := range scores[1:] {
+		if v > peak {
+			peak = v
+		}
+	}
+	return peak
+}
+
+// Mean returns the arithmetic mean of the scores.
+func Mean(scores []float64) float64 {
+	sum := 0.0
+	for _, v := range scores {
+		sum += v
+	}
+	return clamp01(sum / float64(len(scores)))
+}
+
+// normalizeWeights validates WithWeights values against the scorer count and
+// returns them scaled to sum to 1, so Weighted(1, 3) means 25%/75%.
+func normalizeWeights(weights []float64, scorers int) ([]float64, error) {
+	if len(weights) != scorers {
+		return nil, fmt.Errorf("%w: %d weights for %d scorers", ErrInvalidWeights, len(weights), scorers)
+	}
+	sum := 0.0
+	for i, w := range weights {
+		if math.IsNaN(w) || math.IsInf(w, 0) || w < 0 {
+			return nil, fmt.Errorf("%w: weight %d is %v", ErrInvalidWeights, i, w)
+		}
+		sum += w
+	}
+	if sum <= 0 {
+		return nil, fmt.Errorf("%w: weights sum to zero", ErrInvalidWeights)
+	}
+	normalized := make([]float64, len(weights))
+	for i, w := range weights {
+		normalized[i] = w / sum
+	}
+	return normalized, nil
+}


### PR DESCRIPTION
## What

New package `web/risk`: a generic anti-fraud gate. Consumer-supplied scorer functions each return a fraud probability in [0, 1] for an input `T`, a combining strategy folds them into one score, and a threshold gate decides whether the call proceeds. The package owns combining, gating, and error flow only — all fraud logic (useragent checks, fingerprint mismatch, velocity, geo) stays in consumer scorers wired from `web/useragent` / `web/fingerprint` / `web/geoip` / `web/clientip`. Design doc: `docs/superpowers/specs/2026-07-21-web-risk-design.md`.

## API

- `New[T](WithScorer(...), WithGate(0.8), ...)` → immutable, concurrent-safe `Engine[T]`; `Check(ctx, input) error` (nil = proceed), `Score(ctx, input)` (no gating — telemetry / shadow tuning).
- Strategies: `Max` (default — fraud signals are not additive, one strong signal must not be diluted), `Mean`, `WithWeights(1, 3)` normalized weighted average (arity validated in `New`, which is why it is an option, not a `Strategy` value), or any custom `func([]float64) float64`.
- Gate trip (`score >= gate`, boundary inclusive): with no handler, returns `*FraudError` carrying per-scorer attribution (`Peak`/`PeakIdx`/`Scores`), matchable via `errors.Is(err, ErrFraud)`. With `OnFraud`, the handler's return decides: nil proceeds (shadow mode / divert-and-allow), error blocks verbatim.
- `Middleware(engine, buildInput, ...)` adapts to `net/http` per the sibling middleware pattern: default plain 403 on any `Check` failure (fraud and scorer infrastructure errors alike — fail closed), `WithRejectHandler` seam for decoy redirects / problem responses, `WithLogger` defaulting to `logger.NewNope()`.

## Semantics worth reviewing

- **Fail closed everywhere:** scorer error, NaN, ±Inf, or out-of-range score → check fails with the underlying error, never clamped or skipped (a NaN comparing false against the gate is the `auth/lockout` NaN hole). Custom strategy output is validated the same way; built-ins clamp float rounding only.
- **All scorers always run, in registration order, no short-circuit** — attribution stays complete and consumer scorer side effects don't vary with registration order. `ctx.Err()` checked between scorers.
- **Tenancy** is a passed value, not a seam (`core/phone` precedent): pure compute, no storage — tenant travels inside `T` or the consumer builds per-tenant engines.
- Fits the seam `web/smartlink` left consumer-side: a `Decider` decorator calling `Check` (pure scorers) for fraud diversion, `Middleware` in front of the redirect handler for I/O scorers, `Score` in `OnHit` for shadow tagging.

## Benchmarks (Apple M3 Max, before → after pooled scratch buffer)

| Benchmark | baseline | after | allocs |
|---|---|---|---|
| CheckPass/1scorer | 14.27 ns/op | 14.10 ns/op | 1 → **0** |
| CheckPass/4scorers | 25.86 ns/op | 21.67 ns/op | 1 → **0** |
| CheckPass/16scorers | 64.25 ns/op | 59.49 ns/op | 1 → **0** |
| CheckPassMean | 25.97 ns/op | 21.82 ns/op | 1 → **0** |
| CheckPassWeighted | 25.20 ns/op | 21.35 ns/op | 1 → **0** |
| CheckTrip | 46.74 ns/op | 55.68 ns/op | 2 → 2 |
| Score | 25.81 ns/op | 25.92 ns/op | 1 → 1 |
| MiddlewarePass | 32.28 ns/op | 26.82 ns/op | 1 → **0** |

Optimization: `Check` evaluates into a `sync.Pool`-ed scratch slice; the pass path (every legitimate request) allocates nothing, and `Score.Scores` attribution is cloned out of the pooled buffer only on a trip. Trip path pays ~9 ns for the pool round-trip + clone — the rare path by construction.

## Tests

Black-box in `risk_test`: `New` validation matrix, gate boundary, handler nil-proceeds vs error-blocks-verbatim, no-short-circuit ordering, fail-closed matrix (scorer error / NaN / ±Inf / out-of-range / custom-strategy NaN / ctx cancellation), strategy math + weight normalization, middleware pass/403/override/shadow/panic paths, fuzz on the weighted-average invariant (3.3M execs clean), runnable example. `-race` clean, `just lint` clean (incl. nilaway).