### PR TITLE
realtime/fanout: in-process pub/sub hub with pgbus/redisbus backplanes

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -192,19 +192,7 @@ handling, Last-Event-ID resume via the replay ring. The low-level writer
 stays exported as the brick under `web/htmx`'s SendComponent bridge and
 `llm.SSE`. Requires httpserver WriteTimeout=0 (documented).
 
-Deps: `realtime/fanout` (planned).
-
----
-
-**realtime/fanout**
-
-In-process pub/sub hub (bounded buffers, explicit slow-consumer policy)
-with the `Bus` seam for multi-instance backplanes and an optional bounded
-`WithReplay(n)` ring. Drivers: `fanout/pgbus` (LISTEN/NOTIFY — multi-
-instance push with zero new infrastructure), `fanout/redisbus` (takes the
-caller's `data/redis` client).
-
-Deps: drivers ride `data/postgres`, `data/redis`.
+Deps: `realtime/fanout`.
 
 ---
 
@@ -225,7 +213,7 @@ Deps: `ops/supervisor` (coder/websocket external).
 Who-is-here tracking with TTL heartbeats over `fanout` + `cache` — online
 indicators, concurrent-viewer counts.
 
-Deps: `resilience/cache`; `realtime/fanout` (planned).
+Deps: `resilience/cache`; `realtime/fanout`.
 
 ## auth/
 

--- a/realtime/fanout/bench_test.go
+++ b/realtime/fanout/bench_test.go
@@ -1,0 +1,148 @@
+package fanout_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/dmitrymomot/forge/realtime/fanout"
+)
+
+// drain consumes a subscription as fast as possible until its channel
+// closes.
+func drain(sub *fanout.Subscription) {
+	for range sub.C() {
+	}
+}
+
+func BenchmarkPublish(b *testing.B) {
+	ctx := context.Background()
+	payload := []byte(`{"text":"hi"}`)
+
+	for _, subs := range []int{1, 8, 64} {
+		b.Run(strconv.Itoa(subs)+"subs", func(b *testing.B) {
+			hub, err := fanout.New(fanout.WithDefaultBuffer(1024))
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer hub.Close()
+			for range subs {
+				sub, err := hub.Subscribe(ctx, []string{"t"})
+				if err != nil {
+					b.Fatal(err)
+				}
+				go drain(sub)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if err := hub.Publish(ctx, "t", payload); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkPublishNoSubscribers(b *testing.B) {
+	ctx := context.Background()
+	hub, err := fanout.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer hub.Close()
+	payload := []byte("x")
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := hub.Publish(ctx, "nobody", payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPublishReplay(b *testing.B) {
+	ctx := context.Background()
+	hub, err := fanout.New(fanout.WithReplay(64))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer hub.Close()
+	sub, err := hub.Subscribe(ctx, []string{"t"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	go drain(sub)
+	payload := []byte("x")
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := hub.Publish(ctx, "t", payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPublishScoped(b *testing.B) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "tenant-1")
+	hub, err := fanout.New(fanout.WithScope(func(ctx context.Context) (string, error) {
+		s, _ := ctx.Value(key{}).(string)
+		return s, nil
+	}))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer hub.Close()
+	sub, err := hub.Subscribe(ctx, []string{"t"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	go drain(sub)
+	payload := []byte("x")
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := hub.Publish(ctx, "t", payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSubscribeClose(b *testing.B) {
+	ctx := context.Background()
+	hub, err := fanout.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer hub.Close()
+	topics := []string{"t"}
+	b.ReportAllocs()
+	for b.Loop() {
+		sub, err := hub.Subscribe(ctx, topics)
+		if err != nil {
+			b.Fatal(err)
+		}
+		sub.Close()
+	}
+}
+
+func BenchmarkResume(b *testing.B) {
+	ctx := context.Background()
+	hub, err := fanout.New(fanout.WithReplay(64))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer hub.Close()
+	for i := range 64 {
+		if err := hub.Publish(ctx, "t", []byte{byte(i)}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	topics := []string{"t"}
+	b.ReportAllocs()
+	for b.Loop() {
+		sub, err := hub.Subscribe(ctx, topics, fanout.WithResumeAfter(0), fanout.WithBuffer(64))
+		if err != nil {
+			b.Fatal(err)
+		}
+		sub.Close()
+	}
+}

--- a/realtime/fanout/bus.go
+++ b/realtime/fanout/bus.go
@@ -1,0 +1,24 @@
+package fanout
+
+import "context"
+
+// Bus is the multi-instance backplane seam. A hub built with WithBus routes
+// every Publish through Bus.Publish and delivers to its local subscribers
+// only from the bus receive path, so all instances observe one ordering and
+// one loss profile.
+//
+// Contract for implementations: Publish broadcasts the message to every
+// instance's handler, including the publishing instance's own. Subscribe
+// registers the single delivery callback, replacing any previous one — a bus
+// instance backs exactly one hub. The callback must be invoked sequentially
+// per bus instance; it is fast and non-blocking (bounded-buffer sends only).
+// Delivery is at-most-once: messages published while an instance's receive
+// loop is down are lost to that instance.
+//
+// Drivers: fanout/pgbus (Postgres LISTEN/NOTIFY), fanout/redisbus (Redis
+// Pub/Sub). Both also implement supervisor.Service — their Run loop is the
+// receive path.
+type Bus interface {
+	Publish(ctx context.Context, topic string, payload []byte) error
+	Subscribe(fn func(topic string, payload []byte))
+}

--- a/realtime/fanout/bus_test.go
+++ b/realtime/fanout/bus_test.go
@@ -1,0 +1,127 @@
+package fanout_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/realtime/fanout"
+)
+
+// fakeBus is an in-memory fanout.Bus connecting any number of hubs, standing
+// in for pgbus/redisbus.
+type fakeBus struct {
+	mu       sync.Mutex
+	handlers []func(topic string, payload []byte)
+	err      error
+}
+
+func (b *fakeBus) Publish(_ context.Context, topic string, payload []byte) error {
+	b.mu.Lock()
+	handlers := append([]func(string, []byte){}, b.handlers...)
+	err := b.err
+	b.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	for _, fn := range handlers {
+		fn(topic, payload)
+	}
+	return nil
+}
+
+func (b *fakeBus) Subscribe(fn func(topic string, payload []byte)) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.handlers = append(b.handlers, fn)
+}
+
+func (b *fakeBus) fail(err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.err = err
+}
+
+func TestBus(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("delivery spans hubs including the publisher's own", func(t *testing.T) {
+		t.Parallel()
+		bus := &fakeBus{}
+		hub1, err := fanout.New(fanout.WithBus(bus))
+		require.NoError(t, err)
+		defer hub1.Close()
+		hub2, err := fanout.New(fanout.WithBus(bus))
+		require.NoError(t, err)
+		defer hub2.Close()
+
+		local, err := hub1.Subscribe(ctx, []string{"t"})
+		require.NoError(t, err)
+		defer local.Close()
+		remote, err := hub2.Subscribe(ctx, []string{"t"})
+		require.NoError(t, err)
+		defer remote.Close()
+
+		require.NoError(t, hub1.Publish(ctx, "t", []byte("x")))
+		assert.Equal(t, []byte("x"), recv(t, local).Payload)
+		assert.Equal(t, []byte("x"), recv(t, remote).Payload)
+	})
+
+	t.Run("bus publish error propagates", func(t *testing.T) {
+		t.Parallel()
+		bus := &fakeBus{}
+		hub, err := fanout.New(fanout.WithBus(bus))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		boom := errors.New("bus down")
+		bus.fail(boom)
+		assert.ErrorIs(t, hub.Publish(ctx, "t", []byte("x")), boom)
+	})
+
+	t.Run("scope rides the bus", func(t *testing.T) {
+		t.Parallel()
+		bus := &fakeBus{}
+		hub1, err := fanout.New(fanout.WithBus(bus), fanout.WithScope(tenantScope))
+		require.NoError(t, err)
+		defer hub1.Close()
+		hub2, err := fanout.New(fanout.WithBus(bus), fanout.WithScope(tenantScope))
+		require.NoError(t, err)
+		defer hub2.Close()
+
+		alpha, err := hub2.Subscribe(tenantCtx("alpha"), []string{"orders"})
+		require.NoError(t, err)
+		defer alpha.Close()
+		beta, err := hub2.Subscribe(tenantCtx("beta"), []string{"orders"})
+		require.NoError(t, err)
+		defer beta.Close()
+
+		require.NoError(t, hub1.Publish(tenantCtx("alpha"), "orders", []byte("a")))
+		msg := recv(t, alpha)
+		assert.Equal(t, "orders", msg.Topic)
+		select {
+		case m := <-beta.C():
+			t.Fatalf("cross-tenant delivery over bus: %+v", m)
+		case <-time.After(50 * time.Millisecond):
+		}
+	})
+
+	t.Run("closed hub ignores bus deliveries", func(t *testing.T) {
+		t.Parallel()
+		bus := &fakeBus{}
+		hub, err := fanout.New(fanout.WithBus(bus), fanout.WithReplay(4))
+		require.NoError(t, err)
+		hub.Close()
+
+		// Dispatch directly, as a driver would after the hub shut down.
+		for _, fn := range bus.handlers {
+			fn("t", []byte("late"))
+		}
+	})
+}

--- a/realtime/fanout/doc.go
+++ b/realtime/fanout/doc.go
@@ -1,0 +1,63 @@
+// Package fanout is the in-process publish/subscribe hub behind forge's
+// realtime packages: ephemeral, at-most-once fan-out of byte payloads to
+// currently-connected subscribers. Delivery never blocks a publisher — every
+// subscriber owns a bounded buffer with an explicit overflow policy — and
+// nothing survives a restart. Durable, at-least-once messaging is async/
+// eventbus; fanout is the push side of live UI: SSE streams, WebSocket
+// broadcasts, presence.
+//
+// # Usage
+//
+//	hub, _ := fanout.New()
+//	defer hub.Close()
+//
+//	sub, _ := hub.Subscribe(ctx, []string{"chat.42"})
+//	defer sub.Close()
+//	go func() {
+//		for msg := range sub.C() {
+//			render(msg.Topic, msg.Payload)
+//		}
+//	}()
+//
+//	_ = hub.Publish(ctx, "chat.42", []byte(`{"text":"hi"}`))
+//
+// Publishing to a topic with no subscribers delivers nothing and is not an
+// error. Payloads are delivered by reference: subscribers must not mutate
+// Message.Payload.
+//
+// # Slow consumers
+//
+// A subscriber that does not drain its buffer never blocks the hub. The
+// overflow policy — hub-wide via WithDefaultPolicy, per-subscription via
+// WithPolicy — decides what happens instead: DropOldest (default) evicts the
+// oldest buffered message, DropNewest discards the incoming one, CloseSlow
+// tears the subscription down (its channel closes and Err reports
+// ErrSlowConsumer). Every dropped message is counted on
+// Subscription.Dropped.
+//
+// # Replay and resume
+//
+// WithReplay(n) keeps a per-topic ring of the last n messages so a
+// reconnecting client can resume: Subscribe with WithResumeAfter(id) first
+// delivers the buffered messages with ID greater than id, in order, then goes
+// live with no gap. Message IDs are monotonic per hub instance — they are the
+// Last-Event-ID currency for realtime/sse, not cross-instance or
+// cross-restart stable. Rings of topics with no subscribers are retained for
+// WithReplayTTL (default 5m) and then swept.
+//
+// # Multi-instance backplanes
+//
+// The Bus seam extends the hub across instances. With WithBus configured,
+// Publish routes through the bus only, and every instance — including the
+// publishing one — delivers to its local subscribers from the bus receive
+// path, so ordering and loss behavior are identical everywhere. Drivers:
+// fanout/pgbus (Postgres LISTEN/NOTIFY, zero new infrastructure) and
+// fanout/redisbus (Redis Pub/Sub on the caller's client). Both are
+// supervisor.Services; run them for the receive path to work.
+//
+// Multi-tenant apps configure WithScope; the returned tenant namespaces every
+// topic, so subscribers in one tenant can never observe another tenant's
+// messages — including across a shared Bus. Fail-closed: once configured, a
+// hook error or empty scope fails Publish and Subscribe with
+// ErrScopeMissing. Single-tenant apps do not configure it.
+package fanout

--- a/realtime/fanout/errors.go
+++ b/realtime/fanout/errors.go
@@ -1,0 +1,26 @@
+package fanout
+
+import "errors"
+
+var (
+	// ErrClosed is returned by Publish and Subscribe after Close, and reported
+	// by Subscription.Err when the hub shut the subscription down.
+	ErrClosed = errors.New("fanout: hub closed")
+	// ErrSlowConsumer is reported by Subscription.Err when the CloseSlow
+	// policy tore the subscription down because its buffer overflowed.
+	ErrSlowConsumer = errors.New("fanout: slow consumer")
+	// ErrInvalidTopic is returned for an empty topic or one containing the
+	// reserved bytes 0x00 or 0x1F.
+	ErrInvalidTopic = errors.New("fanout: invalid topic")
+	// ErrNoTopics is returned by Subscribe when called with no topics.
+	ErrNoTopics = errors.New("fanout: no topics")
+	// ErrScopeMissing is returned by Publish and Subscribe when a scope hook
+	// is configured and yields an error or empty scope.
+	ErrScopeMissing = errors.New("fanout: scope missing")
+	// ErrInvalidScope is returned when the scope hook yields a scope
+	// containing the reserved bytes 0x00 or 0x1F.
+	ErrInvalidScope = errors.New("fanout: invalid scope")
+	// ErrReplayDisabled is returned by Subscribe when WithResumeAfter is used
+	// on a hub built without WithReplay.
+	ErrReplayDisabled = errors.New("fanout: replay disabled")
+)

--- a/realtime/fanout/example_test.go
+++ b/realtime/fanout/example_test.go
@@ -1,0 +1,44 @@
+package fanout_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/realtime/fanout"
+)
+
+func Example() {
+	ctx := context.Background()
+
+	hub, err := fanout.New(fanout.WithReplay(16))
+	if err != nil {
+		panic(err)
+	}
+	defer hub.Close()
+
+	sub, err := hub.Subscribe(ctx, []string{"chat.42"})
+	if err != nil {
+		panic(err)
+	}
+	defer sub.Close()
+
+	if err := hub.Publish(ctx, "chat.42", []byte("hello")); err != nil {
+		panic(err)
+	}
+
+	msg := <-sub.C()
+	fmt.Println(msg.Topic, string(msg.Payload))
+
+	// A reconnecting client resumes from the replay ring with no gap.
+	resumed, err := hub.Subscribe(ctx, []string{"chat.42"}, fanout.WithResumeAfter(0))
+	if err != nil {
+		panic(err)
+	}
+	defer resumed.Close()
+	replay := <-resumed.C()
+	fmt.Println(replay.ID == msg.ID)
+
+	// Output:
+	// chat.42 hello
+	// true
+}

--- a/realtime/fanout/fanout.go
+++ b/realtime/fanout/fanout.go
@@ -86,15 +86,17 @@ func New(opts ...Option) (*Hub, error) {
 // the message routes through the bus and local delivery happens on the bus
 // receive path; the returned error is then the bus publish error.
 func (h *Hub) Publish(ctx context.Context, topic string, payload []byte) error {
+	// Closed wins over every other error so a shut-down hub reports ErrClosed
+	// even when the scope hook would also fail.
+	if h.closed.Load() {
+		return ErrClosed
+	}
 	if err := validateTopic(topic); err != nil {
 		return err
 	}
 	key, err := h.key(ctx, topic)
 	if err != nil {
 		return err
-	}
-	if h.closed.Load() {
-		return ErrClosed
 	}
 	if h.bus != nil {
 		return h.bus.Publish(ctx, key, payload)

--- a/realtime/fanout/fanout.go
+++ b/realtime/fanout/fanout.go
@@ -114,6 +114,11 @@ func (h *Hub) Publish(ctx context.Context, topic string, payload []byte) error {
 //	if err != nil { ... }
 //	defer sub.Close()
 func (h *Hub) Subscribe(ctx context.Context, topics []string, opts ...SubscribeOption) (*Subscription, error) {
+	// Closed wins over every other error, mirroring Publish; the check under
+	// h.mu below remains the authoritative one.
+	if h.closed.Load() {
+		return nil, ErrClosed
+	}
 	if len(topics) == 0 {
 		return nil, ErrNoTopics
 	}

--- a/realtime/fanout/fanout.go
+++ b/realtime/fanout/fanout.go
@@ -1,0 +1,399 @@
+package fanout
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+// scopeSep joins a tenant scope and a topic into one registry key. It is
+// reserved: topics and scopes containing it (or NUL) are rejected.
+const scopeSep = '\x1f'
+
+// topicState is one topic's registry entry: its live subscribers and, with
+// replay enabled, the ring of its newest messages.
+type topicState struct {
+	lastPub time.Time
+	subs    map[*Subscription]struct{}
+	ring    *ring
+	topic   string
+	mu      sync.Mutex
+}
+
+// Hub is the in-process pub/sub hub. Construct with New; all methods are safe
+// for concurrent use.
+type Hub struct {
+	clk       clock.Clock
+	bus       Bus
+	scope     func(ctx context.Context) (string, error)
+	topics    map[string]*topicState
+	replayTTL time.Duration
+	buffer    int
+	replay    int
+	nextID    atomic.Uint64
+	lastSweep atomic.Int64
+	mu        sync.RWMutex
+	// closed is written under mu but read lock-free on the publish hot path.
+	closed atomic.Bool
+	policy OverflowPolicy
+}
+
+// New builds a Hub. It returns the accumulated option errors, if any, before
+// anything else. With WithBus configured it also registers the hub as the
+// bus's delivery target.
+func New(opts ...Option) (*Hub, error) {
+	c := &config{
+		clk:       clock.System(),
+		buffer:    defaultBuffer,
+		replayTTL: defaultReplayTTL,
+		policy:    DropOldest,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	if len(c.errs) > 0 {
+		return nil, errors.Join(c.errs...)
+	}
+	h := &Hub{
+		clk:       c.clk,
+		bus:       c.bus,
+		scope:     c.scope,
+		topics:    make(map[string]*topicState),
+		replayTTL: c.replayTTL,
+		buffer:    c.buffer,
+		replay:    c.replay,
+		policy:    c.policy,
+	}
+	h.lastSweep.Store(h.clk.Now().UnixNano())
+	if h.bus != nil {
+		h.bus.Subscribe(h.dispatch)
+	}
+	return h, nil
+}
+
+// Publish delivers payload to every current subscriber of topic,
+// at-most-once, never blocking: a full subscriber buffer takes that
+// subscription's overflow policy instead. Publishing to a topic with no
+// subscribers delivers nothing and is not an error. With a Bus configured
+// the message routes through the bus and local delivery happens on the bus
+// receive path; the returned error is then the bus publish error.
+func (h *Hub) Publish(ctx context.Context, topic string, payload []byte) error {
+	if err := validateTopic(topic); err != nil {
+		return err
+	}
+	key, err := h.key(ctx, topic)
+	if err != nil {
+		return err
+	}
+	if h.closed.Load() {
+		return ErrClosed
+	}
+	if h.bus != nil {
+		return h.bus.Publish(ctx, key, payload)
+	}
+	h.dispatch(key, payload)
+	return nil
+}
+
+// Subscribe registers a subscriber on one or more topics (duplicates are
+// collapsed) and returns its delivery stream. The context is used only to
+// resolve the tenant scope; the subscription lives until Close — callers own
+// its lifecycle:
+//
+//	sub, err := hub.Subscribe(ctx, []string{"chat.42"})
+//	if err != nil { ... }
+//	defer sub.Close()
+func (h *Hub) Subscribe(ctx context.Context, topics []string, opts ...SubscribeOption) (*Subscription, error) {
+	if len(topics) == 0 {
+		return nil, ErrNoTopics
+	}
+	sc := &subConfig{buffer: h.buffer, policy: h.policy}
+	for _, opt := range opts {
+		opt(sc)
+	}
+	if len(sc.errs) > 0 {
+		return nil, errors.Join(sc.errs...)
+	}
+	if sc.resume && h.replay == 0 {
+		return nil, ErrReplayDisabled
+	}
+	for _, t := range topics {
+		if err := validateTopic(t); err != nil {
+			return nil, err
+		}
+	}
+	keyed := make([]struct{ key, topic string }, 0, len(topics))
+	for _, t := range topics {
+		key, err := h.key(ctx, t)
+		if err != nil {
+			return nil, err
+		}
+		keyed = append(keyed, struct{ key, topic string }{key, t})
+	}
+	// Sorted unique keys give a stable multi-topic lock order.
+	slices.SortFunc(keyed, func(a, b struct{ key, topic string }) int { return strings.Compare(a.key, b.key) })
+	keyed = slices.CompactFunc(keyed, func(a, b struct{ key, topic string }) bool { return a.key == b.key })
+
+	sub := &Subscription{
+		hub:    h,
+		ch:     make(chan Message, sc.buffer),
+		policy: sc.policy,
+	}
+	h.mu.Lock()
+	if h.closed.Load() {
+		h.mu.Unlock()
+		return nil, ErrClosed
+	}
+	states := make([]*topicState, 0, len(keyed))
+	keys := make([]string, 0, len(keyed))
+	for _, kt := range keyed {
+		ts := h.topics[kt.key]
+		if ts == nil {
+			ts = h.newTopicState(kt.topic)
+			h.topics[kt.key] = ts
+		}
+		states = append(states, ts)
+		keys = append(keys, kt.key)
+	}
+	// Assign before registering: a publisher already waiting on a topic lock
+	// can tear the subscription down (CloseSlow) the moment it is visible,
+	// and that path reads states/keys.
+	sub.states = states
+	sub.keys = keys
+	for _, ts := range states {
+		ts.mu.Lock()
+	}
+	if sc.resume {
+		h.preload(sub, states, sc.resumeAfter)
+	}
+	for _, ts := range states {
+		ts.subs[sub] = struct{}{}
+		ts.mu.Unlock()
+	}
+	h.mu.Unlock()
+	return sub, nil
+}
+
+// Close shuts the hub down: every open subscription is torn down with
+// ErrClosed and further Publish/Subscribe calls fail with ErrClosed.
+// Idempotent.
+func (h *Hub) Close() {
+	h.mu.Lock()
+	if h.closed.Load() {
+		h.mu.Unlock()
+		return
+	}
+	h.closed.Store(true)
+	topics := h.topics
+	h.topics = make(map[string]*topicState)
+	h.mu.Unlock()
+
+	seen := make(map[*Subscription]struct{})
+	for _, ts := range topics {
+		ts.mu.Lock()
+		for sub := range ts.subs {
+			seen[sub] = struct{}{}
+		}
+		clear(ts.subs)
+		ts.mu.Unlock()
+	}
+	for sub := range seen {
+		sub.closeWith(ErrClosed)
+	}
+}
+
+// dispatch delivers one message locally. It is both the direct Publish path
+// (no bus) and the bus receive callback.
+func (h *Hub) dispatch(key string, payload []byte) {
+	ts := h.lookup(key)
+	if ts == nil {
+		return
+	}
+	var stale []*Subscription
+	ts.mu.Lock()
+	msg := Message{Topic: ts.topic, Payload: payload, ID: h.nextID.Add(1)}
+	if ts.ring != nil {
+		ts.ring.push(msg)
+		ts.lastPub = h.clk.Now()
+	}
+	for sub := range ts.subs {
+		if sub.send(msg) {
+			delete(ts.subs, sub)
+			stale = append(stale, sub)
+		}
+	}
+	empty := len(ts.subs) == 0 && ts.ring == nil
+	ts.mu.Unlock()
+	for _, sub := range stale {
+		h.removeSub(sub)
+	}
+	if empty {
+		h.gcTopic(key, ts)
+	}
+	if h.replay > 0 {
+		h.maybeSweep()
+	}
+}
+
+// lookup returns the topic's registry entry, creating one when replay is
+// enabled so late resubscribers can resume from the ring.
+func (h *Hub) lookup(key string) *topicState {
+	h.mu.RLock()
+	ts := h.topics[key]
+	h.mu.RUnlock()
+	if ts != nil || h.replay == 0 {
+		return ts
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed.Load() {
+		return nil
+	}
+	if ts = h.topics[key]; ts != nil {
+		return ts
+	}
+	ts = h.newTopicState(h.display(key))
+	h.topics[key] = ts
+	return ts
+}
+
+// newTopicState builds a registry entry for the given display topic. Callers
+// hold h.mu.
+func (h *Hub) newTopicState(topic string) *topicState {
+	ts := &topicState{
+		subs:    make(map[*Subscription]struct{}),
+		topic:   topic,
+		lastPub: h.clk.Now(),
+	}
+	if h.replay > 0 {
+		ts.ring = newRing(h.replay)
+	}
+	return ts
+}
+
+// preload merges the subscribed rings' backlog newer than after into the
+// subscription buffer, newest-window if it overflows. Callers hold h.mu and
+// every state's mutex, so no publish can slip between replay and going live.
+func (h *Hub) preload(sub *Subscription, states []*topicState, after uint64) {
+	var backlog []Message
+	for _, ts := range states {
+		if ts.ring != nil {
+			backlog = ts.ring.since(after, backlog)
+		}
+	}
+	if len(backlog) == 0 {
+		return
+	}
+	slices.SortFunc(backlog, func(a, b Message) int { return cmp.Compare(a.ID, b.ID) })
+	if over := len(backlog) - cap(sub.ch); over > 0 {
+		backlog = backlog[over:]
+		sub.dropped.Add(uint64(over))
+	}
+	for _, m := range backlog {
+		sub.ch <- m
+	}
+}
+
+// removeSub detaches a closed subscription from every topic it was
+// registered on and garbage-collects topics left with no subscribers and no
+// ring.
+func (h *Hub) removeSub(sub *Subscription) {
+	for i, ts := range sub.states {
+		ts.mu.Lock()
+		delete(ts.subs, sub)
+		empty := len(ts.subs) == 0 && ts.ring == nil
+		ts.mu.Unlock()
+		if empty {
+			h.gcTopic(sub.keys[i], ts)
+		}
+	}
+}
+
+// gcTopic drops the topic's registry entry if it is still the registered one
+// and still empty.
+func (h *Hub) gcTopic(key string, ts *topicState) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.topics[key] != ts {
+		return
+	}
+	ts.mu.Lock()
+	empty := len(ts.subs) == 0 && ts.ring == nil
+	ts.mu.Unlock()
+	if empty {
+		delete(h.topics, key)
+	}
+}
+
+// maybeSweep evicts replay rings of subscriber-less topics idle past the
+// replay TTL. Amortized: it runs at most once per TTL, from the publish
+// path.
+func (h *Hub) maybeSweep() {
+	now := h.clk.Now().UnixNano()
+	last := h.lastSweep.Load()
+	if now-last < int64(h.replayTTL) {
+		return
+	}
+	if !h.lastSweep.CompareAndSwap(last, now) {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for key, ts := range h.topics {
+		ts.mu.Lock()
+		expired := len(ts.subs) == 0 && now-ts.lastPub.UnixNano() >= int64(h.replayTTL)
+		ts.mu.Unlock()
+		if expired {
+			delete(h.topics, key)
+		}
+	}
+}
+
+// key namespaces topic with the tenant scope when configured; fail-closed on
+// a missing or invalid scope.
+func (h *Hub) key(ctx context.Context, topic string) (string, error) {
+	if h.scope == nil {
+		return topic, nil
+	}
+	scope, err := h.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrScopeMissing, err)
+	}
+	if scope == "" {
+		return "", ErrScopeMissing
+	}
+	if strings.IndexByte(scope, 0) >= 0 || strings.IndexByte(scope, scopeSep) >= 0 {
+		return "", ErrInvalidScope
+	}
+	return scope + "\x1f" + topic, nil
+}
+
+// display strips the scope prefix off a registry key, recovering the topic
+// the subscriber sees.
+func (h *Hub) display(key string) string {
+	if h.scope == nil {
+		return key
+	}
+	if _, topic, ok := strings.Cut(key, "\x1f"); ok {
+		return topic
+	}
+	return key
+}
+
+func validateTopic(topic string) error {
+	if topic == "" {
+		return fmt.Errorf("%w: empty", ErrInvalidTopic)
+	}
+	if strings.IndexByte(topic, 0) >= 0 || strings.IndexByte(topic, scopeSep) >= 0 {
+		return fmt.Errorf("%w: %q contains a reserved byte", ErrInvalidTopic, topic)
+	}
+	return nil
+}

--- a/realtime/fanout/fanout_test.go
+++ b/realtime/fanout/fanout_test.go
@@ -1,0 +1,424 @@
+package fanout_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/realtime/fanout"
+)
+
+// recv pulls the next message or fails the test after a timeout.
+func recv(t *testing.T, sub *fanout.Subscription) fanout.Message {
+	t.Helper()
+	select {
+	case m, ok := <-sub.C():
+		require.True(t, ok, "subscription channel closed")
+		return m
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for message")
+		return fanout.Message{}
+	}
+}
+
+// expectClosed asserts the channel closes (draining pending messages) within
+// the timeout.
+func expectClosed(t *testing.T, sub *fanout.Subscription) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-sub.C():
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for channel close")
+		}
+	}
+}
+
+func TestPublishSubscribe(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("delivers to subscriber", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New()
+		require.NoError(t, err)
+		defer hub.Close()
+
+		sub, err := hub.Subscribe(ctx, []string{"orders"})
+		require.NoError(t, err)
+		defer sub.Close()
+
+		require.NoError(t, hub.Publish(ctx, "orders", []byte("one")))
+		msg := recv(t, sub)
+		assert.Equal(t, "orders", msg.Topic)
+		assert.Equal(t, []byte("one"), msg.Payload)
+		assert.Positive(t, msg.ID)
+	})
+
+	t.Run("fans out to all subscribers", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New()
+		require.NoError(t, err)
+		defer hub.Close()
+
+		subs := make([]*fanout.Subscription, 3)
+		for i := range subs {
+			s, err := hub.Subscribe(ctx, []string{"orders"})
+			require.NoError(t, err)
+			defer s.Close()
+			subs[i] = s
+		}
+		require.NoError(t, hub.Publish(ctx, "orders", []byte("x")))
+		for _, s := range subs {
+			assert.Equal(t, []byte("x"), recv(t, s).Payload)
+		}
+	})
+
+	t.Run("topic isolation", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New()
+		require.NoError(t, err)
+		defer hub.Close()
+
+		a, err := hub.Subscribe(ctx, []string{"a"})
+		require.NoError(t, err)
+		defer a.Close()
+		require.NoError(t, hub.Publish(ctx, "b", []byte("x")))
+		require.NoError(t, hub.Publish(ctx, "a", []byte("y")))
+		assert.Equal(t, []byte("y"), recv(t, a).Payload)
+	})
+
+	t.Run("multi-topic subscription with duplicates collapsed", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New()
+		require.NoError(t, err)
+		defer hub.Close()
+
+		sub, err := hub.Subscribe(ctx, []string{"a", "b", "a"})
+		require.NoError(t, err)
+		defer sub.Close()
+
+		require.NoError(t, hub.Publish(ctx, "a", []byte("1")))
+		require.NoError(t, hub.Publish(ctx, "b", []byte("2")))
+		first, second := recv(t, sub), recv(t, sub)
+		assert.Equal(t, "a", first.Topic)
+		assert.Equal(t, "b", second.Topic)
+		select {
+		case m := <-sub.C():
+			t.Fatalf("duplicate delivery: %+v", m)
+		case <-time.After(50 * time.Millisecond):
+		}
+	})
+
+	t.Run("no subscribers is not an error", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New()
+		require.NoError(t, err)
+		defer hub.Close()
+		require.NoError(t, hub.Publish(ctx, "nobody", []byte("x")))
+	})
+
+	t.Run("ordering preserved per subscriber", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New(fanout.WithDefaultBuffer(128))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		sub, err := hub.Subscribe(ctx, []string{"seq"})
+		require.NoError(t, err)
+		defer sub.Close()
+
+		for i := range 100 {
+			require.NoError(t, hub.Publish(ctx, "seq", []byte{byte(i)}))
+		}
+		var lastID uint64
+		for i := range 100 {
+			m := recv(t, sub)
+			assert.Equal(t, byte(i), m.Payload[0])
+			assert.Greater(t, m.ID, lastID)
+			lastID = m.ID
+		}
+	})
+}
+
+func TestValidation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("bad options", func(t *testing.T) {
+		t.Parallel()
+		for _, opt := range []fanout.Option{
+			fanout.WithDefaultBuffer(0),
+			fanout.WithReplay(-1),
+			fanout.WithReplayTTL(0),
+			fanout.WithBus(nil),
+			fanout.WithScope(nil),
+			fanout.WithClock(nil),
+			fanout.WithDefaultPolicy(fanout.OverflowPolicy(99)),
+		} {
+			_, err := fanout.New(opt)
+			assert.Error(t, err)
+		}
+	})
+
+	t.Run("bad topics", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New()
+		require.NoError(t, err)
+		defer hub.Close()
+
+		assert.ErrorIs(t, hub.Publish(ctx, "", nil), fanout.ErrInvalidTopic)
+		assert.ErrorIs(t, hub.Publish(ctx, "a\x00b", nil), fanout.ErrInvalidTopic)
+		assert.ErrorIs(t, hub.Publish(ctx, "a\x1fb", nil), fanout.ErrInvalidTopic)
+
+		_, err = hub.Subscribe(ctx, nil)
+		assert.ErrorIs(t, err, fanout.ErrNoTopics)
+		_, err = hub.Subscribe(ctx, []string{""})
+		assert.ErrorIs(t, err, fanout.ErrInvalidTopic)
+	})
+
+	t.Run("bad subscribe options", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New()
+		require.NoError(t, err)
+		defer hub.Close()
+
+		_, err = hub.Subscribe(ctx, []string{"t"}, fanout.WithBuffer(0))
+		assert.Error(t, err)
+		_, err = hub.Subscribe(ctx, []string{"t"}, fanout.WithPolicy(fanout.OverflowPolicy(99)))
+		assert.Error(t, err)
+	})
+}
+
+func TestOverflowPolicies(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("drop oldest keeps newest window", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New()
+		require.NoError(t, err)
+		defer hub.Close()
+
+		sub, err := hub.Subscribe(ctx, []string{"t"}, fanout.WithBuffer(2))
+		require.NoError(t, err)
+		defer sub.Close()
+
+		for i := range 4 {
+			require.NoError(t, hub.Publish(ctx, "t", []byte{byte(i)}))
+		}
+		assert.Equal(t, byte(2), recv(t, sub).Payload[0])
+		assert.Equal(t, byte(3), recv(t, sub).Payload[0])
+		assert.Equal(t, uint64(2), sub.Dropped())
+	})
+
+	t.Run("drop newest keeps oldest window", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New(fanout.WithDefaultPolicy(fanout.DropNewest))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		sub, err := hub.Subscribe(ctx, []string{"t"}, fanout.WithBuffer(2))
+		require.NoError(t, err)
+		defer sub.Close()
+
+		for i := range 4 {
+			require.NoError(t, hub.Publish(ctx, "t", []byte{byte(i)}))
+		}
+		assert.Equal(t, byte(0), recv(t, sub).Payload[0])
+		assert.Equal(t, byte(1), recv(t, sub).Payload[0])
+		assert.Equal(t, uint64(2), sub.Dropped())
+	})
+
+	t.Run("close slow tears down", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New()
+		require.NoError(t, err)
+		defer hub.Close()
+
+		sub, err := hub.Subscribe(ctx, []string{"t", "u"}, fanout.WithBuffer(1), fanout.WithPolicy(fanout.CloseSlow))
+		require.NoError(t, err)
+		defer sub.Close()
+
+		require.NoError(t, hub.Publish(ctx, "t", []byte("1")))
+		require.NoError(t, hub.Publish(ctx, "t", []byte("2")))
+		assert.Equal(t, []byte("1"), recv(t, sub).Payload)
+		expectClosed(t, sub)
+		assert.ErrorIs(t, sub.Err(), fanout.ErrSlowConsumer)
+
+		// Publishes to any of its former topics keep working.
+		require.NoError(t, hub.Publish(ctx, "t", []byte("3")))
+		require.NoError(t, hub.Publish(ctx, "u", []byte("4")))
+	})
+
+	t.Run("per-subscription policy overrides hub default", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New(fanout.WithDefaultPolicy(fanout.CloseSlow))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		sub, err := hub.Subscribe(ctx, []string{"t"}, fanout.WithBuffer(1), fanout.WithPolicy(fanout.DropOldest))
+		require.NoError(t, err)
+		defer sub.Close()
+
+		require.NoError(t, hub.Publish(ctx, "t", []byte("1")))
+		require.NoError(t, hub.Publish(ctx, "t", []byte("2")))
+		assert.Equal(t, []byte("2"), recv(t, sub).Payload)
+		assert.NoError(t, sub.Err())
+	})
+}
+
+func TestSubscriptionClose(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("close is idempotent and err stays nil", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New()
+		require.NoError(t, err)
+		defer hub.Close()
+
+		sub, err := hub.Subscribe(ctx, []string{"t"})
+		require.NoError(t, err)
+		sub.Close()
+		sub.Close()
+		expectClosed(t, sub)
+		assert.NoError(t, sub.Err())
+		require.NoError(t, hub.Publish(ctx, "t", []byte("after")))
+	})
+
+	t.Run("close during concurrent publishes", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New()
+		require.NoError(t, err)
+		defer hub.Close()
+
+		var wg sync.WaitGroup
+		stop := make(chan struct{})
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = hub.Publish(ctx, "t", []byte("x"))
+				}
+			}
+		})
+		for range 50 {
+			sub, err := hub.Subscribe(ctx, []string{"t"}, fanout.WithBuffer(1))
+			require.NoError(t, err)
+			sub.Close()
+		}
+		close(stop)
+		wg.Wait()
+	})
+}
+
+func TestHubClose(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	hub, err := fanout.New()
+	require.NoError(t, err)
+
+	sub, err := hub.Subscribe(ctx, []string{"t"})
+	require.NoError(t, err)
+
+	hub.Close()
+	hub.Close()
+
+	expectClosed(t, sub)
+	assert.ErrorIs(t, sub.Err(), fanout.ErrClosed)
+	assert.ErrorIs(t, hub.Publish(ctx, "t", []byte("x")), fanout.ErrClosed)
+	_, err = hub.Subscribe(ctx, []string{"t"})
+	assert.ErrorIs(t, err, fanout.ErrClosed)
+
+	// Closing an already-torn-down subscription is a no-op.
+	sub.Close()
+}
+
+// TestCloseSlowDuringSubscribe hammers the window between a subscription
+// becoming visible to publishers and Subscribe returning: a CloseSlow
+// teardown fired by a publisher in that window must see fully-initialized
+// subscription state (caught by -race before the states-assignment order was
+// fixed).
+func TestCloseSlowDuringSubscribe(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	hub, err := fanout.New()
+	require.NoError(t, err)
+	defer hub.Close()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = hub.Publish(ctx, "hot", []byte("x"))
+				}
+			}
+		})
+	}
+	for range 500 {
+		sub, err := hub.Subscribe(ctx, []string{"hot", "cold"}, fanout.WithBuffer(1), fanout.WithPolicy(fanout.CloseSlow))
+		require.NoError(t, err)
+		expectClosed(t, sub)
+		sub.Close()
+	}
+	close(stop)
+	wg.Wait()
+}
+
+func TestConcurrencyStress(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	hub, err := fanout.New(fanout.WithReplay(8))
+	require.NoError(t, err)
+	defer hub.Close()
+
+	topics := []string{"a", "b", "c"}
+	var wg sync.WaitGroup
+	for _, topic := range topics {
+		wg.Go(func() {
+			for range 500 {
+				_ = hub.Publish(ctx, topic, []byte("x"))
+			}
+		})
+	}
+	for range 8 {
+		wg.Go(func() {
+			for range 50 {
+				sub, err := hub.Subscribe(ctx, topics, fanout.WithBuffer(4))
+				if err != nil {
+					if errors.Is(err, fanout.ErrClosed) {
+						return
+					}
+					t.Error(err)
+					return
+				}
+				select {
+				case <-sub.C():
+				case <-time.After(10 * time.Millisecond):
+				}
+				sub.Close()
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/realtime/fanout/options.go
+++ b/realtime/fanout/options.go
@@ -1,0 +1,167 @@
+package fanout
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+const (
+	defaultBuffer    = 64
+	defaultReplayTTL = 5 * time.Minute
+)
+
+type config struct {
+	clk       clock.Clock
+	bus       Bus
+	scope     func(ctx context.Context) (string, error)
+	errs      []error
+	replayTTL time.Duration
+	buffer    int
+	replay    int
+	policy    OverflowPolicy
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithDefaultBuffer sets the per-subscription buffer capacity used when a
+// subscription does not override it with WithBuffer. Must be positive;
+// defaults to 64.
+func WithDefaultBuffer(n int) Option {
+	return func(c *config) {
+		if n <= 0 {
+			c.errs = append(c.errs, fmt.Errorf("fanout: default buffer must be positive, got %d", n))
+			return
+		}
+		c.buffer = n
+	}
+}
+
+// WithDefaultPolicy sets the overflow policy used when a subscription does
+// not override it with WithPolicy. Defaults to DropOldest.
+func WithDefaultPolicy(p OverflowPolicy) Option {
+	return func(c *config) {
+		if p > CloseSlow {
+			c.errs = append(c.errs, fmt.Errorf("fanout: unknown overflow policy %d", p))
+			return
+		}
+		c.policy = p
+	}
+}
+
+// WithReplay keeps a ring of the last n messages per topic so subscribers can
+// resume with WithResumeAfter. n must be positive. Replay retains one ring
+// per published topic (bounded by WithReplayTTL); message IDs stay
+// per-instance — see the package comment.
+func WithReplay(n int) Option {
+	return func(c *config) {
+		if n <= 0 {
+			c.errs = append(c.errs, fmt.Errorf("fanout: replay size must be positive, got %d", n))
+			return
+		}
+		c.replay = n
+	}
+}
+
+// WithReplayTTL bounds how long the replay ring of a topic with no
+// subscribers is retained before being swept. Must be positive; defaults to
+// 5m. Only meaningful together with WithReplay.
+func WithReplayTTL(d time.Duration) Option {
+	return func(c *config) {
+		if d <= 0 {
+			c.errs = append(c.errs, fmt.Errorf("fanout: replay TTL must be positive, got %s", d))
+			return
+		}
+		c.replayTTL = d
+	}
+}
+
+// WithBus attaches a multi-instance backplane. Publish routes through the bus
+// only; local delivery happens from the bus receive path (run the driver's
+// supervisor.Service). See Bus for the contract.
+func WithBus(b Bus) Option {
+	return func(c *config) {
+		if b == nil {
+			c.errs = append(c.errs, fmt.Errorf("fanout: nil bus"))
+			return
+		}
+		c.bus = b
+	}
+}
+
+// WithScope installs the tenancy hook: its result namespaces every topic on
+// Publish and Subscribe, isolating tenants from each other — including
+// across a shared Bus. Fail-closed: once configured, a hook error or empty
+// scope fails the call with ErrScopeMissing. Single-tenant apps simply do
+// not configure it.
+func WithScope(fn func(ctx context.Context) (string, error)) Option {
+	return func(c *config) {
+		if fn == nil {
+			c.errs = append(c.errs, fmt.Errorf("fanout: nil scope hook"))
+			return
+		}
+		c.scope = fn
+	}
+}
+
+// WithClock injects the clock driving replay-ring retention (tests).
+func WithClock(clk clock.Clock) Option {
+	return func(c *config) {
+		if clk == nil {
+			c.errs = append(c.errs, fmt.Errorf("fanout: nil clock"))
+			return
+		}
+		c.clk = clk
+	}
+}
+
+type subConfig struct {
+	errs        []error
+	resumeAfter uint64
+	buffer      int
+	policy      OverflowPolicy
+	resume      bool
+}
+
+// SubscribeOption configures a single subscription.
+type SubscribeOption func(*subConfig)
+
+// WithBuffer overrides the hub's default buffer capacity for this
+// subscription. Must be positive.
+func WithBuffer(n int) SubscribeOption {
+	return func(c *subConfig) {
+		if n <= 0 {
+			c.errs = append(c.errs, fmt.Errorf("fanout: buffer must be positive, got %d", n))
+			return
+		}
+		c.buffer = n
+	}
+}
+
+// WithPolicy overrides the hub's default overflow policy for this
+// subscription.
+func WithPolicy(p OverflowPolicy) SubscribeOption {
+	return func(c *subConfig) {
+		if p > CloseSlow {
+			c.errs = append(c.errs, fmt.Errorf("fanout: unknown overflow policy %d", p))
+			return
+		}
+		c.policy = p
+	}
+}
+
+// WithResumeAfter first delivers the buffered messages with ID greater than
+// id from each subscribed topic's replay ring, in ID order, then goes live
+// with no gap. id 0 replays everything buffered. Requires WithReplay on the
+// hub (ErrReplayDisabled otherwise). If the replayed backlog exceeds the
+// subscription buffer, only the newest messages that fit are delivered and
+// the rest count as dropped.
+func WithResumeAfter(id uint64) SubscribeOption {
+	return func(c *subConfig) {
+		c.resumeAfter = id
+		c.resume = true
+	}
+}

--- a/realtime/fanout/pgbus/bench_test.go
+++ b/realtime/fanout/pgbus/bench_test.go
@@ -1,0 +1,33 @@
+//go:build integration
+
+package pgbus_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/realtime/fanout/pgbus"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+)
+
+func BenchmarkPublish(b *testing.B) {
+	pool, err := pgxpool.New(context.Background(), pgtest.DSN(b))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer pool.Close()
+	bus, err := pgbus.New(pool, pgbus.WithChannel("fanout_bench"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	payload := []byte(`{"text":"hi"}`)
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := bus.Publish(ctx, "bench", payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/realtime/fanout/pgbus/doc.go
+++ b/realtime/fanout/pgbus/doc.go
@@ -1,0 +1,21 @@
+// Package pgbus is the Postgres LISTEN/NOTIFY backplane for realtime/fanout:
+// multi-instance push with zero new infrastructure. Every instance publishes
+// with pg_notify on one Postgres channel and receives on a dedicated
+// listening connection, so a fanout.Hub built with fanout.WithBus(bus) spans
+// all instances sharing the database.
+//
+//	bus, _ := pgbus.New(pool)
+//	hub, _ := fanout.New(fanout.WithBus(bus))
+//	// run the receive loop under ops/supervisor:
+//	sup := supervisor.New(supervisor.WithService(bus))
+//
+// Messages ride a JSON envelope (topic + base64 payload) inside the NOTIFY
+// payload, which Postgres caps at 8000 bytes: Publish rejects anything whose
+// envelope exceeds that with ErrPayloadTooLarge. Fanout payloads are UI
+// pushes — keep them small and let clients fetch the rest.
+//
+// Delivery is at-most-once. NOTIFY drops nothing while the listener is
+// connected, but messages published while the listener reconnects are lost —
+// exactly the fanout contract. The Run loop reconnects with exponential
+// backoff and never returns until its context is cancelled.
+package pgbus

--- a/realtime/fanout/pgbus/doc.go
+++ b/realtime/fanout/pgbus/doc.go
@@ -18,4 +18,8 @@
 // connected, but messages published while the listener reconnects are lost —
 // exactly the fanout contract. The Run loop reconnects with exponential
 // backoff and never returns until its context is cancelled.
+//
+// While Run is live it holds one connection from the pool exclusively for
+// LISTEN; size pgxpool.Pool.MaxConns to account for it when the pool is
+// shared with application traffic.
 package pgbus

--- a/realtime/fanout/pgbus/errors.go
+++ b/realtime/fanout/pgbus/errors.go
@@ -1,0 +1,11 @@
+package pgbus
+
+import "errors"
+
+var (
+	// ErrPayloadTooLarge is returned by Publish when the message envelope
+	// exceeds the Postgres NOTIFY payload limit (8000 bytes).
+	ErrPayloadTooLarge = errors.New("pgbus: payload too large for NOTIFY")
+	// ErrPublish wraps a failed pg_notify round trip.
+	ErrPublish = errors.New("pgbus: publish failed")
+)

--- a/realtime/fanout/pgbus/options.go
+++ b/realtime/fanout/pgbus/options.go
@@ -1,0 +1,62 @@
+package pgbus
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+// defaultChannel is the Postgres NOTIFY channel used when WithChannel is not
+// configured.
+const defaultChannel = "forge_fanout"
+
+// maxChannelLen is Postgres's identifier limit (NAMEDATALEN-1). LISTEN
+// silently truncates longer names while pg_notify does not, so longer
+// channels would never match.
+const maxChannelLen = 63
+
+type config struct {
+	logger  *slog.Logger
+	channel string
+	errs    []error
+}
+
+func defaultConfig() *config {
+	return &config{
+		logger:  logger.NewNope(),
+		channel: defaultChannel,
+	}
+}
+
+func (c *config) err() error {
+	return errors.Join(c.errs...)
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithChannel sets the Postgres NOTIFY channel (default "forge_fanout").
+// Buses only see each other on the same channel; distinct channels isolate
+// independent hubs sharing one database. Must be non-empty and at most 63
+// bytes.
+func WithChannel(name string) Option {
+	return func(c *config) {
+		if name == "" || len(name) > maxChannelLen {
+			c.errs = append(c.errs, fmt.Errorf("pgbus: channel must be 1..%d bytes, got %d", maxChannelLen, len(name)))
+			return
+		}
+		c.channel = name
+	}
+}
+
+// WithLogger sets the logger for reconnect and dropped-message diagnostics.
+// Defaults to a discard logger; nil is ignored.
+func WithLogger(log *slog.Logger) Option {
+	return func(c *config) {
+		if log != nil {
+			c.logger = log
+		}
+	}
+}

--- a/realtime/fanout/pgbus/pgbus.go
+++ b/realtime/fanout/pgbus/pgbus.go
@@ -1,0 +1,164 @@
+package pgbus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// maxNotifyPayload is the Postgres NOTIFY payload cap (8000 bytes) applied to
+// the whole encoded envelope.
+const maxNotifyPayload = 8000
+
+const (
+	initialBackoff = 200 * time.Millisecond
+	maxBackoff     = 10 * time.Second
+)
+
+// envelope frames one message inside a NOTIFY payload. encoding/json encodes
+// P as base64, keeping arbitrary binary payloads text-safe.
+type envelope struct {
+	T string `json:"t"`
+	P []byte `json:"p,omitempty"`
+}
+
+// Bus is the LISTEN/NOTIFY backplane. Construct with New; it implements
+// fanout.Bus, and its Run loop (a supervisor.Service) is the receive path.
+type Bus struct {
+	pool    *pgxpool.Pool
+	log     *slog.Logger
+	handler atomic.Pointer[func(topic string, payload []byte)]
+	channel string
+	quoted  string
+}
+
+// New builds a Bus over the caller's pool. The pool stays owned by the
+// caller; the bus publishes through it and dedicates one acquired connection
+// to LISTEN while Run is live.
+func New(pool *pgxpool.Pool, opts ...Option) (*Bus, error) {
+	if pool == nil {
+		return nil, fmt.Errorf("pgbus: nil pool")
+	}
+	c := defaultConfig()
+	for _, opt := range opts {
+		opt(c)
+	}
+	if err := c.err(); err != nil {
+		return nil, err
+	}
+	return &Bus{
+		pool:    pool,
+		log:     c.logger,
+		channel: c.channel,
+		quoted:  pgx.Identifier{c.channel}.Sanitize(),
+	}, nil
+}
+
+// Publish broadcasts one message to every listening instance — including
+// this one — via pg_notify. It fails with ErrPayloadTooLarge when the
+// envelope exceeds the NOTIFY cap.
+func (b *Bus) Publish(ctx context.Context, topic string, payload []byte) error {
+	env, err := json.Marshal(envelope{T: topic, P: payload})
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrPublish, err)
+	}
+	if len(env) > maxNotifyPayload {
+		return fmt.Errorf("%w: envelope is %d bytes, limit %d", ErrPayloadTooLarge, len(env), maxNotifyPayload)
+	}
+	if _, err := b.pool.Exec(ctx, "SELECT pg_notify($1, $2)", b.channel, string(env)); err != nil {
+		return fmt.Errorf("%w: %w", ErrPublish, err)
+	}
+	return nil
+}
+
+// Subscribe registers the delivery callback, replacing any previous one. The
+// attached hub calls this from fanout.New; messages received while no
+// callback is registered are discarded.
+func (b *Bus) Subscribe(fn func(topic string, payload []byte)) {
+	if fn == nil {
+		b.handler.Store(nil)
+		return
+	}
+	b.handler.Store(&fn)
+}
+
+// Name identifies the service in supervisor logs.
+func (b *Bus) Name() string { return "fanout.pgbus:" + b.channel }
+
+// Run is the receive loop: it dedicates a pooled connection to LISTEN and
+// dispatches every notification to the subscribed callback, reconnecting
+// with exponential backoff until ctx is cancelled. Messages published while
+// the listener is down are lost (at-most-once).
+func (b *Bus) Run(ctx context.Context) error {
+	backoff := initialBackoff
+	for {
+		connected, err := b.listen(ctx)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if connected {
+			backoff = initialBackoff
+		}
+		b.log.WarnContext(ctx, "pgbus listener disconnected, reconnecting",
+			slog.String("channel", b.channel),
+			slog.Duration("backoff", backoff),
+			slog.Any("error", err))
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+		backoff = min(backoff*2, maxBackoff)
+	}
+}
+
+// listen holds one LISTEN connection until it fails or ctx ends. connected
+// reports whether LISTEN was established, resetting the caller's backoff.
+// The connection is closed on exit — never released back into the pool with
+// LISTEN state attached.
+func (b *Bus) listen(ctx context.Context) (connected bool, err error) {
+	conn, err := b.pool.Acquire(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		// Closing the underlying connection makes Release destroy it.
+		_ = conn.Conn().Close(context.WithoutCancel(ctx))
+		conn.Release()
+	}()
+	if _, err := conn.Exec(ctx, "LISTEN "+b.quoted); err != nil {
+		return false, err
+	}
+	for {
+		n, err := conn.Conn().WaitForNotification(ctx)
+		if err != nil {
+			return true, err
+		}
+		if n != nil {
+			b.deliver(ctx, n.Payload)
+		}
+	}
+}
+
+// deliver decodes one NOTIFY payload and hands it to the callback. Foreign
+// or corrupt payloads on the channel are logged and skipped.
+func (b *Bus) deliver(ctx context.Context, payload string) {
+	fn := b.handler.Load()
+	if fn == nil {
+		return
+	}
+	var env envelope
+	if err := json.Unmarshal([]byte(payload), &env); err != nil {
+		b.log.WarnContext(ctx, "pgbus dropped undecodable notification",
+			slog.String("channel", b.channel),
+			slog.Any("error", err))
+		return
+	}
+	(*fn)(env.T, env.P)
+}

--- a/realtime/fanout/pgbus/pgbus_integration_test.go
+++ b/realtime/fanout/pgbus/pgbus_integration_test.go
@@ -143,16 +143,6 @@ func TestChannelIsolation_Integration(t *testing.T) {
 	assert.False(t, ok, "messages must not cross channels")
 }
 
-func TestPayloadTooLarge_Integration(t *testing.T) {
-	t.Parallel()
-	pool := openPool(t)
-	bus, err := pgbus.New(pool, pgbus.WithChannel(uniqueChannel("fanout_big")))
-	require.NoError(t, err)
-
-	err = bus.Publish(context.Background(), "t", make([]byte, 8000))
-	assert.ErrorIs(t, err, pgbus.ErrPayloadTooLarge)
-}
-
 func TestHubEndToEnd_Integration(t *testing.T) {
 	t.Parallel()
 	pool := openPool(t)

--- a/realtime/fanout/pgbus/pgbus_integration_test.go
+++ b/realtime/fanout/pgbus/pgbus_integration_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+package pgbus_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/realtime/fanout"
+	"github.com/dmitrymomot/forge/realtime/fanout/pgbus"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+)
+
+var channelSeq atomic.Int64
+
+// uniqueChannel isolates each test on its own NOTIFY channel so parallel
+// tests sharing the container never cross-deliver.
+func uniqueChannel(prefix string) string {
+	return fmt.Sprintf("%s_%d_%d", prefix, time.Now().UnixNano(), channelSeq.Add(1))
+}
+
+func openPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	pool, err := pgxpool.New(context.Background(), pgtest.DSN(t))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// collector accumulates deliveries for assertion.
+type collector struct {
+	mu   sync.Mutex
+	msgs []fanout.Message
+}
+
+func (c *collector) deliver(topic string, payload []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.msgs = append(c.msgs, fanout.Message{Topic: topic, Payload: payload})
+}
+
+// find returns the first delivery on topic, if any.
+func (c *collector) find(topic string) (fanout.Message, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, m := range c.msgs {
+		if m.Topic == topic {
+			return m, true
+		}
+	}
+	return fanout.Message{}, false
+}
+
+// runBus starts the receive loop and returns once publishing round-trips,
+// proving LISTEN is active. The probe handler is left registered; register
+// the real consumer (or attach the hub) after runBus returns.
+func runBus(t *testing.T, bus *pgbus.Bus) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = bus.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("bus did not stop")
+		}
+	})
+	probe := &collector{}
+	bus.Subscribe(probe.deliver)
+	require.Eventually(t, func() bool {
+		if err := bus.Publish(ctx, "probe", nil); err != nil {
+			return false
+		}
+		_, ok := probe.find("probe")
+		return ok
+	}, 10*time.Second, 50*time.Millisecond, "LISTEN never became active")
+}
+
+func TestPublishReceive_Integration(t *testing.T) {
+	t.Parallel()
+	pool := openPool(t)
+	channel := uniqueChannel("fanout_pr")
+
+	sender, err := pgbus.New(pool, pgbus.WithChannel(channel))
+	require.NoError(t, err)
+	receiver, err := pgbus.New(pool, pgbus.WithChannel(channel))
+	require.NoError(t, err)
+
+	runBus(t, sender)
+	runBus(t, receiver)
+
+	got := &collector{}
+	receiver.Subscribe(got.deliver)
+	self := &collector{}
+	sender.Subscribe(self.deliver)
+
+	payload := []byte{0x00, 0x1f, 0xff, 'b', 'i', 'n'}
+	require.NoError(t, sender.Publish(context.Background(), "orders.42", payload))
+
+	require.Eventually(t, func() bool {
+		_, ok := got.find("orders.42")
+		return ok
+	}, 10*time.Second, 50*time.Millisecond)
+	msg, _ := got.find("orders.42")
+	assert.True(t, bytes.Equal(payload, msg.Payload), "binary payload must survive the envelope")
+
+	require.Eventually(t, func() bool {
+		_, ok := self.find("orders.42")
+		return ok
+	}, 10*time.Second, 50*time.Millisecond, "the publishing instance must receive its own message")
+}
+
+func TestChannelIsolation_Integration(t *testing.T) {
+	t.Parallel()
+	pool := openPool(t)
+
+	busA, err := pgbus.New(pool, pgbus.WithChannel(uniqueChannel("fanout_iso_a")))
+	require.NoError(t, err)
+	busB, err := pgbus.New(pool, pgbus.WithChannel(uniqueChannel("fanout_iso_b")))
+	require.NoError(t, err)
+	runBus(t, busA)
+	runBus(t, busB)
+
+	got := &collector{}
+	busB.Subscribe(got.deliver)
+	require.NoError(t, busA.Publish(context.Background(), "crossing", []byte("x")))
+	time.Sleep(500 * time.Millisecond)
+	_, ok := got.find("crossing")
+	assert.False(t, ok, "messages must not cross channels")
+}
+
+func TestPayloadTooLarge_Integration(t *testing.T) {
+	t.Parallel()
+	pool := openPool(t)
+	bus, err := pgbus.New(pool, pgbus.WithChannel(uniqueChannel("fanout_big")))
+	require.NoError(t, err)
+
+	err = bus.Publish(context.Background(), "t", make([]byte, 8000))
+	assert.ErrorIs(t, err, pgbus.ErrPayloadTooLarge)
+}
+
+func TestHubEndToEnd_Integration(t *testing.T) {
+	t.Parallel()
+	pool := openPool(t)
+	channel := uniqueChannel("fanout_e2e")
+
+	bus1, err := pgbus.New(pool, pgbus.WithChannel(channel))
+	require.NoError(t, err)
+	bus2, err := pgbus.New(pool, pgbus.WithChannel(channel))
+	require.NoError(t, err)
+	runBus(t, bus1)
+	runBus(t, bus2)
+
+	// Attaching the hubs after runBus replaces the probe handlers with the
+	// hubs' dispatch.
+	hub1, err := fanout.New(fanout.WithBus(bus1))
+	require.NoError(t, err)
+	defer hub1.Close()
+	hub2, err := fanout.New(fanout.WithBus(bus2))
+	require.NoError(t, err)
+	defer hub2.Close()
+
+	local, err := hub1.Subscribe(context.Background(), []string{"chat"})
+	require.NoError(t, err)
+	defer local.Close()
+	remote, err := hub2.Subscribe(context.Background(), []string{"chat"})
+	require.NoError(t, err)
+	defer remote.Close()
+
+	require.NoError(t, hub1.Publish(context.Background(), "chat", []byte("hello")))
+
+	for name, sub := range map[string]*fanout.Subscription{"local": local, "remote": remote} {
+		select {
+		case msg := <-sub.C():
+			assert.Equal(t, "chat", msg.Topic, name)
+			assert.Equal(t, []byte("hello"), msg.Payload, name)
+		case <-time.After(10 * time.Second):
+			t.Fatalf("%s subscriber never received the message", name)
+		}
+	}
+}

--- a/realtime/fanout/pgbus/pgbus_test.go
+++ b/realtime/fanout/pgbus/pgbus_test.go
@@ -1,0 +1,54 @@
+package pgbus_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/supervisor"
+	"github.com/dmitrymomot/forge/realtime/fanout"
+	"github.com/dmitrymomot/forge/realtime/fanout/pgbus"
+)
+
+var (
+	_ fanout.Bus         = (*pgbus.Bus)(nil)
+	_ supervisor.Service = (*pgbus.Bus)(nil)
+)
+
+// testPool builds a pool without connecting: pgxpool dials lazily.
+func testPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	pool, err := pgxpool.New(context.Background(), "postgres://localhost:5432/unused")
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil pool", func(t *testing.T) {
+		t.Parallel()
+		_, err := pgbus.New(nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("bad channel", func(t *testing.T) {
+		t.Parallel()
+		_, err := pgbus.New(testPool(t), pgbus.WithChannel(""))
+		assert.Error(t, err)
+		_, err = pgbus.New(testPool(t), pgbus.WithChannel(strings.Repeat("x", 64)))
+		assert.Error(t, err)
+	})
+
+	t.Run("name carries the channel", func(t *testing.T) {
+		t.Parallel()
+		bus, err := pgbus.New(testPool(t), pgbus.WithChannel("app_events"))
+		require.NoError(t, err)
+		assert.Equal(t, "fanout.pgbus:app_events", bus.Name())
+	})
+}

--- a/realtime/fanout/pgbus/pgbus_test.go
+++ b/realtime/fanout/pgbus/pgbus_test.go
@@ -52,3 +52,14 @@ func TestNew(t *testing.T) {
 		assert.Equal(t, "fanout.pgbus:app_events", bus.Name())
 	})
 }
+
+// The envelope-size check runs before any pool I/O, so no live Postgres is
+// needed to exercise it.
+func TestPublishPayloadTooLarge(t *testing.T) {
+	t.Parallel()
+
+	bus, err := pgbus.New(testPool(t))
+	require.NoError(t, err)
+	err = bus.Publish(context.Background(), "t", make([]byte, 8000))
+	assert.ErrorIs(t, err, pgbus.ErrPayloadTooLarge)
+}

--- a/realtime/fanout/redisbus/bench_test.go
+++ b/realtime/fanout/redisbus/bench_test.go
@@ -1,0 +1,30 @@
+//go:build integration
+
+package redisbus_test
+
+import (
+	"context"
+	"testing"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/dmitrymomot/forge/realtime/fanout/redisbus"
+	"github.com/dmitrymomot/forge/testkit/redistest"
+)
+
+func BenchmarkPublish(b *testing.B) {
+	client := goredis.NewClient(&goredis.Options{Addr: redistest.Addr(b)})
+	defer func() { _ = client.Close() }()
+	bus, err := redisbus.New(client, redisbus.WithChannel("fanout:bench"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	payload := []byte(`{"text":"hi"}`)
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := bus.Publish(ctx, "bench", payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/realtime/fanout/redisbus/doc.go
+++ b/realtime/fanout/redisbus/doc.go
@@ -1,0 +1,21 @@
+// Package redisbus is the Redis Pub/Sub backplane for realtime/fanout. Every
+// instance publishes to one Redis channel through the caller's client and
+// receives on a subscribed connection, so a fanout.Hub built with
+// fanout.WithBus(bus) spans all instances sharing the Redis.
+//
+//	client, _ := redis.Open(ctx)                 // data/redis, caller-owned
+//	bus, _ := redisbus.New(client)
+//	hub, _ := fanout.New(fanout.WithBus(bus))
+//	// run the receive loop under ops/supervisor:
+//	sup := supervisor.New(supervisor.WithService(bus))
+//
+// Messages are framed as topic + NUL + payload — binary-safe with zero
+// encoding overhead; topics containing NUL are rejected (the hub never emits
+// them).
+//
+// Delivery is at-most-once: Redis Pub/Sub does not buffer for absent
+// subscribers, and messages published while the receive connection
+// reconnects are lost — exactly the fanout contract. The Run loop rides
+// go-redis's built-in resubscribe and never returns until its context is
+// cancelled.
+package redisbus

--- a/realtime/fanout/redisbus/errors.go
+++ b/realtime/fanout/redisbus/errors.go
@@ -1,0 +1,11 @@
+package redisbus
+
+import "errors"
+
+var (
+	// ErrInvalidTopic is returned by Publish for a topic containing NUL, the
+	// frame separator.
+	ErrInvalidTopic = errors.New("redisbus: invalid topic")
+	// ErrPublish wraps a failed Redis PUBLISH round trip.
+	ErrPublish = errors.New("redisbus: publish failed")
+)

--- a/realtime/fanout/redisbus/options.go
+++ b/realtime/fanout/redisbus/options.go
@@ -1,0 +1,56 @@
+package redisbus
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/dmitrymomot/forge/ops/logger"
+)
+
+// defaultChannel is the Redis Pub/Sub channel used when WithChannel is not
+// configured.
+const defaultChannel = "forge:fanout"
+
+type config struct {
+	logger  *slog.Logger
+	channel string
+	errs    []error
+}
+
+func defaultConfig() *config {
+	return &config{
+		logger:  logger.NewNope(),
+		channel: defaultChannel,
+	}
+}
+
+func (c *config) err() error {
+	return errors.Join(c.errs...)
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithChannel sets the Redis Pub/Sub channel (default "forge:fanout"). Buses
+// only see each other on the same channel; distinct channels isolate
+// independent hubs sharing one Redis. Must be non-empty.
+func WithChannel(name string) Option {
+	return func(c *config) {
+		if name == "" {
+			c.errs = append(c.errs, fmt.Errorf("redisbus: empty channel"))
+			return
+		}
+		c.channel = name
+	}
+}
+
+// WithLogger sets the logger for receive-loop diagnostics. Defaults to a
+// discard logger; nil is ignored.
+func WithLogger(log *slog.Logger) Option {
+	return func(c *config) {
+		if log != nil {
+			c.logger = log
+		}
+	}
+}

--- a/realtime/fanout/redisbus/redisbus.go
+++ b/realtime/fanout/redisbus/redisbus.go
@@ -1,0 +1,123 @@
+package redisbus
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+// receiveRetryDelay paces the receive loop after a transient error so a
+// down Redis does not spin the CPU; go-redis handles the actual reconnect.
+const receiveRetryDelay = 250 * time.Millisecond
+
+// Bus is the Redis Pub/Sub backplane. Construct with New; it implements
+// fanout.Bus, and its Run loop (a supervisor.Service) is the receive path.
+type Bus struct {
+	client  goredis.UniversalClient
+	log     *slog.Logger
+	handler atomic.Pointer[func(topic string, payload []byte)]
+	channel string
+}
+
+// New builds a Bus over the caller's client. The client stays owned by the
+// caller — *goredis.Client, *goredis.ClusterClient, and *goredis.Ring all
+// satisfy goredis.UniversalClient.
+func New(client goredis.UniversalClient, opts ...Option) (*Bus, error) {
+	if client == nil {
+		return nil, fmt.Errorf("redisbus: nil client")
+	}
+	c := defaultConfig()
+	for _, opt := range opts {
+		opt(c)
+	}
+	if err := c.err(); err != nil {
+		return nil, err
+	}
+	return &Bus{
+		client:  client,
+		log:     c.logger,
+		channel: c.channel,
+	}, nil
+}
+
+// Publish broadcasts one message to every subscribed instance — including
+// this one. Topics containing NUL are rejected (the frame separator).
+func (b *Bus) Publish(ctx context.Context, topic string, payload []byte) error {
+	if strings.IndexByte(topic, 0) >= 0 {
+		return fmt.Errorf("%w: %q contains NUL", ErrInvalidTopic, topic)
+	}
+	frame := make([]byte, 0, len(topic)+1+len(payload))
+	frame = append(frame, topic...)
+	frame = append(frame, 0)
+	frame = append(frame, payload...)
+	if err := b.client.Publish(ctx, b.channel, frame).Err(); err != nil {
+		return fmt.Errorf("%w: %w", ErrPublish, err)
+	}
+	return nil
+}
+
+// Subscribe registers the delivery callback, replacing any previous one. The
+// attached hub calls this from fanout.New; messages received while no
+// callback is registered are discarded.
+func (b *Bus) Subscribe(fn func(topic string, payload []byte)) {
+	if fn == nil {
+		b.handler.Store(nil)
+		return
+	}
+	b.handler.Store(&fn)
+}
+
+// Name identifies the service in supervisor logs.
+func (b *Bus) Name() string { return "fanout.redisbus:" + b.channel }
+
+// Run is the receive loop: it subscribes to the bus channel and dispatches
+// every message to the subscribed callback until ctx is cancelled. go-redis
+// reconnects and resubscribes on its own; messages published while the
+// connection is down are lost (at-most-once).
+func (b *Bus) Run(ctx context.Context) error {
+	pubsub := b.client.Subscribe(ctx, b.channel)
+	defer func() { _ = pubsub.Close() }()
+	// ReceiveMessage blocks on the socket without observing ctx; closing the
+	// PubSub is what unblocks it on shutdown.
+	stop := context.AfterFunc(ctx, func() { _ = pubsub.Close() })
+	defer stop()
+	for {
+		msg, err := pubsub.ReceiveMessage(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			b.log.WarnContext(ctx, "redisbus receive failed, retrying",
+				slog.String("channel", b.channel),
+				slog.Any("error", err))
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(receiveRetryDelay):
+			}
+			continue
+		}
+		b.deliver(ctx, msg.Payload)
+	}
+}
+
+// deliver splits one frame and hands it to the callback. Foreign payloads on
+// the channel (no NUL separator) are logged and skipped.
+func (b *Bus) deliver(ctx context.Context, frame string) {
+	fn := b.handler.Load()
+	if fn == nil {
+		return
+	}
+	topic, payload, ok := strings.Cut(frame, "\x00")
+	if !ok {
+		b.log.WarnContext(ctx, "redisbus dropped unframed message",
+			slog.String("channel", b.channel))
+		return
+	}
+	(*fn)(topic, []byte(payload))
+}

--- a/realtime/fanout/redisbus/redisbus_integration_test.go
+++ b/realtime/fanout/redisbus/redisbus_integration_test.go
@@ -1,0 +1,184 @@
+//go:build integration
+
+package redisbus_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/realtime/fanout"
+	"github.com/dmitrymomot/forge/realtime/fanout/redisbus"
+	"github.com/dmitrymomot/forge/testkit/redistest"
+)
+
+var channelSeq atomic.Int64
+
+// uniqueChannel isolates each test on its own Pub/Sub channel so parallel
+// tests sharing the container never cross-deliver.
+func uniqueChannel(prefix string) string {
+	return fmt.Sprintf("%s:%d:%d", prefix, time.Now().UnixNano(), channelSeq.Add(1))
+}
+
+func openClient(t *testing.T) goredis.UniversalClient {
+	t.Helper()
+	client := goredis.NewClient(&goredis.Options{Addr: redistest.Addr(t)})
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+// collector accumulates deliveries for assertion.
+type collector struct {
+	mu   sync.Mutex
+	msgs []fanout.Message
+}
+
+func (c *collector) deliver(topic string, payload []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.msgs = append(c.msgs, fanout.Message{Topic: topic, Payload: payload})
+}
+
+// find returns the first delivery on topic, if any.
+func (c *collector) find(topic string) (fanout.Message, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, m := range c.msgs {
+		if m.Topic == topic {
+			return m, true
+		}
+	}
+	return fanout.Message{}, false
+}
+
+// runBus starts the receive loop and returns once publishing round-trips,
+// proving the subscription is active. The probe handler is left registered;
+// register the real consumer (or attach the hub) after runBus returns.
+func runBus(t *testing.T, bus *redisbus.Bus) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = bus.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("bus did not stop")
+		}
+	})
+	probe := &collector{}
+	bus.Subscribe(probe.deliver)
+	require.Eventually(t, func() bool {
+		if err := bus.Publish(ctx, "probe", nil); err != nil {
+			return false
+		}
+		_, ok := probe.find("probe")
+		return ok
+	}, 10*time.Second, 50*time.Millisecond, "subscription never became active")
+}
+
+func TestPublishReceive_Integration(t *testing.T) {
+	t.Parallel()
+	client := openClient(t)
+	channel := uniqueChannel("fanout:pr")
+
+	sender, err := redisbus.New(client, redisbus.WithChannel(channel))
+	require.NoError(t, err)
+	receiver, err := redisbus.New(client, redisbus.WithChannel(channel))
+	require.NoError(t, err)
+
+	runBus(t, sender)
+	runBus(t, receiver)
+
+	got := &collector{}
+	receiver.Subscribe(got.deliver)
+	self := &collector{}
+	sender.Subscribe(self.deliver)
+
+	payload := []byte{0x00, 0x1f, 0xff, 'b', 'i', 'n'}
+	require.NoError(t, sender.Publish(context.Background(), "orders.42", payload))
+
+	require.Eventually(t, func() bool {
+		_, ok := got.find("orders.42")
+		return ok
+	}, 10*time.Second, 50*time.Millisecond)
+	msg, _ := got.find("orders.42")
+	assert.True(t, bytes.Equal(payload, msg.Payload), "binary payload must survive the frame")
+
+	require.Eventually(t, func() bool {
+		_, ok := self.find("orders.42")
+		return ok
+	}, 10*time.Second, 50*time.Millisecond, "the publishing instance must receive its own message")
+}
+
+func TestChannelIsolation_Integration(t *testing.T) {
+	t.Parallel()
+	client := openClient(t)
+
+	busA, err := redisbus.New(client, redisbus.WithChannel(uniqueChannel("fanout:iso:a")))
+	require.NoError(t, err)
+	busB, err := redisbus.New(client, redisbus.WithChannel(uniqueChannel("fanout:iso:b")))
+	require.NoError(t, err)
+	runBus(t, busA)
+	runBus(t, busB)
+
+	got := &collector{}
+	busB.Subscribe(got.deliver)
+	require.NoError(t, busA.Publish(context.Background(), "crossing", []byte("x")))
+	time.Sleep(500 * time.Millisecond)
+	_, ok := got.find("crossing")
+	assert.False(t, ok, "messages must not cross channels")
+}
+
+func TestHubEndToEnd_Integration(t *testing.T) {
+	t.Parallel()
+	client := openClient(t)
+	channel := uniqueChannel("fanout:e2e")
+
+	bus1, err := redisbus.New(client, redisbus.WithChannel(channel))
+	require.NoError(t, err)
+	bus2, err := redisbus.New(client, redisbus.WithChannel(channel))
+	require.NoError(t, err)
+	runBus(t, bus1)
+	runBus(t, bus2)
+
+	// Attaching the hubs after runBus replaces the probe handlers with the
+	// hubs' dispatch.
+	hub1, err := fanout.New(fanout.WithBus(bus1))
+	require.NoError(t, err)
+	defer hub1.Close()
+	hub2, err := fanout.New(fanout.WithBus(bus2))
+	require.NoError(t, err)
+	defer hub2.Close()
+
+	local, err := hub1.Subscribe(context.Background(), []string{"chat"})
+	require.NoError(t, err)
+	defer local.Close()
+	remote, err := hub2.Subscribe(context.Background(), []string{"chat"})
+	require.NoError(t, err)
+	defer remote.Close()
+
+	require.NoError(t, hub1.Publish(context.Background(), "chat", []byte("hello")))
+
+	for name, sub := range map[string]*fanout.Subscription{"local": local, "remote": remote} {
+		select {
+		case msg := <-sub.C():
+			assert.Equal(t, "chat", msg.Topic, name)
+			assert.Equal(t, []byte("hello"), msg.Payload, name)
+		case <-time.After(10 * time.Second):
+			t.Fatalf("%s subscriber never received the message", name)
+		}
+	}
+}

--- a/realtime/fanout/redisbus/redisbus_test.go
+++ b/realtime/fanout/redisbus/redisbus_test.go
@@ -1,0 +1,59 @@
+package redisbus_test
+
+import (
+	"context"
+	"testing"
+
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/supervisor"
+	"github.com/dmitrymomot/forge/realtime/fanout"
+	"github.com/dmitrymomot/forge/realtime/fanout/redisbus"
+)
+
+var (
+	_ fanout.Bus         = (*redisbus.Bus)(nil)
+	_ supervisor.Service = (*redisbus.Bus)(nil)
+)
+
+// testClient builds a client without connecting: go-redis dials lazily.
+func testClient(t *testing.T) goredis.UniversalClient {
+	t.Helper()
+	client := goredis.NewClient(&goredis.Options{Addr: "localhost:1"})
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil client", func(t *testing.T) {
+		t.Parallel()
+		_, err := redisbus.New(nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty channel", func(t *testing.T) {
+		t.Parallel()
+		_, err := redisbus.New(testClient(t), redisbus.WithChannel(""))
+		assert.Error(t, err)
+	})
+
+	t.Run("name carries the channel", func(t *testing.T) {
+		t.Parallel()
+		bus, err := redisbus.New(testClient(t), redisbus.WithChannel("app:events"))
+		require.NoError(t, err)
+		assert.Equal(t, "fanout.redisbus:app:events", bus.Name())
+	})
+}
+
+func TestPublishValidation(t *testing.T) {
+	t.Parallel()
+
+	bus, err := redisbus.New(testClient(t))
+	require.NoError(t, err)
+	err = bus.Publish(context.Background(), "bad\x00topic", []byte("x"))
+	assert.ErrorIs(t, err, redisbus.ErrInvalidTopic)
+}

--- a/realtime/fanout/replay_test.go
+++ b/realtime/fanout/replay_test.go
@@ -1,0 +1,133 @@
+package fanout_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/realtime/fanout"
+)
+
+func TestReplay(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("resume after id", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New(fanout.WithReplay(4))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		for i := range 6 {
+			require.NoError(t, hub.Publish(ctx, "t", []byte{byte(i)}))
+		}
+		// The ring holds the newest 4 (payloads 2..5). Grab their IDs via a
+		// full resume first.
+		all, err := hub.Subscribe(ctx, []string{"t"}, fanout.WithResumeAfter(0))
+		require.NoError(t, err)
+		defer all.Close()
+		first := recv(t, all)
+		assert.Equal(t, byte(2), first.Payload[0])
+
+		sub, err := hub.Subscribe(ctx, []string{"t"}, fanout.WithResumeAfter(first.ID))
+		require.NoError(t, err)
+		defer sub.Close()
+		for want := byte(3); want <= 5; want++ {
+			assert.Equal(t, want, recv(t, sub).Payload[0])
+		}
+		// Live delivery continues seamlessly after the replayed backlog.
+		require.NoError(t, hub.Publish(ctx, "t", []byte{9}))
+		assert.Equal(t, byte(9), recv(t, sub).Payload[0])
+	})
+
+	t.Run("resume without replay errors", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New()
+		require.NoError(t, err)
+		defer hub.Close()
+
+		_, err = hub.Subscribe(ctx, []string{"t"}, fanout.WithResumeAfter(0))
+		assert.ErrorIs(t, err, fanout.ErrReplayDisabled)
+	})
+
+	t.Run("backlog exceeding buffer keeps newest and counts drops", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New(fanout.WithReplay(8))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		for i := range 6 {
+			require.NoError(t, hub.Publish(ctx, "t", []byte{byte(i)}))
+		}
+		sub, err := hub.Subscribe(ctx, []string{"t"}, fanout.WithResumeAfter(0), fanout.WithBuffer(2))
+		require.NoError(t, err)
+		defer sub.Close()
+		assert.Equal(t, byte(4), recv(t, sub).Payload[0])
+		assert.Equal(t, byte(5), recv(t, sub).Payload[0])
+		assert.Equal(t, uint64(4), sub.Dropped())
+	})
+
+	t.Run("multi-topic resume merges in id order", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New(fanout.WithReplay(4))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		require.NoError(t, hub.Publish(ctx, "a", []byte("1")))
+		require.NoError(t, hub.Publish(ctx, "b", []byte("2")))
+		require.NoError(t, hub.Publish(ctx, "a", []byte("3")))
+
+		sub, err := hub.Subscribe(ctx, []string{"a", "b"}, fanout.WithResumeAfter(0))
+		require.NoError(t, err)
+		defer sub.Close()
+		assert.Equal(t, []byte("1"), recv(t, sub).Payload)
+		assert.Equal(t, []byte("2"), recv(t, sub).Payload)
+		assert.Equal(t, []byte("3"), recv(t, sub).Payload)
+	})
+
+	t.Run("idle rings swept after ttl", func(t *testing.T) {
+		t.Parallel()
+		clk := clock.NewMock(time.Now())
+		hub, err := fanout.New(fanout.WithReplay(4), fanout.WithReplayTTL(time.Minute), fanout.WithClock(clk))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		require.NoError(t, hub.Publish(ctx, "old", []byte("x")))
+		clk.Advance(2 * time.Minute)
+		// A publish on any topic triggers the amortized sweep.
+		require.NoError(t, hub.Publish(ctx, "fresh", []byte("y")))
+
+		sub, err := hub.Subscribe(ctx, []string{"old"}, fanout.WithResumeAfter(0))
+		require.NoError(t, err)
+		defer sub.Close()
+		select {
+		case m := <-sub.C():
+			t.Fatalf("expected swept ring, got %+v", m)
+		case <-time.After(50 * time.Millisecond):
+		}
+	})
+
+	t.Run("subscribed topics survive the sweep", func(t *testing.T) {
+		t.Parallel()
+		clk := clock.NewMock(time.Now())
+		hub, err := fanout.New(fanout.WithReplay(4), fanout.WithReplayTTL(time.Minute), fanout.WithClock(clk))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		keeper, err := hub.Subscribe(ctx, []string{"kept"})
+		require.NoError(t, err)
+		defer keeper.Close()
+
+		require.NoError(t, hub.Publish(ctx, "kept", []byte("x")))
+		clk.Advance(2 * time.Minute)
+		require.NoError(t, hub.Publish(ctx, "other", []byte("y")))
+
+		require.NoError(t, hub.Publish(ctx, "kept", []byte("z")))
+		assert.Equal(t, []byte("x"), recv(t, keeper).Payload)
+		assert.Equal(t, []byte("z"), recv(t, keeper).Payload)
+	})
+}

--- a/realtime/fanout/ring.go
+++ b/realtime/fanout/ring.go
@@ -1,0 +1,40 @@
+package fanout
+
+// ring is a fixed-capacity overwrite buffer of the newest messages on one
+// topic. All access is serialized by the owning topicState's mutex.
+type ring struct {
+	buf  []Message
+	next int
+	size int
+}
+
+func newRing(n int) *ring {
+	return &ring{buf: make([]Message, n)}
+}
+
+func (r *ring) push(m Message) {
+	r.buf[r.next] = m
+	r.next++
+	if r.next == len(r.buf) {
+		r.next = 0
+	}
+	if r.size < len(r.buf) {
+		r.size++
+	}
+}
+
+// since appends the buffered messages with ID greater than after to dst in
+// ascending ID order.
+func (r *ring) since(after uint64, dst []Message) []Message {
+	start := r.next - r.size
+	if start < 0 {
+		start += len(r.buf)
+	}
+	for i := range r.size {
+		m := r.buf[(start+i)%len(r.buf)]
+		if m.ID > after {
+			dst = append(dst, m)
+		}
+	}
+	return dst
+}

--- a/realtime/fanout/scope_test.go
+++ b/realtime/fanout/scope_test.go
@@ -1,0 +1,107 @@
+package fanout_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/realtime/fanout"
+)
+
+type tenantKey struct{}
+
+func tenantCtx(tenant string) context.Context {
+	return context.WithValue(context.Background(), tenantKey{}, tenant)
+}
+
+func tenantScope(ctx context.Context) (string, error) {
+	tenant, _ := ctx.Value(tenantKey{}).(string)
+	return tenant, nil
+}
+
+func TestScope(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tenants are isolated on the same topic", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New(fanout.WithScope(tenantScope))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		alpha, err := hub.Subscribe(tenantCtx("alpha"), []string{"orders"})
+		require.NoError(t, err)
+		defer alpha.Close()
+		beta, err := hub.Subscribe(tenantCtx("beta"), []string{"orders"})
+		require.NoError(t, err)
+		defer beta.Close()
+
+		require.NoError(t, hub.Publish(tenantCtx("alpha"), "orders", []byte("a")))
+		msg := recv(t, alpha)
+		assert.Equal(t, "orders", msg.Topic, "subscriber sees the unscoped topic")
+		assert.Equal(t, []byte("a"), msg.Payload)
+		select {
+		case m := <-beta.C():
+			t.Fatalf("cross-tenant delivery: %+v", m)
+		case <-time.After(50 * time.Millisecond):
+		}
+	})
+
+	t.Run("fail closed on missing scope", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New(fanout.WithScope(tenantScope))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		ctx := context.Background()
+		assert.ErrorIs(t, hub.Publish(ctx, "orders", []byte("x")), fanout.ErrScopeMissing)
+		_, err = hub.Subscribe(ctx, []string{"orders"})
+		assert.ErrorIs(t, err, fanout.ErrScopeMissing)
+	})
+
+	t.Run("fail closed on scope hook error", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("boom")
+		hub, err := fanout.New(fanout.WithScope(func(context.Context) (string, error) { return "", boom }))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		err = hub.Publish(context.Background(), "orders", []byte("x"))
+		assert.ErrorIs(t, err, fanout.ErrScopeMissing)
+		assert.ErrorIs(t, err, boom)
+	})
+
+	t.Run("reserved bytes in scope rejected", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New(fanout.WithScope(func(context.Context) (string, error) { return "bad\x1ftenant", nil }))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		assert.ErrorIs(t, hub.Publish(context.Background(), "orders", nil), fanout.ErrInvalidScope)
+	})
+
+	t.Run("scoped replay resume", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New(fanout.WithScope(tenantScope), fanout.WithReplay(4))
+		require.NoError(t, err)
+		defer hub.Close()
+
+		require.NoError(t, hub.Publish(tenantCtx("alpha"), "orders", []byte("a1")))
+		require.NoError(t, hub.Publish(tenantCtx("beta"), "orders", []byte("b1")))
+
+		sub, err := hub.Subscribe(tenantCtx("alpha"), []string{"orders"}, fanout.WithResumeAfter(0))
+		require.NoError(t, err)
+		defer sub.Close()
+		msg := recv(t, sub)
+		assert.Equal(t, "orders", msg.Topic)
+		assert.Equal(t, []byte("a1"), msg.Payload)
+		select {
+		case m := <-sub.C():
+			t.Fatalf("cross-tenant replay: %+v", m)
+		case <-time.After(50 * time.Millisecond):
+		}
+	})
+}

--- a/realtime/fanout/scope_test.go
+++ b/realtime/fanout/scope_test.go
@@ -74,6 +74,18 @@ func TestScope(t *testing.T) {
 		assert.ErrorIs(t, err, boom)
 	})
 
+	t.Run("closed hub wins over scope errors", func(t *testing.T) {
+		t.Parallel()
+		hub, err := fanout.New(fanout.WithScope(tenantScope))
+		require.NoError(t, err)
+		hub.Close()
+
+		// No scope in ctx: the hook would fail, but ErrClosed must win.
+		err = hub.Publish(context.Background(), "orders", []byte("x"))
+		assert.ErrorIs(t, err, fanout.ErrClosed)
+		assert.NotErrorIs(t, err, fanout.ErrScopeMissing)
+	})
+
 	t.Run("reserved bytes in scope rejected", func(t *testing.T) {
 		t.Parallel()
 		hub, err := fanout.New(fanout.WithScope(func(context.Context) (string, error) { return "bad\x1ftenant", nil }))

--- a/realtime/fanout/scope_test.go
+++ b/realtime/fanout/scope_test.go
@@ -84,6 +84,10 @@ func TestScope(t *testing.T) {
 		err = hub.Publish(context.Background(), "orders", []byte("x"))
 		assert.ErrorIs(t, err, fanout.ErrClosed)
 		assert.NotErrorIs(t, err, fanout.ErrScopeMissing)
+
+		_, err = hub.Subscribe(context.Background(), []string{"orders"})
+		assert.ErrorIs(t, err, fanout.ErrClosed)
+		assert.NotErrorIs(t, err, fanout.ErrScopeMissing)
 	})
 
 	t.Run("reserved bytes in scope rejected", func(t *testing.T) {

--- a/realtime/fanout/subscription.go
+++ b/realtime/fanout/subscription.go
@@ -1,0 +1,129 @@
+package fanout
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Message is one delivery. Payload is shared across every subscriber of the
+// topic — do not mutate it. ID is monotonically increasing per hub instance
+// and is the resume cursor for WithResumeAfter; it is not stable across
+// instances or restarts.
+type Message struct {
+	Topic   string
+	Payload []byte
+	ID      uint64
+}
+
+// OverflowPolicy decides what happens when a message arrives and the
+// subscription's buffer is full.
+type OverflowPolicy uint8
+
+const (
+	// DropOldest evicts the oldest buffered message to make room (default):
+	// a stalled consumer resumes with the newest messages.
+	DropOldest OverflowPolicy = iota
+	// DropNewest discards the incoming message, preserving the buffered
+	// backlog.
+	DropNewest
+	// CloseSlow tears the subscription down: its channel closes and Err
+	// reports ErrSlowConsumer. The client must resubscribe (typically with
+	// WithResumeAfter) to catch up.
+	CloseSlow
+)
+
+// Subscription is one subscriber's bounded delivery stream. Receive from C;
+// Close when done. Safe for concurrent use, but C is a single stream — one
+// consumer per subscription.
+type Subscription struct {
+	err     error
+	hub     *Hub
+	ch      chan Message
+	states  []*topicState
+	keys    []string
+	dropped atomic.Uint64
+	mu      sync.Mutex
+	policy  OverflowPolicy
+	closed  bool
+}
+
+// C returns the delivery channel. It closes when Close is called or the hub
+// tears the subscription down; check Err after it closes to learn why.
+func (s *Subscription) C() <-chan Message { return s.ch }
+
+// Dropped reports how many messages this subscription lost to its overflow
+// policy (including replayed backlog that did not fit the buffer).
+func (s *Subscription) Dropped() uint64 { return s.dropped.Load() }
+
+// Err reports why the hub closed the subscription: ErrSlowConsumer under the
+// CloseSlow policy, ErrClosed on hub Close, nil while open or after the
+// subscriber's own Close.
+func (s *Subscription) Err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err
+}
+
+// Close unsubscribes and closes C. Idempotent and safe concurrently with
+// publishes.
+func (s *Subscription) Close() {
+	if s.closeWith(nil) {
+		s.hub.removeSub(s)
+	}
+}
+
+// closeWith marks the subscription closed with the given reason and closes
+// the channel. It reports whether this call performed the close.
+func (s *Subscription) closeWith(err error) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return false
+	}
+	s.closed = true
+	s.err = err
+	close(s.ch)
+	return true
+}
+
+// send delivers m without ever blocking, applying the overflow policy on a
+// full buffer. It reports whether the subscription is (now) closed and
+// should be removed from topic registries. Callers hold the topicState
+// mutex; lock order is always topicState → Subscription.
+func (s *Subscription) send(m Message) (remove bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return true
+	}
+	select {
+	case s.ch <- m:
+		return false
+	default:
+	}
+	switch s.policy {
+	case DropNewest:
+		s.dropped.Add(1)
+	case CloseSlow:
+		s.closed = true
+		s.err = ErrSlowConsumer
+		close(s.ch)
+		return true
+	default: // DropOldest
+		select {
+		case <-s.ch:
+			s.dropped.Add(1)
+		default:
+			// The consumer drained the buffer between the full check and the
+			// eviction; there is room now.
+		}
+		select {
+		case s.ch <- m:
+		default:
+			// Unreachable: sends are serialized by s.mu and the consumer only
+			// drains, but never block regardless.
+			s.dropped.Add(1)
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Implements the `realtime/fanout` catalog entry: the ephemeral, at-most-once fan-out hub behind the upcoming `realtime/sse` and `realtime/presence` packages, plus both backplane drivers.

### Core (`realtime/fanout`)

- **Hub** — `New(...Option)`, `Publish(ctx, topic, payload)`, `Subscribe(ctx, topics, ...SubscribeOption)` returning a channel-backed `Subscription`. Publishers never block; publishing to a topic with no subscribers is a no-op. Topic registry entries are garbage-collected when their last subscriber leaves.
- **Explicit slow-consumer policy** — per-subscription bounded buffer with `DropOldest` (default), `DropNewest`, or `CloseSlow` (tears the subscription down; `Err()` reports `ErrSlowConsumer`). Every loss is counted on `Subscription.Dropped()`.
- **Replay ring** — `WithReplay(n)` keeps a per-topic ring of the newest n messages; `WithResumeAfter(id)` replays the gap and goes live seamlessly (the Last-Event-ID currency for `realtime/sse`). Rings of subscriber-less topics are retained for `WithReplayTTL` (default 5m) and swept amortized from the publish path — no background goroutine anywhere in the core.
- **Bus seam** — with `WithBus`, publishes route through the backplane only and local delivery happens on the bus receive path, so every instance observes one ordering and one loss profile (no self-echo dedup needed).
- **Tenancy** — fail-closed `WithScope` hook namespaces topics via a reserved separator (`0x1F`, rejected in topics and scopes), isolating tenants including across a shared bus. Single-tenant apps configure nothing.

### Drivers

- **`fanout/pgbus`** — LISTEN/NOTIFY over the caller's `*pgxpool.Pool`. JSON+base64 envelope on one configurable channel; the 8000-byte NOTIFY cap is enforced (`ErrPayloadTooLarge`). `supervisor.Service` receive loop with exponential-backoff reconnect; the LISTEN connection is closed on exit, never released back into the pool with LISTEN state attached.
- **`fanout/redisbus`** — Redis Pub/Sub on the caller's `goredis.UniversalClient`. NUL-framed binary envelope (zero encoding overhead). `ReceiveMessage` ignores ctx cancellation, so shutdown closes the PubSub via `context.AfterFunc` — found by the integration tests hanging on teardown.

### Testing

- Black-box unit suite: policies, replay/resume (incl. buffer-overflow preload and TTL sweep via mock clock), scope isolation, fake-bus wiring, hub/subscription lifecycle, `-race` stress.
- `TestCloseSlowDuringSubscribe` is a proven regression test: a publisher-triggered `CloseSlow` teardown in the window before `Subscribe` returned raced on `sub.states`; the test detects the race pre-fix under `-race` and passes post-fix (assignment moved before registration).
- Integration tier (`-tags=integration`, testcontainers): cross-instance publish/receive incl. self-delivery and binary payload round-trip, channel isolation, oversized-payload rejection (pgbus), and hub-to-hub end-to-end over each driver. Channels are uniquified per test.

### Benchmarks (M3 Max, required pass)

```
BenchmarkPublish/1subs-14           9209701     118.3 ns/op       0 B/op    0 allocs/op
BenchmarkPublish/8subs-14           1823379     652.2 ns/op       0 B/op    0 allocs/op
BenchmarkPublish/64subs-14           125995      8915 ns/op       0 B/op    0 allocs/op
BenchmarkPublishNoSubscribers-14  125275588     9.602 ns/op       0 B/op    0 allocs/op
BenchmarkPublishReplay-14           5171304     231.7 ns/op       0 B/op    0 allocs/op
BenchmarkPublishScoped-14           6036384     198.6 ns/op      16 B/op    1 allocs/op
BenchmarkSubscribeClose-14          2352213     509.4 ns/op    3752 B/op    9 allocs/op
BenchmarkResume-14                   544324      2165 ns/op   11000 B/op   13 allocs/op
```

Post-benchmark optimization pass: the hub-closed check on `Publish` moved from an RLock pair to an `atomic.Bool` (written under the hub mutex), 120.5→115.6 ns/op on the 1-sub path; the publish hot path is zero-alloc (scoped publish pays one 16 B key concat, documented).

### Catalog

`realtime/fanout` entry deleted per the ship rule; the `(planned)` markers on `realtime/sse` and `realtime/presence` deps cleared.