### PR TITLE
feat(auth/session): server-side session lifecycle over pluggable stores

### DIFF
--- a/auth/session/bench_test.go
+++ b/auth/session/bench_test.go
@@ -1,0 +1,118 @@
+package session_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/core/ctxkey"
+	"github.com/dmitrymomot/forge/resilience/cache"
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+type benchData struct {
+	Cart  []string `json:"cart,omitempty"`
+	Theme string   `json:"theme,omitempty"`
+}
+
+func benchSession(b *testing.B, mgr *session.Manager[benchData], ctx context.Context) *session.Session[benchData] {
+	b.Helper()
+	s := mgr.Start(ctx)
+	s.Data = benchData{Cart: []string{"sku-1", "sku-2", "sku-3"}, Theme: "dark"}
+	if err := mgr.Save(ctx, s); err != nil {
+		b.Fatal(err)
+	}
+	return s
+}
+
+func BenchmarkSave_Memory(b *testing.B) {
+	mgr, err := session.New[benchData](session.NewMemoryStore())
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := b.Context()
+	s := benchSession(b, mgr, ctx)
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := mgr.Save(ctx, s); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkLoad_Memory(b *testing.B) {
+	mgr, err := session.New[benchData](session.NewMemoryStore())
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := b.Context()
+	s := benchSession(b, mgr, ctx)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Load(ctx, s.Token); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRotate_Memory(b *testing.B) {
+	mgr, err := session.New[benchData](session.NewMemoryStore())
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := b.Context()
+	s := benchSession(b, mgr, ctx)
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := mgr.Rotate(ctx, s); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+var benchDigestKey = ctxkey.New[fingerprint.Digest]("bench-digest")
+
+func BenchmarkLoad_MemoryFingerprintStrict(b *testing.B) {
+	src := func(ctx context.Context) (fingerprint.Digest, bool) { return benchDigestKey.From(ctx) }
+	mgr, err := session.New[benchData](session.NewMemoryStore(),
+		session.WithFingerprint(session.Strict), session.WithDigestSource(src))
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := benchDigestKey.With(b.Context(), fingerprint.Digest{
+		Parts:   map[string]string{"ua": "aa", "ip": "bb", "tls": "cc"},
+		Hash:    "combined",
+		Version: 1,
+	})
+	s := benchSession(b, mgr, ctx)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Load(ctx, s.Token); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSaveLoad_KV(b *testing.B) {
+	kvBackend := cache.NewMemoryStore()
+	defer func() { _ = kvBackend.Close() }()
+	kv, err := session.NewKVStore(kvBackend)
+	if err != nil {
+		b.Fatal(err)
+	}
+	mgr, err := session.New[benchData](kv)
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := b.Context()
+	s := benchSession(b, mgr, ctx)
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := mgr.Save(ctx, s); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := mgr.Load(ctx, s.Token); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/auth/session/cookiestore/bench_test.go
+++ b/auth/session/cookiestore/bench_test.go
@@ -1,0 +1,57 @@
+package cookiestore_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/auth/session/cookiestore"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/crypto/secret"
+)
+
+func benchStore(b *testing.B) (*cookiestore.Store, session.Record) {
+	b.Helper()
+	box, err := secret.New([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	store, err := cookiestore.New(box)
+	if err != nil {
+		b.Fatal(err)
+	}
+	rec := session.Record{
+		ID:        id.NewUUID(),
+		UserID:    "user-1",
+		Data:      []byte(`{"cart":["sku-1","sku-2","sku-3"],"theme":"dark"}`),
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	return store, rec
+}
+
+func BenchmarkSave(b *testing.B) {
+	store, rec := benchStore(b)
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := store.Save(ctx, "", rec); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkLoad(b *testing.B) {
+	store, rec := benchStore(b)
+	ctx := b.Context()
+	token, err := store.Save(ctx, "", rec)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := store.Load(ctx, token); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/auth/session/cookiestore/cookiestore.go
+++ b/auth/session/cookiestore/cookiestore.go
@@ -1,0 +1,119 @@
+// Package cookiestore is the stateless session.Store driver: the whole
+// record is AEAD-encrypted (crypto/secret.Box) and the ciphertext IS the
+// token, so there is no server-side state at all. Every Save re-encrypts and
+// returns a fresh token — re-set the client cookie after each Save.
+//
+// The trade-offs of statelessness, accepted knowingly:
+//
+//   - No revocation: Delete is a documented no-op. Destroying a session
+//     means clearing the client's cookie; a stolen token stays valid until
+//     its deadline expires. Keep TTLs short, or use a server-side store when
+//     revocation matters.
+//   - No UserIndex: multi-device listings and "log out everywhere" are
+//     impossible without server-side state (session.ErrNoUserIndex).
+//   - Size: the token must fit a cookie. Save fails with ErrTooLarge when
+//     the encoding exceeds the configured limit (default 3800 bytes, leaving
+//     headroom for the cookie name and attributes under the common 4096-byte
+//     browser cap). Keep session payloads small.
+//
+// Build the Box from a keyset to rotate encryption keys without logging
+// everyone out:
+//
+//	ks, _ := keyset.New(keyset.WithBase64Keys(os.Getenv("SESSION_KEYS")))
+//	box, _ := secret.FromKeyset(ks)
+//	store, _ := cookiestore.New(box)
+//	mgr, _ := session.New[Data](store)
+package cookiestore
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/crypto/secret"
+)
+
+// DefaultMaxLen caps the returned token length in bytes.
+const DefaultMaxLen = 3800
+
+var (
+	// ErrTooLarge reports an encoded session exceeding the size limit.
+	ErrTooLarge = errors.New("cookiestore: encoded session exceeds size limit")
+	// ErrInvalidConfig reports invalid constructor input.
+	ErrInvalidConfig = errors.New("cookiestore: invalid config")
+)
+
+// Store is the stateless cookie-backed session.Store. Build it with New.
+type Store struct {
+	box    *secret.Box
+	maxLen int
+}
+
+var _ session.Store = (*Store)(nil)
+
+// Option configures a Store.
+type Option func(*Store)
+
+// WithMaxLen overrides the token size limit (bytes). Lower it when cookie
+// attributes or a long cookie name eat into the 4096-byte browser cap.
+func WithMaxLen(n int) Option { return func(s *Store) { s.maxLen = n } }
+
+// New builds a Store encrypting records with box (see secret.New /
+// secret.FromKeyset).
+func New(box *secret.Box, opts ...Option) (*Store, error) {
+	if box == nil {
+		return nil, fmt.Errorf("%w: box is required", ErrInvalidConfig)
+	}
+	s := &Store{box: box, maxLen: DefaultMaxLen}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.maxLen <= 0 {
+		return nil, fmt.Errorf("%w: max length must be positive", ErrInvalidConfig)
+	}
+	return s, nil
+}
+
+// Save encrypts rec and returns the ciphertext as the new token; the token
+// argument (the previous encoding) is discarded.
+func (s *Store) Save(_ context.Context, _ string, rec session.Record) (string, error) {
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return "", err
+	}
+	ct, err := s.box.Encrypt(b)
+	if err != nil {
+		return "", err
+	}
+	token := base64.RawURLEncoding.EncodeToString(ct)
+	if len(token) > s.maxLen {
+		return "", fmt.Errorf("%w: %d > %d bytes", ErrTooLarge, len(token), s.maxLen)
+	}
+	return token, nil
+}
+
+// Load decrypts token into its record. Any tamper, truncation, or foreign-key
+// ciphertext is indistinguishable from an unknown token and returns
+// session.ErrNotFound.
+func (s *Store) Load(_ context.Context, token string) (session.Record, error) {
+	ct, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return session.Record{}, session.ErrNotFound
+	}
+	b, err := s.box.Decrypt(ct)
+	if err != nil {
+		return session.Record{}, session.ErrNotFound
+	}
+	var rec session.Record
+	if err := json.Unmarshal(b, &rec); err != nil {
+		return session.Record{}, session.ErrNotFound
+	}
+	return rec, nil
+}
+
+// Delete is a no-op: stateless tokens cannot be revoked server-side.
+// Clearing the client's cookie is the real destroy.
+func (s *Store) Delete(_ context.Context, _ string) error { return nil }

--- a/auth/session/cookiestore/cookiestore_test.go
+++ b/auth/session/cookiestore/cookiestore_test.go
@@ -1,0 +1,152 @@
+package cookiestore_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/auth/session/cookiestore"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+	"github.com/dmitrymomot/forge/crypto/secret"
+)
+
+type data struct {
+	Theme string `json:"theme,omitempty"`
+	Blob  string `json:"blob,omitempty"`
+}
+
+func newBox(t *testing.T) *secret.Box {
+	t.Helper()
+	box, err := secret.New([]byte("0123456789abcdef0123456789abcdef"))
+	require.NoError(t, err)
+	return box
+}
+
+func newStore(t *testing.T, opts ...cookiestore.Option) *cookiestore.Store {
+	t.Helper()
+	store, err := cookiestore.New(newBox(t), opts...)
+	require.NoError(t, err)
+	return store
+}
+
+func TestNew_Invalid(t *testing.T) {
+	t.Parallel()
+	_, err := cookiestore.New(nil)
+	assert.ErrorIs(t, err, cookiestore.ErrInvalidConfig)
+	_, err = cookiestore.New(newBox(t), cookiestore.WithMaxLen(0))
+	assert.ErrorIs(t, err, cookiestore.ErrInvalidConfig)
+}
+
+func TestLifecycle(t *testing.T) {
+	t.Parallel()
+	mgr, err := session.New[data](newStore(t))
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	s := mgr.Start(ctx)
+	s.Data.Theme = "dark"
+	require.NoError(t, mgr.Save(ctx, s))
+	require.NotEmpty(t, s.Token)
+
+	got, err := mgr.Load(ctx, s.Token)
+	require.NoError(t, err)
+	assert.Equal(t, s.ID, got.ID)
+	assert.Equal(t, "dark", got.Data.Theme)
+
+	// Every Save re-encrypts: the token changes and both encodings decode
+	// (statelessness means the old one cannot be revoked).
+	old := s.Token
+	require.NoError(t, mgr.Save(ctx, s))
+	assert.NotEqual(t, old, s.Token)
+	_, err = mgr.Load(ctx, old)
+	require.NoError(t, err)
+}
+
+func TestLoad_TamperAndGarbage(t *testing.T) {
+	t.Parallel()
+	store := newStore(t)
+	ctx := t.Context()
+	tok, err := store.Save(ctx, "", session.Record{Data: []byte(`{}`)})
+	require.NoError(t, err)
+
+	cases := map[string]string{
+		"garbage":     "not-a-token",
+		"bad base64":  "!!!!",
+		"empty":       "",
+		"truncated":   tok[:len(tok)/2],
+		"bit flipped": flipChar(tok),
+	}
+	for name, token := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := store.Load(ctx, token)
+			assert.ErrorIs(t, err, session.ErrNotFound)
+		})
+	}
+}
+
+// flipChar changes one ciphertext character so authentication fails.
+func flipChar(s string) string {
+	i := len(s) / 2
+	c := byte('A')
+	if s[i] == 'A' {
+		c = 'B'
+	}
+	return s[:i] + string(c) + s[i+1:]
+}
+
+func TestLoad_ForeignKeyRejected(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	tok, err := newStore(t).Save(ctx, "", session.Record{Data: []byte(`{}`)})
+	require.NoError(t, err)
+
+	otherBox, err := secret.New([]byte("ffffffffffffffffffffffffffffffff"))
+	require.NoError(t, err)
+	other, err := cookiestore.New(otherBox)
+	require.NoError(t, err)
+	_, err = other.Load(ctx, tok)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}
+
+func TestKeysetRotationKeepsOldTokensReadable(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	oldKey, newKey := []byte("0123456789abcdef0123456789abcdef"), []byte("abcdef0123456789abcdef0123456789")
+
+	oldBox, err := secret.New(oldKey)
+	require.NoError(t, err)
+	oldStore, err := cookiestore.New(oldBox)
+	require.NoError(t, err)
+	tok, err := oldStore.Save(ctx, "", session.Record{UserID: "u1"})
+	require.NoError(t, err)
+
+	ks, err := keyset.New(keyset.WithPrimary(2, newKey), keyset.WithRetired(0, oldKey))
+	require.NoError(t, err)
+	box, err := secret.FromKeyset(ks)
+	require.NoError(t, err)
+	rotated, err := cookiestore.New(box)
+	require.NoError(t, err)
+
+	rec, err := rotated.Load(ctx, tok)
+	require.NoError(t, err, "tokens sealed under the retired key must stay readable")
+	assert.Equal(t, "u1", rec.UserID)
+}
+
+func TestSave_TooLarge(t *testing.T) {
+	t.Parallel()
+	mgr, err := session.New[data](newStore(t))
+	require.NoError(t, err)
+	s := mgr.Start(t.Context())
+	s.Data.Blob = strings.Repeat("x", 4000)
+	err = mgr.Save(t.Context(), s)
+	assert.ErrorIs(t, err, cookiestore.ErrTooLarge)
+
+	tight, err := session.New[data](newStore(t, cookiestore.WithMaxLen(100)))
+	require.NoError(t, err)
+	s = tight.Start(t.Context())
+	assert.ErrorIs(t, tight.Save(t.Context(), s), cookiestore.ErrTooLarge)
+}

--- a/auth/session/cookiestore/fuzz_test.go
+++ b/auth/session/cookiestore/fuzz_test.go
@@ -1,0 +1,54 @@
+package cookiestore_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/auth/session/cookiestore"
+	"github.com/dmitrymomot/forge/crypto/secret"
+)
+
+// FuzzLoad pins the only acceptable outcomes for arbitrary tokens: a clean
+// session.ErrNotFound or — for the rare forgery-sized inputs — never a panic
+// or a successfully decoded record.
+func FuzzLoad(f *testing.F) {
+	box, err := secret.New([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		f.Fatal(err)
+	}
+	store, err := cookiestore.New(box)
+	if err != nil {
+		f.Fatal(err)
+	}
+	valid, err := store.Save(f.Context(), "", session.Record{Data: []byte(`{"a":1}`)})
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	f.Add("")
+	f.Add("AAAA")
+	f.Add("!!!not-base64!!!")
+	f.Add(valid)
+	f.Add(valid[:len(valid)-1])
+
+	f.Fuzz(func(t *testing.T, token string) {
+		rec, err := store.Load(t.Context(), token)
+		if err != nil {
+			if !errors.Is(err, session.ErrNotFound) {
+				t.Fatalf("unexpected error class: %v", err)
+			}
+			return
+		}
+		// A successful decode cryptographically implies the AEAD tag
+		// verified, i.e. this key sealed the token — in this or an earlier
+		// process (the fuzz corpus replays tokens across runs), possibly
+		// spelled with different base64 trailing bits. All records this
+		// harness ever seals carry exactly this payload; anything else means
+		// the store decoded a record it never sealed.
+		if !bytes.Equal(rec.Data, []byte(`{"a":1}`)) || rec.UserID != "" || !rec.ID.IsZero() {
+			t.Fatalf("forged token decoded into a record: %q -> %+v", token, rec)
+		}
+	})
+}

--- a/auth/session/doc.go
+++ b/auth/session/doc.go
@@ -1,0 +1,77 @@
+// Package session drives the server-side session lifecycle —
+// Start/Load/Save/Destroy/Rotate — over a pluggable Store, with typed
+// session data, rotate-on-privilege-change, optional multi-device management,
+// and optional fingerprint-based hijack detection.
+//
+// The Manager is generic over the consumer's payload type (JSON-encoded at
+// rest) and transport-agnostic: it deals in bearer tokens, and how a token
+// reaches the client (a cookie via web/cookie, a header) is the handler's
+// choice. Sessions expire on an idle TTL slid by each Save, capped by an
+// absolute lifetime no activity extends.
+//
+//	type Data struct {
+//		Cart []string `json:"cart,omitempty"`
+//	}
+//
+//	mgr, err := session.New[Data](session.NewMemoryStore()) // pgstore/cookiestore/NewKVStore in production
+//	if err != nil { ... }
+//
+//	// First visit: start, mutate, save, hand the token to the client.
+//	s := mgr.Start(ctx)
+//	s.Data.Cart = append(s.Data.Cart, "sku-1")
+//	if err := mgr.Save(ctx, s); err != nil { ... }
+//	http.SetCookie(w, &http.Cookie{Name: "sid", Value: s.Token, HttpOnly: true, Secure: true, Path: "/"})
+//
+//	// Later requests: load by the presented token.
+//	s, err = mgr.Load(ctx, cookieValue)
+//	switch {
+//	case errors.Is(err, session.ErrNotFound), errors.Is(err, session.ErrExpired):
+//		// no session — treat as signed out
+//	case err != nil: ...
+//	}
+//
+//	// Login: Authenticate binds the user and rotates the token so a
+//	// pre-login token planted by an attacker (session fixation) dies.
+//	if err := mgr.Authenticate(ctx, s, userID); err != nil { ... }
+//	http.SetCookie(w, ...) // s.Token changed — re-set the cookie
+//
+//	// Logout.
+//	if err := mgr.Destroy(ctx, s); err != nil { ... }
+//
+// # Stores
+//
+// The built-in MemoryStore is for tests and development. Production
+// backings: pgstore (Postgres, the only driver with UserIndex — multi-device
+// listings, "log out everywhere", GDPR deletion), cookiestore (stateless
+// encrypted cookie, no server state, no revocation), and NewKVStore over any
+// durable cache.Store (cache/redis).
+//
+// Multi-device management (UserIndex stores only):
+//
+//	devices, err := mgr.ListUserSessions(ctx, userID) // newest first, Token empty
+//	err = mgr.DeleteUserSessions(ctx, userID)         // log out everywhere
+//	err = mgr.Save(ctx, current)                      // then keep this device: re-persist it
+//
+// # Hijack detection
+//
+// WithFingerprint(session.Warn|session.Strict) compares each Load against
+// the fingerprint captured at Start/Rotate (from web/fingerprint.Middleware
+// via context, or a custom WithDigestSource). Warn logs the drifted
+// components; Strict revokes the session and returns
+// ErrFingerprintMismatch.
+//
+// # Tenancy
+//
+// Single-tenant apps pay no ceremony. Multi-tenant apps install a
+// construction-time scope hook; sessions are stamped at Save and invisible
+// outside their scope, and resolution fails closed when the hook errors or
+// returns empty:
+//
+//	mgr, err := session.New[Data](store, session.WithScope(func(ctx context.Context) (string, error) {
+//		t, ok := tenant.FromContext(ctx) // web/tenant
+//		if !ok {
+//			return "", errors.New("no tenant in context")
+//		}
+//		return t.ID, nil
+//	}))
+package session

--- a/auth/session/doc.go
+++ b/auth/session/doc.go
@@ -47,10 +47,11 @@
 // # Stores
 //
 // The built-in MemoryStore is for tests and development. Production
-// backings: pgstore (Postgres, the only driver with UserIndex — device
-// listings, per-device revocation, "log out everywhere", GDPR deletion),
-// cookiestore (stateless encrypted cookie, no server state, no revocation),
-// and NewKVStore over any durable cache.Store (cache/redis).
+// backings: pgstore (Postgres) and mongostore (MongoDB) — the UserIndex
+// drivers behind device listings, per-device revocation, "log out
+// everywhere", and GDPR deletion — plus cookiestore (stateless encrypted
+// cookie, no server state, no revocation) and NewKVStore over any durable
+// cache.Store (cache/redis).
 //
 // # Device management (UserIndex stores only)
 //

--- a/auth/session/doc.go
+++ b/auth/session/doc.go
@@ -1,56 +1,67 @@
 // Package session drives the server-side session lifecycle —
 // Start/Load/Save/Destroy/Rotate — over a pluggable Store, with typed
-// session data, rotate-on-privilege-change, optional multi-device management,
-// and optional fingerprint-based hijack detection.
+// session data, rotate-on-privilege-change, multi-device management
+// (list/revoke/logout-others with UI-ready metadata), pluggable client
+// transports, and optional fingerprint-based hijack detection.
 //
 // The Manager is generic over the consumer's payload type (JSON-encoded at
-// rest) and transport-agnostic: it deals in bearer tokens, and how a token
-// reaches the client (a cookie via web/cookie, a header) is the handler's
-// choice. Sessions expire on an idle TTL slid by each Save, capped by an
-// absolute lifetime no activity extends.
+// rest) and deals in bearer tokens; the request-level methods ride a
+// pluggable Transport (session/transport: Cookie, Bearer, Basic, JWT, or
+// any custom implementation). Sessions expire on an idle TTL slid by each
+// Save, capped by an absolute lifetime no activity extends.
 //
 //	type Data struct {
 //		Cart []string `json:"cart,omitempty"`
 //	}
 //
-//	mgr, err := session.New[Data](session.NewMemoryStore()) // pgstore/cookiestore/NewKVStore in production
+//	mgr, err := session.New[Data](session.NewMemoryStore(), // pgstore/cookiestore/NewKVStore in production
+//		session.WithTransport(transport.Cookie()))
 //	if err != nil { ... }
 //
-//	// First visit: start, mutate, save, hand the token to the client.
-//	s := mgr.Start(ctx)
+//	// First visit: start, mutate, save — SaveRequest sets the cookie and
+//	// stamps IP/User-Agent/LastSeenAt for the device listing.
+//	s := mgr.Start(r.Context())
 //	s.Data.Cart = append(s.Data.Cart, "sku-1")
-//	if err := mgr.Save(ctx, s); err != nil { ... }
-//	http.SetCookie(w, &http.Cookie{Name: "sid", Value: s.Token, HttpOnly: true, Secure: true, Path: "/"})
+//	if err := mgr.SaveRequest(w, r, s); err != nil { ... }
 //
-//	// Later requests: load by the presented token.
-//	s, err = mgr.Load(ctx, cookieValue)
+//	// Later requests.
+//	s, err = mgr.LoadRequest(r)
 //	switch {
 //	case errors.Is(err, session.ErrNotFound), errors.Is(err, session.ErrExpired):
 //		// no session — treat as signed out
 //	case err != nil: ...
 //	}
 //
-//	// Login: Authenticate binds the user and rotates the token so a
-//	// pre-login token planted by an attacker (session fixation) dies.
-//	if err := mgr.Authenticate(ctx, s, userID); err != nil { ... }
-//	http.SetCookie(w, ...) // s.Token changed — re-set the cookie
+//	// Login: binds the user and rotates the token so a pre-login token
+//	// planted by an attacker (session fixation) dies; the transport
+//	// re-embeds the replacement automatically.
+//	if err := mgr.AuthenticateRequest(w, r, s, userID); err != nil { ... }
 //
-//	// Logout.
-//	if err := mgr.Destroy(ctx, s); err != nil { ... }
+//	// Logout: revokes the session and clears the client credential.
+//	if err := mgr.DestroyRequest(w, r, s); err != nil { ... }
+//
+// The token-level API (Load/Save/Authenticate/Rotate/Destroy with a
+// context) remains fully usable without any transport — for non-HTTP
+// callers or hand-rolled wiring.
 //
 // # Stores
 //
 // The built-in MemoryStore is for tests and development. Production
-// backings: pgstore (Postgres, the only driver with UserIndex — multi-device
-// listings, "log out everywhere", GDPR deletion), cookiestore (stateless
-// encrypted cookie, no server state, no revocation), and NewKVStore over any
-// durable cache.Store (cache/redis).
+// backings: pgstore (Postgres, the only driver with UserIndex — device
+// listings, per-device revocation, "log out everywhere", GDPR deletion),
+// cookiestore (stateless encrypted cookie, no server state, no revocation),
+// and NewKVStore over any durable cache.Store (cache/redis).
 //
-// Multi-device management (UserIndex stores only):
+// # Device management (UserIndex stores only)
 //
-//	devices, err := mgr.ListUserSessions(ctx, userID) // newest first, Token empty
-//	err = mgr.DeleteUserSessions(ctx, userID)         // log out everywhere
-//	err = mgr.Save(ctx, current)                      // then keep this device: re-persist it
+// Sessions carry the metadata a "manage devices" page renders — ID,
+// IP, UserAgent, CreatedAt, LastSeenAt, ExpiresAt — and the current device
+// is the one whose ID matches the caller's own session:
+//
+//	devices, err := mgr.ListUserSessions(ctx, userID)      // newest first, Token empty
+//	err = mgr.RevokeUserSession(ctx, userID, devices[1].ID) // revoke one device
+//	err = mgr.LogoutOthers(ctx, current)                    // every device but this one
+//	err = mgr.DeleteUserSessions(ctx, userID)               // log out everywhere / GDPR
 //
 // # Hijack detection
 //

--- a/auth/session/errors.go
+++ b/auth/session/errors.go
@@ -1,0 +1,27 @@
+package session
+
+import "errors"
+
+var (
+	// ErrNotFound reports that no session exists for the token — never
+	// issued, destroyed, rotated away, or belonging to another scope.
+	ErrNotFound = errors.New("session: not found")
+	// ErrExpired reports a session past its idle or absolute deadline.
+	ErrExpired = errors.New("session: expired")
+	// ErrFingerprintMismatch reports a Strict-mode fingerprint drift; the
+	// stored session is revoked before this is returned.
+	ErrFingerprintMismatch = errors.New("session: fingerprint mismatch")
+	// ErrNoUserIndex reports a user-level operation on a Store that does not
+	// implement UserIndex (KV and cookie backings cannot list by user).
+	ErrNoUserIndex = errors.New("session: store does not implement UserIndex")
+	// ErrScope reports a configured scope hook that failed or returned empty.
+	ErrScope = errors.New("session: scope resolution failed")
+	// ErrStore wraps failures of the underlying Store.
+	ErrStore = errors.New("session: store operation failed")
+	// ErrCodec wraps session-data encode/decode failures.
+	ErrCodec = errors.New("session: data encoding failed")
+	// ErrInvalidConfig reports invalid constructor input.
+	ErrInvalidConfig = errors.New("session: invalid config")
+	// ErrInvalidInput reports an invalid method argument (empty user id).
+	ErrInvalidInput = errors.New("session: invalid input")
+)

--- a/auth/session/errors.go
+++ b/auth/session/errors.go
@@ -14,6 +14,9 @@ var (
 	// ErrNoUserIndex reports a user-level operation on a Store that does not
 	// implement UserIndex (KV and cookie backings cannot list by user).
 	ErrNoUserIndex = errors.New("session: store does not implement UserIndex")
+	// ErrNoTransport reports a request-level method on a Manager built
+	// without WithTransport.
+	ErrNoTransport = errors.New("session: no transport configured")
 	// ErrScope reports a configured scope hook that failed or returned empty.
 	ErrScope = errors.New("session: scope resolution failed")
 	// ErrStore wraps failures of the underlying Store.

--- a/auth/session/fingerprint_test.go
+++ b/auth/session/fingerprint_test.go
@@ -1,0 +1,161 @@
+package session_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/core/ctxkey"
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+var digestKey = ctxkey.New[fingerprint.Digest]("digest")
+
+// ctxDigest reads the test's digest straight from context, standing in for
+// fingerprint.Middleware.
+func ctxDigest(ctx context.Context) (fingerprint.Digest, bool) { return digestKey.From(ctx) }
+
+func digestCtx(t *testing.T, hash string, parts map[string]string) context.Context {
+	t.Helper()
+	return digestKey.With(t.Context(), fingerprint.Digest{Hash: hash, Parts: parts, Version: 1})
+}
+
+func newFPManager(t *testing.T, mode session.Mode, opts ...session.Option) (*session.Manager[data], *session.MemoryStore) {
+	t.Helper()
+	store := session.NewMemoryStore()
+	opts = append([]session.Option{session.WithFingerprint(mode), session.WithDigestSource(ctxDigest)}, opts...)
+	mgr, err := session.New[data](store, opts...)
+	require.NoError(t, err)
+	return mgr, store
+}
+
+func TestFingerprint_MatchPasses(t *testing.T) {
+	t.Parallel()
+	for _, mode := range []session.Mode{session.Warn, session.Strict} {
+		mgr, _ := newFPManager(t, mode)
+		ctx := digestCtx(t, "h1", map[string]string{"ua": "a"})
+		s := mgr.Start(ctx)
+		require.NoError(t, mgr.Save(ctx, s))
+		_, err := mgr.Load(ctx, s.Token)
+		require.NoError(t, err)
+	}
+}
+
+func TestFingerprint_StrictMismatchRevokes(t *testing.T) {
+	t.Parallel()
+	mgr, _ := newFPManager(t, session.Strict)
+	ctx := digestCtx(t, "h1", map[string]string{"ua": "a"})
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+
+	hijacked := digestCtx(t, "h2", map[string]string{"ua": "b"})
+	_, err := mgr.Load(hijacked, s.Token)
+	assert.ErrorIs(t, err, session.ErrFingerprintMismatch)
+
+	// The session must be revoked, not merely refused: even the original
+	// client is out.
+	_, err = mgr.Load(ctx, s.Token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}
+
+func TestFingerprint_StrictMissingDigestFailsClosed(t *testing.T) {
+	t.Parallel()
+	mgr, _ := newFPManager(t, session.Strict)
+	ctx := digestCtx(t, "h1", nil)
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+
+	// A baselined session presented without any live fingerprint is treated
+	// as hijacked, not waved through.
+	_, err := mgr.Load(t.Context(), s.Token)
+	assert.ErrorIs(t, err, session.ErrFingerprintMismatch)
+}
+
+func TestFingerprint_WarnLogsAndPasses(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil))
+	mgr, _ := newFPManager(t, session.Warn, session.WithLogger(log))
+
+	ctx := digestCtx(t, "h1", map[string]string{"ua": "a", "ip": "x"})
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+
+	drifted := digestCtx(t, "h2", map[string]string{"ua": "b", "ip": "x"})
+	got, err := mgr.Load(drifted, s.Token)
+	require.NoError(t, err, "warn mode must let the session through")
+	assert.Equal(t, s.ID, got.ID)
+	assert.Contains(t, buf.String(), "fingerprint drift")
+	assert.Contains(t, buf.String(), "ua", "drifted component names belong in the log")
+}
+
+func TestFingerprint_NoBaselineSkipsCheck(t *testing.T) {
+	t.Parallel()
+	mgr, _ := newFPManager(t, session.Strict)
+
+	// Started without any available fingerprint: no baseline, never checked.
+	s := mgr.Start(t.Context())
+	require.NoError(t, mgr.Save(t.Context(), s))
+	_, err := mgr.Load(digestCtx(t, "h1", nil), s.Token)
+	require.NoError(t, err)
+}
+
+func TestFingerprint_RotateRecapturesBaseline(t *testing.T) {
+	t.Parallel()
+	mgr, _ := newFPManager(t, session.Strict)
+	oldCtx := digestCtx(t, "h1", nil)
+	s := mgr.Start(oldCtx)
+	require.NoError(t, mgr.Save(oldCtx, s))
+
+	// Login from a new device: Authenticate rotates and adopts its digest.
+	newCtx := digestCtx(t, "h2", nil)
+	require.NoError(t, mgr.Authenticate(newCtx, s, "user-1"))
+	_, err := mgr.Load(newCtx, s.Token)
+	require.NoError(t, err)
+	_, err = mgr.Load(oldCtx, s.Token)
+	assert.ErrorIs(t, err, session.ErrFingerprintMismatch)
+}
+
+// TestFingerprint_DefaultSourceRidesMiddleware proves the default digest
+// source picks up web/fingerprint.Middleware without any wiring.
+func TestFingerprint_DefaultSourceRidesMiddleware(t *testing.T) {
+	t.Parallel()
+	fp, err := fingerprint.Session(fingerprint.Config{Secret: "0123456789abcdef0123456789abcdef", Version: 1, TokenTTL: time.Minute})
+	require.NoError(t, err)
+	mgr, err := session.New[data](session.NewMemoryStore(), session.WithFingerprint(session.Strict))
+	require.NoError(t, err)
+
+	var token string
+	var loadErr error
+	mux := http.NewServeMux()
+	mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+		s := mgr.Start(r.Context())
+		require.NoError(t, mgr.Save(r.Context(), s))
+		token = s.Token
+	})
+	mux.HandleFunc("/load", func(w http.ResponseWriter, r *http.Request) {
+		_, loadErr = mgr.Load(r.Context(), token)
+	})
+	handler := fp.Middleware()(mux)
+
+	do := func(path, ua string) {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("User-Agent", ua)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	do("/start", "browser-a")
+	require.NotEmpty(t, token)
+	do("/load", "browser-a")
+	require.NoError(t, loadErr)
+	do("/load", "browser-b")
+	assert.ErrorIs(t, loadErr, session.ErrFingerprintMismatch)
+}

--- a/auth/session/fingerprint_test.go
+++ b/auth/session/fingerprint_test.go
@@ -3,6 +3,7 @@ package session_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -122,6 +123,72 @@ func TestFingerprint_RotateRecapturesBaseline(t *testing.T) {
 	require.NoError(t, err)
 	_, err = mgr.Load(oldCtx, s.Token)
 	assert.ErrorIs(t, err, session.ErrFingerprintMismatch)
+}
+
+// failDeleteStore fails Delete while delegating everything else.
+type failDeleteStore struct {
+	session.Store
+	err error
+}
+
+func (f *failDeleteStore) Delete(ctx context.Context, token string) error {
+	if f.err != nil {
+		return f.err
+	}
+	return f.Store.Delete(ctx, token)
+}
+
+func TestFingerprint_RotateSaveFailureRestoresBaseline(t *testing.T) {
+	t.Parallel()
+	store := session.NewMemoryStore()
+	fs := &failSaveStore{Store: store}
+	mgr, err := session.New[data](fs,
+		session.WithFingerprint(session.Strict), session.WithDigestSource(ctxDigest))
+	require.NoError(t, err)
+
+	ctxA := digestCtx(t, "h1", nil)
+	s := mgr.Start(ctxA)
+	require.NoError(t, mgr.Save(ctxA, s))
+
+	// A rotation from a new device fails at the store; the in-memory session
+	// must roll back to the baseline the store still holds.
+	fs.err = errors.New("boom")
+	require.Error(t, mgr.Rotate(digestCtx(t, "h2", nil), s))
+	fs.err = nil
+
+	require.NoError(t, mgr.Save(ctxA, s))
+	_, err = mgr.Load(ctxA, s.Token)
+	require.NoError(t, err, "the original device must still match after a failed rotation")
+}
+
+// failSaveStore fails Save while delegating everything else.
+type failSaveStore struct {
+	session.Store
+	err error
+}
+
+func (f *failSaveStore) Save(ctx context.Context, token string, rec session.Record) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.Store.Save(ctx, token, rec)
+}
+
+func TestFingerprint_StrictRevokeFailureKeepsMismatchSignal(t *testing.T) {
+	t.Parallel()
+	fs := &failDeleteStore{Store: session.NewMemoryStore()}
+	mgr, err := session.New[data](fs,
+		session.WithFingerprint(session.Strict), session.WithDigestSource(ctxDigest))
+	require.NoError(t, err)
+
+	ctx := digestCtx(t, "h1", nil)
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+
+	fs.err = errors.New("boom")
+	_, err = mgr.Load(digestCtx(t, "h2", nil), s.Token)
+	assert.ErrorIs(t, err, session.ErrFingerprintMismatch, "a failed revoke must not swallow the hijack signal")
+	assert.ErrorIs(t, err, session.ErrStore, "and the revoke failure must surface too")
 }
 
 // TestFingerprint_DefaultSourceRidesMiddleware proves the default digest

--- a/auth/session/http.go
+++ b/auth/session/http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"time"
+	"unicode/utf8"
 
 	"github.com/dmitrymomot/forge/web/clientip"
 )
@@ -96,7 +97,13 @@ func (m *Manager[T]) saveRequest(w http.ResponseWriter, r *http.Request, s *Sess
 	}
 	ip, ua := m.cfg.clientInfo(r)
 	if len(ua) > maxUserAgentLen {
-		ua = ua[:maxUserAgentLen]
+		// Cut on a rune boundary: a byte-count slice through a multi-byte
+		// UTF-8 sequence would store an invalid string.
+		cut := maxUserAgentLen
+		for cut > 0 && !utf8.RuneStart(ua[cut]) {
+			cut--
+		}
+		ua = ua[:cut]
 	}
 	s.IP, s.UserAgent = ip, ua
 	if err := op(m, r.Context(), s); err != nil {

--- a/auth/session/http.go
+++ b/auth/session/http.go
@@ -1,0 +1,106 @@
+package session
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/dmitrymomot/forge/web/clientip"
+)
+
+// maxUserAgentLen caps the stored User-Agent so an attacker-controlled header
+// can't bloat records (or blow the cookiestore size limit).
+const maxUserAgentLen = 256
+
+// Transport carries the bearer token between client and server — the seam
+// the request-level Manager methods ride. Implementations ship in
+// session/transport (Cookie, Bearer, Basic, JWT); anything satisfying the
+// interface plugs in via WithTransport.
+type Transport interface {
+	// Extract returns the token presented by r, or "" when none is carried.
+	Extract(r *http.Request) string
+	// Embed hands token to the client on w (Set-Cookie, response header).
+	// expiresAt bounds client-side retention. Transports whose credential is
+	// client-managed (Basic) may no-op.
+	Embed(w http.ResponseWriter, token string, expiresAt time.Time) error
+	// Clear removes the client-side credential.
+	Clear(w http.ResponseWriter) error
+}
+
+// ClientInfo extracts display metadata (client IP, User-Agent) from a
+// request for device listings. See WithClientInfo.
+type ClientInfo func(r *http.Request) (ip, userAgent string)
+
+func defaultClientInfo(r *http.Request) (string, string) {
+	return clientip.Resolve(r), r.UserAgent()
+}
+
+// LoadRequest extracts the token via the configured Transport and loads its
+// session — Load's request-level form. A request carrying no token fails
+// with ErrNotFound.
+func (m *Manager[T]) LoadRequest(r *http.Request) (*Session[T], error) {
+	t, err := m.transport()
+	if err != nil {
+		return nil, err
+	}
+	return m.Load(r.Context(), t.Extract(r))
+}
+
+// SaveRequest stamps the session's client metadata (IP, User-Agent),
+// persists it, and embeds the current token in the response — Save's
+// request-level form. Call it whenever the session changed; the transport
+// keeps the client's credential in sync (stateless stores mint a new token
+// on every save).
+func (m *Manager[T]) SaveRequest(w http.ResponseWriter, r *http.Request, s *Session[T]) error {
+	return m.saveRequest(w, r, s, (*Manager[T]).Save)
+}
+
+// AuthenticateRequest is Authenticate's request-level form: it binds userID,
+// rotates the token, and embeds the replacement in the response.
+func (m *Manager[T]) AuthenticateRequest(w http.ResponseWriter, r *http.Request, s *Session[T], userID string) error {
+	return m.saveRequest(w, r, s, func(m *Manager[T], ctx context.Context, s *Session[T]) error {
+		return m.Authenticate(ctx, s, userID)
+	})
+}
+
+// RotateRequest is Rotate's request-level form: it re-keys the session and
+// embeds the replacement token in the response.
+func (m *Manager[T]) RotateRequest(w http.ResponseWriter, r *http.Request, s *Session[T]) error {
+	return m.saveRequest(w, r, s, (*Manager[T]).Rotate)
+}
+
+// DestroyRequest is Destroy's request-level form: it revokes the session and
+// clears the client-side credential.
+func (m *Manager[T]) DestroyRequest(w http.ResponseWriter, r *http.Request, s *Session[T]) error {
+	t, err := m.transport()
+	if err != nil {
+		return err
+	}
+	if err := m.Destroy(r.Context(), s); err != nil {
+		return err
+	}
+	return t.Clear(w)
+}
+
+func (m *Manager[T]) transport() (Transport, error) {
+	if m.cfg.transport == nil {
+		return nil, ErrNoTransport
+	}
+	return m.cfg.transport, nil
+}
+
+func (m *Manager[T]) saveRequest(w http.ResponseWriter, r *http.Request, s *Session[T], op func(*Manager[T], context.Context, *Session[T]) error) error {
+	t, err := m.transport()
+	if err != nil {
+		return err
+	}
+	ip, ua := m.cfg.clientInfo(r)
+	if len(ua) > maxUserAgentLen {
+		ua = ua[:maxUserAgentLen]
+	}
+	s.IP, s.UserAgent = ip, ua
+	if err := op(m, r.Context(), s); err != nil {
+		return err
+	}
+	return t.Embed(w, s.Token, s.ExpiresAt)
+}

--- a/auth/session/http_test.go
+++ b/auth/session/http_test.go
@@ -1,0 +1,148 @@
+package session_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/auth/session/transport"
+)
+
+func newWebManager(t *testing.T, opts ...session.Option) *session.Manager[data] {
+	t.Helper()
+	opts = append([]session.Option{session.WithTransport(transport.Cookie(transport.WithCookieName("sid")))}, opts...)
+	mgr, err := session.New[data](session.NewMemoryStore(), opts...)
+	require.NoError(t, err)
+	return mgr
+}
+
+// cookieRequest builds a request carrying the session cookie from a prior
+// response, mimicking a browser.
+func cookieRequest(t *testing.T, rec *httptest.ResponseRecorder) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	for _, ck := range rec.Result().Cookies() {
+		if ck.MaxAge >= 0 && ck.Value != "" {
+			r.AddCookie(&http.Cookie{Name: ck.Name, Value: ck.Value})
+		}
+	}
+	return r
+}
+
+func TestRequestFlow_CookieBrowser(t *testing.T) {
+	t.Parallel()
+	mgr := newWebManager(t)
+
+	// First visit: start + save sets the cookie.
+	w1 := httptest.NewRecorder()
+	r1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r1.Header.Set("User-Agent", "browser-a")
+	r1.RemoteAddr = "203.0.113.7:4711"
+	s := mgr.Start(r1.Context())
+	s.Data.Theme = "dark"
+	require.NoError(t, mgr.SaveRequest(w1, r1, s))
+	cks := w1.Result().Cookies()
+	require.Len(t, cks, 1)
+	assert.Equal(t, "sid", cks[0].Name)
+	assert.Equal(t, s.Token, cks[0].Value)
+	assert.True(t, cks[0].HttpOnly)
+	assert.True(t, cks[0].Secure)
+
+	// Metadata stamped for the device listing.
+	assert.Equal(t, "203.0.113.7", s.IP)
+	assert.Equal(t, "browser-a", s.UserAgent)
+	assert.False(t, s.LastSeenAt.IsZero())
+
+	// Next request: the browser presents the cookie.
+	got, err := mgr.LoadRequest(cookieRequest(t, w1))
+	require.NoError(t, err)
+	assert.Equal(t, s.ID, got.ID)
+	assert.Equal(t, "dark", got.Data.Theme)
+	assert.Equal(t, "203.0.113.7", got.IP)
+
+	// Login: rotation must re-set the cookie with the new token.
+	w2 := httptest.NewRecorder()
+	r2 := cookieRequest(t, w1)
+	require.NoError(t, mgr.AuthenticateRequest(w2, r2, got, "user-1"))
+	cks = w2.Result().Cookies()
+	require.Len(t, cks, 1)
+	assert.Equal(t, got.Token, cks[0].Value)
+	assert.NotEqual(t, s.Token, cks[0].Value)
+
+	// The old cookie is dead, the new one works.
+	_, err = mgr.LoadRequest(cookieRequest(t, w1))
+	assert.ErrorIs(t, err, session.ErrNotFound)
+	authed, err := mgr.LoadRequest(cookieRequest(t, w2))
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", authed.UserID)
+
+	// Logout: destroy revokes and expires the cookie.
+	w3 := httptest.NewRecorder()
+	require.NoError(t, mgr.DestroyRequest(w3, cookieRequest(t, w2), authed))
+	cks = w3.Result().Cookies()
+	require.Len(t, cks, 1)
+	assert.Negative(t, cks[0].MaxAge, "logout must expire the cookie")
+	_, err = mgr.LoadRequest(cookieRequest(t, w2))
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}
+
+func TestRequestFlow_NoTokenIsNotFound(t *testing.T) {
+	t.Parallel()
+	mgr := newWebManager(t)
+	_, err := mgr.LoadRequest(httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}
+
+func TestRequestFlow_NoTransport(t *testing.T) {
+	t.Parallel()
+	mgr, _, _ := newManager(t)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	s := mgr.Start(r.Context())
+
+	_, err := mgr.LoadRequest(r)
+	assert.ErrorIs(t, err, session.ErrNoTransport)
+	assert.ErrorIs(t, mgr.SaveRequest(w, r, s), session.ErrNoTransport)
+	assert.ErrorIs(t, mgr.AuthenticateRequest(w, r, s, "u"), session.ErrNoTransport)
+	assert.ErrorIs(t, mgr.RotateRequest(w, r, s), session.ErrNoTransport)
+	assert.ErrorIs(t, mgr.DestroyRequest(w, r, s), session.ErrNoTransport)
+}
+
+func TestRequestFlow_ClientInfoHookAndUACap(t *testing.T) {
+	t.Parallel()
+	custom := func(r *http.Request) (string, string) { return "10.0.0.1", r.Header.Get("X-Custom-UA") }
+	mgr := newWebManager(t, session.WithClientInfo(custom))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	longUA := make([]byte, 1000)
+	for i := range longUA {
+		longUA[i] = 'u'
+	}
+	r.Header.Set("X-Custom-UA", string(longUA))
+	s := mgr.Start(r.Context())
+	require.NoError(t, mgr.SaveRequest(w, r, s))
+	assert.Equal(t, "10.0.0.1", s.IP)
+	assert.Len(t, s.UserAgent, 256, "hostile User-Agent must be truncated")
+}
+
+func TestRequestFlow_RotateRequest(t *testing.T) {
+	t.Parallel()
+	mgr := newWebManager(t)
+	w1 := httptest.NewRecorder()
+	r1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	s := mgr.Start(r1.Context())
+	require.NoError(t, mgr.SaveRequest(w1, r1, s))
+	old := s.Token
+
+	w2 := httptest.NewRecorder()
+	require.NoError(t, mgr.RotateRequest(w2, cookieRequest(t, w1), s))
+	assert.NotEqual(t, old, s.Token)
+	cks := w2.Result().Cookies()
+	require.Len(t, cks, 1)
+	assert.Equal(t, s.Token, cks[0].Value)
+}

--- a/auth/session/http_test.go
+++ b/auth/session/http_test.go
@@ -3,7 +3,9 @@ package session_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -128,6 +130,17 @@ func TestRequestFlow_ClientInfoHookAndUACap(t *testing.T) {
 	require.NoError(t, mgr.SaveRequest(w, r, s))
 	assert.Equal(t, "10.0.0.1", s.IP)
 	assert.Len(t, s.UserAgent, 256, "hostile User-Agent must be truncated")
+
+	// A multi-byte rune straddling the cap must not be split mid-sequence:
+	// after the ASCII prefix every 2-byte rune starts on an odd index, so
+	// byte 256 falls mid-rune and the cut must retreat to 255.
+	multi := "a" + strings.Repeat("é", 200)
+	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2.Header.Set("X-Custom-UA", multi)
+	s2 := mgr.Start(r2.Context())
+	require.NoError(t, mgr.SaveRequest(httptest.NewRecorder(), r2, s2))
+	assert.True(t, utf8.ValidString(s2.UserAgent), "truncation must land on a rune boundary")
+	assert.Equal(t, 255, len(s2.UserAgent))
 }
 
 func TestRequestFlow_RotateRequest(t *testing.T) {

--- a/auth/session/kvstore.go
+++ b/auth/session/kvstore.go
@@ -1,0 +1,78 @@
+package session
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/crypto/digest"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+// kvStore adapts the framework-wide TTL-KV seam (cache.Store) into a session
+// Store. Records ride the backend's native TTL, keyed by a digest of the
+// token so the bearer credential never appears in backend keys (Redis SCAN,
+// dashboards). Plain KV cannot list by user, so there is no UserIndex —
+// use pgstore when multi-device management matters.
+type kvStore struct {
+	kv cache.Store
+}
+
+// NewKVStore returns a Store over kv. Use a durable backend (cache/redis) —
+// cache's LRU memory store evicts live sessions under pressure; for
+// tests/dev prefer NewMemoryStore.
+func NewKVStore(kv cache.Store) (Store, error) {
+	if kv == nil {
+		return nil, fmt.Errorf("%w: kv store is required", ErrInvalidConfig)
+	}
+	return &kvStore{kv: kv}, nil
+}
+
+func kvKey(token string) string {
+	return "session:" + hex.EncodeToString(digest.SHA256([]byte(token)))
+}
+
+// Save upserts rec with a TTL matching its deadline; the token is returned
+// unchanged. An already-expired record is deleted instead of stored, so a
+// backend treating TTL<=0 as "no expiry" can never hold an eternal session.
+func (s *kvStore) Save(ctx context.Context, token string, rec Record) (string, error) {
+	ttl := time.Until(rec.ExpiresAt)
+	if ttl <= 0 {
+		if err := s.kv.Delete(ctx, kvKey(token)); err != nil {
+			return "", err
+		}
+		return token, nil
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return "", err
+	}
+	if err := s.kv.Set(ctx, kvKey(token), b, cache.WithTTL(ttl)); err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// Load returns the record for token, or ErrNotFound.
+func (s *kvStore) Load(ctx context.Context, token string) (Record, error) {
+	b, err := s.kv.Get(ctx, kvKey(token))
+	if err != nil {
+		if errors.Is(err, cache.ErrNotFound) {
+			return Record{}, ErrNotFound
+		}
+		return Record{}, err
+	}
+	var rec Record
+	if err := json.Unmarshal(b, &rec); err != nil {
+		return Record{}, err
+	}
+	return rec, nil
+}
+
+// Delete removes the record for token; absent tokens are a no-op.
+func (s *kvStore) Delete(ctx context.Context, token string) error {
+	return s.kv.Delete(ctx, kvKey(token))
+}

--- a/auth/session/kvstore_test.go
+++ b/auth/session/kvstore_test.go
@@ -1,0 +1,82 @@
+package session_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/resilience/cache"
+)
+
+func newCacheStore(t *testing.T) cache.Store {
+	t.Helper()
+	kv := cache.NewMemoryStore()
+	t.Cleanup(func() { _ = kv.Close() })
+	return kv
+}
+
+func TestKVStore_Lifecycle(t *testing.T) {
+	t.Parallel()
+	kv, err := session.NewKVStore(newCacheStore(t))
+	require.NoError(t, err)
+	mgr, err := session.New[data](kv)
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	s := mgr.Start(ctx)
+	s.Data.Cart = []string{"sku-1", "sku-2"}
+	require.NoError(t, mgr.Save(ctx, s))
+
+	got, err := mgr.Load(ctx, s.Token)
+	require.NoError(t, err)
+	assert.Equal(t, s.ID, got.ID)
+	assert.Equal(t, s.Data, got.Data)
+	assert.WithinDuration(t, s.ExpiresAt, got.ExpiresAt, time.Second)
+
+	require.NoError(t, mgr.Rotate(ctx, s))
+	_, err = mgr.Load(ctx, got.Token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+
+	require.NoError(t, mgr.Destroy(ctx, s))
+}
+
+func TestKVStore_NilBackend(t *testing.T) {
+	t.Parallel()
+	_, err := session.NewKVStore(nil)
+	assert.ErrorIs(t, err, session.ErrInvalidConfig)
+}
+
+func TestKVStore_ExpiredRecordNeverStored(t *testing.T) {
+	t.Parallel()
+	kv, err := session.NewKVStore(newCacheStore(t))
+	require.NoError(t, err)
+
+	// Direct Store use: a record already past its deadline must not be
+	// written (a backend treating TTL<=0 as eternal would keep it forever).
+	rec := session.Record{ExpiresAt: time.Now().Add(-time.Minute)}
+	tok, err := kv.Save(t.Context(), "tok", rec)
+	require.NoError(t, err)
+	assert.Equal(t, "tok", tok)
+	_, err = kv.Load(t.Context(), "tok")
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}
+
+func TestKVStore_ExpiredSaveReplacesLiveRecord(t *testing.T) {
+	t.Parallel()
+	kv, err := session.NewKVStore(newCacheStore(t))
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	live := session.Record{ExpiresAt: time.Now().Add(time.Hour)}
+	_, err = kv.Save(ctx, "tok", live)
+	require.NoError(t, err)
+
+	dead := session.Record{ExpiresAt: time.Now().Add(-time.Minute)}
+	_, err = kv.Save(ctx, "tok", dead)
+	require.NoError(t, err)
+	_, err = kv.Load(ctx, "tok")
+	assert.ErrorIs(t, err, session.ErrNotFound, "an expired save must revoke, not retain, the live record")
+}

--- a/auth/session/memory.go
+++ b/auth/session/memory.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"sync"
 	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
 )
 
 // MemoryStore is the built-in Store + UserIndex for tests and development.
@@ -78,12 +80,24 @@ func (s *MemoryStore) ListByUser(_ context.Context, scope, userID string) ([]Rec
 	return out, nil
 }
 
-// DeleteByUser removes every record bound to userID within scope.
-func (s *MemoryStore) DeleteByUser(_ context.Context, scope, userID string) error {
+// DeleteByUser removes every record bound to userID within scope, except the
+// ids in keep.
+func (s *MemoryStore) DeleteByUser(_ context.Context, scope, userID string, keep ...id.UUID) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	maps.DeleteFunc(s.byToken, func(_ string, rec Record) bool {
-		return rec.Scope == scope && rec.UserID == userID
+		return rec.Scope == scope && rec.UserID == userID && !slices.Contains(keep, rec.ID)
+	})
+	return nil
+}
+
+// DeleteOne removes the record for sessionID when it is bound to userID
+// within scope; anything else is a no-op.
+func (s *MemoryStore) DeleteOne(_ context.Context, scope, userID string, sessionID id.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	maps.DeleteFunc(s.byToken, func(_ string, rec Record) bool {
+		return rec.Scope == scope && rec.UserID == userID && rec.ID == sessionID
 	})
 	return nil
 }

--- a/auth/session/memory.go
+++ b/auth/session/memory.go
@@ -1,0 +1,102 @@
+package session
+
+import (
+	"bytes"
+	"context"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+)
+
+// MemoryStore is the built-in Store + UserIndex for tests and development.
+// It grows unbounded (expired records are removed lazily on Load and via
+// PurgeExpired) — production deployments use pgstore, cookiestore, or
+// NewKVStore over a durable cache.Store.
+type MemoryStore struct {
+	byToken map[string]Record
+	mu      sync.RWMutex
+}
+
+// NewMemoryStore returns an empty in-memory store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{byToken: make(map[string]Record)}
+}
+
+var (
+	_ Store     = (*MemoryStore)(nil)
+	_ UserIndex = (*MemoryStore)(nil)
+)
+
+// cloneRecord copies the record's reference fields so callers cannot mutate
+// stored state through shared slices/maps (and vice versa).
+func cloneRecord(rec Record) Record {
+	rec.Data = bytes.Clone(rec.Data)
+	rec.Fingerprint.Parts = maps.Clone(rec.Fingerprint.Parts)
+	return rec
+}
+
+// Save upserts rec under token; the token is returned unchanged.
+func (s *MemoryStore) Save(_ context.Context, token string, rec Record) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.byToken[token] = cloneRecord(rec)
+	return token, nil
+}
+
+// Load returns the record for token, or ErrNotFound.
+func (s *MemoryStore) Load(_ context.Context, token string) (Record, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	rec, ok := s.byToken[token]
+	if !ok {
+		return Record{}, ErrNotFound
+	}
+	return cloneRecord(rec), nil
+}
+
+// Delete removes the record for token; absent tokens are a no-op.
+func (s *MemoryStore) Delete(_ context.Context, token string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.byToken, token)
+	return nil
+}
+
+// ListByUser returns the records bound to userID within scope, newest first.
+func (s *MemoryStore) ListByUser(_ context.Context, scope, userID string) ([]Record, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := []Record{}
+	for _, rec := range s.byToken {
+		if rec.Scope == scope && rec.UserID == userID {
+			out = append(out, cloneRecord(rec))
+		}
+	}
+	// UUIDv7 ids are time-ordered, so byte-descending is newest first.
+	slices.SortFunc(out, func(a, b Record) int { return bytes.Compare(b.ID[:], a.ID[:]) })
+	return out, nil
+}
+
+// DeleteByUser removes every record bound to userID within scope.
+func (s *MemoryStore) DeleteByUser(_ context.Context, scope, userID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	maps.DeleteFunc(s.byToken, func(_ string, rec Record) bool {
+		return rec.Scope == scope && rec.UserID == userID
+	})
+	return nil
+}
+
+// PurgeExpired removes records whose deadline is at or before now and reports
+// how many were dropped. Long-lived dev processes call it periodically;
+// tests usually don't need it.
+func (s *MemoryStore) PurgeExpired(now time.Time) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := len(s.byToken)
+	maps.DeleteFunc(s.byToken, func(_ string, rec Record) bool {
+		return !rec.ExpiresAt.After(now)
+	})
+	return n - len(s.byToken)
+}

--- a/auth/session/memory_test.go
+++ b/auth/session/memory_test.go
@@ -1,0 +1,72 @@
+package session_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+func TestMemoryStore_CallerCannotMutateStoredState(t *testing.T) {
+	t.Parallel()
+	store := session.NewMemoryStore()
+	ctx := t.Context()
+
+	rec := session.Record{ID: id.NewUUID(), Data: []byte(`{"a":1}`), ExpiresAt: time.Now().Add(time.Hour)}
+	_, err := store.Save(ctx, "tok", rec)
+	require.NoError(t, err)
+	rec.Data[0] = 'X' // caller keeps mutating its copy after Save
+
+	got, err := store.Load(ctx, "tok")
+	require.NoError(t, err)
+	assert.Equal(t, byte('{'), got.Data[0], "stored state leaked the caller's slice")
+	got.Data[0] = 'Y' // and mutating a loaded record must not write through
+
+	again, err := store.Load(ctx, "tok")
+	require.NoError(t, err)
+	assert.Equal(t, byte('{'), again.Data[0])
+}
+
+func TestMemoryStore_ListByUserNewestFirst(t *testing.T) {
+	t.Parallel()
+	store := session.NewMemoryStore()
+	ctx := t.Context()
+
+	// Monotonic ids: same-millisecond UUIDv7 ties are otherwise unordered.
+	gen := id.NewGenerator(id.WithMonotonic())
+	var ids [3]id.UUID
+	for i := range 3 {
+		rec := session.Record{ID: gen.UUID(), UserID: "u", ExpiresAt: time.Now().Add(time.Hour)}
+		ids[i] = rec.ID
+		_, err := store.Save(ctx, string(rune('a'+i)), rec)
+		require.NoError(t, err)
+	}
+	list, err := store.ListByUser(ctx, "", "u")
+	require.NoError(t, err)
+	require.Len(t, list, 3)
+	assert.Equal(t, ids[2], list[0].ID)
+	assert.Equal(t, ids[0], list[2].ID)
+}
+
+func TestMemoryStore_PurgeExpired(t *testing.T) {
+	t.Parallel()
+	store := session.NewMemoryStore()
+	ctx := t.Context()
+	now := time.Now()
+
+	_, err := store.Save(ctx, "dead", session.Record{ID: id.NewUUID(), ExpiresAt: now.Add(-time.Minute)})
+	require.NoError(t, err)
+	_, err = store.Save(ctx, "live", session.Record{ID: id.NewUUID(), ExpiresAt: now.Add(time.Hour)})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, store.PurgeExpired(now))
+	_, err = store.Load(ctx, "dead")
+	assert.ErrorIs(t, err, session.ErrNotFound)
+	_, err = store.Load(ctx, "live")
+	require.NoError(t, err)
+	assert.Equal(t, 0, store.PurgeExpired(now))
+}

--- a/auth/session/mongostore/doc.go
+++ b/auth/session/mongostore/doc.go
@@ -1,0 +1,23 @@
+// Package mongostore is the MongoDB session.Store + session.UserIndex driver
+// over the official v2 client — full multi-device management (device
+// listings, per-device revocation, "log out everywhere", GDPR deletion) for
+// Mongo-backed apps. Tokens are persisted only as SHA-256 digests, so a
+// database leak exposes no usable session credentials.
+//
+// Construction performs no I/O; create the indexes once at boot:
+//
+//	store, err := mongostore.New(client.Database("app"))
+//	if err != nil { ... }
+//	if err := store.EnsureIndexes(ctx); err != nil { ... }
+//	mgr, err := session.New[Data](store)
+//
+// Expired sessions are reaped by MongoDB's native TTL monitor (the
+// expires_at TTL index, roughly once a minute) — no sweep job to schedule;
+// the Manager refuses expired records regardless, so the reaping lag is
+// invisible to callers. Reads are pinned to the primary: a session store
+// must read its own acknowledged writes, and a secondary-lagging read would
+// miss a just-saved session or resurrect a just-revoked one.
+//
+// BSON datetimes carry millisecond precision, so stored timestamps are
+// truncated to the millisecond on round-trip.
+package mongostore

--- a/auth/session/mongostore/mongostore.go
+++ b/auth/session/mongostore/mongostore.go
@@ -1,0 +1,240 @@
+package mongostore
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	mongodriver "go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/crypto/digest"
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+var collectionNameRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// sessionDoc is the BSON shape of one session record. _id is the hex SHA-256
+// of the bearer token (never the token itself), session_id the stable UUID as
+// its canonical string — UUIDv7 hex sorts lexicographically in time order, so
+// a descending sort on it is newest-first. The fingerprint digest is stored
+// as its JSON encoding, matching pgstore, so the wire shape stays identical
+// across drivers.
+type sessionDoc struct {
+	CreatedAt   time.Time `bson:"created_at"`
+	ExpiresAt   time.Time `bson:"expires_at"`
+	LastSeenAt  time.Time `bson:"last_seen_at"`
+	ID          string    `bson:"_id"`
+	SessionID   string    `bson:"session_id"`
+	UserID      string    `bson:"user_id"`
+	Scope       string    `bson:"scope"`
+	IP          string    `bson:"ip,omitempty"`
+	UserAgent   string    `bson:"user_agent,omitempty"`
+	Data        []byte    `bson:"data,omitempty"`
+	Fingerprint []byte    `bson:"fingerprint,omitempty"`
+}
+
+// Store is the MongoDB implementation of session.Store + session.UserIndex.
+// Tokens are persisted only as SHA-256 digests, so a database leak exposes no
+// usable credentials. The client's lifecycle is the caller's.
+type Store struct {
+	coll *mongodriver.Collection
+}
+
+var (
+	_ session.Store     = (*Store)(nil)
+	_ session.UserIndex = (*Store)(nil)
+)
+
+// config carries construction-time settings.
+type config struct {
+	collection string
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithCollection overrides the collection name (default "forge_sessions").
+func WithCollection(name string) Option {
+	return func(c *config) { c.collection = name }
+}
+
+// New builds a MongoDB session Store over db. It performs no I/O; call
+// EnsureIndexes once at boot. The collection handle is pinned to primary
+// reads regardless of the client's read preference: a session store must
+// read its own acknowledged writes — a secondary-lagging read would miss a
+// just-saved session or, worse, resurrect a just-revoked one.
+func New(db *mongodriver.Database, opts ...Option) (*Store, error) {
+	cfg := config{collection: "forge_sessions"}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if db == nil {
+		return nil, errors.New("mongostore: nil database")
+	}
+	if !collectionNameRe.MatchString(cfg.collection) {
+		return nil, fmt.Errorf("mongostore: invalid collection name %q", cfg.collection)
+	}
+	coll := db.Collection(cfg.collection, options.Collection().SetReadPreference(readpref.Primary()))
+	return &Store{coll: coll}, nil
+}
+
+// EnsureIndexes idempotently creates the indexes the store relies on: the
+// user-listing index over authenticated sessions and a TTL index on
+// expires_at, so MongoDB's TTL monitor reaps expired sessions natively
+// (roughly once a minute — the Manager refuses expired records regardless,
+// so the lag is invisible to callers). Run once at boot; re-running is a
+// server-side no-op.
+func (s *Store) EnsureIndexes(ctx context.Context) error {
+	models := []mongodriver.IndexModel{
+		{
+			Keys: bson.D{{Key: "scope", Value: 1}, {Key: "user_id", Value: 1}, {Key: "session_id", Value: -1}},
+			Options: options.Index().SetName("session_user").
+				SetPartialFilterExpression(bson.D{{Key: "user_id", Value: bson.D{{Key: "$gt", Value: ""}}}}),
+		},
+		{
+			Keys:    bson.D{{Key: "expires_at", Value: 1}},
+			Options: options.Index().SetName("session_ttl").SetExpireAfterSeconds(0),
+		},
+	}
+	if _, err := s.coll.Indexes().CreateMany(ctx, models); err != nil {
+		return fmt.Errorf("mongostore: ensure indexes: %w", err)
+	}
+	return nil
+}
+
+func tokenHash(token string) string {
+	return hex.EncodeToString(digest.SHA256([]byte(token)))
+}
+
+// Save upserts rec under token's digest; the token is returned unchanged.
+func (s *Store) Save(ctx context.Context, token string, rec session.Record) (string, error) {
+	doc := sessionDoc{
+		ID:         tokenHash(token),
+		SessionID:  rec.ID.String(),
+		UserID:     rec.UserID,
+		Scope:      rec.Scope,
+		IP:         rec.IP,
+		UserAgent:  rec.UserAgent,
+		Data:       rec.Data,
+		CreatedAt:  rec.CreatedAt,
+		ExpiresAt:  rec.ExpiresAt,
+		LastSeenAt: rec.LastSeenAt,
+	}
+	if rec.Fingerprint.Hash != "" {
+		b, err := json.Marshal(rec.Fingerprint)
+		if err != nil {
+			return "", err
+		}
+		doc.Fingerprint = b
+	}
+	_, err := s.coll.ReplaceOne(ctx, bson.D{{Key: "_id", Value: doc.ID}}, doc,
+		options.Replace().SetUpsert(true))
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// Load returns the record for token, or session.ErrNotFound.
+func (s *Store) Load(ctx context.Context, token string) (session.Record, error) {
+	var doc sessionDoc
+	err := s.coll.FindOne(ctx, bson.D{{Key: "_id", Value: tokenHash(token)}}).Decode(&doc)
+	if errors.Is(err, mongodriver.ErrNoDocuments) {
+		return session.Record{}, session.ErrNotFound
+	}
+	if err != nil {
+		return session.Record{}, err
+	}
+	return recordOf(doc)
+}
+
+// Delete removes the record for token; absent tokens are a no-op.
+func (s *Store) Delete(ctx context.Context, token string) error {
+	_, err := s.coll.DeleteOne(ctx, bson.D{{Key: "_id", Value: tokenHash(token)}})
+	return err
+}
+
+// ListByUser returns the records bound to userID within scope, newest first.
+func (s *Store) ListByUser(ctx context.Context, scope, userID string) ([]session.Record, error) {
+	cur, err := s.coll.Find(ctx,
+		bson.D{{Key: "scope", Value: scope}, {Key: "user_id", Value: userID}},
+		options.Find().SetSort(bson.D{{Key: "session_id", Value: -1}}))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cur.Close(ctx) }()
+	out := []session.Record{}
+	for cur.Next(ctx) {
+		var doc sessionDoc
+		if err := cur.Decode(&doc); err != nil {
+			return nil, err
+		}
+		rec, err := recordOf(doc)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	return out, cur.Err()
+}
+
+// DeleteByUser removes every record bound to userID within scope, except the
+// ids in keep.
+func (s *Store) DeleteByUser(ctx context.Context, scope, userID string, keep ...id.UUID) error {
+	filter := bson.D{{Key: "scope", Value: scope}, {Key: "user_id", Value: userID}}
+	if len(keep) > 0 {
+		keepIDs := make([]string, len(keep))
+		for i, k := range keep {
+			keepIDs[i] = k.String()
+		}
+		filter = append(filter, bson.E{Key: "session_id", Value: bson.D{{Key: "$nin", Value: keepIDs}}})
+	}
+	_, err := s.coll.DeleteMany(ctx, filter)
+	return err
+}
+
+// DeleteOne removes the record for sessionID when it is bound to userID
+// within scope; anything else is a no-op.
+func (s *Store) DeleteOne(ctx context.Context, scope, userID string, sessionID id.UUID) error {
+	_, err := s.coll.DeleteOne(ctx, bson.D{
+		{Key: "scope", Value: scope},
+		{Key: "user_id", Value: userID},
+		{Key: "session_id", Value: sessionID.String()},
+	})
+	return err
+}
+
+func recordOf(doc sessionDoc) (session.Record, error) {
+	var sid id.UUID
+	if err := sid.UnmarshalText([]byte(doc.SessionID)); err != nil {
+		return session.Record{}, fmt.Errorf("mongostore: corrupt session_id %q: %w", doc.SessionID, err)
+	}
+	rec := session.Record{
+		ID:         sid,
+		UserID:     doc.UserID,
+		Scope:      doc.Scope,
+		IP:         doc.IP,
+		UserAgent:  doc.UserAgent,
+		Data:       doc.Data,
+		CreatedAt:  doc.CreatedAt,
+		ExpiresAt:  doc.ExpiresAt,
+		LastSeenAt: doc.LastSeenAt,
+	}
+	if len(doc.Fingerprint) > 0 {
+		var d fingerprint.Digest
+		if err := json.Unmarshal(doc.Fingerprint, &d); err != nil {
+			return session.Record{}, err
+		}
+		rec.Fingerprint = d
+	}
+	return rec, nil
+}

--- a/auth/session/mongostore/mongostore_integration_test.go
+++ b/auth/session/mongostore/mongostore_integration_test.go
@@ -1,0 +1,248 @@
+//go:build integration
+
+package mongostore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	mongodriver "go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/auth/session/mongostore"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/core/random"
+	"github.com/dmitrymomot/forge/testkit/mongotest"
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+// runID keeps re-runs against a persistent server (FORGE_TEST_MONGO_URI)
+// collision-free: every process uses its own collection.
+var runID = id.NewULID().String()
+
+func newStore(t *testing.T) *mongostore.Store {
+	t.Helper()
+	client, err := mongodriver.Connect(options.Client().ApplyURI(mongotest.URI(t)))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = client.Disconnect(ctx)
+	})
+	s, err := mongostore.New(client.Database("forge_session_test"), mongostore.WithCollection("st_"+runID))
+	require.NoError(t, err)
+	require.NoError(t, s.EnsureIndexes(context.Background()))
+	return s
+}
+
+// mkRecord builds a record whose user/scope are unique per call so tests
+// sharing the process collection never see each other's rows.
+func mkRecord(t *testing.T) session.Record {
+	t.Helper()
+	uid := id.NewUUID()
+	now := time.Now().UTC().Truncate(time.Millisecond) // BSON datetime precision
+	return session.Record{
+		ID:         uid,
+		UserID:     "user-" + uid.String(),
+		Scope:      "scope-" + uid.String(),
+		IP:         "203.0.113.7",
+		UserAgent:  "browser-a",
+		Data:       []byte(`{"theme":"dark"}`),
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(time.Hour),
+		LastSeenAt: now,
+	}
+}
+
+func newToken() string { return random.URLSafe(32) }
+
+func TestMongo_InvalidConfig(t *testing.T) {
+	_, err := mongostore.New(nil)
+	require.Error(t, err)
+	client, err := mongodriver.Connect(options.Client().ApplyURI(mongotest.URI(t)))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Disconnect(context.Background()) })
+	_, err = mongostore.New(client.Database("forge_session_test"), mongostore.WithCollection("bad name!"))
+	require.Error(t, err)
+}
+
+func TestMongo_SaveLoadRoundTrip(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	rec := mkRecord(t)
+	rec.Fingerprint = fingerprint.Digest{
+		Parts:   map[string]string{"ua": "aa", "ip": "bb"},
+		Hash:    "combined",
+		Version: 1,
+	}
+	token := newToken()
+
+	returned, err := s.Save(ctx, token, rec)
+	require.NoError(t, err)
+	assert.Equal(t, token, returned, "server-side stores must not rewrite the token")
+
+	got, err := s.Load(ctx, token)
+	require.NoError(t, err)
+	assert.Equal(t, rec.ID, got.ID)
+	assert.Equal(t, rec.UserID, got.UserID)
+	assert.Equal(t, rec.Scope, got.Scope)
+	assert.Equal(t, rec.Data, got.Data)
+	assert.Equal(t, rec.Fingerprint, got.Fingerprint)
+	assert.Equal(t, rec.IP, got.IP)
+	assert.Equal(t, rec.UserAgent, got.UserAgent)
+	// BSON datetimes are millisecond-precision; mkRecord pre-truncates, so
+	// exact equality is expected (in UTC).
+	assert.True(t, rec.CreatedAt.Equal(got.CreatedAt), "created_at: want %v got %v", rec.CreatedAt, got.CreatedAt)
+	assert.True(t, rec.ExpiresAt.Equal(got.ExpiresAt), "expires_at: want %v got %v", rec.ExpiresAt, got.ExpiresAt)
+	assert.True(t, rec.LastSeenAt.Equal(got.LastSeenAt), "last_seen_at: want %v got %v", rec.LastSeenAt, got.LastSeenAt)
+}
+
+func TestMongo_LoadUnknown(t *testing.T) {
+	s := newStore(t)
+	_, err := s.Load(context.Background(), newToken())
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}
+
+func TestMongo_SaveUpsertsAndFingerprintEmpty(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	rec := mkRecord(t)
+	token := newToken()
+
+	_, err := s.Save(ctx, token, rec)
+	require.NoError(t, err)
+
+	rec.UserID = "rebound-" + rec.UserID
+	rec.Data = []byte(`{"theme":"light"}`)
+	rec.ExpiresAt = rec.ExpiresAt.Add(time.Hour)
+	_, err = s.Save(ctx, token, rec)
+	require.NoError(t, err, "second save under the same token must upsert")
+
+	got, err := s.Load(ctx, token)
+	require.NoError(t, err)
+	assert.Equal(t, rec.UserID, got.UserID)
+	assert.Equal(t, rec.Data, got.Data)
+	assert.Empty(t, got.Fingerprint.Hash, "a zero digest must round-trip as zero")
+}
+
+func TestMongo_Delete(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	token := newToken()
+	_, err := s.Save(ctx, token, mkRecord(t))
+	require.NoError(t, err)
+
+	require.NoError(t, s.Delete(ctx, token))
+	_, err = s.Load(ctx, token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+	require.NoError(t, s.Delete(ctx, token), "deleting an absent token is a no-op")
+}
+
+func TestMongo_UserIndex(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	scope := "scope-" + id.NewUUID().String()
+	user := "user-" + id.NewUUID().String()
+	gen := id.NewGenerator(id.WithMonotonic())
+
+	var ids [3]id.UUID
+	for i := range 3 {
+		rec := mkRecord(t)
+		rec.ID = gen.UUID()
+		rec.Scope, rec.UserID = scope, user
+		ids[i] = rec.ID
+		_, err := s.Save(ctx, newToken(), rec)
+		require.NoError(t, err)
+	}
+	// Same user in a sibling scope must stay invisible.
+	other := mkRecord(t)
+	other.UserID = user
+	otherToken := newToken()
+	_, err := s.Save(ctx, otherToken, other)
+	require.NoError(t, err)
+
+	list, err := s.ListByUser(ctx, scope, user)
+	require.NoError(t, err)
+	require.Len(t, list, 3)
+	assert.Equal(t, ids[2], list[0].ID, "newest first")
+	assert.Equal(t, ids[0], list[2].ID)
+
+	// Keep-list: "log out other devices" preserves exactly the kept id.
+	require.NoError(t, s.DeleteByUser(ctx, scope, user, ids[2]))
+	list, err = s.ListByUser(ctx, scope, user)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, ids[2], list[0].ID)
+
+	require.NoError(t, s.DeleteByUser(ctx, scope, user))
+	list, err = s.ListByUser(ctx, scope, user)
+	require.NoError(t, err)
+	assert.Empty(t, list)
+	_, err = s.Load(ctx, otherToken)
+	require.NoError(t, err, "sibling-scope session must survive DeleteByUser")
+
+	require.NoError(t, s.DeleteByUser(ctx, scope, user), "deleting a user with no sessions is a no-op")
+}
+
+func TestMongo_DeleteOne(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	rec := mkRecord(t)
+	token := newToken()
+	_, err := s.Save(ctx, token, rec)
+	require.NoError(t, err)
+
+	// Wrong user binding revokes nothing (IDOR guard).
+	require.NoError(t, s.DeleteOne(ctx, rec.Scope, "someone-else", rec.ID))
+	_, err = s.Load(ctx, token)
+	require.NoError(t, err)
+
+	require.NoError(t, s.DeleteOne(ctx, rec.Scope, rec.UserID, rec.ID))
+	_, err = s.Load(ctx, token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+	require.NoError(t, s.DeleteOne(ctx, rec.Scope, rec.UserID, rec.ID), "revoking an absent session is a no-op")
+}
+
+// TestMongo_ManagerEndToEnd runs the full Manager lifecycle against MongoDB,
+// including the device-management verbs.
+func TestMongo_ManagerEndToEnd(t *testing.T) {
+	type data struct {
+		Theme string `json:"theme,omitempty"`
+	}
+	mgr, err := session.New[data](newStore(t))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	s := mgr.Start(ctx)
+	s.Data.Theme = "dark"
+	require.NoError(t, mgr.Save(ctx, s))
+	user := "user-" + s.ID.String()
+	require.NoError(t, mgr.Authenticate(ctx, s, user))
+
+	otherDevice := mgr.Start(ctx)
+	require.NoError(t, mgr.Authenticate(ctx, otherDevice, user))
+
+	got, err := mgr.Load(ctx, s.Token)
+	require.NoError(t, err)
+	assert.Equal(t, "dark", got.Data.Theme)
+
+	list, err := mgr.ListUserSessions(ctx, user)
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+
+	require.NoError(t, mgr.LogoutOthers(ctx, s))
+	_, err = mgr.Load(ctx, otherDevice.Token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+	_, err = mgr.Load(ctx, s.Token)
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.Destroy(ctx, s))
+	_, err = mgr.Load(ctx, got.Token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}

--- a/auth/session/options.go
+++ b/auth/session/options.go
@@ -28,13 +28,15 @@ const (
 type DigestSource func(ctx context.Context) (fingerprint.Digest, bool)
 
 type config struct {
-	clock    clock.Clock
-	scope    func(ctx context.Context) (string, error)
-	logger   *slog.Logger
-	digest   DigestSource
-	ttl      time.Duration
-	lifetime time.Duration
-	fpMode   Mode
+	clock      clock.Clock
+	scope      func(ctx context.Context) (string, error)
+	logger     *slog.Logger
+	digest     DigestSource
+	transport  Transport
+	clientInfo ClientInfo
+	ttl        time.Duration
+	lifetime   time.Duration
+	fpMode     Mode
 }
 
 // Option configures a Manager.
@@ -69,6 +71,20 @@ func WithDigestSource(src DigestSource) Option { return func(c *config) { c.dige
 func WithScope(fn func(ctx context.Context) (string, error)) Option {
 	return func(c *config) { c.scope = fn }
 }
+
+// WithTransport installs the client-credential transport backing the
+// request-level methods (LoadRequest, SaveRequest, AuthenticateRequest,
+// RotateRequest, DestroyRequest). Ship implementations live in
+// session/transport (Cookie, Bearer, Basic, JWT); any Transport
+// implementation plugs in. Without it the request-level methods fail with
+// ErrNoTransport — the token-level API stays fully usable.
+func WithTransport(t Transport) Option { return func(c *config) { c.transport = t } }
+
+// WithClientInfo overrides how the request-level methods extract the client
+// IP and User-Agent stamped onto sessions for device listings. The default
+// resolves the IP via web/clientip and takes the User-Agent header verbatim
+// (truncated to 256 bytes).
+func WithClientInfo(fn ClientInfo) Option { return func(c *config) { c.clientInfo = fn } }
 
 // WithLogger sets the logger for Warn-mode drift reports. Default is a no-op
 // logger.

--- a/auth/session/options.go
+++ b/auth/session/options.go
@@ -1,0 +1,78 @@
+package session
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+// Mode selects how a fingerprint mismatch on Load is handled; see
+// WithFingerprint.
+type Mode int
+
+const (
+	// Warn logs the drift (session id + drifted component names) and lets the
+	// session through — telemetry mode for tuning before enforcing.
+	Warn Mode = iota + 1
+	// Strict revokes the stored session and fails the Load with
+	// ErrFingerprintMismatch. A missing current fingerprint also fails closed
+	// when the session has a stored baseline.
+	Strict
+)
+
+// DigestSource extracts the current request's fingerprint digest from ctx.
+// ok is false when no fingerprint is available.
+type DigestSource func(ctx context.Context) (fingerprint.Digest, bool)
+
+type config struct {
+	clock    clock.Clock
+	scope    func(ctx context.Context) (string, error)
+	logger   *slog.Logger
+	digest   DigestSource
+	ttl      time.Duration
+	lifetime time.Duration
+	fpMode   Mode
+}
+
+// Option configures a Manager.
+type Option func(*config)
+
+// WithTTL sets the idle timeout: each Save pushes the deadline ttl into the
+// future (capped by the absolute lifetime). Default 24h.
+func WithTTL(ttl time.Duration) Option { return func(c *config) { c.ttl = ttl } }
+
+// WithLifetime sets the absolute cap counted from CreatedAt; no amount of
+// activity or rotation extends a session past it. Default 30 days.
+func WithLifetime(d time.Duration) Option { return func(c *config) { c.lifetime = d } }
+
+// WithFingerprint enables hijack detection. Start (and Rotate) captures the
+// current request's fingerprint digest as the session's baseline; Load
+// compares the baseline against the live request and applies mode on
+// mismatch. The digest comes from fingerprint.FromContext, so run
+// fingerprint.Middleware ahead of session handlers (or supply
+// WithDigestSource). Sessions started without an available fingerprint carry
+// no baseline and are never checked.
+func WithFingerprint(mode Mode) Option { return func(c *config) { c.fpMode = mode } }
+
+// WithDigestSource overrides where WithFingerprint reads the live request's
+// digest from — for consumers fingerprinting via their own middleware or
+// edge/CDN headers.
+func WithDigestSource(src DigestSource) Option { return func(c *config) { c.digest = src } }
+
+// WithScope installs the tenancy hook mapping a request context to a scope
+// string (e.g. the tenant id). Sessions are stamped with the scope at Save
+// and invisible outside it. Resolution fails closed: a hook error or empty
+// scope aborts the operation. Single-tenant apps omit this option entirely.
+func WithScope(fn func(ctx context.Context) (string, error)) Option {
+	return func(c *config) { c.scope = fn }
+}
+
+// WithLogger sets the logger for Warn-mode drift reports. Default is a no-op
+// logger.
+func WithLogger(l *slog.Logger) Option { return func(c *config) { c.logger = l } }
+
+// WithClock injects a clock for tests.
+func WithClock(ck clock.Clock) Option { return func(c *config) { c.clock = ck } }

--- a/auth/session/pgstore/doc.go
+++ b/auth/session/pgstore/doc.go
@@ -1,0 +1,16 @@
+// Package pgstore is the Postgres session.Store + session.UserIndex driver
+// over pgx — the backing for multi-device management ("log out other
+// devices", GDPR deletion). Tokens are persisted only as SHA-256 digests, so
+// a database leak exposes no usable session credentials.
+//
+// The DDL (forge_sessions) ships as an embedded goose migration in
+// Migrations; apply it via data/migration under its own version table before
+// first use:
+//
+//	_ = migration.New(pgstore.Migrations, migration.WithTable("forge_session_schema")).Up(ctx, db)
+//
+// Expired rows are deleted lazily on Load; schedule DeleteExpired
+// (async/scheduler or cron) to keep the table bounded:
+//
+//	n, err := store.DeleteExpired(ctx, time.Now())
+package pgstore

--- a/auth/session/pgstore/migrations/00001_create_forge_sessions.sql
+++ b/auth/session/pgstore/migrations/00001_create_forge_sessions.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+CREATE TABLE forge_sessions (
+    token_hash  text PRIMARY KEY,
+    id          uuid NOT NULL,
+    user_id     text NOT NULL DEFAULT '',
+    scope       text NOT NULL DEFAULT '',
+    data        bytea NOT NULL DEFAULT ''::bytea,
+    fingerprint bytea,
+    created_at  timestamptz NOT NULL,
+    expires_at  timestamptz NOT NULL
+);
+
+-- Multi-device listings and per-user deletion; anonymous sessions carry no
+-- user and stay out of the index.
+CREATE INDEX forge_sessions_user_idx ON forge_sessions (scope, user_id, id DESC)
+    WHERE user_id <> '';
+
+-- DeleteExpired sweep.
+CREATE INDEX forge_sessions_expires_idx ON forge_sessions (expires_at);
+
+-- +goose Down
+DROP TABLE forge_sessions;

--- a/auth/session/pgstore/migrations/00001_create_forge_sessions.sql
+++ b/auth/session/pgstore/migrations/00001_create_forge_sessions.sql
@@ -1,13 +1,16 @@
 -- +goose Up
 CREATE TABLE forge_sessions (
-    token_hash  text PRIMARY KEY,
-    id          uuid NOT NULL,
-    user_id     text NOT NULL DEFAULT '',
-    scope       text NOT NULL DEFAULT '',
-    data        bytea NOT NULL DEFAULT ''::bytea,
-    fingerprint bytea,
-    created_at  timestamptz NOT NULL,
-    expires_at  timestamptz NOT NULL
+    token_hash   text PRIMARY KEY,
+    id           uuid NOT NULL,
+    user_id      text NOT NULL DEFAULT '',
+    scope        text NOT NULL DEFAULT '',
+    ip           text NOT NULL DEFAULT '',
+    user_agent   text NOT NULL DEFAULT '',
+    data         bytea NOT NULL DEFAULT ''::bytea,
+    fingerprint  bytea,
+    created_at   timestamptz NOT NULL,
+    expires_at   timestamptz NOT NULL,
+    last_seen_at timestamptz NOT NULL
 );
 
 -- Multi-device listings and per-user deletion; anonymous sessions carry no

--- a/auth/session/pgstore/pgstore.go
+++ b/auth/session/pgstore/pgstore.go
@@ -1,0 +1,159 @@
+package pgstore
+
+import (
+	"context"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/crypto/digest"
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_sessions, rooted so
+// its .sql files sit at fsys root (data/migration.New globs fsys's root,
+// not subdirectories). Apply via data/migration under its own version
+// table ("forge_session_schema").
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// Store is the Postgres implementation of session.Store + session.UserIndex.
+// Tokens are persisted only as SHA-256 digests, so a database leak exposes
+// no usable credentials. The pool's lifecycle is the caller's.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+var (
+	_ session.Store     = (*Store)(nil)
+	_ session.UserIndex = (*Store)(nil)
+)
+
+// New builds a Postgres session Store. Apply Migrations first.
+func New(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+func tokenHash(token string) string {
+	return hex.EncodeToString(digest.SHA256([]byte(token)))
+}
+
+const cols = `id, user_id, scope, data, fingerprint, created_at, expires_at`
+
+const saveSQL = `
+INSERT INTO forge_sessions (token_hash, ` + cols + `)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (token_hash) DO UPDATE SET
+	id = EXCLUDED.id, user_id = EXCLUDED.user_id, scope = EXCLUDED.scope,
+	data = EXCLUDED.data, fingerprint = EXCLUDED.fingerprint,
+	created_at = EXCLUDED.created_at, expires_at = EXCLUDED.expires_at`
+
+// Save upserts rec under token's digest; the token is returned unchanged.
+func (s *Store) Save(ctx context.Context, token string, rec session.Record) (string, error) {
+	var fp []byte
+	if rec.Fingerprint.Hash != "" {
+		b, err := json.Marshal(rec.Fingerprint)
+		if err != nil {
+			return "", err
+		}
+		fp = b
+	}
+	_, err := s.pool.Exec(ctx, saveSQL,
+		tokenHash(token), rec.ID, rec.UserID, rec.Scope, rec.Data, fp,
+		rec.CreatedAt, rec.ExpiresAt)
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// Load returns the record for token, or session.ErrNotFound.
+func (s *Store) Load(ctx context.Context, token string) (session.Record, error) {
+	return scanRecord(s.pool.QueryRow(ctx,
+		`SELECT `+cols+` FROM forge_sessions WHERE token_hash = $1`, tokenHash(token)))
+}
+
+// Delete removes the record for token; absent tokens are a no-op.
+func (s *Store) Delete(ctx context.Context, token string) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM forge_sessions WHERE token_hash = $1`, tokenHash(token))
+	return err
+}
+
+// ListByUser returns the records bound to userID within scope, newest first
+// (UUIDv7 ids are time-ordered, so id DESC is creation order).
+func (s *Store) ListByUser(ctx context.Context, scope, userID string) ([]session.Record, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+cols+` FROM forge_sessions WHERE scope = $1 AND user_id = $2 ORDER BY id DESC`,
+		scope, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []session.Record{}
+	for rows.Next() {
+		rec, err := scanRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
+// DeleteByUser removes every record bound to userID within scope.
+func (s *Store) DeleteByUser(ctx context.Context, scope, userID string) error {
+	_, err := s.pool.Exec(ctx,
+		`DELETE FROM forge_sessions WHERE scope = $1 AND user_id = $2`, scope, userID)
+	return err
+}
+
+// DeleteExpired removes records whose deadline is at or before now and
+// reports how many were dropped. Run it periodically (async/scheduler or
+// cron) — expired rows are otherwise only deleted lazily on Load.
+func (s *Store) DeleteExpired(ctx context.Context, now time.Time) (int64, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM forge_sessions WHERE expires_at <= $1`, now)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}
+
+// row is satisfied by both pgx.Row and pgx.Rows.
+type row interface{ Scan(dest ...any) error }
+
+func scanRecord(r row) (session.Record, error) {
+	var rec session.Record
+	var fp []byte
+	err := r.Scan(&rec.ID, &rec.UserID, &rec.Scope, &rec.Data, &fp, &rec.CreatedAt, &rec.ExpiresAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return session.Record{}, session.ErrNotFound
+	}
+	if err != nil {
+		return session.Record{}, err
+	}
+	if len(fp) > 0 {
+		var d fingerprint.Digest
+		if err := json.Unmarshal(fp, &d); err != nil {
+			return session.Record{}, err
+		}
+		rec.Fingerprint = d
+	}
+	return rec, nil
+}

--- a/auth/session/pgstore/pgstore.go
+++ b/auth/session/pgstore/pgstore.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/core/id"
 	"github.com/dmitrymomot/forge/crypto/digest"
 	"github.com/dmitrymomot/forge/web/fingerprint"
 )
@@ -55,15 +56,17 @@ func tokenHash(token string) string {
 	return hex.EncodeToString(digest.SHA256([]byte(token)))
 }
 
-const cols = `id, user_id, scope, data, fingerprint, created_at, expires_at`
+const cols = `id, user_id, scope, ip, user_agent, data, fingerprint, created_at, expires_at, last_seen_at`
 
 const saveSQL = `
 INSERT INTO forge_sessions (token_hash, ` + cols + `)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 ON CONFLICT (token_hash) DO UPDATE SET
 	id = EXCLUDED.id, user_id = EXCLUDED.user_id, scope = EXCLUDED.scope,
+	ip = EXCLUDED.ip, user_agent = EXCLUDED.user_agent,
 	data = EXCLUDED.data, fingerprint = EXCLUDED.fingerprint,
-	created_at = EXCLUDED.created_at, expires_at = EXCLUDED.expires_at`
+	created_at = EXCLUDED.created_at, expires_at = EXCLUDED.expires_at,
+	last_seen_at = EXCLUDED.last_seen_at`
 
 // Save upserts rec under token's digest; the token is returned unchanged.
 func (s *Store) Save(ctx context.Context, token string, rec session.Record) (string, error) {
@@ -76,8 +79,8 @@ func (s *Store) Save(ctx context.Context, token string, rec session.Record) (str
 		fp = b
 	}
 	_, err := s.pool.Exec(ctx, saveSQL,
-		tokenHash(token), rec.ID, rec.UserID, rec.Scope, rec.Data, fp,
-		rec.CreatedAt, rec.ExpiresAt)
+		tokenHash(token), rec.ID, rec.UserID, rec.Scope, rec.IP, rec.UserAgent, rec.Data, fp,
+		rec.CreatedAt, rec.ExpiresAt, rec.LastSeenAt)
 	if err != nil {
 		return "", err
 	}
@@ -117,10 +120,27 @@ func (s *Store) ListByUser(ctx context.Context, scope, userID string) ([]session
 	return out, rows.Err()
 }
 
-// DeleteByUser removes every record bound to userID within scope.
-func (s *Store) DeleteByUser(ctx context.Context, scope, userID string) error {
+// DeleteByUser removes every record bound to userID within scope, except the
+// ids in keep.
+func (s *Store) DeleteByUser(ctx context.Context, scope, userID string, keep ...id.UUID) error {
+	// pgx encodes []id.UUID via each element's driver.Valuer; an explicit
+	// string slice keeps the array encoding boring and predictable.
+	keepIDs := make([]string, len(keep))
+	for i, k := range keep {
+		keepIDs[i] = k.String()
+	}
 	_, err := s.pool.Exec(ctx,
-		`DELETE FROM forge_sessions WHERE scope = $1 AND user_id = $2`, scope, userID)
+		`DELETE FROM forge_sessions WHERE scope = $1 AND user_id = $2 AND NOT (id = ANY($3::uuid[]))`,
+		scope, userID, keepIDs)
+	return err
+}
+
+// DeleteOne removes the record for sessionID when it is bound to userID
+// within scope; anything else is a no-op.
+func (s *Store) DeleteOne(ctx context.Context, scope, userID string, sessionID id.UUID) error {
+	_, err := s.pool.Exec(ctx,
+		`DELETE FROM forge_sessions WHERE scope = $1 AND user_id = $2 AND id = $3`,
+		scope, userID, sessionID)
 	return err
 }
 
@@ -141,7 +161,8 @@ type row interface{ Scan(dest ...any) error }
 func scanRecord(r row) (session.Record, error) {
 	var rec session.Record
 	var fp []byte
-	err := r.Scan(&rec.ID, &rec.UserID, &rec.Scope, &rec.Data, &fp, &rec.CreatedAt, &rec.ExpiresAt)
+	err := r.Scan(&rec.ID, &rec.UserID, &rec.Scope, &rec.IP, &rec.UserAgent, &rec.Data, &fp,
+		&rec.CreatedAt, &rec.ExpiresAt, &rec.LastSeenAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return session.Record{}, session.ErrNotFound
 	}

--- a/auth/session/pgstore/pgstore_integration_test.go
+++ b/auth/session/pgstore/pgstore_integration_test.go
@@ -41,19 +41,21 @@ func mkRecord(t *testing.T) session.Record {
 	t.Helper()
 	uid := id.NewUUID()
 	return session.Record{
-		ID:        uid,
-		UserID:    "user-" + uid.String(),
-		Scope:     "scope-" + uid.String(),
-		Data:      []byte(`{"theme":"dark"}`),
-		CreatedAt: time.Now().UTC(),
-		ExpiresAt: time.Now().UTC().Add(time.Hour),
+		ID:         uid,
+		UserID:     "user-" + uid.String(),
+		Scope:      "scope-" + uid.String(),
+		IP:         "203.0.113.7",
+		UserAgent:  "browser-a",
+		Data:       []byte(`{"theme":"dark"}`),
+		CreatedAt:  time.Now().UTC(),
+		ExpiresAt:  time.Now().UTC().Add(time.Hour),
+		LastSeenAt: time.Now().UTC(),
 	}
 }
 
 func newToken() string { return random.URLSafe(32) }
 
 func TestPg_SaveLoadRoundTrip(t *testing.T) {
-	t.Parallel()
 	s := newStore(t)
 	ctx := context.Background()
 	rec := mkRecord(t)
@@ -75,20 +77,21 @@ func TestPg_SaveLoadRoundTrip(t *testing.T) {
 	assert.Equal(t, rec.Scope, got.Scope)
 	assert.Equal(t, rec.Data, got.Data)
 	assert.Equal(t, rec.Fingerprint, got.Fingerprint)
+	assert.Equal(t, rec.IP, got.IP)
+	assert.Equal(t, rec.UserAgent, got.UserAgent)
 	// timestamptz stores microseconds; compare within that precision.
 	assert.WithinDuration(t, rec.CreatedAt, got.CreatedAt, time.Millisecond)
 	assert.WithinDuration(t, rec.ExpiresAt, got.ExpiresAt, time.Millisecond)
+	assert.WithinDuration(t, rec.LastSeenAt, got.LastSeenAt, time.Millisecond)
 }
 
 func TestPg_LoadUnknown(t *testing.T) {
-	t.Parallel()
 	s := newStore(t)
 	_, err := s.Load(context.Background(), newToken())
 	assert.ErrorIs(t, err, session.ErrNotFound)
 }
 
 func TestPg_SaveUpsertsAndFingerprintNull(t *testing.T) {
-	t.Parallel()
 	s := newStore(t)
 	ctx := context.Background()
 	rec := mkRecord(t)
@@ -111,7 +114,6 @@ func TestPg_SaveUpsertsAndFingerprintNull(t *testing.T) {
 }
 
 func TestPg_Delete(t *testing.T) {
-	t.Parallel()
 	s := newStore(t)
 	ctx := context.Background()
 	rec := mkRecord(t)
@@ -126,7 +128,6 @@ func TestPg_Delete(t *testing.T) {
 }
 
 func TestPg_UserIndex(t *testing.T) {
-	t.Parallel()
 	s := newStore(t)
 	ctx := context.Background()
 
@@ -156,6 +157,13 @@ func TestPg_UserIndex(t *testing.T) {
 	assert.Equal(t, ids[2], list[0].ID, "newest first")
 	assert.Equal(t, ids[0], list[2].ID)
 
+	// Keep-list: "log out other devices" preserves exactly the kept id.
+	require.NoError(t, s.DeleteByUser(ctx, scope, user, ids[2]))
+	list, err = s.ListByUser(ctx, scope, user)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, ids[2], list[0].ID)
+
 	require.NoError(t, s.DeleteByUser(ctx, scope, user))
 	list, err = s.ListByUser(ctx, scope, user)
 	require.NoError(t, err)
@@ -166,8 +174,27 @@ func TestPg_UserIndex(t *testing.T) {
 	require.NoError(t, s.DeleteByUser(ctx, scope, user), "deleting a user with no sessions is a no-op")
 }
 
+func TestPg_DeleteOne(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	rec := mkRecord(t)
+	token := newToken()
+	_, err := s.Save(ctx, token, rec)
+	require.NoError(t, err)
+
+	// Wrong user binding revokes nothing (IDOR guard).
+	require.NoError(t, s.DeleteOne(ctx, rec.Scope, "someone-else", rec.ID))
+	_, err = s.Load(ctx, token)
+	require.NoError(t, err)
+
+	require.NoError(t, s.DeleteOne(ctx, rec.Scope, rec.UserID, rec.ID))
+	_, err = s.Load(ctx, token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+	require.NoError(t, s.DeleteOne(ctx, rec.Scope, rec.UserID, rec.ID), "revoking an absent session is a no-op")
+}
+
 func TestPg_DeleteExpired(t *testing.T) {
-	t.Parallel()
 	s := newStore(t)
 	ctx := context.Background()
 
@@ -193,7 +220,6 @@ func TestPg_DeleteExpired(t *testing.T) {
 
 // TestPg_ManagerEndToEnd runs the full Manager lifecycle against Postgres.
 func TestPg_ManagerEndToEnd(t *testing.T) {
-	t.Parallel()
 	type data struct {
 		Theme string `json:"theme,omitempty"`
 	}

--- a/auth/session/pgstore/pgstore_integration_test.go
+++ b/auth/session/pgstore/pgstore_integration_test.go
@@ -1,0 +1,220 @@
+//go:build integration
+
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/auth/session/pgstore"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/core/random"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+func newStore(t *testing.T) *pgstore.Store {
+	t.Helper()
+	cfg := postgres.DefaultConfig()
+	cfg.URL = pgtest.DSN(t)
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgstore.Migrations, migration.WithTable("forge_session_schema")).Up(context.Background(), db))
+	return pgstore.New(pool)
+}
+
+// mkRecord builds a record whose user/scope are unique per call: the table
+// persists across test runs, so deterministic values would inflate
+// ListByUser counts on re-runs.
+func mkRecord(t *testing.T) session.Record {
+	t.Helper()
+	uid := id.NewUUID()
+	return session.Record{
+		ID:        uid,
+		UserID:    "user-" + uid.String(),
+		Scope:     "scope-" + uid.String(),
+		Data:      []byte(`{"theme":"dark"}`),
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	}
+}
+
+func newToken() string { return random.URLSafe(32) }
+
+func TestPg_SaveLoadRoundTrip(t *testing.T) {
+	t.Parallel()
+	s := newStore(t)
+	ctx := context.Background()
+	rec := mkRecord(t)
+	rec.Fingerprint = fingerprint.Digest{
+		Parts:   map[string]string{"ua": "aa", "ip": "bb"},
+		Hash:    "combined",
+		Version: 1,
+	}
+	token := newToken()
+
+	returned, err := s.Save(ctx, token, rec)
+	require.NoError(t, err)
+	assert.Equal(t, token, returned, "server-side stores must not rewrite the token")
+
+	got, err := s.Load(ctx, token)
+	require.NoError(t, err)
+	assert.Equal(t, rec.ID, got.ID)
+	assert.Equal(t, rec.UserID, got.UserID)
+	assert.Equal(t, rec.Scope, got.Scope)
+	assert.Equal(t, rec.Data, got.Data)
+	assert.Equal(t, rec.Fingerprint, got.Fingerprint)
+	// timestamptz stores microseconds; compare within that precision.
+	assert.WithinDuration(t, rec.CreatedAt, got.CreatedAt, time.Millisecond)
+	assert.WithinDuration(t, rec.ExpiresAt, got.ExpiresAt, time.Millisecond)
+}
+
+func TestPg_LoadUnknown(t *testing.T) {
+	t.Parallel()
+	s := newStore(t)
+	_, err := s.Load(context.Background(), newToken())
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}
+
+func TestPg_SaveUpsertsAndFingerprintNull(t *testing.T) {
+	t.Parallel()
+	s := newStore(t)
+	ctx := context.Background()
+	rec := mkRecord(t)
+	token := newToken()
+
+	_, err := s.Save(ctx, token, rec)
+	require.NoError(t, err)
+
+	rec.UserID = "rebound-" + rec.UserID
+	rec.Data = []byte(`{"theme":"light"}`)
+	rec.ExpiresAt = rec.ExpiresAt.Add(time.Hour)
+	_, err = s.Save(ctx, token, rec)
+	require.NoError(t, err, "second save under the same token must upsert")
+
+	got, err := s.Load(ctx, token)
+	require.NoError(t, err)
+	assert.Equal(t, rec.UserID, got.UserID)
+	assert.Equal(t, rec.Data, got.Data)
+	assert.Empty(t, got.Fingerprint.Hash, "a zero digest must round-trip as zero (SQL NULL)")
+}
+
+func TestPg_Delete(t *testing.T) {
+	t.Parallel()
+	s := newStore(t)
+	ctx := context.Background()
+	rec := mkRecord(t)
+	token := newToken()
+	_, err := s.Save(ctx, token, rec)
+	require.NoError(t, err)
+
+	require.NoError(t, s.Delete(ctx, token))
+	_, err = s.Load(ctx, token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+	require.NoError(t, s.Delete(ctx, token), "deleting an absent token is a no-op")
+}
+
+func TestPg_UserIndex(t *testing.T) {
+	t.Parallel()
+	s := newStore(t)
+	ctx := context.Background()
+
+	scope := "scope-" + id.NewUUID().String()
+	user := "user-" + id.NewUUID().String()
+	gen := id.NewGenerator(id.WithMonotonic())
+
+	var ids [3]id.UUID
+	for i := range 3 {
+		rec := mkRecord(t)
+		rec.ID = gen.UUID()
+		rec.Scope, rec.UserID = scope, user
+		ids[i] = rec.ID
+		_, err := s.Save(ctx, newToken(), rec)
+		require.NoError(t, err)
+	}
+	// Same user in a sibling scope must stay invisible.
+	other := mkRecord(t)
+	other.UserID = user
+	otherToken := newToken()
+	_, err := s.Save(ctx, otherToken, other)
+	require.NoError(t, err)
+
+	list, err := s.ListByUser(ctx, scope, user)
+	require.NoError(t, err)
+	require.Len(t, list, 3)
+	assert.Equal(t, ids[2], list[0].ID, "newest first")
+	assert.Equal(t, ids[0], list[2].ID)
+
+	require.NoError(t, s.DeleteByUser(ctx, scope, user))
+	list, err = s.ListByUser(ctx, scope, user)
+	require.NoError(t, err)
+	assert.Empty(t, list)
+	_, err = s.Load(ctx, otherToken)
+	require.NoError(t, err, "sibling-scope session must survive DeleteByUser")
+
+	require.NoError(t, s.DeleteByUser(ctx, scope, user), "deleting a user with no sessions is a no-op")
+}
+
+func TestPg_DeleteExpired(t *testing.T) {
+	t.Parallel()
+	s := newStore(t)
+	ctx := context.Background()
+
+	dead := mkRecord(t)
+	dead.ExpiresAt = time.Now().UTC().Add(-time.Minute)
+	deadToken := newToken()
+	_, err := s.Save(ctx, deadToken, dead)
+	require.NoError(t, err)
+	live := mkRecord(t)
+	liveToken := newToken()
+	_, err = s.Save(ctx, liveToken, live)
+	require.NoError(t, err)
+
+	n, err := s.DeleteExpired(ctx, time.Now().UTC())
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, n, int64(1), "parallel tests may add other expired rows")
+
+	_, err = s.Load(ctx, deadToken)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+	_, err = s.Load(ctx, liveToken)
+	require.NoError(t, err)
+}
+
+// TestPg_ManagerEndToEnd runs the full Manager lifecycle against Postgres.
+func TestPg_ManagerEndToEnd(t *testing.T) {
+	t.Parallel()
+	type data struct {
+		Theme string `json:"theme,omitempty"`
+	}
+	mgr, err := session.New[data](newStore(t))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	s := mgr.Start(ctx)
+	s.Data.Theme = "dark"
+	require.NoError(t, mgr.Save(ctx, s))
+	require.NoError(t, mgr.Authenticate(ctx, s, "user-"+s.ID.String()))
+
+	got, err := mgr.Load(ctx, s.Token)
+	require.NoError(t, err)
+	assert.Equal(t, "dark", got.Data.Theme)
+
+	list, err := mgr.ListUserSessions(ctx, s.UserID)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+
+	require.NoError(t, mgr.Destroy(ctx, s))
+	_, err = mgr.Load(ctx, got.Token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}

--- a/auth/session/session.go
+++ b/auth/session/session.go
@@ -24,14 +24,22 @@ const tokenBytes = 32
 // Rotate. ID is a stable identifier that survives rotation — use it for
 // logging and device listings, never as a credential. Mutate UserID/Data and
 // call Save to persist.
+//
+// IP, UserAgent, and LastSeenAt are display metadata for a "manage devices"
+// UI: the request-level helpers (SaveRequest and friends) stamp IP/UserAgent
+// from the request, and every Save refreshes LastSeenAt. Mark the current
+// device by comparing a listed ID with the caller's own session ID.
 type Session[T any] struct {
-	CreatedAt time.Time
-	ExpiresAt time.Time
-	Token     string
-	UserID    string
-	Data      T
-	fp        fingerprint.Digest
-	ID        id.UUID
+	CreatedAt  time.Time
+	ExpiresAt  time.Time
+	LastSeenAt time.Time
+	Token      string
+	UserID     string
+	IP         string
+	UserAgent  string
+	Data       T
+	fp         fingerprint.Digest
+	ID         id.UUID
 }
 
 // Manager drives the session lifecycle over a pluggable Store. T is the
@@ -45,10 +53,11 @@ type Manager[T any] struct {
 // lifetime, no fingerprint checking, no tenancy scoping.
 func New[T any](store Store, opts ...Option) (*Manager[T], error) {
 	cfg := config{
-		clock:    clock.System(),
-		logger:   logger.NewNope(),
-		ttl:      24 * time.Hour,
-		lifetime: 30 * 24 * time.Hour,
+		clock:      clock.System(),
+		logger:     logger.NewNope(),
+		clientInfo: defaultClientInfo,
+		ttl:        24 * time.Hour,
+		lifetime:   30 * 24 * time.Hour,
 	}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -75,6 +84,8 @@ func New[T any](store Store, opts ...Option) (*Manager[T], error) {
 		return nil, fmt.Errorf("%w: clock must not be nil", ErrInvalidConfig)
 	case cfg.logger == nil:
 		return nil, fmt.Errorf("%w: logger must not be nil", ErrInvalidConfig)
+	case cfg.clientInfo == nil:
+		return nil, fmt.Errorf("%w: client info hook must not be nil", ErrInvalidConfig)
 	}
 	return &Manager[T]{store: store, cfg: cfg}, nil
 }
@@ -135,13 +146,16 @@ func (m *Manager[T]) Load(ctx context.Context, token string) (*Session[T], error
 		}
 	}
 	return &Session[T]{
-		ID:        rec.ID,
-		CreatedAt: rec.CreatedAt,
-		ExpiresAt: rec.ExpiresAt,
-		Token:     token,
-		UserID:    rec.UserID,
-		Data:      data,
-		fp:        rec.Fingerprint,
+		ID:         rec.ID,
+		CreatedAt:  rec.CreatedAt,
+		ExpiresAt:  rec.ExpiresAt,
+		LastSeenAt: rec.LastSeenAt,
+		Token:      token,
+		UserID:     rec.UserID,
+		IP:         rec.IP,
+		UserAgent:  rec.UserAgent,
+		Data:       data,
+		fp:         rec.Fingerprint,
 	}, nil
 }
 
@@ -171,10 +185,13 @@ func (m *Manager[T]) Save(ctx context.Context, s *Session[T]) error {
 		ID:          s.ID,
 		UserID:      s.UserID,
 		Scope:       scope,
+		IP:          s.IP,
+		UserAgent:   s.UserAgent,
 		Data:        data,
 		Fingerprint: s.fp,
 		CreatedAt:   s.CreatedAt,
 		ExpiresAt:   deadline,
+		LastSeenAt:  now,
 	}
 	token, err := m.store.Save(ctx, s.Token, rec)
 	if err != nil {
@@ -182,6 +199,7 @@ func (m *Manager[T]) Save(ctx context.Context, s *Session[T]) error {
 	}
 	s.Token = token
 	s.ExpiresAt = deadline
+	s.LastSeenAt = now
 	return nil
 }
 
@@ -191,6 +209,7 @@ func (m *Manager[T]) Save(ctx context.Context, s *Session[T]) error {
 // authenticated session (session fixation). When fingerprinting is enabled
 // the baseline is re-captured from the current request.
 func (m *Manager[T]) Rotate(ctx context.Context, s *Session[T]) error {
+	oldFP := s.fp
 	if m.cfg.fpMode != 0 {
 		if d, ok := m.cfg.digest(ctx); ok {
 			s.fp = d
@@ -199,7 +218,11 @@ func (m *Manager[T]) Rotate(ctx context.Context, s *Session[T]) error {
 	old := s.Token
 	s.Token = ""
 	if err := m.Save(ctx, s); err != nil {
+		// Roll the session back to exactly what the store still holds — the
+		// old token AND the old fingerprint baseline, or a later successful
+		// Save would persist a baseline the rotation never established.
 		s.Token = old
+		s.fp = oldFP
 		return err
 	}
 	if old != "" && old != s.Token {
@@ -293,23 +316,65 @@ func (m *Manager[T]) ListUserSessions(ctx context.Context, userID string) ([]Ses
 			}
 		}
 		out = append(out, Session[T]{
-			ID:        rec.ID,
-			CreatedAt: rec.CreatedAt,
-			ExpiresAt: rec.ExpiresAt,
-			UserID:    rec.UserID,
-			Data:      data,
-			fp:        rec.Fingerprint,
+			ID:         rec.ID,
+			CreatedAt:  rec.CreatedAt,
+			ExpiresAt:  rec.ExpiresAt,
+			LastSeenAt: rec.LastSeenAt,
+			UserID:     rec.UserID,
+			IP:         rec.IP,
+			UserAgent:  rec.UserAgent,
+			Data:       data,
+			fp:         rec.Fingerprint,
 		})
 	}
 	return out, nil
 }
 
 // DeleteUserSessions revokes every session bound to userID within the
-// current scope — "log out everywhere" and GDPR deletion. For "log out other
-// devices", follow it with Save of the current session to re-persist it
-// under its existing token. Fails with ErrNoUserIndex when the Store lacks
-// the UserIndex extension.
+// current scope — "log out everywhere" and GDPR deletion. Fails with
+// ErrNoUserIndex when the Store lacks the UserIndex extension.
 func (m *Manager[T]) DeleteUserSessions(ctx context.Context, userID string) error {
+	return m.deleteUserSessions(ctx, userID)
+}
+
+// LogoutOthers revokes every other session of s's user — "log out other
+// devices" — leaving s alive. It requires an authenticated, saved session.
+func (m *Manager[T]) LogoutOthers(ctx context.Context, s *Session[T]) error {
+	if s.UserID == "" {
+		return fmt.Errorf("%w: anonymous session", ErrInvalidInput)
+	}
+	if s.Token == "" {
+		return fmt.Errorf("%w: session was never saved", ErrInvalidInput)
+	}
+	return m.deleteUserSessions(ctx, s.UserID, s.ID)
+}
+
+// RevokeUserSession revokes the single session sessionID belonging to userID
+// within the current scope — the "revoke this device" button. Revoking an
+// absent (or someone else's) session is a no-op. Fails with ErrNoUserIndex
+// when the Store lacks the UserIndex extension.
+func (m *Manager[T]) RevokeUserSession(ctx context.Context, userID string, sessionID id.UUID) error {
+	if userID == "" {
+		return fmt.Errorf("%w: empty user id", ErrInvalidInput)
+	}
+	if sessionID.IsZero() {
+		return fmt.Errorf("%w: zero session id", ErrInvalidInput)
+	}
+	ui, ok := m.store.(UserIndex)
+	if !ok {
+		return ErrNoUserIndex
+	}
+	scope, err := m.resolveScope(ctx)
+	if err != nil {
+		return err
+	}
+	if err := ui.DeleteOne(ctx, scope, userID, sessionID); err != nil {
+		return errors.Join(ErrStore, err)
+	}
+	return nil
+}
+
+func (m *Manager[T]) deleteUserSessions(ctx context.Context, userID string, keep ...id.UUID) error {
 	if userID == "" {
 		return fmt.Errorf("%w: empty user id", ErrInvalidInput)
 	}
@@ -321,7 +386,7 @@ func (m *Manager[T]) DeleteUserSessions(ctx context.Context, userID string) erro
 	if err != nil {
 		return err
 	}
-	if err := ui.DeleteByUser(ctx, scope, userID); err != nil {
+	if err := ui.DeleteByUser(ctx, scope, userID, keep...); err != nil {
 		return errors.Join(ErrStore, err)
 	}
 	return nil
@@ -374,9 +439,11 @@ func (m *Manager[T]) checkFingerprint(ctx context.Context, token string, rec Rec
 		return nil
 	}
 	// Strict: revoke before reporting so the token cannot be replayed from a
-	// better-spoofed client.
+	// better-spoofed client. A failed revoke must not swallow the mismatch —
+	// callers branching on ErrFingerprintMismatch (security alerts, forced
+	// logout) still need the signal.
 	if err := m.store.Delete(ctx, token); err != nil {
-		return errors.Join(ErrStore, err)
+		return errors.Join(ErrFingerprintMismatch, ErrStore, err)
 	}
 	return ErrFingerprintMismatch
 }

--- a/auth/session/session.go
+++ b/auth/session/session.go
@@ -1,0 +1,382 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/core/random"
+	"github.com/dmitrymomot/forge/ops/logger"
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+// tokenBytes is the entropy of a bearer token (base64url-encoded to 43
+// chars). 256 bits matches OWASP guidance with a wide margin.
+const tokenBytes = 32
+
+// Session is one live session. Token is the bearer credential to transport to
+// the client (cookie value); it is empty until the first Save and replaced by
+// Rotate. ID is a stable identifier that survives rotation — use it for
+// logging and device listings, never as a credential. Mutate UserID/Data and
+// call Save to persist.
+type Session[T any] struct {
+	CreatedAt time.Time
+	ExpiresAt time.Time
+	Token     string
+	UserID    string
+	Data      T
+	fp        fingerprint.Digest
+	ID        id.UUID
+}
+
+// Manager drives the session lifecycle over a pluggable Store. T is the
+// consumer's session payload, JSON-encoded at rest. Create one with New.
+type Manager[T any] struct {
+	store Store
+	cfg   config
+}
+
+// New builds a Manager over store. Defaults: 24h idle TTL, 30-day absolute
+// lifetime, no fingerprint checking, no tenancy scoping.
+func New[T any](store Store, opts ...Option) (*Manager[T], error) {
+	cfg := config{
+		clock:    clock.System(),
+		logger:   logger.NewNope(),
+		ttl:      24 * time.Hour,
+		lifetime: 30 * 24 * time.Hour,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.digest == nil {
+		cfg.digest = func(ctx context.Context) (fingerprint.Digest, bool) {
+			res, ok := fingerprint.FromContext(ctx)
+			if !ok || res.Fingerprint.Hash == "" {
+				return fingerprint.Digest{}, false
+			}
+			return res.Fingerprint.Digest(), true
+		}
+	}
+	switch {
+	case store == nil:
+		return nil, fmt.Errorf("%w: store is required", ErrInvalidConfig)
+	case cfg.ttl <= 0:
+		return nil, fmt.Errorf("%w: ttl must be positive", ErrInvalidConfig)
+	case cfg.lifetime < cfg.ttl:
+		return nil, fmt.Errorf("%w: lifetime must be >= ttl", ErrInvalidConfig)
+	case cfg.fpMode < 0 || cfg.fpMode > Strict:
+		return nil, fmt.Errorf("%w: unknown fingerprint mode", ErrInvalidConfig)
+	case cfg.clock == nil:
+		return nil, fmt.Errorf("%w: clock must not be nil", ErrInvalidConfig)
+	case cfg.logger == nil:
+		return nil, fmt.Errorf("%w: logger must not be nil", ErrInvalidConfig)
+	}
+	return &Manager[T]{store: store, cfg: cfg}, nil
+}
+
+// Start creates a fresh anonymous session. Nothing is persisted and Token is
+// empty until Save — abandoned starts cost no storage. When fingerprinting is
+// enabled and the request carries one, the current digest becomes the
+// session's hijack-detection baseline.
+func (m *Manager[T]) Start(ctx context.Context) *Session[T] {
+	now := m.cfg.clock.Now()
+	s := &Session[T]{ID: id.NewUUID(), CreatedAt: now, ExpiresAt: m.deadline(now, now)}
+	if m.cfg.fpMode != 0 {
+		if d, ok := m.cfg.digest(ctx); ok {
+			s.fp = d
+		}
+	}
+	return s
+}
+
+// Load resolves token to its session. It fails with ErrNotFound for unknown
+// or out-of-scope tokens, ErrExpired past either deadline (the record is
+// deleted), and — in Strict mode — ErrFingerprintMismatch on drift (the
+// record is revoked). Warn mode logs drift and lets the session through.
+func (m *Manager[T]) Load(ctx context.Context, token string) (*Session[T], error) {
+	if token == "" {
+		return nil, ErrNotFound
+	}
+	scope, err := m.resolveScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := m.store.Load(ctx, token)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, errors.Join(ErrStore, err)
+	}
+	if rec.Scope != scope {
+		// Cross-scope tokens are indistinguishable from unknown ones, and the
+		// record is left alone: a guessed token must not let one tenant
+		// revoke another's session.
+		return nil, ErrNotFound
+	}
+	if !rec.ExpiresAt.After(m.cfg.clock.Now()) {
+		// Defense-in-depth for stores without native TTL; best-effort delete,
+		// the record is unusable either way.
+		_ = m.store.Delete(ctx, token)
+		return nil, ErrExpired
+	}
+	if err := m.checkFingerprint(ctx, token, rec); err != nil {
+		return nil, err
+	}
+	var data T
+	if len(rec.Data) > 0 {
+		if err := json.Unmarshal(rec.Data, &data); err != nil {
+			return nil, errors.Join(ErrCodec, err)
+		}
+	}
+	return &Session[T]{
+		ID:        rec.ID,
+		CreatedAt: rec.CreatedAt,
+		ExpiresAt: rec.ExpiresAt,
+		Token:     token,
+		UserID:    rec.UserID,
+		Data:      data,
+		fp:        rec.Fingerprint,
+	}, nil
+}
+
+// Save persists s and slides its idle deadline, stamping the current scope.
+// The first Save mints the bearer token; afterwards s.Token is current and
+// must be re-transported to the client whenever it changed (stateless stores
+// change it on every Save). Saving a session past its absolute lifetime fails
+// with ErrExpired.
+func (m *Manager[T]) Save(ctx context.Context, s *Session[T]) error {
+	scope, err := m.resolveScope(ctx)
+	if err != nil {
+		return err
+	}
+	now := m.cfg.clock.Now()
+	deadline := m.deadline(s.CreatedAt, now)
+	if !deadline.After(now) {
+		return ErrExpired
+	}
+	data, err := json.Marshal(s.Data)
+	if err != nil {
+		return errors.Join(ErrCodec, err)
+	}
+	if s.Token == "" {
+		s.Token = random.URLSafe(tokenBytes)
+	}
+	rec := Record{
+		ID:          s.ID,
+		UserID:      s.UserID,
+		Scope:       scope,
+		Data:        data,
+		Fingerprint: s.fp,
+		CreatedAt:   s.CreatedAt,
+		ExpiresAt:   deadline,
+	}
+	token, err := m.store.Save(ctx, s.Token, rec)
+	if err != nil {
+		return errors.Join(ErrStore, err)
+	}
+	s.Token = token
+	s.ExpiresAt = deadline
+	return nil
+}
+
+// Rotate re-keys s: a fresh token is saved and the old one revoked, keeping
+// ID, CreatedAt, and the absolute deadline. Call it on every privilege
+// change — before that Save an attacker-planted token would become an
+// authenticated session (session fixation). When fingerprinting is enabled
+// the baseline is re-captured from the current request.
+func (m *Manager[T]) Rotate(ctx context.Context, s *Session[T]) error {
+	if m.cfg.fpMode != 0 {
+		if d, ok := m.cfg.digest(ctx); ok {
+			s.fp = d
+		}
+	}
+	old := s.Token
+	s.Token = ""
+	if err := m.Save(ctx, s); err != nil {
+		s.Token = old
+		return err
+	}
+	if old != "" && old != s.Token {
+		// The old token must die with the rotation: a Delete failure is
+		// reported so the caller can retry rather than leave two live tokens.
+		if err := m.store.Delete(ctx, old); err != nil {
+			return errors.Join(ErrStore, err)
+		}
+	}
+	return nil
+}
+
+// Authenticate binds userID to s and rotates the token — the login (and
+// privilege-change) helper. The zero UserID stays reserved for anonymous
+// sessions, so an empty userID fails with ErrInvalidInput.
+func (m *Manager[T]) Authenticate(ctx context.Context, s *Session[T], userID string) error {
+	if userID == "" {
+		return fmt.Errorf("%w: empty user id", ErrInvalidInput)
+	}
+	prev := s.UserID
+	s.UserID = userID
+	if err := m.Rotate(ctx, s); err != nil {
+		s.UserID = prev
+		return err
+	}
+	return nil
+}
+
+// Destroy revokes s and zeroes it. Destroying a never-saved or already-gone
+// session is a no-op; a token belonging to another scope fails with
+// ErrNotFound and stays alive. With stateless stores (cookiestore)
+// revocation is impossible server-side — clearing the client's cookie is the
+// real destroy.
+func (m *Manager[T]) Destroy(ctx context.Context, s *Session[T]) error {
+	if s.Token == "" {
+		*s = Session[T]{}
+		return nil
+	}
+	scope, err := m.resolveScope(ctx)
+	if err != nil {
+		return err
+	}
+	rec, err := m.store.Load(ctx, s.Token)
+	switch {
+	case errors.Is(err, ErrNotFound):
+		// Already revoked elsewhere; zeroing below is all that's left.
+	case err != nil:
+		return errors.Join(ErrStore, err)
+	case rec.Scope != scope:
+		// The scope owning the record is the only one allowed to revoke it.
+		return ErrNotFound
+	default:
+		if err := m.store.Delete(ctx, s.Token); err != nil {
+			return errors.Join(ErrStore, err)
+		}
+	}
+	*s = Session[T]{}
+	return nil
+}
+
+// ListUserSessions returns the live sessions bound to userID within the
+// current scope, newest first — the "manage devices" listing. Tokens are
+// stored only as digests, so returned sessions carry an empty Token. Fails
+// with ErrNoUserIndex when the Store lacks the UserIndex extension.
+func (m *Manager[T]) ListUserSessions(ctx context.Context, userID string) ([]Session[T], error) {
+	if userID == "" {
+		return nil, fmt.Errorf("%w: empty user id", ErrInvalidInput)
+	}
+	ui, ok := m.store.(UserIndex)
+	if !ok {
+		return nil, ErrNoUserIndex
+	}
+	scope, err := m.resolveScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	recs, err := ui.ListByUser(ctx, scope, userID)
+	if err != nil {
+		return nil, errors.Join(ErrStore, err)
+	}
+	now := m.cfg.clock.Now()
+	out := make([]Session[T], 0, len(recs))
+	for _, rec := range recs {
+		if !rec.ExpiresAt.After(now) {
+			continue
+		}
+		var data T
+		if len(rec.Data) > 0 {
+			if err := json.Unmarshal(rec.Data, &data); err != nil {
+				return nil, errors.Join(ErrCodec, err)
+			}
+		}
+		out = append(out, Session[T]{
+			ID:        rec.ID,
+			CreatedAt: rec.CreatedAt,
+			ExpiresAt: rec.ExpiresAt,
+			UserID:    rec.UserID,
+			Data:      data,
+			fp:        rec.Fingerprint,
+		})
+	}
+	return out, nil
+}
+
+// DeleteUserSessions revokes every session bound to userID within the
+// current scope — "log out everywhere" and GDPR deletion. For "log out other
+// devices", follow it with Save of the current session to re-persist it
+// under its existing token. Fails with ErrNoUserIndex when the Store lacks
+// the UserIndex extension.
+func (m *Manager[T]) DeleteUserSessions(ctx context.Context, userID string) error {
+	if userID == "" {
+		return fmt.Errorf("%w: empty user id", ErrInvalidInput)
+	}
+	ui, ok := m.store.(UserIndex)
+	if !ok {
+		return ErrNoUserIndex
+	}
+	scope, err := m.resolveScope(ctx)
+	if err != nil {
+		return err
+	}
+	if err := ui.DeleteByUser(ctx, scope, userID); err != nil {
+		return errors.Join(ErrStore, err)
+	}
+	return nil
+}
+
+// resolveScope runs the configured scope hook, failing closed: a hook error
+// or empty scope aborts the operation so a scoped session can never land in
+// an unscoped (or another tenant's) namespace.
+func (m *Manager[T]) resolveScope(ctx context.Context) (string, error) {
+	if m.cfg.scope == nil {
+		return "", nil
+	}
+	s, err := m.cfg.scope(ctx)
+	if err != nil {
+		return "", errors.Join(ErrScope, err)
+	}
+	if s == "" {
+		return "", ErrScope
+	}
+	return s, nil
+}
+
+// deadline computes the next expiry: idle TTL from now, capped by the
+// absolute lifetime from createdAt.
+func (m *Manager[T]) deadline(createdAt, now time.Time) time.Time {
+	idle := now.Add(m.cfg.ttl)
+	if abs := createdAt.Add(m.cfg.lifetime); abs.Before(idle) {
+		return abs
+	}
+	return idle
+}
+
+// checkFingerprint applies the configured mode. Sessions without a stored
+// baseline are never checked; with one, a missing live digest counts as a
+// mismatch (fail closed in Strict).
+func (m *Manager[T]) checkFingerprint(ctx context.Context, token string, rec Record) error {
+	if m.cfg.fpMode == 0 || rec.Fingerprint.Hash == "" {
+		return nil
+	}
+	cur, ok := m.cfg.digest(ctx)
+	if ok && cur.Hash == rec.Fingerprint.Hash {
+		return nil
+	}
+	if m.cfg.fpMode == Warn {
+		if m.cfg.logger.Enabled(ctx, slog.LevelWarn) {
+			m.cfg.logger.WarnContext(ctx, "session: fingerprint drift",
+				slog.String("session_id", rec.ID.String()),
+				slog.Any("components", fingerprint.Drift(rec.Fingerprint, cur)))
+		}
+		return nil
+	}
+	// Strict: revoke before reporting so the token cannot be replayed from a
+	// better-spoofed client.
+	if err := m.store.Delete(ctx, token); err != nil {
+		return errors.Join(ErrStore, err)
+	}
+	return ErrFingerprintMismatch
+}

--- a/auth/session/session_test.go
+++ b/auth/session/session_test.go
@@ -1,0 +1,386 @@
+package session_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type data struct {
+	Cart  []string `json:"cart,omitempty"`
+	Theme string   `json:"theme,omitempty"`
+}
+
+func newManager(t *testing.T, opts ...session.Option) (*session.Manager[data], *session.MemoryStore, *clock.Mock) {
+	t.Helper()
+	ck := clock.NewMock(time.Now())
+	store := session.NewMemoryStore()
+	mgr, err := session.New[data](store, append([]session.Option{session.WithClock(ck)}, opts...)...)
+	require.NoError(t, err)
+	return mgr, store, ck
+}
+
+func TestNew_InvalidConfig(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		store session.Store
+		opts  []session.Option
+	}{
+		{"nil store", nil, nil},
+		{"non-positive ttl", session.NewMemoryStore(), []session.Option{session.WithTTL(0)}},
+		{"lifetime below ttl", session.NewMemoryStore(), []session.Option{session.WithTTL(time.Hour), session.WithLifetime(time.Minute)}},
+		{"unknown mode", session.NewMemoryStore(), []session.Option{session.WithFingerprint(session.Mode(9))}},
+		{"nil clock", session.NewMemoryStore(), []session.Option{session.WithClock(nil)}},
+		{"nil logger", session.NewMemoryStore(), []session.Option{session.WithLogger(nil)}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := session.New[data](tc.store, tc.opts...)
+			assert.ErrorIs(t, err, session.ErrInvalidConfig)
+		})
+	}
+}
+
+func TestLifecycle_RoundTrip(t *testing.T) {
+	t.Parallel()
+	mgr, _, _ := newManager(t)
+	ctx := t.Context()
+
+	s := mgr.Start(ctx)
+	assert.Empty(t, s.Token, "token must not exist before Save")
+	assert.False(t, s.ID.IsZero())
+
+	s.Data.Cart = []string{"sku-1"}
+	s.Data.Theme = "dark"
+	require.NoError(t, mgr.Save(ctx, s))
+	require.NotEmpty(t, s.Token)
+
+	got, err := mgr.Load(ctx, s.Token)
+	require.NoError(t, err)
+	assert.Equal(t, s.ID, got.ID)
+	assert.Equal(t, s.Data, got.Data)
+	assert.Equal(t, s.Token, got.Token)
+	assert.Empty(t, got.UserID)
+}
+
+func TestLoad_UnknownAndEmptyToken(t *testing.T) {
+	t.Parallel()
+	mgr, _, _ := newManager(t)
+	_, err := mgr.Load(t.Context(), "no-such-token")
+	assert.ErrorIs(t, err, session.ErrNotFound)
+	_, err = mgr.Load(t.Context(), "")
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}
+
+func TestLoad_UnsavedStartIsNotFound(t *testing.T) {
+	t.Parallel()
+	mgr, _, _ := newManager(t)
+	s := mgr.Start(t.Context())
+	_, err := mgr.Load(t.Context(), s.Token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}
+
+func TestExpiry_IdleTTL(t *testing.T) {
+	t.Parallel()
+	mgr, store, ck := newManager(t, session.WithTTL(time.Hour))
+	ctx := t.Context()
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+
+	ck.Advance(time.Hour)
+	_, err := mgr.Load(ctx, s.Token)
+	assert.ErrorIs(t, err, session.ErrExpired)
+	// The expired record is deleted, not just refused.
+	_, err = store.Load(ctx, s.Token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+}
+
+func TestExpiry_SaveSlidesIdleDeadline(t *testing.T) {
+	t.Parallel()
+	mgr, _, ck := newManager(t, session.WithTTL(time.Hour))
+	ctx := t.Context()
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+
+	ck.Advance(30 * time.Minute)
+	require.NoError(t, mgr.Save(ctx, s))
+
+	ck.Advance(45 * time.Minute) // 75min after start: alive only because Save slid the deadline
+	got, err := mgr.Load(ctx, s.Token)
+	require.NoError(t, err)
+	assert.Equal(t, s.ID, got.ID)
+}
+
+func TestExpiry_AbsoluteLifetimeCapsSliding(t *testing.T) {
+	t.Parallel()
+	mgr, _, ck := newManager(t, session.WithTTL(time.Hour), session.WithLifetime(2*time.Hour))
+	ctx := t.Context()
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+
+	// Keep the session active; the absolute cap must still kill it.
+	for range 3 {
+		ck.Advance(30 * time.Minute)
+		require.NoError(t, mgr.Save(ctx, s))
+	}
+	ck.Advance(30 * time.Minute) // 2h after start
+	_, err := mgr.Load(ctx, s.Token)
+	assert.ErrorIs(t, err, session.ErrExpired)
+
+	// Saving a session past its absolute lifetime must not resurrect it.
+	err = mgr.Save(ctx, s)
+	assert.ErrorIs(t, err, session.ErrExpired)
+}
+
+func TestRotate(t *testing.T) {
+	t.Parallel()
+	mgr, _, _ := newManager(t)
+	ctx := t.Context()
+	s := mgr.Start(ctx)
+	s.Data.Theme = "dark"
+	require.NoError(t, mgr.Save(ctx, s))
+	oldToken, oldID, oldCreated := s.Token, s.ID, s.CreatedAt
+
+	require.NoError(t, mgr.Rotate(ctx, s))
+	assert.NotEqual(t, oldToken, s.Token, "rotation must mint a new token")
+	assert.Equal(t, oldID, s.ID, "identity survives rotation")
+	assert.Equal(t, oldCreated, s.CreatedAt, "absolute deadline anchor survives rotation")
+
+	_, err := mgr.Load(ctx, oldToken)
+	assert.ErrorIs(t, err, session.ErrNotFound, "old token must die with the rotation")
+
+	got, err := mgr.Load(ctx, s.Token)
+	require.NoError(t, err)
+	assert.Equal(t, "dark", got.Data.Theme)
+}
+
+func TestRotate_NeverSaved(t *testing.T) {
+	t.Parallel()
+	mgr, _, _ := newManager(t)
+	s := mgr.Start(t.Context())
+	require.NoError(t, mgr.Rotate(t.Context(), s))
+	require.NotEmpty(t, s.Token)
+	_, err := mgr.Load(t.Context(), s.Token)
+	require.NoError(t, err)
+}
+
+func TestAuthenticate(t *testing.T) {
+	t.Parallel()
+	mgr, _, _ := newManager(t)
+	ctx := t.Context()
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+	anon := s.Token
+
+	require.NoError(t, mgr.Authenticate(ctx, s, "user-1"))
+	assert.Equal(t, "user-1", s.UserID)
+	assert.NotEqual(t, anon, s.Token, "login must rotate the token (fixation)")
+
+	got, err := mgr.Load(ctx, s.Token)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", got.UserID)
+
+	assert.ErrorIs(t, mgr.Authenticate(ctx, s, ""), session.ErrInvalidInput)
+}
+
+func TestDestroy(t *testing.T) {
+	t.Parallel()
+	mgr, _, _ := newManager(t)
+	ctx := t.Context()
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+	token := s.Token
+
+	require.NoError(t, mgr.Destroy(ctx, s))
+	assert.Empty(t, s.Token)
+	assert.Empty(t, s.UserID)
+	_, err := mgr.Load(ctx, token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+
+	// Destroying a never-saved session is a no-op.
+	require.NoError(t, mgr.Destroy(ctx, mgr.Start(ctx)))
+}
+
+func TestUserSessions(t *testing.T) {
+	t.Parallel()
+	mgr, _, _ := newManager(t)
+	ctx := t.Context()
+
+	var tokens [3]string
+	for i := range 3 {
+		s := mgr.Start(ctx)
+		require.NoError(t, mgr.Authenticate(ctx, s, "user-1"))
+		tokens[i] = s.Token
+	}
+	other := mgr.Start(ctx)
+	require.NoError(t, mgr.Authenticate(ctx, other, "user-2"))
+
+	list, err := mgr.ListUserSessions(ctx, "user-1")
+	require.NoError(t, err)
+	require.Len(t, list, 3)
+	for _, s := range list {
+		assert.Equal(t, "user-1", s.UserID)
+		assert.Empty(t, s.Token, "listings must not expose bearer tokens")
+	}
+
+	// Log out everywhere, then re-persist the current device.
+	current, err := mgr.Load(ctx, tokens[2])
+	require.NoError(t, err)
+	require.NoError(t, mgr.DeleteUserSessions(ctx, "user-1"))
+	require.NoError(t, mgr.Save(ctx, current))
+
+	list, err = mgr.ListUserSessions(ctx, "user-1")
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, current.ID, list[0].ID)
+
+	for _, tok := range tokens[:2] {
+		_, err := mgr.Load(ctx, tok)
+		assert.ErrorIs(t, err, session.ErrNotFound)
+	}
+	// The other user is untouched.
+	_, err = mgr.Load(ctx, other.Token)
+	require.NoError(t, err)
+
+	_, err = mgr.ListUserSessions(ctx, "")
+	assert.ErrorIs(t, err, session.ErrInvalidInput)
+	assert.ErrorIs(t, mgr.DeleteUserSessions(ctx, ""), session.ErrInvalidInput)
+}
+
+func TestUserSessions_NoUserIndex(t *testing.T) {
+	t.Parallel()
+	kv, err := session.NewKVStore(newCacheStore(t))
+	require.NoError(t, err)
+	mgr, err := session.New[data](kv)
+	require.NoError(t, err)
+
+	_, err = mgr.ListUserSessions(t.Context(), "user-1")
+	assert.ErrorIs(t, err, session.ErrNoUserIndex)
+	assert.ErrorIs(t, mgr.DeleteUserSessions(t.Context(), "user-1"), session.ErrNoUserIndex)
+}
+
+// failStore lets tests fail individual Store calls.
+type failStore struct {
+	session.Store
+	saveErr   error
+	loadErr   error
+	deleteErr error
+}
+
+func (f *failStore) Save(ctx context.Context, token string, rec session.Record) (string, error) {
+	if f.saveErr != nil {
+		return "", f.saveErr
+	}
+	return f.Store.Save(ctx, token, rec)
+}
+
+func (f *failStore) Load(ctx context.Context, token string) (session.Record, error) {
+	if f.loadErr != nil {
+		return session.Record{}, f.loadErr
+	}
+	return f.Store.Load(ctx, token)
+}
+
+func (f *failStore) Delete(ctx context.Context, token string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	return f.Store.Delete(ctx, token)
+}
+
+func TestStoreErrors_Wrapped(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("boom")
+	ctx := t.Context()
+
+	fs := &failStore{Store: session.NewMemoryStore()}
+	mgr, err := session.New[data](fs)
+	require.NoError(t, err)
+
+	fs.saveErr = boom
+	s := mgr.Start(ctx)
+	err = mgr.Save(ctx, s)
+	assert.ErrorIs(t, err, session.ErrStore)
+	assert.ErrorIs(t, err, boom)
+	fs.saveErr = nil
+
+	require.NoError(t, mgr.Save(ctx, s))
+	fs.loadErr = boom
+	_, err = mgr.Load(ctx, s.Token)
+	assert.ErrorIs(t, err, session.ErrStore)
+	fs.loadErr = nil
+
+	fs.deleteErr = boom
+	err = mgr.Destroy(ctx, s)
+	assert.ErrorIs(t, err, session.ErrStore)
+	assert.NotEmpty(t, s.Token, "a failed destroy must not pretend the session is gone")
+}
+
+func TestRotate_SaveFailureKeepsOldToken(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("boom")
+	ctx := t.Context()
+	fs := &failStore{Store: session.NewMemoryStore()}
+	mgr, err := session.New[data](fs)
+	require.NoError(t, err)
+
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+	token := s.Token
+
+	fs.saveErr = boom
+	require.ErrorIs(t, mgr.Rotate(ctx, s), session.ErrStore)
+	assert.Equal(t, token, s.Token, "failed rotation must keep the session loadable")
+	fs.saveErr = nil
+	_, err = mgr.Load(ctx, s.Token)
+	require.NoError(t, err)
+}
+
+func TestRotate_DeleteFailureReported(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("boom")
+	ctx := t.Context()
+	fs := &failStore{Store: session.NewMemoryStore()}
+	mgr, err := session.New[data](fs)
+	require.NoError(t, err)
+
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+
+	fs.deleteErr = boom
+	err = mgr.Rotate(ctx, s)
+	assert.ErrorIs(t, err, session.ErrStore, "a live old token must be reported, not swallowed")
+}
+
+func TestAuthenticate_FailureRestoresUser(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	fs := &failStore{Store: session.NewMemoryStore()}
+	mgr, err := session.New[data](fs)
+	require.NoError(t, err)
+
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+	fs.saveErr = errors.New("boom")
+	require.Error(t, mgr.Authenticate(ctx, s, "user-1"))
+	assert.Empty(t, s.UserID, "failed login must not leave the session claiming a user")
+}
+
+func TestCodecError(t *testing.T) {
+	t.Parallel()
+	store := session.NewMemoryStore()
+	mgr, err := session.New[chan int](store)
+	require.NoError(t, err)
+	s := mgr.Start(t.Context())
+	s.Data = make(chan int)
+	assert.ErrorIs(t, mgr.Save(t.Context(), s), session.ErrCodec)
+}

--- a/auth/session/session_test.go
+++ b/auth/session/session_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dmitrymomot/forge/auth/session"
 	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/id"
 )
 
 type data struct {
@@ -254,6 +255,90 @@ func TestUserSessions(t *testing.T) {
 	_, err = mgr.ListUserSessions(ctx, "")
 	assert.ErrorIs(t, err, session.ErrInvalidInput)
 	assert.ErrorIs(t, mgr.DeleteUserSessions(ctx, ""), session.ErrInvalidInput)
+}
+
+func TestLogoutOthers(t *testing.T) {
+	t.Parallel()
+	mgr, _, _ := newManager(t)
+	ctx := t.Context()
+
+	var others [2]*session.Session[data]
+	for i := range others {
+		s := mgr.Start(ctx)
+		require.NoError(t, mgr.Authenticate(ctx, s, "user-1"))
+		others[i] = s
+	}
+	current := mgr.Start(ctx)
+	require.NoError(t, mgr.Authenticate(ctx, current, "user-1"))
+
+	require.NoError(t, mgr.LogoutOthers(ctx, current))
+
+	// The current device survives, every other one is gone.
+	_, err := mgr.Load(ctx, current.Token)
+	require.NoError(t, err)
+	for _, o := range others {
+		_, err := mgr.Load(ctx, o.Token)
+		assert.ErrorIs(t, err, session.ErrNotFound)
+	}
+	list, err := mgr.ListUserSessions(ctx, "user-1")
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, current.ID, list[0].ID)
+
+	// Anonymous or never-saved sessions cannot anchor a LogoutOthers.
+	anon := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, anon))
+	assert.ErrorIs(t, mgr.LogoutOthers(ctx, anon), session.ErrInvalidInput)
+	fresh := mgr.Start(ctx)
+	fresh.UserID = "user-1"
+	assert.ErrorIs(t, mgr.LogoutOthers(ctx, fresh), session.ErrInvalidInput)
+}
+
+func TestRevokeUserSession(t *testing.T) {
+	t.Parallel()
+	mgr, _, _ := newManager(t)
+	ctx := t.Context()
+
+	victim := mgr.Start(ctx)
+	require.NoError(t, mgr.Authenticate(ctx, victim, "user-1"))
+	keeper := mgr.Start(ctx)
+	require.NoError(t, mgr.Authenticate(ctx, keeper, "user-1"))
+
+	require.NoError(t, mgr.RevokeUserSession(ctx, "user-1", victim.ID))
+	_, err := mgr.Load(ctx, victim.Token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+	_, err = mgr.Load(ctx, keeper.Token)
+	require.NoError(t, err)
+
+	// Another user naming the same id revokes nothing (IDOR guard).
+	other := mgr.Start(ctx)
+	require.NoError(t, mgr.Authenticate(ctx, other, "user-2"))
+	require.NoError(t, mgr.RevokeUserSession(ctx, "user-1", other.ID))
+	_, err = mgr.Load(ctx, other.Token)
+	require.NoError(t, err, "a session id under the wrong user must revoke nothing")
+
+	// Idempotent: revoking an already-gone session is a no-op.
+	require.NoError(t, mgr.RevokeUserSession(ctx, "user-1", victim.ID))
+
+	assert.ErrorIs(t, mgr.RevokeUserSession(ctx, "", keeper.ID), session.ErrInvalidInput)
+	assert.ErrorIs(t, mgr.RevokeUserSession(ctx, "user-1", id.UUID{}), session.ErrInvalidInput)
+}
+
+func TestLastSeenAt_RefreshedOnSave(t *testing.T) {
+	t.Parallel()
+	mgr, _, ck := newManager(t)
+	ctx := t.Context()
+	s := mgr.Start(ctx)
+	require.NoError(t, mgr.Save(ctx, s))
+	first := s.LastSeenAt
+
+	ck.Advance(time.Hour)
+	require.NoError(t, mgr.Save(ctx, s))
+	assert.Equal(t, first.Add(time.Hour), s.LastSeenAt)
+
+	got, err := mgr.Load(ctx, s.Token)
+	require.NoError(t, err)
+	assert.Equal(t, s.LastSeenAt, got.LastSeenAt)
 }
 
 func TestUserSessions_NoUserIndex(t *testing.T) {

--- a/auth/session/store.go
+++ b/auth/session/store.go
@@ -11,12 +11,16 @@ import (
 // Record is the storage form of one session. Data is the opaque JSON-encoded
 // session payload; the Manager owns its typing. A zero Fingerprint (empty
 // Hash) means hijack detection was off or no fingerprint was available when
-// the session started.
+// the session started. IP and UserAgent are display metadata for device
+// listings, stamped by the request-level helpers.
 type Record struct {
 	CreatedAt   time.Time
 	ExpiresAt   time.Time
+	LastSeenAt  time.Time
 	UserID      string
 	Scope       string
+	IP          string
+	UserAgent   string
 	Data        []byte
 	Fingerprint fingerprint.Digest
 	ID          id.UUID
@@ -38,14 +42,19 @@ type Store interface {
 }
 
 // UserIndex is the optional Store extension backing multi-device management:
-// "log out other devices" listings and GDPR deletion. scope is the resolved
-// tenancy scope ("" in single-tenant apps); implementations must filter by it
-// so one tenant can never see or delete another's sessions. Stateless
-// backings (cookiestore) and plain KV backings cannot implement it.
+// device listings, per-device revocation, "log out other devices", and GDPR
+// deletion. scope is the resolved tenancy scope ("" in single-tenant apps);
+// implementations must filter by it so one tenant can never see or delete
+// another's sessions. Stateless backings (cookiestore) and plain KV backings
+// cannot implement it.
 type UserIndex interface {
 	// ListByUser returns the records bound to userID, newest first.
 	ListByUser(ctx context.Context, scope, userID string) ([]Record, error)
-	// DeleteByUser revokes every session bound to userID. Deleting a user
-	// with no sessions is a no-op.
-	DeleteByUser(ctx context.Context, scope, userID string) error
+	// DeleteByUser revokes every session bound to userID except the ids in
+	// keep. Deleting a user with no sessions is a no-op.
+	DeleteByUser(ctx context.Context, scope, userID string, keep ...id.UUID) error
+	// DeleteOne revokes the single session sessionID bound to userID —
+	// binding the delete to the user is what stops one user revoking
+	// another's session by guessed id. Absent sessions are a no-op.
+	DeleteOne(ctx context.Context, scope, userID string, sessionID id.UUID) error
 }

--- a/auth/session/store.go
+++ b/auth/session/store.go
@@ -1,0 +1,51 @@
+package session
+
+import (
+	"context"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/web/fingerprint"
+)
+
+// Record is the storage form of one session. Data is the opaque JSON-encoded
+// session payload; the Manager owns its typing. A zero Fingerprint (empty
+// Hash) means hijack detection was off or no fingerprint was available when
+// the session started.
+type Record struct {
+	CreatedAt   time.Time
+	ExpiresAt   time.Time
+	UserID      string
+	Scope       string
+	Data        []byte
+	Fingerprint fingerprint.Digest
+	ID          id.UUID
+}
+
+// Store persists session records keyed by their bearer token.
+// Implementations must be safe for concurrent use, must never persist the raw
+// token (server-side stores key by a digest of it), and return ErrNotFound
+// for unknown tokens.
+type Store interface {
+	// Save upserts rec under token and returns the token the client must be
+	// handed: server-side stores persist rec and return token unchanged;
+	// stateless stores (cookiestore) encode rec itself and return the fresh
+	// encoding as the new token.
+	Save(ctx context.Context, token string, rec Record) (string, error)
+	Load(ctx context.Context, token string) (Record, error)
+	// Delete revokes token. Deleting an absent token is a no-op.
+	Delete(ctx context.Context, token string) error
+}
+
+// UserIndex is the optional Store extension backing multi-device management:
+// "log out other devices" listings and GDPR deletion. scope is the resolved
+// tenancy scope ("" in single-tenant apps); implementations must filter by it
+// so one tenant can never see or delete another's sessions. Stateless
+// backings (cookiestore) and plain KV backings cannot implement it.
+type UserIndex interface {
+	// ListByUser returns the records bound to userID, newest first.
+	ListByUser(ctx context.Context, scope, userID string) ([]Record, error)
+	// DeleteByUser revokes every session bound to userID. Deleting a user
+	// with no sessions is a no-op.
+	DeleteByUser(ctx context.Context, scope, userID string) error
+}

--- a/auth/session/tenancy_test.go
+++ b/auth/session/tenancy_test.go
@@ -113,6 +113,15 @@ func TestTenancy_PlatformUserSwitchesTenants(t *testing.T) {
 	require.Len(t, listA, 1)
 	assert.Equal(t, sa.ID, listA[0].ID)
 
+	// Per-device revocation and logout-others are scope-bound too: issued
+	// from tenant B they must not touch tenant A's session.
+	require.NoError(t, mgr.RevokeUserSession(ctxB, "user-1", sa.ID))
+	_, err = mgr.Load(ctxA, sa.Token)
+	require.NoError(t, err, "cross-tenant revoke by id must be a no-op")
+	require.NoError(t, mgr.LogoutOthers(ctxB, sb))
+	_, err = mgr.Load(ctxA, sa.Token)
+	require.NoError(t, err, "cross-tenant logout-others must be a no-op")
+
 	// GDPR-deleting the user inside tenant A leaves tenant B intact.
 	require.NoError(t, mgr.DeleteUserSessions(ctxA, "user-1"))
 	_, err = mgr.Load(ctxA, sa.Token)

--- a/auth/session/tenancy_test.go
+++ b/auth/session/tenancy_test.go
@@ -1,0 +1,122 @@
+package session_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/core/ctxkey"
+)
+
+// The tests below are executable proof that the single WithScope construction
+// seam serves the three tenancy shapes a real application needs: a
+// single-tenant app, a white-label app where every user is locked to one
+// tenant, and a platform where a global user switches between tenants. The
+// scope hook is arbitrary app logic mapping the request context to a scope
+// string, so "switching tenants" is nothing more than a different context per
+// request.
+
+var tenantKey = ctxkey.New[string]("tenant")
+
+func tenantScope(ctx context.Context) (string, error) {
+	tenant, ok := tenantKey.From(ctx)
+	if !ok {
+		return "", errors.New("no tenant in context")
+	}
+	return tenant, nil
+}
+
+func tenantCtx(t *testing.T, tenant string) context.Context {
+	t.Helper()
+	return tenantKey.With(t.Context(), tenant)
+}
+
+// TestTenancy_SingleTenant: omit WithScope entirely. Scope resolves to "" and
+// every session shares one flat namespace — zero ceremony.
+func TestTenancy_SingleTenant(t *testing.T) {
+	t.Parallel()
+	mgr, _, _ := newManager(t)
+	s := mgr.Start(t.Context())
+	require.NoError(t, mgr.Save(t.Context(), s))
+	_, err := mgr.Load(t.Context(), s.Token)
+	require.NoError(t, err)
+}
+
+// TestTenancy_WhiteLabelTenantLocked: every request is bound to exactly one
+// tenant. A session saved under tenant A is invisible under tenant B, and a
+// request arriving without a tenant fails closed rather than leaking into a
+// shared bucket.
+func TestTenancy_WhiteLabelTenantLocked(t *testing.T) {
+	t.Parallel()
+	store := session.NewMemoryStore()
+	mgr, err := session.New[data](store, session.WithScope(tenantScope))
+	require.NoError(t, err)
+
+	ctxA, ctxB := tenantCtx(t, "tenant-a"), tenantCtx(t, "tenant-b")
+
+	s := mgr.Start(ctxA)
+	require.NoError(t, mgr.Authenticate(ctxA, s, "user-1"))
+
+	// The token is a valid credential — but only inside its own tenant.
+	_, err = mgr.Load(ctxA, s.Token)
+	require.NoError(t, err)
+	_, err = mgr.Load(ctxB, s.Token)
+	assert.ErrorIs(t, err, session.ErrNotFound, "cross-tenant token must be indistinguishable from unknown")
+
+	// And tenant B must not be able to revoke it either.
+	sb := *s
+	assert.ErrorIs(t, mgr.Destroy(ctxB, &sb), session.ErrNotFound)
+	_, err = mgr.Load(ctxA, s.Token)
+	require.NoError(t, err, "a cross-tenant probe must not destroy the session")
+
+	// Every operation fails closed without a tenant in context.
+	_, err = mgr.Load(t.Context(), s.Token)
+	assert.ErrorIs(t, err, session.ErrScope)
+	assert.ErrorIs(t, mgr.Save(t.Context(), s), session.ErrScope)
+	assert.ErrorIs(t, mgr.Rotate(t.Context(), s), session.ErrScope)
+	assert.ErrorIs(t, mgr.Destroy(t.Context(), s), session.ErrScope)
+	_, err = mgr.ListUserSessions(t.Context(), "user-1")
+	assert.ErrorIs(t, err, session.ErrScope)
+	assert.ErrorIs(t, mgr.DeleteUserSessions(t.Context(), "user-1"), session.ErrScope)
+
+	// An erroring hook fails closed too. Destroy is the case that matters
+	// most: it must not delete another scope's record.
+	empty, err := session.New[data](store, session.WithScope(func(context.Context) (string, error) {
+		return "", nil
+	}))
+	require.NoError(t, err)
+	_, err = empty.Load(t.Context(), s.Token)
+	assert.ErrorIs(t, err, session.ErrScope)
+}
+
+// TestTenancy_PlatformUserSwitchesTenants: the same user id holds separate
+// sessions in different tenants; per-tenant listing and deletion never bleed
+// across.
+func TestTenancy_PlatformUserSwitchesTenants(t *testing.T) {
+	t.Parallel()
+	mgr, err := session.New[data](session.NewMemoryStore(), session.WithScope(tenantScope))
+	require.NoError(t, err)
+
+	ctxA, ctxB := tenantCtx(t, "tenant-a"), tenantCtx(t, "tenant-b")
+
+	sa := mgr.Start(ctxA)
+	require.NoError(t, mgr.Authenticate(ctxA, sa, "user-1"))
+	sb := mgr.Start(ctxB)
+	require.NoError(t, mgr.Authenticate(ctxB, sb, "user-1"))
+
+	listA, err := mgr.ListUserSessions(ctxA, "user-1")
+	require.NoError(t, err)
+	require.Len(t, listA, 1)
+	assert.Equal(t, sa.ID, listA[0].ID)
+
+	// GDPR-deleting the user inside tenant A leaves tenant B intact.
+	require.NoError(t, mgr.DeleteUserSessions(ctxA, "user-1"))
+	_, err = mgr.Load(ctxA, sa.Token)
+	assert.ErrorIs(t, err, session.ErrNotFound)
+	_, err = mgr.Load(ctxB, sb.Token)
+	require.NoError(t, err)
+}

--- a/auth/session/transport/basic.go
+++ b/auth/session/transport/basic.go
@@ -1,0 +1,51 @@
+package transport
+
+import (
+	"net/http"
+	"time"
+)
+
+// BasicTransport reads the token from the password slot of HTTP Basic auth
+// ("curl -u user:TOKEN"). Build it with Basic.
+type BasicTransport struct {
+	username string
+}
+
+// BasicOption configures a BasicTransport.
+type BasicOption func(*BasicTransport)
+
+// WithBasicUsername requires the Basic username to match exactly; requests
+// with any other username extract nothing. Without it the username is
+// ignored.
+func WithBasicUsername(u string) BasicOption {
+	return func(b *BasicTransport) { b.username = u }
+}
+
+// Basic returns the extraction-only transport for curl-friendly APIs and
+// legacy integrations: the session token rides the Basic-auth password slot.
+// The credential is client-managed, so Embed and Clear are no-ops — deliver
+// the token out of band (the login response body) and treat Destroy as pure
+// server-side revocation.
+func Basic(opts ...BasicOption) *BasicTransport {
+	b := &BasicTransport{}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
+}
+
+// Extract returns the Basic-auth password, or "" when absent (or when a
+// required username does not match).
+func (b *BasicTransport) Extract(r *http.Request) string {
+	user, pass, ok := r.BasicAuth()
+	if !ok || (b.username != "" && user != b.username) {
+		return ""
+	}
+	return pass
+}
+
+// Embed is a no-op: Basic credentials are stored by the client.
+func (b *BasicTransport) Embed(http.ResponseWriter, string, time.Time) error { return nil }
+
+// Clear is a no-op: Basic credentials are stored by the client.
+func (b *BasicTransport) Clear(http.ResponseWriter) error { return nil }

--- a/auth/session/transport/bearer.go
+++ b/auth/session/transport/bearer.go
@@ -1,0 +1,63 @@
+package transport
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+// defaultTokenHeader is the response header carrying issued/rotated tokens
+// for header-based transports.
+const defaultTokenHeader = "X-Session-Token"
+
+// BearerTransport reads "Authorization: Bearer <token>" and returns
+// issued/rotated tokens in a response header the client persists. Build it
+// with Bearer.
+type BearerTransport struct {
+	header string
+}
+
+// BearerOption configures a BearerTransport.
+type BearerOption func(*BearerTransport)
+
+// WithBearerResponseHeader overrides the response header carrying new tokens
+// (default X-Session-Token).
+func WithBearerResponseHeader(name string) BearerOption {
+	return func(b *BearerTransport) { b.header = name }
+}
+
+// Bearer returns the SPA/mobile transport: tokens arrive as an
+// Authorization Bearer credential; Embed answers with the current token in
+// the response header (default X-Session-Token) whenever it was minted or
+// rotated, and the client replaces its stored copy. Clear sends the header
+// empty — the signal to forget the token.
+func Bearer(opts ...BearerOption) *BearerTransport {
+	b := &BearerTransport{header: defaultTokenHeader}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
+}
+
+// Extract returns the Bearer credential, or "" when absent.
+func (b *BearerTransport) Extract(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if len(auth) <= len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+		return ""
+	}
+	return auth[len(prefix):]
+}
+
+// Embed writes token to the response header.
+func (b *BearerTransport) Embed(w http.ResponseWriter, token string, _ time.Time) error {
+	w.Header().Set(b.header, token)
+	return nil
+}
+
+// Clear writes an empty response header — the client's signal to drop its
+// stored token.
+func (b *BearerTransport) Clear(w http.ResponseWriter) error {
+	w.Header().Set(b.header, "")
+	return nil
+}

--- a/auth/session/transport/bench_test.go
+++ b/auth/session/transport/bench_test.go
@@ -1,0 +1,64 @@
+package transport_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+	"github.com/dmitrymomot/forge/auth/session/transport"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+func BenchmarkCookie_Extract(b *testing.B) {
+	tr := transport.Cookie()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.AddCookie(&http.Cookie{Name: "session", Value: "tok-123456789"})
+	b.ReportAllocs()
+	for b.Loop() {
+		if tr.Extract(r) == "" {
+			b.Fatal("no token")
+		}
+	}
+}
+
+func BenchmarkBearer_Extract(b *testing.B) {
+	tr := transport.Bearer()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer tok-123456789")
+	b.ReportAllocs()
+	for b.Loop() {
+		if tr.Extract(r) == "" {
+			b.Fatal("no token")
+		}
+	}
+}
+
+func BenchmarkJWT_Extract(b *testing.B) {
+	ks, err := keyset.New(keyset.WithPrimary(1, []byte("0123456789abcdef0123456789abcdef")))
+	if err != nil {
+		b.Fatal(err)
+	}
+	signer, err := jwt.NewSigner(jwt.WithHS256Keyset(ks))
+	if err != nil {
+		b.Fatal(err)
+	}
+	verifier, err := jwt.NewVerifier(jwt.WithVerifyHS256Keyset(ks))
+	if err != nil {
+		b.Fatal(err)
+	}
+	tr := transport.JWT(signer, verifier)
+	w := httptest.NewRecorder()
+	if err := tr.Embed(w, "opaque-tok", time.Now().Add(time.Hour)); err != nil {
+		b.Fatal(err)
+	}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer "+w.Header().Get("X-Session-Token"))
+	b.ReportAllocs()
+	for b.Loop() {
+		if tr.Extract(r) == "" {
+			b.Fatal("no token")
+		}
+	}
+}

--- a/auth/session/transport/cookie.go
+++ b/auth/session/transport/cookie.go
@@ -1,0 +1,92 @@
+package transport
+
+import (
+	"net/http"
+	"time"
+)
+
+// CookieTransport carries the token in an HttpOnly cookie. Build it with
+// Cookie.
+type CookieTransport struct {
+	name     string
+	path     string
+	domain   string
+	sameSite http.SameSite
+	secure   bool
+	httpOnly bool
+}
+
+// CookieOption configures a CookieTransport.
+type CookieOption func(*CookieTransport)
+
+// WithCookieName overrides the cookie name (default "session").
+func WithCookieName(name string) CookieOption { return func(c *CookieTransport) { c.name = name } }
+
+// WithCookiePath overrides the cookie path (default "/").
+func WithCookiePath(p string) CookieOption { return func(c *CookieTransport) { c.path = p } }
+
+// WithCookieDomain sets an explicit cookie domain (default host-only).
+func WithCookieDomain(d string) CookieOption { return func(c *CookieTransport) { c.domain = d } }
+
+// WithCookieSameSite overrides the SameSite attribute (default Lax).
+func WithCookieSameSite(s http.SameSite) CookieOption {
+	return func(c *CookieTransport) { c.sameSite = s }
+}
+
+// WithCookieSecure toggles the Secure attribute — disable only for local
+// plain-HTTP development.
+func WithCookieSecure(v bool) CookieOption { return func(c *CookieTransport) { c.secure = v } }
+
+// Cookie returns the browser-default transport: an HttpOnly, Secure,
+// SameSite=Lax cookie named "session" scoped to "/". The cookie's Expires
+// mirrors the session deadline, so the browser drops it when the server
+// would refuse it anyway.
+func Cookie(opts ...CookieOption) *CookieTransport {
+	c := &CookieTransport{
+		name:     "session",
+		path:     "/",
+		sameSite: http.SameSiteLaxMode,
+		secure:   true,
+		httpOnly: true,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Extract returns the cookie's value, or "" when absent.
+func (c *CookieTransport) Extract(r *http.Request) string {
+	ck, err := r.Cookie(c.name)
+	if err != nil {
+		return ""
+	}
+	return ck.Value
+}
+
+// Embed sets the cookie carrying token, expiring at expiresAt.
+func (c *CookieTransport) Embed(w http.ResponseWriter, token string, expiresAt time.Time) error {
+	http.SetCookie(w, c.cookie(token, expiresAt))
+	return nil
+}
+
+// Clear expires the cookie immediately.
+func (c *CookieTransport) Clear(w http.ResponseWriter) error {
+	ck := c.cookie("", time.Time{})
+	ck.MaxAge = -1
+	http.SetCookie(w, ck)
+	return nil
+}
+
+func (c *CookieTransport) cookie(value string, expires time.Time) *http.Cookie {
+	return &http.Cookie{
+		Name:     c.name,
+		Value:    value,
+		Path:     c.path,
+		Domain:   c.domain,
+		Expires:  expires,
+		SameSite: c.sameSite,
+		Secure:   c.secure,
+		HttpOnly: c.httpOnly,
+	}
+}

--- a/auth/session/transport/doc.go
+++ b/auth/session/transport/doc.go
@@ -1,0 +1,34 @@
+// Package transport ships the client-credential transports behind
+// session.WithTransport: how a session token travels between server and
+// client. Any session.Transport implementation plugs into the same seam, so
+// custom carriers (query-signed URLs, gRPC metadata bridges) are one small
+// struct away.
+//
+//   - Cookie: HttpOnly/Secure/SameSite cookie — the browser-app default.
+//     The safest attributes are on by default; loosen them explicitly.
+//
+//   - Bearer: "Authorization: Bearer <token>" in, a response header
+//     (default X-Session-Token) out — SPAs and mobile clients that store
+//     the token themselves.
+//
+//   - Basic: the token rides the password slot of HTTP Basic auth —
+//     curl-friendly APIs and legacy integrations. Extraction-only: the
+//     client manages its own credential, so Embed/Clear are no-ops and the
+//     consumer delivers the token out of band (response body at login).
+//
+//   - JWT: the opaque token travels wrapped in a signed JWT (auth/jwt) with
+//     exp bound to the session deadline — for edges and gateways that
+//     already speak JWT. The JWT is transport dressing: the server-side
+//     session stays the source of truth and revocation keeps working.
+//
+// Wiring and the request-level flow:
+//
+//	mgr, err := session.New[Data](store,
+//		session.WithTransport(transport.Cookie(transport.WithCookieName("sid"))))
+//
+//	// handlers:
+//	s, err := mgr.LoadRequest(r)                       // extract + load
+//	err = mgr.SaveRequest(w, r, s)                     // save + Set-Cookie
+//	err = mgr.AuthenticateRequest(w, r, s, userID)     // login: rotate + re-set
+//	err = mgr.DestroyRequest(w, r, s)                  // logout: revoke + clear
+package transport

--- a/auth/session/transport/jwt.go
+++ b/auth/session/transport/jwt.go
@@ -1,0 +1,88 @@
+package transport
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+)
+
+// jwtClaims wraps the opaque session token in registered JWT claims. The
+// token rides a private claim; exp mirrors the session deadline so standard
+// JWT validation rejects what the server would refuse anyway.
+type jwtClaims struct {
+	SessionToken string `json:"sid"`
+	jwt.Claims
+}
+
+// JWTTransport wraps the session token in a signed JWT riding the
+// Authorization Bearer credential. Build it with JWT.
+type JWTTransport struct {
+	verifier *jwt.Verifier
+	signer   *jwt.Signer
+	bearer   BearerTransport
+	issuer   string
+}
+
+// JWTOption configures a JWTTransport.
+type JWTOption func(*JWTTransport)
+
+// WithJWTIssuer stamps iss on issued JWTs. Pair it with jwt.WithIssuer on
+// the Verifier to enforce it.
+func WithJWTIssuer(iss string) JWTOption { return func(t *JWTTransport) { t.issuer = iss } }
+
+// WithJWTResponseHeader overrides the response header carrying freshly
+// issued JWTs (default X-Session-Token).
+func WithJWTResponseHeader(name string) JWTOption {
+	return func(t *JWTTransport) { t.bearer.header = name }
+}
+
+// JWT returns a transport for infrastructure that already speaks JWT (edge
+// gateways, service meshes): the opaque session token travels inside a
+// signed JWT presented as an Authorization Bearer credential, and fresh
+// JWTs are answered in a response header (default X-Session-Token) exactly
+// like Bearer. The JWT is transport dressing only — the server-side session
+// stays the source of truth, so rotation and revocation keep working, and
+// exp mirrors the session deadline.
+func JWT(signer *jwt.Signer, verifier *jwt.Verifier, opts ...JWTOption) *JWTTransport {
+	t := &JWTTransport{signer: signer, verifier: verifier, bearer: BearerTransport{header: defaultTokenHeader}}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+// Extract verifies the presented JWT and returns the wrapped session token;
+// missing, malformed, tampered, or expired JWTs extract "".
+func (t *JWTTransport) Extract(r *http.Request) string {
+	raw := t.bearer.Extract(r)
+	if raw == "" {
+		return ""
+	}
+	claims, err := jwt.Verify[jwtClaims](r.Context(), t.verifier, raw)
+	if err != nil {
+		return ""
+	}
+	return claims.SessionToken
+}
+
+// Embed signs a fresh JWT wrapping token, with exp = expiresAt, into the
+// response header.
+func (t *JWTTransport) Embed(w http.ResponseWriter, token string, expiresAt time.Time) error {
+	signed, err := t.signer.Sign(jwtClaims{
+		Claims: jwt.Claims{
+			Issuer:    t.issuer,
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+		SessionToken: token,
+	})
+	if err != nil {
+		return err
+	}
+	return t.bearer.Embed(w, signed, expiresAt)
+}
+
+// Clear writes an empty response header — the client's signal to drop its
+// stored JWT.
+func (t *JWTTransport) Clear(w http.ResponseWriter) error { return t.bearer.Clear(w) }

--- a/auth/session/transport/transport_test.go
+++ b/auth/session/transport/transport_test.go
@@ -1,0 +1,194 @@
+package transport_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/jwt"
+	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/auth/session/transport"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/crypto/keyset"
+)
+
+// Every ship transport must satisfy the seam.
+var (
+	_ session.Transport = (*transport.CookieTransport)(nil)
+	_ session.Transport = (*transport.BearerTransport)(nil)
+	_ session.Transport = (*transport.BasicTransport)(nil)
+	_ session.Transport = (*transport.JWTTransport)(nil)
+)
+
+func TestCookie_RoundTrip(t *testing.T) {
+	t.Parallel()
+	tr := transport.Cookie()
+	w := httptest.NewRecorder()
+	exp := time.Now().Add(time.Hour).UTC()
+	require.NoError(t, tr.Embed(w, "tok-1", exp))
+
+	cks := w.Result().Cookies()
+	require.Len(t, cks, 1)
+	ck := cks[0]
+	assert.Equal(t, "session", ck.Name)
+	assert.Equal(t, "tok-1", ck.Value)
+	assert.Equal(t, "/", ck.Path)
+	assert.True(t, ck.HttpOnly)
+	assert.True(t, ck.Secure)
+	assert.Equal(t, http.SameSiteLaxMode, ck.SameSite)
+	assert.WithinDuration(t, exp, ck.Expires, time.Second)
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.AddCookie(ck)
+	assert.Equal(t, "tok-1", tr.Extract(r))
+	assert.Empty(t, tr.Extract(httptest.NewRequest(http.MethodGet, "/", nil)))
+}
+
+func TestCookie_OptionsAndClear(t *testing.T) {
+	t.Parallel()
+	tr := transport.Cookie(
+		transport.WithCookieName("sid"),
+		transport.WithCookiePath("/app"),
+		transport.WithCookieDomain("example.com"),
+		transport.WithCookieSameSite(http.SameSiteStrictMode),
+		transport.WithCookieSecure(false),
+	)
+	w := httptest.NewRecorder()
+	require.NoError(t, tr.Embed(w, "tok", time.Now().Add(time.Hour)))
+	ck := w.Result().Cookies()[0]
+	assert.Equal(t, "sid", ck.Name)
+	assert.Equal(t, "/app", ck.Path)
+	assert.Equal(t, "example.com", ck.Domain)
+	assert.Equal(t, http.SameSiteStrictMode, ck.SameSite)
+	assert.False(t, ck.Secure)
+
+	wc := httptest.NewRecorder()
+	require.NoError(t, tr.Clear(wc))
+	cleared := wc.Result().Cookies()[0]
+	assert.Equal(t, "sid", cleared.Name)
+	assert.Negative(t, cleared.MaxAge)
+	assert.Empty(t, cleared.Value)
+	assert.Equal(t, "/app", cleared.Path, "clear must match the set attributes or browsers keep the cookie")
+}
+
+func TestBearer(t *testing.T) {
+	t.Parallel()
+	tr := transport.Bearer()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer tok-9")
+	assert.Equal(t, "tok-9", tr.Extract(r))
+
+	lower := httptest.NewRequest(http.MethodGet, "/", nil)
+	lower.Header.Set("Authorization", "bearer tok-9")
+	assert.Equal(t, "tok-9", tr.Extract(lower), "scheme is case-insensitive")
+
+	for _, h := range []string{"", "Bearer", "Bearer ", "Basic dG9rOg=="} {
+		bad := httptest.NewRequest(http.MethodGet, "/", nil)
+		if h != "" {
+			bad.Header.Set("Authorization", h)
+		}
+		assert.Empty(t, tr.Extract(bad), "header %q", h)
+	}
+
+	w := httptest.NewRecorder()
+	require.NoError(t, tr.Embed(w, "tok-9", time.Now()))
+	assert.Equal(t, "tok-9", w.Header().Get("X-Session-Token"))
+	require.NoError(t, tr.Clear(w))
+	assert.Empty(t, w.Header().Get("X-Session-Token"))
+
+	named := transport.Bearer(transport.WithBearerResponseHeader("X-Auth"))
+	wn := httptest.NewRecorder()
+	require.NoError(t, named.Embed(wn, "tok", time.Now()))
+	assert.Equal(t, "tok", wn.Header().Get("X-Auth"))
+}
+
+func TestBasic(t *testing.T) {
+	t.Parallel()
+	tr := transport.Basic()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.SetBasicAuth("anyone", "tok-3")
+	assert.Equal(t, "tok-3", tr.Extract(r))
+	assert.Empty(t, tr.Extract(httptest.NewRequest(http.MethodGet, "/", nil)))
+
+	strict := transport.Basic(transport.WithBasicUsername("api"))
+	assert.Empty(t, strict.Extract(r), "wrong username must extract nothing")
+	ok := httptest.NewRequest(http.MethodGet, "/", nil)
+	ok.SetBasicAuth("api", "tok-3")
+	assert.Equal(t, "tok-3", strict.Extract(ok))
+
+	// Client-managed credential: nothing to embed or clear.
+	w := httptest.NewRecorder()
+	require.NoError(t, tr.Embed(w, "tok-3", time.Now()))
+	require.NoError(t, tr.Clear(w))
+	assert.Empty(t, w.Header())
+}
+
+func newJWTPair(t *testing.T, vopts ...jwt.VerifierOption) (*jwt.Signer, *jwt.Verifier) {
+	t.Helper()
+	ks, err := keyset.New(keyset.WithPrimary(1, []byte("0123456789abcdef0123456789abcdef")))
+	require.NoError(t, err)
+	signer, err := jwt.NewSigner(jwt.WithHS256Keyset(ks))
+	require.NoError(t, err)
+	verifier, err := jwt.NewVerifier(append([]jwt.VerifierOption{jwt.WithVerifyHS256Keyset(ks)}, vopts...)...)
+	require.NoError(t, err)
+	return signer, verifier
+}
+
+func TestJWT_RoundTrip(t *testing.T) {
+	t.Parallel()
+	signer, verifier := newJWTPair(t)
+	tr := transport.JWT(signer, verifier, transport.WithJWTIssuer("app"))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, tr.Embed(w, "opaque-tok", time.Now().Add(time.Hour)))
+	signed := w.Header().Get("X-Session-Token")
+	require.NotEmpty(t, signed)
+	assert.NotContains(t, signed, "opaque-tok", "the raw token must not appear in the JWT envelope verbatim")
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer "+signed)
+	assert.Equal(t, "opaque-tok", tr.Extract(r))
+}
+
+func TestJWT_RejectsForgedAndExpired(t *testing.T) {
+	t.Parallel()
+	signer, verifier := newJWTPair(t)
+	tr := transport.JWT(signer, verifier)
+
+	// Tampered signature.
+	w := httptest.NewRecorder()
+	require.NoError(t, tr.Embed(w, "tok", time.Now().Add(time.Hour)))
+	signed := w.Header().Get("X-Session-Token")
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer "+signed+"x")
+	assert.Empty(t, tr.Extract(r))
+
+	// Signed under a different key.
+	otherKS, err := keyset.New(keyset.WithPrimary(1, []byte("ffffffffffffffffffffffffffffffff")))
+	require.NoError(t, err)
+	otherSigner, err := jwt.NewSigner(jwt.WithHS256Keyset(otherKS))
+	require.NoError(t, err)
+	foreign := transport.JWT(otherSigner, verifier)
+	wf := httptest.NewRecorder()
+	require.NoError(t, foreign.Embed(wf, "tok", time.Now().Add(time.Hour)))
+	rf := httptest.NewRequest(http.MethodGet, "/", nil)
+	rf.Header.Set("Authorization", "Bearer "+wf.Header().Get("X-Session-Token"))
+	assert.Empty(t, tr.Extract(rf))
+
+	// Expired envelope: verification happens against the verifier's clock.
+	future := clock.NewMock(time.Now().Add(48 * time.Hour))
+	_, lateVerifier := newJWTPair(t, jwt.WithClock(future))
+	late := transport.JWT(signer, lateVerifier)
+	rl := httptest.NewRequest(http.MethodGet, "/", nil)
+	rl.Header.Set("Authorization", "Bearer "+signed)
+	assert.Empty(t, late.Extract(rl), "an expired JWT envelope must extract nothing")
+
+	// No credential at all.
+	assert.Empty(t, tr.Extract(httptest.NewRequest(http.MethodGet, "/", nil)))
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -245,20 +245,6 @@ Deps: `resilience/cache`; `realtime/fanout`.
 
 ---
 
-**auth/session**
-
-Server-side session lifecycle (Start/Load/Save/Destroy/Rotate) over a
-pluggable Store; rotate-on-privilege-change; multi-device management via
-an optional `UserIndex` store extension (ListByUser/DeleteByUser — "log
-out other devices", GDPR deletion); `WithFingerprint(Warn|Strict)` hijack
-detection. In-memory store built in; drivers: `session/pgstore`
-(user-indexed), `session/cookiestore` (stateless-encrypted, no UserIndex —
-documented); generic KV backing rides `cache.Store`.
-
-Deps: `resilience/cache`, `data/postgres`; `web/fingerprint`.
-
----
-
 **auth/impersonation**
 
 Support-agent "log in as": time-boxed impersonation sessions with a
@@ -267,7 +253,7 @@ events on start/end and every action, optional `ops/approval` gate.
 Composes `session` and the `access` decision seam — the hand-rolled
 version is where privilege escalation lives.
 
-Deps: `auth/access`; `auth/session`, `ops/approval` (both planned);
+Deps: `auth/access`, `auth/session`; `ops/approval` (planned);
 `ops/auditlog`.
 
 ---


### PR DESCRIPTION
## Summary

Implements the `auth/session` catalog entry: server-side session lifecycle (Start/Load/Save/Destroy/Rotate) over a pluggable Store, with rotate-on-privilege-change, optional multi-device management, and fingerprint-based hijack detection.

### Core (`auth/session`)

- Generic `Manager[T]` — typed session payload, JSON-encoded at rest; transport-agnostic (deals in bearer tokens; cookie transport is the handler's choice).
- Expiry: sliding idle TTL (`WithTTL`, default 24h) capped by an absolute lifetime (`WithLifetime`, default 30d) that no activity or rotation extends.
- `Rotate` mints a new token and revokes the old one (ID/CreatedAt survive); `Authenticate` = bind user + rotate — the session-fixation defense. Failed rotations/logins roll the in-memory session back to a loadable state.
- `Start` is storage-free: abandoned anonymous sessions (crawlers) cost nothing; the token is minted on first `Save`.
- `WithFingerprint(Warn|Strict)` hijack detection: baseline digest captured at Start/Rotate (default source is `web/fingerprint.FromContext`; `WithDigestSource` for custom middleware/CDN headers). Warn logs drifted component names; Strict revokes the session before returning `ErrFingerprintMismatch`, and a missing live digest fails closed.
- Tenancy per forge rule: single construction-time `WithScope` hook, fail-closed on error/empty; sessions are stamped at Save and invisible outside their scope. Cross-scope tokens are indistinguishable from unknown ones and cannot be revoked cross-tenant (Destroy verifies record ownership before deleting).
- Optional `UserIndex` store extension (`ListByUser`/`DeleteByUser`) surfaces as `ListUserSessions` (tokens never exposed — stored only as digests) and `DeleteUserSessions`; "log out other devices" = delete-all + re-save current (documented recipe).

### Stores

- **MemoryStore** (built-in, tests/dev): Store + UserIndex, defensive record cloning, `PurgeExpired` sweep. Deliberately not `cache`'s LRU memory store — LRU eviction drops live sessions.
- **`NewKVStore(cache.Store)`**: rides the framework TTL-KV seam (`cache/redis` in production). Keys are SHA-256 digests of tokens (no bearer credentials in Redis SCAN); an already-expired record is deleted instead of stored so a TTL<=0-means-eternal backend can never hold an immortal session. No UserIndex (documented).
- **`pgstore`**: token-digest PK (DB leak exposes no usable credentials), upsert Save, partial index for the user listings, `DeleteExpired` for a scheduled sweep, embedded goose migration under its own version table. Full UserIndex.
- **`cookiestore`**: stateless — the AEAD-encrypted record (crypto/secret.Box, keyset-rotatable) IS the token. Documented trade-offs: no revocation (Delete is a no-op; clearing the cookie is the destroy), no UserIndex, size-capped (`ErrTooLarge`, default 3800 bytes). Tamper/truncation/foreign-key tokens are indistinguishable from unknown (`ErrNotFound`).

### Testing

- Black-box unit suite: lifecycle, expiry semantics (slide + absolute cap + no-resurrection), rotation atomicity and failure rollback, store-error wrapping, codec failure, user-session management.
- Tenancy proof tests (single-tenant / white-label / platform-switching shapes), including the cross-tenant Destroy case — which caught a real bug during development (Destroy originally deleted blindly without scope verification).
- Fingerprint suite via an injected digest source + one end-to-end test riding the real `fingerprint.Session` preset middleware.
- `cookiestore` fuzz (17M+ execs clean): arbitrary tokens either fail with clean `ErrNotFound` or decode only records genuinely sealed by the key (AEAD guarantee).
- `pgstore` integration tier (testcontainers): round-trip incl. digest JSON + timestamptz µs precision, upsert, scoped user index, DeleteExpired, and a full Manager end-to-end run. Passing locally.

### Benchmarks (Apple M3 Max)

```
BenchmarkSave_Memory-14                     4589611    248.0 ns/op    176 B/op     3 allocs/op
BenchmarkLoad_Memory-14                     1435766    832.4 ns/op    656 B/op    15 allocs/op
BenchmarkRotate_Memory-14                   2132191    564.0 ns/op    464 B/op     7 allocs/op
BenchmarkLoad_MemoryFingerprintStrict-14    1355648    892.0 ns/op    992 B/op    17 allocs/op
BenchmarkSaveLoad_KV-14                      247724     4521 ns/op   3060 B/op    43 allocs/op
cookiestore BenchmarkSave-14                 743354     1591 ns/op   3172 B/op    11 allocs/op
cookiestore BenchmarkLoad-14                 450984     2630 ns/op   2496 B/op    14 allocs/op
```

Post-benchmark pass: the JSON codec dominates Load; all ops are sub-µs to low-µs against in-memory backing (network stores dwarf this in production), so no perf-motivated complexity was taken.

### Catalog

`auth/session` entry removed from docs/packages.md (shipped packages leave the roadmap); `auth/impersonation` deps updated accordingly.

## Update (c96baff): device management, client transports, UI metadata

### Auth-session management for a "manage devices" UI

- Sessions now carry **IP, UserAgent, LastSeenAt** (persisted; stamped automatically by the request-level helpers, LastSeenAt refreshed on every Save) alongside ID/CreatedAt/ExpiresAt — everything a device listing renders. The current device is the one whose ID matches the caller's session.
- `UserIndex` extended: `DeleteByUser(..., keep ...id.UUID)` (keep-list) and `DeleteOne(scope, userID, sessionID)` (user-bound, so a guessed session id under the wrong user revokes nothing — IDOR guard).
- New Manager verbs, all scope-isolated and covered by tenancy tests: `LogoutOthers(ctx, current)` (every device but this one, atomic keep-list — no more delete-all + re-save recipe), `RevokeUserSession(ctx, userID, sessionID)` (single device, idempotent), joining the existing `ListUserSessions` / `DeleteUserSessions`.
- pgstore migration gained `ip`, `user_agent`, `last_seen_at` columns (amended in place — the migration is unreleased) and the new UserIndex methods; integration tests cover keep-list, DeleteOne wrong-user no-op, and metadata round-trip.

### Pluggable client transports

- New `session.Transport` seam (`Extract`/`Embed`/`Clear`) via `WithTransport`; request-level Manager methods ride it: `LoadRequest`, `SaveRequest`, `AuthenticateRequest`, `RotateRequest`, `DestroyRequest` — rotation re-embeds the replacement token automatically, destroy clears the client credential, and client metadata is stamped per save (IP via web/clientip, User-Agent capped at 256 bytes against hostile headers; `WithClientInfo` overrides). The token-level API stays fully usable without any transport (`ErrNoTransport` otherwise).
- `session/transport` package: **Cookie** (HttpOnly/Secure/SameSite-Lax by default, attribute options), **Bearer** (`Authorization: Bearer` in, `X-Session-Token` response header out — SPA/mobile), **Basic** (token in the password slot, extraction-only, optional fixed username), **JWT** (opaque token wrapped in a signed envelope via auth/jwt, `exp` = session deadline; the server-side session stays the source of truth so revocation keeps working). Any custom implementation plugs into the same seam.
- Tests: full browser-flow test over the cookie transport (set → load → login-rotate re-set → logout expire), transport unit suites incl. JWT forged/foreign-key/expired rejection, keyset rotation.

### Review fixes

Both inline findings fixed with regression tests proven to fail pre-fix: `Rotate` now rolls back the fingerprint baseline alongside the token on a failed save, and a failed Strict-mode revoke joins `ErrFingerprintMismatch` with `ErrStore` instead of swallowing the hijack signal. The `integration` CI failure was pgstore tests racing concurrent goose migrations on the shared container (`pg_type` unique violation) — they now run serially like apikey's.

### Benchmarks after the update (Apple M3 Max)

```
BenchmarkSave_Memory-14                     4645386    255.0 ns/op    176 B/op     3 allocs/op
BenchmarkLoad_Memory-14                     1433604    844.0 ns/op    704 B/op    15 allocs/op
BenchmarkRotate_Memory-14                   2070198    582.1 ns/op    512 B/op     7 allocs/op
BenchmarkLoad_MemoryFingerprintStrict-14    1311066    913.3 ns/op   1040 B/op    17 allocs/op
BenchmarkSaveLoad_KV-14                      233409     5179 ns/op   3445 B/op    44 allocs/op
transport BenchmarkCookie_Extract-14       11318107    89.13 ns/op    200 B/op     2 allocs/op
transport BenchmarkBearer_Extract-14       51839491    23.44 ns/op      0 B/op     0 allocs/op
transport BenchmarkJWT_Extract-14            497452     2374 ns/op   1840 B/op    33 allocs/op
```

Core numbers moved within noise despite the added metadata fields; transport extraction is 23–89ns for the common paths, JWT's 2.4µs is signature verification (inherent).
