### PR TITLE
feat(approval): ops/approval maker-checker dual control

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -253,8 +253,8 @@ events on start/end and every action, optional `ops/approval` gate.
 Composes `session` and the `access` decision seam — the hand-rolled
 version is where privilege escalation lives.
 
-Deps: `auth/access`; `auth/session`, `ops/approval` (both planned);
-`ops/auditlog`.
+Deps: `auth/access`, `ops/approval`, `ops/auditlog`; `auth/session`
+(planned).
 
 ---
 
@@ -394,18 +394,6 @@ schemas, no reflection; official MCP go-sdk isolated here.
 Deps: `ops/supervisor` (MCP go-sdk external, isolated).
 
 ## ops/
-
----
-
-**ops/approval**
-
-Maker-checker dual control: typed approval requests (action + payload) a
-second person approves or rejects over a storage-agnostic Store; decisions
-emit `auditlog` events and approver eligibility rides the `auth/access`
-decision seam. The two-person rule for payouts, limit overrides, and
-config changes.
-
-Deps: `auth/access`; `ops/auditlog`.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-21-ops-approval.md
+++ b/docs/superpowers/plans/2026-07-21-ops-approval.md
@@ -1,0 +1,4153 @@
+# ops/approval Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `ops/approval` — maker-checker dual control: typed approval requests a second person approves or rejects over a storage-agnostic Store, with an execute-once claim so an approved action runs exactly once.
+
+**Architecture:** A non-generic `Manager` owns a kind→`Policy` registry (immutable after `New`) and drives every state transition through one concurrency primitive: whole-record compare-and-swap on `Store.Update(ctx, r, expectVersion)`. Type safety lives in package-level generic functions (`Submit`, `PayloadOf`, `WithKind`) over a `Kind[T]` token, mirroring `async/queue`. Expiry is derived on read, never written. Eligibility rides `auth/access`; the trail rides `ops/auditlog`; both are optional seams.
+
+**Tech Stack:** Go 1.26, stdlib + `github.com/dmitrymomot/forge/{core/id,core/clock,auth/access,ops/auditlog}`; `pgx/v5` isolated in `ops/approval/pgstore`; tests use `testify` and `testkit/pgtest`.
+
+**Spec:** [2026-07-21-ops-approval-design.md](../specs/2026-07-21-ops-approval-design.md) — read it before Task 1.
+
+## Global Constraints
+
+- **Module path:** `github.com/dmitrymomot/forge`. Package lives at `ops/approval`, import path `github.com/dmitrymomot/forge/ops/approval`.
+- **Tests are black-box:** every test file is `package approval_test`. No white-box test files in this package.
+- **Run `just fmt ./ops/approval/...` after every file change.** Never `just fmt` a single file — it trips betteralign.
+- **Run `just lint` before the final commit.** It runs vet, build, golangci-lint, nilaway, betteralign, modernize, and the integration-tagged pass.
+- **`just test ./ops/approval/...`** runs unit tests with `-race`. Integration tier is `just test-integration ./ops/approval/...`.
+- **Field order in structs is betteralign's call.** Write fields in readable order; `just fmt` reorders them. Do not fight it.
+- **All timestamps:** `.UTC().Truncate(time.Microsecond)` before they enter a `Request`. Postgres `timestamptz` is microsecond-precision; untruncated nanoseconds do not survive the round-trip and break equality assertions.
+- **No `time.Now()` in package code.** Always `m.cfg.clock.Now()`, so tests are deterministic.
+- **Errors are single-line sentinels** in `errors.go`, prefixed `approval: `, matched with `errors.Is`.
+- **Go 1.26:** use `new(expr)` where a pointer to a value is needed; run `go tool modernize` (part of `just lint`). Note: the `claude-review` bot false-flags `new(expr)` as invalid — it is valid Go 1.26; reject that review comment with a link to the spec of `new`.
+- **Commit after every task** with a `feat(approval):` / `test(approval):` conventional prefix. No Claude attribution in any commit message.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `ops/approval/errors.go` | All sentinels |
+| `ops/approval/approval.go` | `Status`, `Vote`, `Request`, `Decision`, `Kind[T]`, `Actor`, `SubmitParams`, `Filter` |
+| `ops/approval/policy.go` | `Policy` + validation |
+| `ops/approval/store.go` | `Store` interface |
+| `ops/approval/memory.go` | In-memory `Store` |
+| `ops/approval/options.go` | `config`, `Option`, all `With*` |
+| `ops/approval/manager.go` | `New`, `Get`, `List`, `applyExpiry`, `mutate` CAS loop, scope resolution |
+| `ops/approval/submit.go` | `Submit[T]`, `PayloadOf[T]` |
+| `ops/approval/decide.go` | `Approve`, `Reject`, `Cancel` |
+| `ops/approval/execute.go` | `Claim`, `Complete`, `Fail`, `Release`, `Execute` |
+| `ops/approval/eligibility.go` | Decider invocation, fail-closed mapping |
+| `ops/approval/audit.go` | auditlog emission |
+| `ops/approval/doc.go` | Package doc + runnable example |
+| `ops/approval/approvaltest/` | Exported Store conformance suite (`Run`), shared by memory and pgstore |
+| `ops/approval/pgstore/` | Postgres driver, migrations, integration tests |
+
+---
+
+## Task 1: Core types and errors
+
+**Files:**
+- Create: `ops/approval/errors.go`
+- Create: `ops/approval/approval.go`
+- Test: `ops/approval/approval_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Status` (+ `String`, `Terminal`), `Vote`, `Request`, `Decision`, `Kind[T]` (+ `NewKind[T]`, `Name`), `Actor`, `SubmitParams`, `Filter`, and every sentinel in `errors.go`. Every later task depends on these names.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/approval/approval_test.go`:
+
+```go
+package approval_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+func TestStatusString(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		want string
+		s    approval.Status
+	}{
+		{"pending", approval.Pending},
+		{"approved", approval.Approved},
+		{"rejected", approval.Rejected},
+		{"cancelled", approval.Cancelled},
+		{"expired", approval.Expired},
+		{"executing", approval.Executing},
+		{"executed", approval.Executed},
+		{"failed", approval.Failed},
+		{"unknown", approval.Status(99)},
+	} {
+		assert.Equal(t, tc.want, tc.s.String())
+	}
+}
+
+func TestStatusTerminal(t *testing.T) {
+	t.Parallel()
+	terminal := []approval.Status{
+		approval.Rejected, approval.Cancelled, approval.Expired,
+		approval.Executed, approval.Failed,
+	}
+	for _, s := range terminal {
+		assert.True(t, s.Terminal(), "%s must be terminal", s)
+	}
+	nonTerminal := []approval.Status{approval.Pending, approval.Approved, approval.Executing}
+	for _, s := range nonTerminal {
+		assert.False(t, s.Terminal(), "%s must not be terminal", s)
+	}
+}
+
+func TestNewKind(t *testing.T) {
+	t.Parallel()
+	k := approval.NewKind[struct{ A int }]("payout.release")
+	require.Equal(t, "payout.release", k.Name())
+	assert.Panics(t, func() { approval.NewKind[int]("") }, "empty name is a wiring bug")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/approval/...`
+Expected: FAIL — `no required module provides package github.com/dmitrymomot/forge/ops/approval`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/approval/errors.go`:
+
+```go
+package approval
+
+import "errors"
+
+var (
+	// ErrNotFound is returned by a Store when no request matches, and by
+	// Manager operations for other tenants' requests under WithScope (so
+	// cross-tenant existence cannot be probed).
+	ErrNotFound = errors.New("approval: request not found")
+
+	// ErrDuplicate is returned by Store.Create when the ID already exists.
+	ErrDuplicate = errors.New("approval: duplicate request")
+
+	// ErrConflict is returned by Store.Update when the stored Version no
+	// longer matches the expected one. The Manager retries on it.
+	ErrConflict = errors.New("approval: version conflict")
+
+	// ErrUnknownKind rejects a submission for a kind that was not
+	// registered with WithKind.
+	ErrUnknownKind = errors.New("approval: unknown kind")
+
+	// ErrKindMismatch rejects PayloadOf when the Kind does not match the
+	// request's kind — the payload would decode into the wrong type.
+	ErrKindMismatch = errors.New("approval: kind mismatch")
+
+	// ErrRequesterRequired rejects SubmitParams with an empty Requester.
+	ErrRequesterRequired = errors.New("approval: requester required")
+
+	// ErrActorRequired rejects a decision from an Actor with an empty
+	// Subject.ID — an anonymous checker cannot satisfy dual control.
+	ErrActorRequired = errors.New("approval: actor required")
+
+	// ErrExecutorRequired rejects a claim with an empty executor id.
+	ErrExecutorRequired = errors.New("approval: executor required")
+
+	// ErrSelfApproval enforces the maker-checker rule: the requester may
+	// never decide their own request, at any quorum.
+	ErrSelfApproval = errors.New("approval: requester cannot decide own request")
+
+	// ErrAlreadyVoted rejects a second decision from an approver who has
+	// already voted, whichever way they voted first.
+	ErrAlreadyVoted = errors.New("approval: approver already voted")
+
+	// ErrNotPending rejects a decision on a request that is no longer
+	// awaiting one.
+	ErrNotPending = errors.New("approval: request not pending")
+
+	// ErrExpired rejects every transition on a request past its TTL.
+	ErrExpired = errors.New("approval: request expired")
+
+	// ErrNotApproved rejects a claim on a request that has not reached
+	// quorum.
+	ErrNotApproved = errors.New("approval: request not approved")
+
+	// ErrAlreadyClaimed rejects a claim held by another executor whose
+	// lease has not gone stale.
+	ErrAlreadyClaimed = errors.New("approval: request already claimed")
+
+	// ErrNotExecuting rejects Complete, Fail, or Release on a request that
+	// is not currently claimed.
+	ErrNotExecuting = errors.New("approval: request not executing")
+
+	// ErrNotClaimHolder rejects Complete or Fail from an executor other
+	// than the one holding the claim. Release is deliberately exempt.
+	ErrNotClaimHolder = errors.New("approval: executor does not hold the claim")
+
+	// ErrNotCancellable rejects Cancel on a request that is executing or
+	// already terminal.
+	ErrNotCancellable = errors.New("approval: request not cancellable")
+
+	// ErrNotEligible rejects a decision from an actor the decider denied,
+	// or whose eligibility could not be established (fail closed).
+	ErrNotEligible = errors.New("approval: actor not eligible")
+
+	// ErrScope is the fail-closed result of a WithScope hook that errored
+	// or returned an empty tenant, or of a request tenant that disagrees
+	// with the scoped one.
+	ErrScope = errors.New("approval: tenant scope unavailable")
+
+	// ErrAuditFailed reports that a transition was persisted but its audit
+	// event could not be written. The returned Request is durable; the
+	// trail is not. Match it with errors.Is and alert — never swallow it.
+	ErrAuditFailed = errors.New("approval: audit write failed")
+)
+```
+
+Create `ops/approval/approval.go`:
+
+```go
+package approval
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Status is the lifecycle state of an approval request.
+type Status uint8
+
+// Request statuses. Expired is derived on read from ExpiresAt and is never
+// persisted — see Manager.Get.
+const (
+	Pending   Status = iota // awaiting decisions
+	Approved                // quorum met, awaiting claim
+	Rejected                // a checker rejected it
+	Cancelled               // withdrawn before execution
+	Expired                 // TTL elapsed while Pending or Approved
+	Executing               // claimed by an executor
+	Executed                // executor reported success
+	Failed                  // executor reported failure
+)
+
+// String renders the status for logs, audit metadata, and errors.
+func (s Status) String() string {
+	switch s {
+	case Pending:
+		return "pending"
+	case Approved:
+		return "approved"
+	case Rejected:
+		return "rejected"
+	case Cancelled:
+		return "cancelled"
+	case Expired:
+		return "expired"
+	case Executing:
+		return "executing"
+	case Executed:
+		return "executed"
+	case Failed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+// Terminal reports whether the status admits no further transitions.
+func (s Status) Terminal() bool {
+	switch s {
+	case Rejected, Cancelled, Expired, Executed, Failed:
+		return true
+	default:
+		return false
+	}
+}
+
+// Vote is the direction of a checker's decision.
+type Vote uint8
+
+// Vote directions. The zero value is invalid so an unset Vote cannot pass
+// for an approval.
+const (
+	VoteApprove Vote = iota + 1
+	VoteReject
+)
+
+// String renders the vote for audit metadata.
+func (v Vote) String() string {
+	switch v {
+	case VoteApprove:
+		return "approve"
+	case VoteReject:
+		return "reject"
+	default:
+		return "unknown"
+	}
+}
+
+// Kind binds an approval action name to its payload type T. Declare one
+// package-level Kind per action and share it between the code that submits
+// and the code that executes: the name exists in exactly one place, and
+// payload type drift becomes a compile error.
+//
+//	var KindReleasePayout = approval.NewKind[ReleasePayout]("payout.release")
+type Kind[T any] struct {
+	name string
+}
+
+// NewKind creates a Kind for payload type T. Panics on an empty name:
+// kinds are package-level wiring, not runtime data.
+func NewKind[T any](name string) Kind[T] {
+	if name == "" {
+		panic("approval: NewKind requires a non-empty name")
+	}
+	return Kind[T]{name: name}
+}
+
+// Name returns the action name.
+func (k Kind[T]) Name() string { return k.name }
+
+// Decision is one checker's vote on a request. Decisions are append-only.
+type Decision struct {
+	// At is when the decision was cast, UTC, microsecond precision.
+	At time.Time `json:"at"`
+	// Approver is the deciding subject's id.
+	Approver string `json:"approver"`
+	// Reason is the checker's free-form justification.
+	Reason string `json:"reason,omitempty"`
+	// Vote is the direction of the decision.
+	Vote Vote `json:"vote"`
+}
+
+// Request is one privileged action awaiting dual control.
+type Request struct {
+	// CreatedAt is when the request was submitted.
+	CreatedAt time.Time `json:"created_at"`
+	// ExpiresAt is when the request stops being actionable. Zero means it
+	// never expires.
+	ExpiresAt time.Time `json:"expires_at,omitzero"`
+	// ClaimedAt is when the current executor claimed it. Zero when
+	// unclaimed.
+	ClaimedAt time.Time `json:"claimed_at,omitzero"`
+	// DecidedAt is when the request reached Approved or a terminal status.
+	DecidedAt time.Time `json:"decided_at,omitzero"`
+	// Decisions holds every vote cast, in the order cast.
+	Decisions []Decision `json:"decisions,omitempty"`
+	// Meta carries free-form submitter context.
+	Meta map[string]string `json:"meta,omitempty"`
+	// Payload is the JSON-encoded action payload. Decode it with PayloadOf.
+	Payload json.RawMessage `json:"payload"`
+	// Kind is the registered action name.
+	Kind string `json:"kind"`
+	// Tenant is the owning tenant; empty in single-tenant applications.
+	Tenant string `json:"tenant,omitempty"`
+	// Requester is the maker — the principal that submitted the request.
+	Requester string `json:"requester"`
+	// Reason is the maker's justification, shown to checkers.
+	Reason string `json:"reason,omitempty"`
+	// ClaimedBy is the executor currently holding the claim.
+	ClaimedBy string `json:"claimed_by,omitempty"`
+	// ID is a time-ordered UUIDv7 assigned at submit.
+	ID id.UUID `json:"id"`
+	// Version is the optimistic-concurrency counter. Store.Update accepts a
+	// write only when the stored value matches.
+	Version int64 `json:"version"`
+	// Status is the lifecycle state.
+	Status Status `json:"status"`
+}
+
+// Approvals counts the approving votes cast so far.
+func (r Request) Approvals() int {
+	n := 0
+	for i := range r.Decisions {
+		if r.Decisions[i].Vote == VoteApprove {
+			n++
+		}
+	}
+	return n
+}
+
+// SubmitParams carries the maker's side of a submission.
+type SubmitParams struct {
+	// Meta is free-form context, cloned on submit.
+	Meta map[string]string
+	// Requester is the maker's principal id. Required.
+	Requester string
+	// Tenant is optional; under WithScope it must be empty or equal to the
+	// scoped tenant.
+	Tenant string
+	// Reason is the maker's justification, persisted on the request.
+	Reason string
+}
+
+// Actor is the human acting on a request — a checker casting a decision, or
+// the party cancelling. It carries an access.Subject rather than a bare id
+// so a decider has real attributes to judge on. Executors are machines and
+// pass a plain executor id instead.
+type Actor struct {
+	Subject access.Subject
+	Reason  string
+}
+
+// Filter selects requests for List.
+type Filter struct {
+	// Statuses matches the STORED status. Expired is never stored (it is
+	// derived on read), so listing it matches nothing — query
+	// []Status{Pending, Approved} with ExpiresBefore instead.
+	Statuses []Status
+	// ExpiresBefore bounds ExpiresAt, selecting requests that have expired
+	// or are about to. Zero means no bound. Requests with no expiry are
+	// never matched by it.
+	ExpiresBefore time.Time
+	// Kind, Tenant, and Requester are exact matches; empty means "any".
+	Kind      string
+	Tenant    string
+	Requester string
+	// Limit caps the number of records returned. Zero means the store's
+	// default.
+	Limit int
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./ops/approval/... && just test ./ops/approval/...`
+Expected: PASS — `ok github.com/dmitrymomot/forge/ops/approval`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ops/approval/
+git commit -m "feat(approval): core request, status, vote, and kind types"
+```
+
+---
+
+## Task 2: Store interface, in-memory store, and the conformance suite
+
+**Files:**
+- Create: `ops/approval/store.go`
+- Create: `ops/approval/memory.go`
+- Create: `ops/approval/approvaltest/approvaltest.go`
+- Test: `ops/approval/store_test.go`
+
+**Interfaces:**
+- Consumes: `Request`, `Filter`, `Status`, `ErrNotFound`, `ErrDuplicate`, `ErrConflict` from Task 1.
+- Produces: `Store` interface (`Create`, `Get`, `List`, `Update`), `NewMemoryStore() Store`, and `approvaltest.Run(t *testing.T, factory func(t *testing.T) approval.Store)` — the shared conformance suite `pgstore` reruns in Task 12.
+
+The suite lives in its own package, mirroring `async/queue/brokertest`: an
+integration-tagged `pgstore_test` cannot import `package approval_test`, so
+the contract has to be importable production code.
+
+**Critical:** the Postgres table persists across test runs (`pgstore_test`
+does not truncate, matching `auth/apikey/pgstore/pgstore_test.go`). Every
+subtest therefore namespaces its fixtures with a fresh UUID and filters
+`List` by that namespace. A suite with fixed kinds and exact global counts
+passes once and fails on every re-run.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/approval/approvaltest/approvaltest.go`:
+
+```go
+// Package approvaltest is the executable contract for approval.Store
+// implementations. Every driver's test suite must call Run; the in-memory
+// store is the reference implementation.
+//
+// Fixtures are namespaced per subtest with a fresh UUID because a real
+// backend's table outlives the test process: deterministic kinds and
+// tenants would collide with a previous run's rows and inflate List counts.
+package approvaltest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+// ns is a per-subtest namespace keeping fixtures disjoint from every other
+// run against the same backend.
+type ns struct{ kind, tenant string }
+
+func newNS() ns {
+	u := id.NewUUID().String()
+	return ns{kind: "kind-" + u, tenant: "tenant-" + u}
+}
+
+func (n ns) request(requester string, status approval.Status) approval.Request {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	return approval.Request{
+		ID:        id.NewUUID(),
+		Kind:      n.kind,
+		Tenant:    n.tenant,
+		Requester: requester,
+		Status:    status,
+		Version:   1,
+		Payload:   json.RawMessage(`{"amount":100}`),
+		CreatedAt: now,
+	}
+}
+
+// Run executes the Store conformance suite. factory must return a fresh or
+// namespace-isolated store each call. The Manager's CAS retry loop depends
+// on these exact semantics, so an implementation that diverges here breaks
+// dual control.
+func Run(t *testing.T, factory func(t *testing.T) approval.Store) {
+	t.Helper()
+
+	t.Run("CreateGetRoundTrip", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		r := n.request("alice", approval.Pending)
+		require.NoError(t, s.Create(ctx, r))
+
+		got, err := s.Get(ctx, r.ID)
+		require.NoError(t, err)
+		assert.Equal(t, r.ID, got.ID)
+		assert.Equal(t, r.Kind, got.Kind)
+		assert.Equal(t, r.Requester, got.Requester)
+		assert.Equal(t, approval.Pending, got.Status)
+		assert.Equal(t, int64(1), got.Version)
+		assert.JSONEq(t, string(r.Payload), string(got.Payload))
+		assert.True(t, r.CreatedAt.Equal(got.CreatedAt), "timestamps survive the round-trip")
+	})
+
+	t.Run("CreateRejectsDuplicateID", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		r := n.request("alice", approval.Pending)
+		require.NoError(t, s.Create(ctx, r))
+		assert.ErrorIs(t, s.Create(ctx, r), approval.ErrDuplicate)
+	})
+
+	t.Run("GetReportsNotFound", func(t *testing.T) {
+		s := factory(t)
+		_, err := s.Get(context.Background(), id.NewUUID())
+		assert.ErrorIs(t, err, approval.ErrNotFound)
+	})
+
+	t.Run("UpdateAdvancesVersion", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		r := n.request("alice", approval.Pending)
+		require.NoError(t, s.Create(ctx, r))
+
+		r.Status = approval.Approved
+		require.NoError(t, s.Update(ctx, r, 1))
+
+		got, err := s.Get(ctx, r.ID)
+		require.NoError(t, err)
+		assert.Equal(t, approval.Approved, got.Status)
+		assert.Equal(t, int64(2), got.Version, "store sets version to expect+1")
+	})
+
+	t.Run("UpdateConflictsOnStaleVersion", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		r := n.request("alice", approval.Pending)
+		require.NoError(t, s.Create(ctx, r))
+		require.NoError(t, s.Update(ctx, r, 1))
+
+		// A second writer still believing the version is 1 must lose.
+		assert.ErrorIs(t, s.Update(ctx, r, 1), approval.ErrConflict)
+	})
+
+	t.Run("UpdateReportsNotFound", func(t *testing.T) {
+		s, n := factory(t), newNS()
+		assert.ErrorIs(t, s.Update(context.Background(), n.request("alice", approval.Pending), 1),
+			approval.ErrNotFound)
+	})
+
+	t.Run("StoredStateIsNotAliased", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		r := n.request("alice", approval.Pending)
+		r.Decisions = []approval.Decision{{
+			At: time.Now().UTC().Truncate(time.Microsecond), Approver: "bob", Vote: approval.VoteApprove,
+		}}
+		require.NoError(t, s.Create(ctx, r))
+
+		r.Decisions[0].Approver = "mallory" // mutate the caller's slice
+		got, err := s.Get(ctx, r.ID)
+		require.NoError(t, err)
+		require.Len(t, got.Decisions, 1)
+		assert.Equal(t, "bob", got.Decisions[0].Approver,
+			"a caller must not be able to rewrite a persisted vote")
+	})
+
+	t.Run("DecisionsRoundTrip", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		at := time.Now().UTC().Truncate(time.Microsecond)
+		r := n.request("alice", approval.Pending)
+		r.Decisions = []approval.Decision{
+			{At: at, Approver: "bob", Reason: "checked", Vote: approval.VoteApprove},
+			{At: at, Approver: "carol", Vote: approval.VoteReject},
+		}
+		require.NoError(t, s.Create(ctx, r))
+
+		got, err := s.Get(ctx, r.ID)
+		require.NoError(t, err)
+		require.Len(t, got.Decisions, 2)
+		assert.Equal(t, "bob", got.Decisions[0].Approver)
+		assert.Equal(t, "checked", got.Decisions[0].Reason)
+		assert.Equal(t, approval.VoteApprove, got.Decisions[0].Vote)
+		assert.Equal(t, approval.VoteReject, got.Decisions[1].Vote)
+		assert.True(t, at.Equal(got.Decisions[0].At))
+	})
+
+	t.Run("ListFilters", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		pending := n.request("alice", approval.Pending)
+		approved := n.request("alice", approval.Approved)
+		otherRequester := n.request("carol", approval.Pending)
+		for _, r := range []approval.Request{pending, approved, otherRequester} {
+			require.NoError(t, s.Create(ctx, r))
+		}
+		// A same-kind row in a different tenant must never leak in.
+		foreign := n.request("alice", approval.Pending)
+		foreign.Tenant = "tenant-" + id.NewUUID().String()
+		require.NoError(t, s.Create(ctx, foreign))
+
+		got, err := s.List(ctx, approval.Filter{
+			Statuses:  []approval.Status{approval.Pending},
+			Kind:      n.kind,
+			Tenant:    n.tenant,
+			Requester: "alice",
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, pending.ID, got[0].ID)
+	})
+
+	t.Run("ListFiltersByExpiryBound", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		now := time.Now().UTC().Truncate(time.Microsecond)
+
+		soon := n.request("alice", approval.Pending)
+		soon.ExpiresAt = now.Add(time.Minute)
+		late := n.request("alice", approval.Pending)
+		late.ExpiresAt = now.Add(time.Hour)
+		never := n.request("alice", approval.Pending)
+		for _, r := range []approval.Request{soon, late, never} {
+			require.NoError(t, s.Create(ctx, r))
+		}
+
+		got, err := s.List(ctx, approval.Filter{
+			Tenant:        n.tenant,
+			ExpiresBefore: now.Add(10 * time.Minute),
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1, "never-expiring rows are excluded from an expiry bound")
+		assert.Equal(t, soon.ID, got[0].ID)
+	})
+
+	t.Run("ListLimitAndOrder", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		var ids []id.UUID
+		for range 5 {
+			r := n.request("alice", approval.Pending)
+			require.NoError(t, s.Create(ctx, r))
+			ids = append(ids, r.ID)
+			time.Sleep(2 * time.Millisecond) // UUIDv7 order is millisecond-grained
+		}
+
+		got, err := s.List(ctx, approval.Filter{Tenant: n.tenant, Limit: 2})
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.Equal(t, ids[4], got[0].ID, "newest first")
+		assert.Equal(t, ids[3], got[1].ID)
+	})
+
+	t.Run("ListReturnsNonNilEmpty", func(t *testing.T) {
+		s := factory(t)
+		got, err := s.List(context.Background(), approval.Filter{Kind: "kind-" + id.NewUUID().String()})
+		require.NoError(t, err)
+		assert.NotNil(t, got, "nil vs empty must not differ across implementations")
+		assert.Empty(t, got)
+	})
+}
+```
+
+Create `ops/approval/store_test.go`:
+
+```go
+package approval_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/approval"
+	"github.com/dmitrymomot/forge/ops/approval/approvaltest"
+)
+
+func TestMemoryStoreContract(t *testing.T) {
+	t.Parallel()
+	approvaltest.Run(t, func(t *testing.T) approval.Store {
+		return approval.NewMemoryStore()
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/approval/...`
+Expected: FAIL — `undefined: approval.Store`, `undefined: approval.NewMemoryStore`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/approval/store.go`:
+
+```go
+package approval
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Store persists approval requests. Implementations must be safe for
+// concurrent use.
+//
+// Update is the package's only concurrency primitive: every state
+// transition is a compare-and-swap on Version. An implementation that does
+// not enforce it atomically breaks dual control — two checkers voting
+// concurrently could both read quorum-1 approvals and both write, losing a
+// vote or counting one approver twice.
+//
+// Implementations may normalize nil and empty Decisions/Meta in either
+// direction; callers must not depend on which form is returned. List must
+// return a non-nil empty slice rather than nil when nothing matches.
+//
+// approvaltest.Run is the executable contract; every implementation must
+// pass it.
+type Store interface {
+	// Create persists a new request. It returns ErrDuplicate when a
+	// request with the same ID already exists.
+	Create(ctx context.Context, r Request) error
+
+	// Get loads one request. It returns ErrNotFound for unknown ids.
+	Get(ctx context.Context, reqID id.UUID) (Request, error)
+
+	// List returns requests matching f, newest first (UUIDv7 id order;
+	// ties within one millisecond are unordered).
+	List(ctx context.Context, f Filter) ([]Request, error)
+
+	// Update persists r only when the stored Version equals expect,
+	// returning ErrConflict otherwise and ErrNotFound for unknown ids. The
+	// implementation persists r with Version set to expect+1.
+	Update(ctx context.Context, r Request, expect int64) error
+}
+```
+
+Create `ops/approval/memory.go`:
+
+```go
+package approval
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sort"
+	"sync"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+type memoryStore struct {
+	byID map[id.UUID]Request
+	mu   sync.RWMutex
+}
+
+// NewMemoryStore returns an in-memory Store for tests and development. It
+// is not durable: process exit loses every request.
+func NewMemoryStore() Store {
+	return &memoryStore{byID: make(map[id.UUID]Request)}
+}
+
+// cloneRequest copies the reference fields so callers cannot mutate stored
+// state through a shared slice or map, and vice versa. Aliased Decisions
+// would be a dual-control hole: a caller could rewrite a persisted vote.
+func cloneRequest(r Request) Request {
+	r.Decisions = slices.Clone(r.Decisions)
+	r.Meta = maps.Clone(r.Meta)
+	r.Payload = slices.Clone(r.Payload)
+	return r
+}
+
+func (s *memoryStore) Create(_ context.Context, r Request) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.byID[r.ID]; ok {
+		return ErrDuplicate
+	}
+	s.byID[r.ID] = cloneRequest(r)
+	return nil
+}
+
+func (s *memoryStore) Get(_ context.Context, reqID id.UUID) (Request, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.byID[reqID]
+	if !ok {
+		return Request{}, ErrNotFound
+	}
+	return cloneRequest(r), nil
+}
+
+func (s *memoryStore) Update(_ context.Context, r Request, expect int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cur, ok := s.byID[r.ID]
+	if !ok {
+		return ErrNotFound
+	}
+	if cur.Version != expect {
+		return ErrConflict
+	}
+	next := cloneRequest(r)
+	next.Version = expect + 1
+	s.byID[r.ID] = next
+	return nil
+}
+
+func (s *memoryStore) List(_ context.Context, f Filter) ([]Request, error) {
+	s.mu.RLock()
+	out := make([]Request, 0, len(s.byID))
+	for _, r := range s.byID {
+		if !matches(r, f) {
+			continue
+		}
+		out = append(out, cloneRequest(r))
+	}
+	s.mu.RUnlock()
+
+	// UUIDv7 ids are time-ordered, so descending id order is newest-first.
+	sort.Slice(out, func(i, j int) bool {
+		return string(out[i].ID[:]) > string(out[j].ID[:])
+	})
+	if f.Limit > 0 && len(out) > f.Limit {
+		out = out[:f.Limit]
+	}
+	return out, nil
+}
+
+func matches(r Request, f Filter) bool {
+	if f.Kind != "" && r.Kind != f.Kind {
+		return false
+	}
+	if f.Tenant != "" && r.Tenant != f.Tenant {
+		return false
+	}
+	if f.Requester != "" && r.Requester != f.Requester {
+		return false
+	}
+	if len(f.Statuses) > 0 && !slices.Contains(f.Statuses, r.Status) {
+		return false
+	}
+	if !f.ExpiresBefore.IsZero() {
+		// Rows with no expiry never match an expiry bound.
+		if r.ExpiresAt.IsZero() || !r.ExpiresAt.Before(f.ExpiresBefore) {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./ops/approval/... && just test ./ops/approval/...`
+Expected: PASS — every `TestMemoryStoreContract` subtest green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ops/approval/
+git commit -m "feat(approval): store seam, conformance suite, and in-memory implementation"
+```
+
+---
+
+## Task 3: Policy, options, and New
+
+**Files:**
+- Create: `ops/approval/policy.go`
+- Create: `ops/approval/options.go`
+- Create: `ops/approval/manager.go`
+- Test: `ops/approval/manager_test.go`
+
+**Interfaces:**
+- Consumes: `Store`, `Kind[T]`, sentinels from Tasks 1–2.
+- Produces: `Policy{Quorum, TTL, ClaimTTL}`, `Manager`, `New(store Store, opts ...Option) *Manager`, `Option`, `WithKind[T](k Kind[T], p Policy) Option`, `WithClock(clock.Clock) Option`, `WithMaxRetries(int) Option`, and the unexported `(*Manager).policyFor(kind string) (Policy, bool)` used by Tasks 4–8. `WithDecider`, `WithAuditor`, and `WithScope` are added in Tasks 9–11.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/approval/manager_test.go`:
+
+```go
+package approval_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+type payoutPayload struct {
+	PayoutID string `json:"payout_id"`
+	Amount   int64  `json:"amount"`
+}
+
+var kindPayout = approval.NewKind[payoutPayload]("payout.release")
+
+func TestNewPanics(t *testing.T) {
+	t.Parallel()
+
+	assert.PanicsWithValue(t, "approval: nil store", func() {
+		approval.New(nil, approval.WithKind(kindPayout, approval.Policy{Quorum: 2}))
+	})
+
+	assert.Panics(t, func() {
+		approval.New(approval.NewMemoryStore(),
+			approval.WithKind(kindPayout, approval.Policy{Quorum: 0}))
+	}, "quorum below 1 is a wiring bug")
+
+	assert.Panics(t, func() {
+		approval.New(approval.NewMemoryStore(),
+			approval.WithKind(kindPayout, approval.Policy{Quorum: 2}),
+			approval.WithKind(kindPayout, approval.Policy{Quorum: 3}))
+	}, "duplicate kind registration is a wiring bug")
+
+	assert.Panics(t, func() {
+		approval.New(approval.NewMemoryStore(),
+			approval.WithKind(kindPayout, approval.Policy{Quorum: 2, TTL: -time.Hour}))
+	}, "negative TTL is a wiring bug")
+
+	assert.Panics(t, func() {
+		approval.New(approval.NewMemoryStore(),
+			approval.WithKind(kindPayout, approval.Policy{Quorum: 2, ClaimTTL: -time.Hour}))
+	}, "negative ClaimTTL is a wiring bug")
+
+	assert.Panics(t, func() {
+		approval.New(approval.NewMemoryStore())
+	}, "a manager with no registered kinds can never accept a submission")
+}
+
+func TestNewAcceptsValidWiring(t *testing.T) {
+	t.Parallel()
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2, TTL: 24 * time.Hour}))
+	require.NotNil(t, m)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/approval/...`
+Expected: FAIL — `undefined: approval.New`, `undefined: approval.Policy`, `undefined: approval.WithKind`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/approval/policy.go`:
+
+```go
+package approval
+
+import (
+	"fmt"
+	"time"
+)
+
+// Policy is the per-kind rule set. It is registered at construction with
+// WithKind and never supplied by the caller at submit time: a caller who
+// could choose the quorum could weaken the gate on the action they are
+// asking permission for.
+type Policy struct {
+	// TTL is how long a request stays actionable after submission. Zero
+	// means it never expires.
+	TTL time.Duration
+	// ClaimTTL is how long an executor's claim is held before another
+	// executor may take it over. Zero — the default — means the claim never
+	// expires: an executor that dies mid-action wedges the request until
+	// Release is called. That is the safe default for actions that move
+	// money. Setting it non-zero opts into at-least-once execution, so the
+	// action behind it must be idempotent.
+	ClaimTTL time.Duration
+	// Quorum is the number of distinct approvals required. Must be at
+	// least 1. Note that Quorum 1 is still dual control: the requester can
+	// never be the approver.
+	Quorum int
+}
+
+// validate reports why a policy is unusable, or nil.
+func (p Policy) validate(kind string) error {
+	if p.Quorum < 1 {
+		return fmt.Errorf("approval: kind %q: quorum must be >= 1, got %d", kind, p.Quorum)
+	}
+	if p.TTL < 0 {
+		return fmt.Errorf("approval: kind %q: negative TTL %s", kind, p.TTL)
+	}
+	if p.ClaimTTL < 0 {
+		return fmt.Errorf("approval: kind %q: negative ClaimTTL %s", kind, p.ClaimTTL)
+	}
+	return nil
+}
+```
+
+Create `ops/approval/options.go`:
+
+```go
+package approval
+
+import (
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type config struct {
+	clk        clock.Clock
+	kinds      map[string]Policy
+	maxRetries int
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithKind registers an action name and the policy that governs it. It is
+// the only way a kind enters a Manager — the registry is immutable after
+// New, so the read path needs no lock and no caller can register a weaker
+// policy at runtime. Repeat it once per action.
+//
+// New panics on a duplicate name, a quorum below 1, or a negative duration.
+func WithKind[T any](k Kind[T], p Policy) Option {
+	return func(c *config) {
+		name := k.Name()
+		if _, dup := c.kinds[name]; dup {
+			panic("approval: duplicate kind " + name)
+		}
+		if err := p.validate(name); err != nil {
+			panic(err.Error())
+		}
+		c.kinds[name] = p
+	}
+}
+
+// WithClock injects a clock for deterministic tests. Defaults to
+// clock.System().
+func WithClock(clk clock.Clock) Option {
+	return func(c *config) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+// WithMaxRetries caps how many times a transition re-reads and retries
+// after losing a version race (default 3). Each retry re-validates from a
+// fresh read, so a retry can still legitimately fail with ErrAlreadyVoted.
+// Values below zero are clamped to zero (a single attempt).
+func WithMaxRetries(n int) Option {
+	return func(c *config) {
+		if n < 0 {
+			n = 0
+		}
+		c.maxRetries = n
+	}
+}
+```
+
+Create `ops/approval/manager.go`:
+
+```go
+package approval
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Manager records approval requests, collects decisions on them, and hands
+// approved requests to exactly one executor. Safe for concurrent use.
+type Manager struct {
+	store Store
+	cfg   config
+}
+
+// New builds a Manager over store. Register at least one kind with
+// WithKind.
+//
+// It panics on a nil store, on a Manager with no registered kinds, and on
+// any invalid policy — wiring bugs caught at startup rather than on the
+// first payout, matching apikey.New's nil-store panic.
+func New(store Store, opts ...Option) *Manager {
+	if store == nil {
+		panic("approval: nil store")
+	}
+	cfg := config{
+		clk:        clock.System(),
+		kinds:      make(map[string]Policy),
+		maxRetries: 3,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if len(cfg.kinds) == 0 {
+		panic("approval: no kinds registered; every submission would fail with ErrUnknownKind")
+	}
+	return &Manager{store: store, cfg: cfg}
+}
+
+// policyFor returns the policy registered for kind. The registry is
+// immutable after New, so this read needs no lock.
+func (m *Manager) policyFor(kind string) (Policy, bool) {
+	p, ok := m.cfg.kinds[kind]
+	return p, ok
+}
+
+// Get loads one request, with expiry applied: a Pending or Approved
+// request past its ExpiresAt reports Status Expired even though the stored
+// row still carries its last written status.
+func (m *Manager) Get(ctx context.Context, reqID id.UUID) (Request, error) {
+	r, err := m.store.Get(ctx, reqID)
+	if err != nil {
+		return Request{}, err
+	}
+	m.applyExpiry(&r)
+	return r, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+`applyExpiry` does not exist yet — add the minimal version now; Task 5 tests it directly. Append to `ops/approval/manager.go`:
+
+```go
+// applyExpiry derives the effective status of r. Expiry is never written:
+// the stored row keeps its last written status and the effective status is
+// computed on every read, so no sweeper is needed for correctness. Only
+// Pending and Approved expire — an Executing request is governed by its
+// claim lease, not by TTL.
+func (m *Manager) applyExpiry(r *Request) {
+	if r.ExpiresAt.IsZero() {
+		return
+	}
+	if r.Status != Pending && r.Status != Approved {
+		return
+	}
+	if m.cfg.clk.Now().Before(r.ExpiresAt) {
+		return
+	}
+	r.Status = Expired
+}
+```
+
+Run: `just fmt ./ops/approval/... && just test ./ops/approval/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ops/approval/
+git commit -m "feat(approval): policy registry, options, and manager construction"
+```
+
+---
+
+## Task 4: Submit and PayloadOf
+
+**Files:**
+- Create: `ops/approval/submit.go`
+- Test: `ops/approval/submit_test.go`
+
+**Interfaces:**
+- Consumes: `Manager`, `policyFor`, `Kind[T]`, `SubmitParams`, `Request` from Tasks 1–3.
+- Produces: `Submit[T](ctx, m *Manager, k Kind[T], payload T, p SubmitParams) (Request, error)` and `PayloadOf[T](k Kind[T], r Request) (T, error)`, plus the unexported `(*Manager).now() time.Time` helper used by every later task.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/approval/submit_test.go`:
+
+```go
+package approval_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+var fixedNow = time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+
+// newManager builds a Manager with a fixed clock and the payout kind.
+func newManager(t *testing.T, p approval.Policy, extra ...approval.Option) *approval.Manager {
+	t.Helper()
+	opts := append([]approval.Option{
+		approval.WithKind(kindPayout, p),
+		approval.WithClock(clock.NewMock(fixedNow)),
+	}, extra...)
+	return approval.New(approval.NewMemoryStore(), opts...)
+}
+
+func TestSubmit(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 2, TTL: 24 * time.Hour})
+	ctx := context.Background()
+
+	r, err := approval.Submit(ctx, m, kindPayout,
+		payoutPayload{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice", Reason: "invoice #4471"})
+	require.NoError(t, err)
+
+	assert.False(t, r.ID.IsZero())
+	assert.Equal(t, "payout.release", r.Kind)
+	assert.Equal(t, "alice", r.Requester)
+	assert.Equal(t, "invoice #4471", r.Reason)
+	assert.Equal(t, approval.Pending, r.Status)
+	assert.Equal(t, int64(1), r.Version)
+	assert.Empty(t, r.Decisions)
+	assert.True(t, fixedNow.Equal(r.CreatedAt))
+	assert.True(t, fixedNow.Add(24*time.Hour).Equal(r.ExpiresAt))
+}
+
+func TestSubmitZeroTTLNeverExpires(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 1})
+	r, err := approval.Submit(context.Background(), m, kindPayout,
+		payoutPayload{PayoutID: "po_1"}, approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+	assert.True(t, r.ExpiresAt.IsZero())
+}
+
+func TestSubmitRejectsEmptyRequester(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 2})
+	_, err := approval.Submit(context.Background(), m, kindPayout,
+		payoutPayload{}, approval.SubmitParams{})
+	assert.ErrorIs(t, err, approval.ErrRequesterRequired)
+}
+
+func TestSubmitRejectsUnknownKind(t *testing.T) {
+	t.Parallel()
+	unregistered := approval.NewKind[payoutPayload]("payout.unregistered")
+	m := newManager(t, approval.Policy{Quorum: 2})
+	_, err := approval.Submit(context.Background(), m, unregistered,
+		payoutPayload{}, approval.SubmitParams{Requester: "alice"})
+	assert.ErrorIs(t, err, approval.ErrUnknownKind)
+}
+
+func TestSubmitClonesMeta(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 2})
+	meta := map[string]string{"request_id": "req_1"}
+
+	r, err := approval.Submit(context.Background(), m, kindPayout,
+		payoutPayload{}, approval.SubmitParams{Requester: "alice", Meta: meta})
+	require.NoError(t, err)
+
+	meta["request_id"] = "tampered"
+	assert.Equal(t, "req_1", r.Meta["request_id"], "meta is cloned at submit")
+}
+
+func TestPayloadOf(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 2})
+	want := payoutPayload{PayoutID: "po_88", Amount: 250000}
+
+	r, err := approval.Submit(context.Background(), m, kindPayout, want,
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	got, err := approval.PayloadOf(kindPayout, r)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestPayloadOfRejectsWrongKind(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 2})
+	r, err := approval.Submit(context.Background(), m, kindPayout,
+		payoutPayload{PayoutID: "po_88"}, approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	other := approval.NewKind[struct{ Days int }]("hr.vacation")
+	_, err = approval.PayloadOf(other, r)
+	assert.ErrorIs(t, err, approval.ErrKindMismatch)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/approval/...`
+Expected: FAIL — `undefined: approval.Submit`, `undefined: approval.PayloadOf`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/approval/submit.go`:
+
+```go
+package approval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// now returns the manager's clock time, normalized to what a Postgres
+// timestamptz can hold. Untruncated nanoseconds do not survive the
+// round-trip, so a stored request would not equal the one just returned.
+func (m *Manager) now() time.Time {
+	return m.cfg.clk.Now().UTC().Truncate(time.Microsecond)
+}
+
+// Submit records a new approval request for kind k carrying payload.
+//
+// The returned request is Pending: it becomes actionable to checkers
+// immediately and expires after the kind's policy TTL. Submitting does not
+// authorize anything by itself — the maker's own decision never counts.
+func Submit[T any](ctx context.Context, m *Manager, k Kind[T], payload T, p SubmitParams) (Request, error) {
+	pol, ok := m.policyFor(k.Name())
+	if !ok {
+		return Request{}, ErrUnknownKind
+	}
+	if p.Requester == "" {
+		return Request{}, ErrRequesterRequired
+	}
+	tenant, err := m.scoped(ctx, p.Tenant)
+	if err != nil {
+		return Request{}, err
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return Request{}, fmt.Errorf("approval: marshal payload: %w", err)
+	}
+
+	now := m.now()
+	r := Request{
+		ID:        id.NewUUID(),
+		Kind:      k.Name(),
+		Tenant:    tenant,
+		Requester: p.Requester,
+		Reason:    p.Reason,
+		Status:    Pending,
+		Version:   1,
+		Payload:   raw,
+		Meta:      maps.Clone(p.Meta),
+		Decisions: make([]Decision, 0, pol.Quorum),
+		CreatedAt: now,
+	}
+	if pol.TTL > 0 {
+		r.ExpiresAt = now.Add(pol.TTL)
+	}
+	if err := m.store.Create(ctx, r); err != nil {
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, actionSubmit, p.Requester, outcomeSuccess, p.Reason)
+}
+
+// PayloadOf decodes r's payload as T. It returns ErrKindMismatch when k is
+// not the kind r was submitted under — decoding another action's payload
+// into T would silently produce a zero-valued struct.
+func PayloadOf[T any](k Kind[T], r Request) (T, error) {
+	var out T
+	if r.Kind != k.Name() {
+		return out, fmt.Errorf("%w: request is %q, kind is %q", ErrKindMismatch, r.Kind, k.Name())
+	}
+	if err := json.Unmarshal(r.Payload, &out); err != nil {
+		return out, fmt.Errorf("approval: unmarshal payload: %w", err)
+	}
+	return out, nil
+}
+```
+
+`m.scoped` and `m.audit` do not exist yet (Tasks 10–11). Add temporary no-op versions to `ops/approval/manager.go` so this compiles; Tasks 10 and 11 replace their bodies:
+
+```go
+// scoped resolves the tenant an operation is confined to. Tenancy lands in
+// Task 11; until then it passes the requested tenant through.
+func (m *Manager) scoped(_ context.Context, requested string) (string, error) {
+	return requested, nil
+}
+
+// audit records a state change. The auditlog seam lands in Task 10; until
+// then it is a no-op.
+func (m *Manager) audit(_ context.Context, _ Request, _, _, _, _ string) error {
+	return nil
+}
+
+// Audit action names and outcomes.
+const (
+	actionSubmit   = "approval.submit"
+	outcomeSuccess = "success"
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./ops/approval/... && just test ./ops/approval/...`
+Expected: PASS — all `TestSubmit*` and `TestPayloadOf*` green.
+
+- [ ] **Step 5: Add the fuzz test**
+
+`PayloadOf` decodes bytes that came out of a database, so it must reject
+garbage rather than panic — a corrupted or hand-edited payload column must
+not take down the approvals UI. Create `ops/approval/fuzz_test.go`:
+
+```go
+package approval_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+func FuzzPayloadOf(f *testing.F) {
+	f.Add([]byte(`{"payout_id":"po_1","amount":100}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(``))
+	f.Add([]byte(`{"amount":"not-a-number"}`))
+	f.Add([]byte(`[1,2,3]`))
+	f.Add([]byte("\x00\x01\x02"))
+
+	f.Fuzz(func(t *testing.T, payload []byte) {
+		r := approval.Request{
+			ID:      id.NewUUID(),
+			Kind:    kindPayout.Name(),
+			Payload: json.RawMessage(payload),
+		}
+		// Must never panic; an error is a perfectly good outcome.
+		_, _ = approval.PayloadOf(kindPayout, r)
+	})
+}
+```
+
+Run: `go test -run Fuzz -fuzz FuzzPayloadOf -fuzztime=30s ./ops/approval/`
+Expected: no crashers. Then `just test ./ops/approval/...` to confirm the
+seed corpus passes in the normal run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ops/approval/
+git commit -m "feat(approval): typed submit and payload decode"
+```
+
+---
+
+## Task 5: List, lazy expiry, and the CAS retry loop
+
+**Files:**
+- Modify: `ops/approval/manager.go`
+- Test: `ops/approval/expiry_test.go`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4.
+- Produces: `(*Manager).List(ctx, Filter) ([]Request, error)` and the unexported `(*Manager).mutate(ctx, reqID, fn func(*Request) error) (Request, error)` — the single CAS retry loop every transition in Tasks 6–8 is built on.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/approval/expiry_test.go`:
+
+```go
+package approval_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+func TestGetAppliesLazyExpiry(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2, TTL: time.Hour}),
+		approval.WithClock(clk))
+	ctx := context.Background()
+
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	got, err := m.Get(ctx, r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, approval.Pending, got.Status)
+
+	clk.Set(fixedNow.Add(time.Hour)) // exactly at ExpiresAt
+	got, err = m.Get(ctx, r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, approval.Expired, got.Status, "expiry is inclusive of ExpiresAt")
+}
+
+func TestZeroTTLNeverExpires(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2}),
+		approval.WithClock(clk))
+	ctx := context.Background()
+
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	clk.Set(fixedNow.Add(10 * 365 * 24 * time.Hour))
+	got, err := m.Get(ctx, r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, approval.Pending, got.Status)
+}
+
+func TestListDropsRecordsExpiredOutOfTheFilter(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2, TTL: time.Hour}),
+		approval.WithClock(clk))
+	ctx := context.Background()
+
+	_, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	got, err := m.List(ctx, approval.Filter{Statuses: []approval.Status{approval.Pending}})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	clk.Set(fixedNow.Add(2 * time.Hour))
+	got, err = m.List(ctx, approval.Filter{Statuses: []approval.Status{approval.Pending}})
+	require.NoError(t, err)
+	assert.Empty(t, got, "the stored row is still Pending but reads as Expired")
+
+	// Unfiltered, it still comes back — carrying the derived status.
+	got, err = m.List(ctx, approval.Filter{})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, approval.Expired, got[0].Status)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/approval/...`
+Expected: FAIL — `m.List undefined (type *approval.Manager has no field or method List)`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `ops/approval/manager.go`:
+
+```go
+// List returns requests matching f, newest first, with expiry applied to
+// each record.
+//
+// Filter.Statuses matches the STORED status, so a record that has expired
+// out of the requested set is dropped after the fact: List returns UP TO
+// Limit records, and a Statuses filter may yield fewer than the store
+// matched. Query with no Statuses to see expired records with their derived
+// status.
+func (m *Manager) List(ctx context.Context, f Filter) ([]Request, error) {
+	tenant, err := m.scoped(ctx, f.Tenant)
+	if err != nil {
+		return nil, err
+	}
+	f.Tenant = tenant
+
+	out, err := m.store.List(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+	kept := out[:0]
+	for i := range out {
+		m.applyExpiry(&out[i])
+		if len(f.Statuses) > 0 && !slices.Contains(f.Statuses, out[i].Status) {
+			continue
+		}
+		kept = append(kept, out[i])
+	}
+	return kept, nil
+}
+
+// mutate is the one concurrency primitive every transition rides: read the
+// current record, derive its effective status, let fn validate and apply
+// the transition, then compare-and-swap it back.
+//
+// fn is re-run from a FRESH read on every conflict retry — never from the
+// previous attempt's copy. That re-validation is load-bearing: without it a
+// vote that lost a race could be applied a second time on top of the
+// winner's write, pushing a request past quorum with one approver counted
+// twice.
+func (m *Manager) mutate(ctx context.Context, reqID id.UUID, fn func(r *Request) error) (Request, error) {
+	tenant, err := m.scoped(ctx, "")
+	if err != nil {
+		return Request{}, err
+	}
+	for attempt := 0; ; attempt++ {
+		r, err := m.store.Get(ctx, reqID)
+		if err != nil {
+			return Request{}, err
+		}
+		// Report a foreign-tenant request as missing rather than forbidden,
+		// so cross-tenant existence cannot be probed.
+		if tenant != "" && r.Tenant != tenant {
+			return Request{}, ErrNotFound
+		}
+		expect := r.Version
+		m.applyExpiry(&r)
+
+		if err := fn(&r); err != nil {
+			return Request{}, err
+		}
+
+		err = m.store.Update(ctx, r, expect)
+		switch {
+		case err == nil:
+			r.Version = expect + 1
+			return r, nil
+		case !errors.Is(err, ErrConflict):
+			return Request{}, err
+		case attempt >= m.cfg.maxRetries:
+			return Request{}, ErrConflict
+		}
+	}
+}
+
+// statusErr maps a non-Pending status to the sentinel that explains it.
+func statusErr(s Status) error {
+	if s == Expired {
+		return ErrExpired
+	}
+	return ErrNotPending
+}
+```
+
+Update the import block of `ops/approval/manager.go` to:
+
+```go
+import (
+	"context"
+	"errors"
+	"slices"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/id"
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./ops/approval/... && just test ./ops/approval/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ops/approval/
+git commit -m "feat(approval): list with lazy expiry and the CAS retry loop"
+```
+
+---
+
+## Task 6: Approve, Reject, and the structural invariants
+
+**Files:**
+- Create: `ops/approval/decide.go`
+- Test: `ops/approval/decide_test.go`
+
+**Interfaces:**
+- Consumes: `mutate`, `statusErr`, `Actor`, `Decision`, `Vote` from Tasks 1–5.
+- Produces: `(*Manager).Approve(ctx, reqID, Actor) (Request, error)` and `(*Manager).Reject(ctx, reqID, Actor) (Request, error)`. Task 7 adds `Cancel` to the same file.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/approval/decide_test.go`:
+
+```go
+package approval_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+// actor builds an Actor for subject id.
+func actor(id string) approval.Actor {
+	return approval.Actor{Subject: access.Subject{ID: id}}
+}
+
+// submitted returns a fresh manager and one Pending request.
+func submitted(t *testing.T, p approval.Policy, extra ...approval.Option) (*approval.Manager, approval.Request) {
+	t.Helper()
+	m := newManager(t, p, extra...)
+	r, err := approval.Submit(context.Background(), m, kindPayout,
+		payoutPayload{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice", Reason: "invoice #4471"})
+	require.NoError(t, err)
+	return m, r
+}
+
+func TestApproveReachesQuorum(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2})
+	ctx := context.Background()
+
+	got, err := m.Approve(ctx, r.ID, approval.Actor{
+		Subject: access.Subject{ID: "bob"}, Reason: "matched to invoice"})
+	require.NoError(t, err)
+	assert.Equal(t, approval.Pending, got.Status, "1 of 2")
+	require.Len(t, got.Decisions, 1)
+	assert.Equal(t, "bob", got.Decisions[0].Approver)
+	assert.Equal(t, approval.VoteApprove, got.Decisions[0].Vote)
+	assert.Equal(t, "matched to invoice", got.Decisions[0].Reason)
+	assert.True(t, got.DecidedAt.IsZero(), "not decided until quorum")
+
+	got, err = m.Approve(ctx, r.ID, actor("carol"))
+	require.NoError(t, err)
+	assert.Equal(t, approval.Approved, got.Status, "2 of 2")
+	assert.Len(t, got.Decisions, 2)
+	assert.True(t, fixedNow.Equal(got.DecidedAt))
+	assert.Equal(t, int64(3), got.Version, "one version bump per vote")
+}
+
+func TestRejectIsTerminalAtOneVote(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 3})
+	ctx := context.Background()
+
+	got, err := m.Reject(ctx, r.ID, approval.Actor{
+		Subject: access.Subject{ID: "bob"}, Reason: "duplicate payment"})
+	require.NoError(t, err)
+	assert.Equal(t, approval.Rejected, got.Status, "one reject ends it regardless of quorum")
+	assert.Equal(t, "duplicate payment", got.Decisions[0].Reason)
+
+	_, err = m.Approve(ctx, r.ID, actor("carol"))
+	assert.ErrorIs(t, err, approval.ErrNotPending, "a rejected request never becomes approved")
+}
+
+func TestSelfApprovalRejected(t *testing.T) {
+	t.Parallel()
+	for _, quorum := range []int{1, 2} {
+		m, r := submitted(t, approval.Policy{Quorum: quorum})
+		_, err := m.Approve(context.Background(), r.ID, actor("alice"))
+		assert.ErrorIs(t, err, approval.ErrSelfApproval,
+			"quorum %d: the maker is never a checker", quorum)
+
+		_, err = m.Reject(context.Background(), r.ID, actor("alice"))
+		assert.ErrorIs(t, err, approval.ErrSelfApproval, "quorum %d: nor may they reject", quorum)
+	}
+}
+
+func TestDoubleVoteRejected(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 3})
+	ctx := context.Background()
+
+	_, err := m.Approve(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrAlreadyVoted)
+
+	_, err = m.Reject(ctx, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrAlreadyVoted, "cannot switch a vote either")
+}
+
+func TestVoteRequiresActorID(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2})
+	_, err := m.Approve(context.Background(), r.ID, approval.Actor{})
+	assert.ErrorIs(t, err, approval.ErrActorRequired)
+}
+
+func TestVoteOnExpiredRequest(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2, TTL: time.Hour}),
+		approval.WithClock(clk))
+	ctx := context.Background()
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	clk.Set(fixedNow.Add(2 * time.Hour))
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrExpired)
+}
+
+func TestVoteOnUnknownRequest(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 2})
+	_, err := m.Approve(context.Background(), id.NewUUID(), actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrNotFound)
+}
+
+// TestConcurrentApprovalsRespectQuorum is the test this whole package
+// exists for: many checkers voting at once must produce exactly one
+// Approved transition and exactly one recorded vote per approver.
+func TestConcurrentApprovalsRespectQuorum(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2},
+		approval.WithMaxRetries(20))
+	ctx := context.Background()
+
+	approvers := []string{"bob", "carol", "dave", "erin", "frank"}
+	var wg sync.WaitGroup
+	errs := make([]error, len(approvers))
+	for i, name := range approvers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errs[i] = m.Approve(ctx, r.ID, actor(name))
+		}()
+	}
+	wg.Wait()
+
+	got, err := m.Get(ctx, r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, approval.Approved, got.Status)
+	assert.Len(t, got.Decisions, 2, "voting stops at quorum; late voters are refused")
+
+	seen := map[string]bool{}
+	for _, d := range got.Decisions {
+		assert.False(t, seen[d.Approver], "approver %s counted twice", d.Approver)
+		seen[d.Approver] = true
+	}
+
+	var ok, refused int
+	for _, err := range errs {
+		switch {
+		case err == nil:
+			ok++
+		case assert.ErrorIs(t, err, approval.ErrNotPending):
+			refused++
+		}
+	}
+	assert.Equal(t, 2, ok, "exactly quorum many votes succeed")
+	assert.Equal(t, len(approvers)-2, refused)
+}
+```
+
+Add `"github.com/dmitrymomot/forge/core/id"` to this file's imports for `TestVoteOnUnknownRequest`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/approval/...`
+Expected: FAIL — `m.Approve undefined`, `m.Reject undefined`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/approval/decide.go`:
+
+```go
+package approval
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Approve records an approving decision from a. When it is the quorum-th
+// distinct approval the request becomes Approved.
+//
+// It refuses the request's own requester (ErrSelfApproval) at every quorum
+// — including quorum 1, which is still dual control — and refuses a second
+// decision from an approver who has already voted (ErrAlreadyVoted).
+func (m *Manager) Approve(ctx context.Context, reqID id.UUID, a Actor) (Request, error) {
+	return m.vote(ctx, reqID, a, VoteApprove)
+}
+
+// Reject records a rejecting decision from a. A single rejection is
+// terminal: there is no reject quorum, because one checker seeing a problem
+// is reason enough to stop.
+func (m *Manager) Reject(ctx context.Context, reqID id.UUID, a Actor) (Request, error) {
+	return m.vote(ctx, reqID, a, VoteReject)
+}
+
+func (m *Manager) vote(ctx context.Context, reqID id.UUID, a Actor, v Vote) (Request, error) {
+	if a.Subject.ID == "" {
+		return Request{}, ErrActorRequired
+	}
+	action := actionApprove
+	if v == VoteReject {
+		action = actionReject
+	}
+
+	var denied bool
+	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		if r.Status != Pending {
+			return statusErr(r.Status)
+		}
+		if r.Requester == a.Subject.ID {
+			return ErrSelfApproval
+		}
+		for i := range r.Decisions {
+			if r.Decisions[i].Approver == a.Subject.ID {
+				return ErrAlreadyVoted
+			}
+		}
+		// The decider runs last: it may hit a database or an org chart, so
+		// it only pays off once the vote is otherwise legal.
+		if err := m.eligible(ctx, *r, a, verbDecide); err != nil {
+			denied = true
+			return err
+		}
+
+		now := m.now()
+		r.Decisions = append(r.Decisions, Decision{
+			At:       now,
+			Approver: a.Subject.ID,
+			Reason:   a.Reason,
+			Vote:     v,
+		})
+		pol, ok := m.policyFor(r.Kind)
+		if !ok {
+			return ErrUnknownKind
+		}
+		switch {
+		case v == VoteReject:
+			r.Status = Rejected
+			r.DecidedAt = now
+		case r.Approvals() >= pol.Quorum:
+			r.Status = Approved
+			r.DecidedAt = now
+		}
+		return nil
+	})
+	if err != nil {
+		if denied {
+			// An ineligible actor trying to push a request through is the
+			// most security-relevant event this package sees. Record it,
+			// and let the audit error win only if the caller has no error
+			// of their own to act on.
+			if aerr := m.auditDenied(ctx, reqID, action, a.Subject.ID, err); aerr != nil {
+				return Request{}, aerr
+			}
+		}
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, action, a.Subject.ID, outcomeSuccess, a.Reason)
+}
+```
+
+`m.eligible`, `verbDecide`, `m.auditDenied`, `actionApprove`, and `actionReject` do not exist yet. Add stubs so this compiles — Task 9 fills `eligible`, Task 10 fills the audit funcs. Append to `ops/approval/manager.go`:
+
+```go
+// Audit action names.
+const (
+	actionApprove = "approval.approve"
+	actionReject  = "approval.reject"
+)
+
+// Eligibility verbs, appended to a kind name to form the access.Action.
+const verbDecide = "decide"
+
+// eligible checks the actor against the decider seam. Landed in Task 9;
+// until then every actor is eligible.
+func (m *Manager) eligible(_ context.Context, _ Request, _ Actor, _ string) error {
+	return nil
+}
+
+// auditDenied records a refused attempt. Landed in Task 10.
+func (m *Manager) auditDenied(_ context.Context, _ id.UUID, _, _ string, _ error) error {
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./ops/approval/... && just test ./ops/approval/...`
+Expected: PASS, including `TestConcurrentApprovalsRespectQuorum` under `-race`.
+
+Run it 20 times to shake out ordering flakes:
+`go test -race -count=20 -run TestConcurrentApprovals ./ops/approval/`
+Expected: `ok` — 20 consecutive passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ops/approval/
+git commit -m "feat(approval): approve and reject with quorum and dual-control invariants"
+```
+
+---
+
+## Task 7: Cancel
+
+**Files:**
+- Modify: `ops/approval/decide.go`
+- Test: `ops/approval/cancel_test.go`
+
+**Interfaces:**
+- Consumes: `mutate`, `Actor`, `eligible` from Tasks 5–6.
+- Produces: `(*Manager).Cancel(ctx, reqID, Actor) (Request, error)` and the `verbCancel` eligibility verb consumed by Task 9.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/approval/cancel_test.go`:
+
+```go
+package approval_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+func TestCancelFromPending(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2})
+
+	got, err := m.Cancel(context.Background(), r.ID,
+		approval.Actor{Subject: access.Subject{ID: "alice"}, Reason: "wrong vendor"})
+	require.NoError(t, err)
+	assert.Equal(t, approval.Cancelled, got.Status)
+	assert.True(t, fixedNow.Equal(got.DecidedAt))
+}
+
+func TestCancelFromApproved(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+
+	_, err := m.Approve(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+
+	got, err := m.Cancel(ctx, r.ID, actor("alice"))
+	require.NoError(t, err)
+	assert.Equal(t, approval.Cancelled, got.Status, "approved but unexecuted is still cancellable")
+}
+
+func TestCancelRejectedOnTerminalRequest(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2})
+	ctx := context.Background()
+
+	_, err := m.Reject(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+
+	_, err = m.Cancel(ctx, r.ID, actor("alice"))
+	assert.ErrorIs(t, err, approval.ErrNotCancellable)
+}
+
+func TestCancelRequiresActorID(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2})
+	_, err := m.Cancel(context.Background(), r.ID, approval.Actor{})
+	assert.ErrorIs(t, err, approval.ErrActorRequired)
+}
+```
+
+Add `"github.com/dmitrymomot/forge/auth/access"` to this file's imports.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/approval/...`
+Expected: FAIL — `m.Cancel undefined`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `ops/approval/decide.go`:
+
+```go
+// Cancel withdraws a request before it executes. It is legal from Pending
+// and Approved but not from Executing — an in-flight action is not
+// cancellable; the executor reports the outcome with Complete or Fail.
+//
+// The requester may always cancel their own request. Any other actor is
+// gated on "<kind>:cancel" when a decider is configured: withdrawing
+// someone else's request is a different privilege from judging it, and a
+// policy that grants one need not grant the other.
+func (m *Manager) Cancel(ctx context.Context, reqID id.UUID, a Actor) (Request, error) {
+	if a.Subject.ID == "" {
+		return Request{}, ErrActorRequired
+	}
+
+	var denied bool
+	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		if r.Status != Pending && r.Status != Approved {
+			if r.Status == Expired {
+				return ErrExpired
+			}
+			return ErrNotCancellable
+		}
+		if r.Requester != a.Subject.ID {
+			if err := m.eligible(ctx, *r, a, verbCancel); err != nil {
+				denied = true
+				return err
+			}
+		}
+		r.Status = Cancelled
+		r.DecidedAt = m.now()
+		return nil
+	})
+	if err != nil {
+		if denied {
+			if aerr := m.auditDenied(ctx, reqID, actionCancel, a.Subject.ID, err); aerr != nil {
+				return Request{}, aerr
+			}
+		}
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, actionCancel, a.Subject.ID, outcomeSuccess, a.Reason)
+}
+```
+
+Append the new constants to `ops/approval/manager.go`'s const blocks:
+
+```go
+const actionCancel = "approval.cancel"
+
+const verbCancel = "cancel"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./ops/approval/... && just test ./ops/approval/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ops/approval/
+git commit -m "feat(approval): cancel with requester short-circuit"
+```
+
+---
+
+## Task 8: Claim, Complete, Fail, Release, and Execute
+
+**Files:**
+- Create: `ops/approval/execute.go`
+- Test: `ops/approval/execute_test.go`
+
+**Interfaces:**
+- Consumes: `mutate`, `Policy.ClaimTTL`, sentinels from Tasks 1–7.
+- Produces: `(*Manager).Claim`, `Complete`, `Fail`, `Release`, `Execute`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/approval/execute_test.go`:
+
+```go
+package approval_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+// approved returns a manager and a request that has reached quorum.
+func approved(t *testing.T, p approval.Policy, extra ...approval.Option) (*approval.Manager, approval.Request) {
+	t.Helper()
+	m, r := submitted(t, p, extra...)
+	got, err := m.Approve(context.Background(), r.ID, actor("bob"))
+	require.NoError(t, err)
+	require.Equal(t, approval.Approved, got.Status)
+	return m, got
+}
+
+func TestClaimAndComplete(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+
+	got, err := m.Claim(ctx, r.ID, "worker-3")
+	require.NoError(t, err)
+	assert.Equal(t, approval.Executing, got.Status)
+	assert.Equal(t, "worker-3", got.ClaimedBy)
+	assert.True(t, fixedNow.Equal(got.ClaimedAt))
+
+	got, err = m.Complete(ctx, r.ID, "worker-3")
+	require.NoError(t, err)
+	assert.Equal(t, approval.Executed, got.Status)
+	assert.True(t, got.Status.Terminal())
+}
+
+func TestClaimIsExclusive(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	_, err = m.Claim(ctx, r.ID, "worker-2")
+	assert.ErrorIs(t, err, approval.ErrAlreadyClaimed)
+}
+
+func TestClaimRequiresApproved(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2})
+	_, err := m.Claim(context.Background(), r.ID, "worker-1")
+	assert.ErrorIs(t, err, approval.ErrNotApproved, "a pending request is not executable")
+}
+
+func TestClaimRequiresExecutorID(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	_, err := m.Claim(context.Background(), r.ID, "")
+	assert.ErrorIs(t, err, approval.ErrExecutorRequired)
+}
+
+func TestZeroClaimTTLWedgesUntilRelease(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m, r := approved(t, approval.Policy{Quorum: 1}, approval.WithClock(clk))
+	ctx := context.Background()
+
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	clk.Set(fixedNow.Add(365 * 24 * time.Hour))
+	_, err = m.Claim(ctx, r.ID, "worker-2")
+	assert.ErrorIs(t, err, approval.ErrAlreadyClaimed,
+		"ClaimTTL 0 never lets a second executor in — the safe default for money")
+
+	// Release is the escape hatch, and it is deliberately not holder-checked.
+	got, err := m.Release(ctx, r.ID, actor("ops-oncall"))
+	require.NoError(t, err)
+	assert.Equal(t, approval.Approved, got.Status)
+	assert.Empty(t, got.ClaimedBy)
+	assert.True(t, got.ClaimedAt.IsZero())
+
+	got, err = m.Claim(ctx, r.ID, "worker-2")
+	require.NoError(t, err)
+	assert.Equal(t, "worker-2", got.ClaimedBy)
+}
+
+func TestStaleClaimIsReclaimable(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m, r := approved(t, approval.Policy{Quorum: 1, ClaimTTL: 5 * time.Minute},
+		approval.WithClock(clk))
+	ctx := context.Background()
+
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	clk.Set(fixedNow.Add(time.Minute))
+	_, err = m.Claim(ctx, r.ID, "worker-2")
+	assert.ErrorIs(t, err, approval.ErrAlreadyClaimed, "lease still held")
+
+	clk.Set(fixedNow.Add(5 * time.Minute))
+	got, err := m.Claim(ctx, r.ID, "worker-2")
+	require.NoError(t, err, "lease expired at exactly ClaimTTL")
+	assert.Equal(t, "worker-2", got.ClaimedBy)
+}
+
+func TestCompleteAndFailAreHolderChecked(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	_, err = m.Complete(ctx, r.ID, "worker-2")
+	assert.ErrorIs(t, err, approval.ErrNotClaimHolder)
+
+	_, err = m.Fail(ctx, r.ID, "worker-2", "nope")
+	assert.ErrorIs(t, err, approval.ErrNotClaimHolder)
+}
+
+func TestCompleteRequiresExecuting(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	_, err := m.Complete(context.Background(), r.ID, "worker-1")
+	assert.ErrorIs(t, err, approval.ErrNotExecuting)
+}
+
+func TestFailRecordsReason(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	got, err := m.Fail(ctx, r.ID, "worker-1", "gateway rejected: insufficient funds")
+	require.NoError(t, err)
+	assert.Equal(t, approval.Failed, got.Status)
+	assert.Equal(t, "gateway rejected: insufficient funds", got.Meta["failure"])
+}
+
+func TestApprovedRequestExpiresBeforeClaim(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 1, TTL: time.Hour}),
+		approval.WithClock(clk))
+	ctx := context.Background()
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+
+	clk.Set(fixedNow.Add(2 * time.Hour))
+	_, err = m.Claim(ctx, r.ID, "worker-1")
+	assert.ErrorIs(t, err, approval.ErrExpired, "an approved-but-unexecuted request is not immortal")
+}
+
+func TestExecutingDoesNotExpire(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 1, TTL: time.Hour}),
+		approval.WithClock(clk))
+	ctx := context.Background()
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+	_, err = m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	clk.Set(fixedNow.Add(2 * time.Hour))
+	got, err := m.Complete(ctx, r.ID, "worker-1")
+	require.NoError(t, err, "TTL does not reap an in-flight action; ClaimTTL governs it")
+	assert.Equal(t, approval.Executed, got.Status)
+}
+
+// TestConcurrentClaimsHaveOneWinner is the execute-once guarantee.
+func TestConcurrentClaimsHaveOneWinner(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1}, approval.WithMaxRetries(20))
+	ctx := context.Background()
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, workers)
+	for i := range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errs[i] = m.Claim(ctx, r.ID, "worker")
+		}()
+	}
+	wg.Wait()
+
+	var won int
+	for _, err := range errs {
+		if err == nil {
+			won++
+		} else {
+			assert.ErrorIs(t, err, approval.ErrAlreadyClaimed)
+		}
+	}
+	assert.Equal(t, 1, won, "exactly one executor claims the action")
+}
+
+func TestExecuteWrapsTheTrio(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+
+	var sawPayload payoutPayload
+	got, err := m.Execute(ctx, r.ID, "worker-1", func(ctx context.Context, req approval.Request) error {
+		p, err := approval.PayloadOf(kindPayout, req)
+		require.NoError(t, err)
+		sawPayload = p
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, approval.Executed, got.Status)
+	assert.Equal(t, "po_88", sawPayload.PayoutID)
+}
+
+func TestExecuteFailsOnActionError(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	boom := errors.New("gateway down")
+
+	got, err := m.Execute(context.Background(), r.ID, "worker-1",
+		func(context.Context, approval.Request) error { return boom })
+	assert.ErrorIs(t, err, boom)
+	assert.Equal(t, approval.Failed, got.Status, "the failure is recorded, not swallowed")
+}
+
+func TestExecuteYieldsToTheClaimHolder(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	var ran bool
+	_, err = m.Execute(ctx, r.ID, "worker-2", func(context.Context, approval.Request) error {
+		ran = true
+		return nil
+	})
+	assert.ErrorIs(t, err, approval.ErrAlreadyClaimed)
+	assert.False(t, ran, "the action must not run without the claim")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/approval/...`
+Expected: FAIL — `m.Claim undefined`, `m.Complete undefined`, `m.Fail undefined`, `m.Release undefined`, `m.Execute undefined`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/approval/execute.go`:
+
+```go
+package approval
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Claim takes exclusive ownership of an approved request so its action runs
+// once. It is the transition that makes double execution impossible: two
+// operators clicking the same button, or two webhook deliveries racing,
+// produce exactly one winner and one ErrAlreadyClaimed.
+//
+// It is legal only from Approved, or from Executing when the current claim
+// has gone stale under the kind's ClaimTTL. With ClaimTTL 0 — the default —
+// a claim is never stale, so an executor that dies mid-action wedges the
+// request until Release is called.
+func (m *Manager) Claim(ctx context.Context, reqID id.UUID, executor string) (Request, error) {
+	if executor == "" {
+		return Request{}, ErrExecutorRequired
+	}
+	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		switch r.Status {
+		case Approved:
+			// claimable
+		case Executing:
+			pol, ok := m.policyFor(r.Kind)
+			if !ok {
+				return ErrUnknownKind
+			}
+			if pol.ClaimTTL <= 0 {
+				return ErrAlreadyClaimed
+			}
+			if m.now().Before(r.ClaimedAt.Add(pol.ClaimTTL)) {
+				return ErrAlreadyClaimed
+			}
+		case Expired:
+			return ErrExpired
+		default:
+			return ErrNotApproved
+		}
+		r.Status = Executing
+		r.ClaimedBy = executor
+		r.ClaimedAt = m.now()
+		return nil
+	})
+	if err != nil {
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, actionClaim, executor, outcomeSuccess, "")
+}
+
+// Complete records that the claimed action succeeded. Only the executor
+// holding the claim may call it.
+func (m *Manager) Complete(ctx context.Context, reqID id.UUID, executor string) (Request, error) {
+	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		if err := checkHolder(*r, executor); err != nil {
+			return err
+		}
+		r.Status = Executed
+		r.DecidedAt = m.now()
+		return nil
+	})
+	if err != nil {
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, actionComplete, executor, outcomeSuccess, "")
+}
+
+// Fail records that the claimed action failed, storing reason under the
+// "failure" meta key. Only the claim holder may call it. The request is
+// terminal afterwards: re-running it means submitting a new request, which
+// means asking for approval again.
+func (m *Manager) Fail(ctx context.Context, reqID id.UUID, executor, reason string) (Request, error) {
+	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		if err := checkHolder(*r, executor); err != nil {
+			return err
+		}
+		r.Status = Failed
+		r.DecidedAt = m.now()
+		if r.Meta == nil {
+			r.Meta = make(map[string]string, 1)
+		}
+		r.Meta["failure"] = reason
+		return nil
+	})
+	if err != nil {
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, actionFail, executor, outcomeFailure, reason)
+}
+
+// Release returns a claimed request to Approved so another executor can
+// take it. It is the administrative escape hatch for a request wedged by a
+// dead executor, so it is deliberately NOT holder-checked — the holder is
+// precisely the party that cannot call it. Gate access to it in your own
+// application; every call is audited.
+func (m *Manager) Release(ctx context.Context, reqID id.UUID, a Actor) (Request, error) {
+	if a.Subject.ID == "" {
+		return Request{}, ErrActorRequired
+	}
+	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		if r.Status != Executing {
+			return ErrNotExecuting
+		}
+		r.Status = Approved
+		r.ClaimedBy = ""
+		r.ClaimedAt = time.Time{}
+		return nil
+	})
+	if err != nil {
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, actionRelease, a.Subject.ID, outcomeSuccess, a.Reason)
+}
+
+// Execute claims the request, runs fn, and reports the outcome — the
+// Claim/Complete/Fail trio wired correctly so that forgetting the failure
+// path cannot wedge a request.
+//
+// fn receives the claimed request; decode its payload with PayloadOf. A
+// non-nil fn error transitions the request to Failed and is returned joined
+// with any transition error. ErrAlreadyClaimed is returned unwrapped when
+// another executor holds the claim, and fn never runs.
+//
+// fn runs exactly once per successful claim. Under a non-zero ClaimTTL a
+// stale claim can be taken over, so fn may run more than once across
+// executor deaths — make it idempotent, or leave ClaimTTL at 0.
+func (m *Manager) Execute(ctx context.Context, reqID id.UUID, executor string, fn func(context.Context, Request) error) (Request, error) {
+	r, err := m.Claim(ctx, reqID, executor)
+	if err != nil {
+		return Request{}, err
+	}
+	if err := fn(ctx, r); err != nil {
+		failed, ferr := m.Fail(ctx, reqID, executor, err.Error())
+		return failed, errors.Join(err, ferr)
+	}
+	return m.Complete(ctx, reqID, executor)
+}
+
+// checkHolder gates Complete and Fail on the claim.
+func checkHolder(r Request, executor string) error {
+	if r.Status != Executing {
+		return ErrNotExecuting
+	}
+	if r.ClaimedBy != executor {
+		return ErrNotClaimHolder
+	}
+	return nil
+}
+```
+
+Add `"time"` to `execute.go`'s imports (used by `Release`).
+
+Append the new constants to `ops/approval/manager.go`:
+
+```go
+const (
+	actionClaim    = "approval.claim"
+	actionComplete = "approval.complete"
+	actionFail     = "approval.fail"
+	actionRelease  = "approval.release"
+)
+
+const outcomeFailure = "failure"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./ops/approval/... && just test ./ops/approval/...`
+Expected: PASS.
+
+Run the race test repeatedly: `go test -race -count=20 -run TestConcurrentClaims ./ops/approval/`
+Expected: `ok` — 20 consecutive passes, `won == 1` every time.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ops/approval/
+git commit -m "feat(approval): execute-once claim lease with complete, fail, release, and execute"
+```
+
+---
+
+## Task 9: Eligibility via the access decision seam
+
+**Files:**
+- Create: `ops/approval/eligibility.go`
+- Modify: `ops/approval/manager.go` (remove the stub `eligible`), `ops/approval/options.go` (add `WithDecider`)
+- Test: `ops/approval/eligibility_test.go`
+
+**Interfaces:**
+- Consumes: `Actor`, `Request`, `verbDecide`, `verbCancel`, `ErrNotEligible`.
+- Produces: `WithDecider(access.Decider) Option`, and the real `(*Manager).eligible(ctx, r Request, a Actor, verb string) error`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/approval/eligibility_test.go`:
+
+```go
+package approval_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+// recordingDecider captures what the manager asked, and answers with effect.
+type recordingDecider struct {
+	gotAction   access.Action
+	gotResource access.Resource
+	gotSubject  access.Subject
+	effect      access.Effect
+	err         error
+}
+
+func (d *recordingDecider) Decide(_ context.Context, s access.Subject, a access.Action, r access.Resource) (access.Decision, error) {
+	d.gotSubject, d.gotAction, d.gotResource = s, a, r
+	if d.err != nil {
+		return access.Decision{}, d.err
+	}
+	return access.Decision{Effect: d.effect, Reason: "test"}, nil
+}
+
+func TestEligibilityAllows(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Allow}
+	m, r := submitted(t, approval.Policy{Quorum: 1}, approval.WithDecider(d))
+
+	got, err := m.Approve(context.Background(), r.ID, approval.Actor{
+		Subject: access.Subject{ID: "bob", Roles: []string{"finance"}}})
+	require.NoError(t, err)
+	assert.Equal(t, approval.Approved, got.Status)
+
+	assert.Equal(t, access.Action("payout.release:decide"), d.gotAction)
+	assert.Equal(t, "bob", d.gotSubject.ID)
+	assert.Equal(t, []string{"finance"}, d.gotSubject.Roles)
+	assert.Equal(t, "approval", d.gotResource.Type)
+	assert.Equal(t, r.ID.String(), d.gotResource.ID)
+	assert.Equal(t, "payout.release", d.gotResource.Attrs["kind"])
+	assert.Equal(t, "alice", d.gotResource.Attrs["requester"],
+		"relational policies need the requester")
+
+	raw, ok := d.gotResource.Attrs["payload"].(json.RawMessage)
+	require.True(t, ok, "value-aware policies need the raw payload")
+	assert.JSONEq(t, `{"payout_id":"po_88","amount":250000}`, string(raw))
+}
+
+func TestEligibilityDenies(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Deny}
+	m, r := submitted(t, approval.Policy{Quorum: 1}, approval.WithDecider(d))
+
+	_, err := m.Approve(context.Background(), r.ID, actor("dave"))
+	assert.ErrorIs(t, err, approval.ErrNotEligible)
+
+	got, err := m.Get(context.Background(), r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, approval.Pending, got.Status, "a denied vote leaves no trace on the record")
+	assert.Empty(t, got.Decisions)
+}
+
+func TestEligibilityFailsClosedOnDeciderError(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{err: errors.New("org chart unreachable")}
+	m, r := submitted(t, approval.Policy{Quorum: 1}, approval.WithDecider(d))
+
+	_, err := m.Approve(context.Background(), r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrNotEligible,
+		"an unavailable decider must never grant approval")
+}
+
+func TestEligibilityGatesRejectToo(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Deny}
+	m, r := submitted(t, approval.Policy{Quorum: 2}, approval.WithDecider(d))
+
+	_, err := m.Reject(context.Background(), r.ID, actor("mallory"))
+	assert.ErrorIs(t, err, approval.ErrNotEligible,
+		"an ungated reject lets anyone DoS the approval queue")
+	assert.Equal(t, access.Action("payout.release:decide"), d.gotAction)
+}
+
+func TestEligibilityRunsAfterCheapInvariants(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Allow}
+	m, r := submitted(t, approval.Policy{Quorum: 2}, approval.WithDecider(d))
+
+	_, err := m.Approve(context.Background(), r.ID, actor("alice"))
+	require.ErrorIs(t, err, approval.ErrSelfApproval)
+	assert.Empty(t, d.gotAction, "self-approval is refused without consulting the decider")
+}
+
+func TestCancelUsesCancelVerbForNonRequester(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Allow}
+	m, r := submitted(t, approval.Policy{Quorum: 2}, approval.WithDecider(d))
+
+	_, err := m.Cancel(context.Background(), r.ID, actor("ops-oncall"))
+	require.NoError(t, err)
+	assert.Equal(t, access.Action("payout.release:cancel"), d.gotAction)
+}
+
+func TestCancelByRequesterSkipsTheDecider(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Deny}
+	m, r := submitted(t, approval.Policy{Quorum: 2}, approval.WithDecider(d))
+
+	got, err := m.Cancel(context.Background(), r.ID, actor("alice"))
+	require.NoError(t, err, "withdrawing your own request is never gated")
+	assert.Equal(t, approval.Cancelled, got.Status)
+	assert.Empty(t, d.gotAction)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/approval/...`
+Expected: FAIL — `undefined: approval.WithDecider`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/approval/eligibility.go`:
+
+```go
+package approval
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+// eligible asks the decision seam whether a may act on r.
+//
+// The action is "<kind>:<verb>" — "payout.release:decide" for a vote,
+// "payout.release:cancel" for a third-party withdrawal. Both votes share
+// one verb: being a checker is the privilege, and which way a checker votes
+// is not a separate grant.
+//
+// It fails closed. access.Authorize already collapses Abstain and decider
+// errors into Deny, so anything short of an explicit Allow refuses the
+// action. A decider that cannot reach its data must never let a payout
+// through.
+func (m *Manager) eligible(ctx context.Context, r Request, a Actor, verb string) error {
+	if m.cfg.decider == nil {
+		return nil
+	}
+	res := access.Resource{
+		Type:   "approval",
+		ID:     r.ID.String(),
+		Tenant: r.Tenant,
+		Attrs: map[string]any{
+			"kind":      r.Kind,
+			"requester": r.Requester,
+			// The raw payload, not a decoded map: value-aware rules decode
+			// it themselves, and rules that ignore it pay nothing.
+			"payload": r.Payload,
+		},
+	}
+	dec, err := access.Authorize(ctx, m.cfg.decider, a.Subject, access.Action(r.Kind+":"+verb), res)
+	if err != nil {
+		// Never surface the decider's raw error to the caller: it may carry
+		// internal detail, and the caller sees a generic refusal either way.
+		return fmt.Errorf("%w: %s", ErrNotEligible, "eligibility could not be established")
+	}
+	if dec.Effect != access.Allow {
+		return ErrNotEligible
+	}
+	return nil
+}
+```
+
+Delete the stub `eligible` from `ops/approval/manager.go`.
+
+Add to `ops/approval/options.go`'s `config` struct and options:
+
+```go
+// in config:
+	decider access.Decider
+
+// WithDecider gates who may decide on a request. The manager asks it
+// "<kind>:decide" before recording any vote and "<kind>:cancel" before a
+// non-requester cancellation, passing the request's kind, requester, and
+// raw payload as resource attributes so relational rules ("must be the
+// requester's manager") and value-aware rules ("over 10 days needs the
+// department head") both work.
+//
+// Without it, any principal other than the requester may decide — the
+// correct single-team default. The structural invariants (no self-approval,
+// one vote per approver) hold either way.
+func WithDecider(d access.Decider) Option {
+	return func(c *config) { c.decider = d }
+}
+```
+
+Add `"github.com/dmitrymomot/forge/auth/access"` to `options.go`'s imports.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./ops/approval/... && just test ./ops/approval/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ops/approval/
+git commit -m "feat(approval): approver eligibility over the access decision seam"
+```
+
+---
+
+## Task 10: Audit trail
+
+**Files:**
+- Create: `ops/approval/audit.go`
+- Modify: `ops/approval/manager.go` (remove the `audit`/`auditDenied` stubs), `ops/approval/options.go` (add `WithAuditor`)
+- Test: `ops/approval/audit_test.go`
+
+**Interfaces:**
+- Consumes: every `action*`/`outcome*` constant, `Request`, `ErrAuditFailed`.
+- Produces: `WithAuditor(*auditlog.Recorder) Option`, and the real `(*Manager).audit(ctx, r Request, action, actor, outcome, reason string) error` plus `(*Manager).auditDenied(ctx, reqID id.UUID, action, actor string, cause error) error`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/approval/audit_test.go`:
+
+```go
+package approval_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/ops/approval"
+	"github.com/dmitrymomot/forge/ops/auditlog"
+)
+
+// failingSink rejects every write.
+type failingSink struct{}
+
+func (failingSink) Write(context.Context, auditlog.Event) error {
+	return errors.New("sink unavailable")
+}
+
+func TestAuditRecordsEveryTransition(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	m, r := submitted(t, approval.Policy{Quorum: 1},
+		approval.WithAuditor(auditlog.New(sink)))
+	ctx := context.Background()
+
+	_, err := m.Approve(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+	_, err = m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+	_, err = m.Complete(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	events := sink.Events()
+	require.Len(t, events, 4)
+
+	assert.Equal(t, "approval.submit", events[0].Action)
+	assert.Equal(t, "alice", events[0].Actor)
+	assert.Equal(t, auditlog.OutcomeSuccess, events[0].Outcome)
+	assert.Equal(t, "approval:"+r.ID.String(), events[0].Resource)
+	assert.Equal(t, "payout.release", events[0].Meta["kind"])
+
+	assert.Equal(t, "approval.approve", events[1].Action)
+	assert.Equal(t, "bob", events[1].Actor)
+	assert.Equal(t, "approved", events[1].Meta["status"])
+
+	assert.Equal(t, "approval.claim", events[2].Action)
+	assert.Equal(t, "worker-1", events[2].Actor)
+
+	assert.Equal(t, "approval.complete", events[3].Action)
+}
+
+func TestAuditRecordsDeniedAttempts(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	d := &recordingDecider{effect: access.Deny}
+	m, r := submitted(t, approval.Policy{Quorum: 1},
+		approval.WithDecider(d), approval.WithAuditor(auditlog.New(sink)))
+
+	_, err := m.Approve(context.Background(), r.ID, actor("mallory"))
+	require.ErrorIs(t, err, approval.ErrNotEligible)
+
+	events := sink.Events()
+	require.Len(t, events, 2, "submit + the denied attempt")
+	denied := events[1]
+	assert.Equal(t, "approval.approve", denied.Action)
+	assert.Equal(t, auditlog.OutcomeDenied, denied.Outcome)
+	assert.Equal(t, "mallory", denied.Actor)
+	assert.Equal(t, "approval:"+r.ID.String(), denied.Resource)
+}
+
+func TestAuditFailureReturnsDurableRequest(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 1},
+		approval.WithAuditor(auditlog.New(failingSink{})))
+	ctx := context.Background()
+
+	got, err := m.Approve(ctx, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrAuditFailed)
+	assert.Equal(t, approval.Approved, got.Status,
+		"the transition is durable even though the trail write failed")
+
+	stored, gerr := m.Get(ctx, r.ID)
+	require.NoError(t, gerr)
+	assert.Equal(t, approval.Approved, stored.Status, "and it really is persisted")
+}
+
+func TestNoAuditorIsSilent(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 1})
+	_, err := m.Approve(context.Background(), r.ID, actor("bob"))
+	assert.NoError(t, err, "the auditor seam is optional")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/approval/...`
+Expected: FAIL — `undefined: approval.WithAuditor`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/approval/audit.go`:
+
+```go
+package approval
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/auditlog"
+)
+
+// audit records a completed transition.
+//
+// It runs AFTER the store write, never before: auditing first would record
+// transitions that a lost CAS race then discarded. The cost of that
+// ordering is that a failed trail write cannot undo a durable transition,
+// so the caller gets the updated Request AND an ErrAuditFailed-wrapped
+// error. Match it with errors.Is and alert — in a dual-control package a
+// silent gap in the trail is the failure mode that matters.
+func (m *Manager) audit(ctx context.Context, r Request, action, actor, outcome, reason string) error {
+	if m.cfg.auditor == nil {
+		return nil
+	}
+	meta := map[string]string{
+		"kind":   r.Kind,
+		"status": r.Status.String(),
+	}
+	if reason != "" {
+		meta["reason"] = reason
+	}
+	if action == actionApprove || action == actionReject {
+		if pol, ok := m.policyFor(r.Kind); ok {
+			meta["quorum"] = strconv.Itoa(pol.Quorum)
+			meta["approvals"] = strconv.Itoa(r.Approvals())
+		}
+	}
+	_, err := m.cfg.auditor.Record(ctx, auditlog.Event{
+		Actor:    actor,
+		Action:   action,
+		Resource: "approval:" + r.ID.String(),
+		Outcome:  auditlog.Outcome(outcome),
+		Tenant:   r.Tenant,
+		Meta:     meta,
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrAuditFailed, err)
+	}
+	return nil
+}
+
+// auditDenied records a refused attempt. An ineligible actor trying to push
+// a request through is the most security-relevant event this package sees,
+// so it is never invisible — even though no state changed.
+func (m *Manager) auditDenied(ctx context.Context, reqID id.UUID, action, actor string, cause error) error {
+	if m.cfg.auditor == nil {
+		return nil
+	}
+	_, err := m.cfg.auditor.Record(ctx, auditlog.Event{
+		Actor:    actor,
+		Action:   action,
+		Resource: "approval:" + reqID.String(),
+		Outcome:  auditlog.OutcomeDenied,
+		Meta:     map[string]string{"cause": cause.Error()},
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrAuditFailed, err)
+	}
+	return nil
+}
+```
+
+Delete the stub `audit` and `auditDenied` from `ops/approval/manager.go`, and change the `outcomeSuccess`/`outcomeFailure` constants there to match auditlog's values:
+
+```go
+const (
+	outcomeSuccess = string(auditlog.OutcomeSuccess)
+	outcomeFailure = string(auditlog.OutcomeFailure)
+)
+```
+
+Add to `ops/approval/options.go`:
+
+```go
+// in config:
+	auditor *auditlog.Recorder
+
+// WithAuditor records every state change to the audit trail: submissions,
+// decisions, cancellations, claims, and outcomes — plus every attempt a
+// decider refused, as OutcomeDenied.
+//
+// The trail is written after the state change is durable. If the sink
+// fails, the transition still happened and the operation returns
+// ErrAuditFailed alongside the updated request.
+func WithAuditor(rec *auditlog.Recorder) Option {
+	return func(c *config) { c.auditor = rec }
+}
+```
+
+Add `"github.com/dmitrymomot/forge/ops/auditlog"` to `options.go` and `manager.go` imports.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./ops/approval/... && just test ./ops/approval/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ops/approval/
+git commit -m "feat(approval): audit trail with denied-attempt recording"
+```
+
+---
+
+## Task 11: Tenant scoping
+
+**Files:**
+- Modify: `ops/approval/manager.go` (replace the stub `scoped`), `ops/approval/options.go` (add `WithScope`)
+- Test: `ops/approval/tenancy_test.go`
+
+**Interfaces:**
+- Consumes: `ErrScope`, `ErrNotFound`, `mutate`, `List`, `Submit`.
+- Produces: `WithScope(func(context.Context) (string, error)) Option` and the real `(*Manager).scoped(ctx, requested string) (string, error)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/approval/tenancy_test.go`:
+
+```go
+package approval_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+type tenantKey struct{}
+
+func ctxTenant(t string) context.Context {
+	return context.WithValue(context.Background(), tenantKey{}, t)
+}
+
+func tenantFromCtx(ctx context.Context) (string, error) {
+	t, _ := ctx.Value(tenantKey{}).(string)
+	return t, nil
+}
+
+func scopedManager(t *testing.T, store approval.Store) *approval.Manager {
+	t.Helper()
+	return approval.New(store,
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2}),
+		approval.WithClock(clock.NewMock(fixedNow)),
+		approval.WithScope(tenantFromCtx))
+}
+
+func TestScopeStampsTenantOnSubmit(t *testing.T) {
+	t.Parallel()
+	m := scopedManager(t, approval.NewMemoryStore())
+
+	r, err := approval.Submit(ctxTenant("acme"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+	assert.Equal(t, "acme", r.Tenant)
+}
+
+func TestScopeFailsClosedOnEmptyTenant(t *testing.T) {
+	t.Parallel()
+	m := scopedManager(t, approval.NewMemoryStore())
+
+	_, err := approval.Submit(context.Background(), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	assert.ErrorIs(t, err, approval.ErrScope, "a missing tenant must not fall back to global")
+}
+
+func TestScopeFailsClosedOnHookError(t *testing.T) {
+	t.Parallel()
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2}),
+		approval.WithScope(func(context.Context) (string, error) {
+			return "", errors.New("tenant lookup failed")
+		}))
+
+	_, err := approval.Submit(context.Background(), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	assert.ErrorIs(t, err, approval.ErrScope)
+}
+
+func TestScopeRejectsDisagreeingExplicitTenant(t *testing.T) {
+	t.Parallel()
+	m := scopedManager(t, approval.NewMemoryStore())
+
+	_, err := approval.Submit(ctxTenant("acme"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice", Tenant: "globex"})
+	assert.ErrorIs(t, err, approval.ErrScope)
+
+	// Agreeing is fine.
+	_, err = approval.Submit(ctxTenant("acme"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice", Tenant: "acme"})
+	assert.NoError(t, err)
+}
+
+func TestCrossTenantAccessReportsNotFound(t *testing.T) {
+	t.Parallel()
+	store := approval.NewMemoryStore()
+	m := scopedManager(t, store)
+
+	r, err := approval.Submit(ctxTenant("acme"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	other := ctxTenant("globex")
+	_, err = m.Approve(other, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrNotFound,
+		"not ErrScope — cross-tenant existence must not be probeable")
+
+	_, err = m.Cancel(other, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrNotFound)
+}
+
+func TestListIsConfinedToScope(t *testing.T) {
+	t.Parallel()
+	store := approval.NewMemoryStore()
+	m := scopedManager(t, store)
+
+	_, err := approval.Submit(ctxTenant("acme"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+	_, err = approval.Submit(ctxTenant("globex"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "carol"})
+	require.NoError(t, err)
+
+	got, err := m.List(ctxTenant("acme"), approval.Filter{})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "acme", got[0].Tenant)
+}
+
+func TestUnscopedManagerPaysNoCeremony(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 1})
+	assert.Empty(t, r.Tenant)
+
+	got, err := m.Approve(context.Background(), r.ID, actor("bob"))
+	require.NoError(t, err)
+	assert.Equal(t, approval.Approved, got.Status)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test ./ops/approval/...`
+Expected: FAIL — `undefined: approval.WithScope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Replace the stub `scoped` in `ops/approval/manager.go`:
+
+```go
+// scoped resolves the tenant an operation is confined to.
+//
+// With no WithScope hook it passes the requested tenant through, so
+// single-tenant applications pay nothing. With one, it fails closed: a hook
+// error or an empty tenant aborts with ErrScope rather than silently
+// operating across every tenant, and an explicitly requested tenant must
+// agree with the scoped one.
+func (m *Manager) scoped(ctx context.Context, requested string) (string, error) {
+	if m.cfg.scope == nil {
+		return requested, nil
+	}
+	tenant, err := m.cfg.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrScope, err)
+	}
+	if tenant == "" {
+		return "", ErrScope
+	}
+	if requested != "" && requested != tenant {
+		return "", fmt.Errorf("%w: requested tenant %q is outside scope %q", ErrScope, requested, tenant)
+	}
+	return tenant, nil
+}
+```
+
+Add `"fmt"` to `manager.go`'s imports.
+
+Add to `ops/approval/options.go`:
+
+```go
+// in config:
+	scope func(context.Context) (string, error)
+
+// WithScope derives the tenant from context for every operation: Submit
+// stamps it, List is confined to it, and Get and every transition report
+// ErrNotFound for other tenants' requests — not a forbidden error, so
+// cross-tenant existence cannot be probed.
+//
+// Fail-closed: a hook error or an empty tenant fails the operation with
+// ErrScope. A nil fn leaves the manager unscoped, which is the correct
+// single-tenant default.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) { c.scope = fn }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just fmt ./ops/approval/... && just test ./ops/approval/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ops/approval/
+git commit -m "feat(approval): fail-closed tenant scoping seam"
+```
+
+---
+
+## Task 12: Postgres store
+
+**Files:**
+- Create: `ops/approval/pgstore/migrations/00001_create_forge_approval_requests.sql`
+- Create: `ops/approval/pgstore/pgstore.go`
+- Create: `ops/approval/pgstore/doc.go`
+- Test: `ops/approval/pgstore/pgstore_test.go`
+
+**Interfaces:**
+- Consumes: `approval.Store`, `approval.Request`, `approval.Filter`, sentinels, `approvaltest.Run`.
+- Produces: `pgstore.New(pool *pgxpool.Pool) *Store` implementing `approval.Store`, and `pgstore.Migrations fs.FS`.
+
+Read `auth/apikey/pgstore/pgstore.go` and `auth/apikey/pgstore/pgstore_test.go` in full before starting — this task mirrors both exactly.
+
+Note the setup chain, which is easy to get wrong: `pgtest` exposes only
+`DSN(tb)`, so the pool comes from `postgres.Open`, and `migration.Up` takes
+a `*sql.DB` (via `stdlib.OpenDBFromPool`), not the pool. The version table
+is set with `migration.WithTable`, and it must be unique — a colliding
+group name silently skips the migration and every test then fails on a
+missing table.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ops/approval/pgstore/pgstore_test.go`:
+
+```go
+//go:build integration
+
+package pgstore_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+	"github.com/dmitrymomot/forge/ops/approval"
+	"github.com/dmitrymomot/forge/ops/approval/approvaltest"
+	"github.com/dmitrymomot/forge/ops/approval/pgstore"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+)
+
+var _ approval.Store = (*pgstore.Store)(nil)
+
+func newPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	cfg := postgres.DefaultConfig()
+	cfg.URL = pgtest.DSN(t)
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgstore.Migrations,
+		migration.WithTable("forge_approval_schema")).Up(context.Background(), db))
+	return pool
+}
+
+// TestPgStoreContract runs the same suite the memory store passes. The
+// table outlives the process, so the suite namespaces its own fixtures —
+// nothing here truncates.
+func TestPgStoreContract(t *testing.T) {
+	pool := newPool(t)
+	approvaltest.Run(t, func(t *testing.T) approval.Store {
+		return pgstore.New(pool)
+	})
+}
+
+// TestConcurrentUpdatesConflict proves the CAS is enforced by Postgres
+// itself, not by a mutex the memory store happens to hold.
+func TestConcurrentUpdatesConflict(t *testing.T) {
+	s := pgstore.New(newPool(t))
+	ctx := context.Background()
+
+	r := approval.Request{
+		ID:        id.NewUUID(),
+		Kind:      "kind-" + id.NewUUID().String(),
+		Tenant:    "tenant-" + id.NewUUID().String(),
+		Requester: "alice",
+		Status:    approval.Pending,
+		Version:   1,
+		Payload:   json.RawMessage(`{}`),
+		CreatedAt: time.Now().UTC().Truncate(time.Microsecond),
+	}
+	require.NoError(t, s.Create(ctx, r))
+
+	const writers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, writers)
+	for i := range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = s.Update(ctx, r, 1)
+		}()
+	}
+	wg.Wait()
+
+	var won int
+	for _, err := range errs {
+		if err == nil {
+			won++
+			continue
+		}
+		require.ErrorIs(t, err, approval.ErrConflict)
+	}
+	require.Equal(t, 1, won, "exactly one CAS wins at a given version")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-integration ./ops/approval/...`
+Expected: FAIL — `no required module provides package .../ops/approval/pgstore`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `ops/approval/pgstore/migrations/00001_create_forge_approval_requests.sql`:
+
+```sql
+-- +goose Up
+CREATE TABLE forge_approval_requests (
+    id          uuid PRIMARY KEY,
+    kind        text NOT NULL,
+    tenant      text NOT NULL DEFAULT '',
+    requester   text NOT NULL,
+    reason      text NOT NULL DEFAULT '',
+    status      smallint NOT NULL,
+    version     bigint NOT NULL DEFAULT 1,
+    payload     json NOT NULL,
+    decisions   json NOT NULL DEFAULT '[]'::json,
+    meta        jsonb NOT NULL DEFAULT '{}'::jsonb,
+    claimed_by  text NOT NULL DEFAULT '',
+    created_at  timestamptz NOT NULL,
+    expires_at  timestamptz,
+    claimed_at  timestamptz,
+    decided_at  timestamptz
+);
+
+-- Covers the Filter WHERE columns in filter order, then id for the
+-- newest-first ordering. An index that does not cover the filter is an
+-- index Postgres will not use.
+CREATE INDEX forge_approval_requests_list_idx
+    ON forge_approval_requests (tenant, kind, status, id DESC);
+
+-- Partial: rows with no expiry are never selected by an expiry bound, so
+-- they do not belong in this index.
+CREATE INDEX forge_approval_requests_expiry_idx
+    ON forge_approval_requests (status, expires_at)
+    WHERE expires_at IS NOT NULL;
+
+-- +goose Down
+DROP TABLE forge_approval_requests;
+```
+
+Create `ops/approval/pgstore/pgstore.go`. `payload` and `decisions` are
+`json`, not `jsonb`: neither is queried by content, and `json` round-trips
+the exact bytes with no reparse — so a payload a consumer hashes stays
+byte-identical.
+
+```go
+package pgstore
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_approval_requests,
+// rooted so its .sql files sit at fsys root (data/migration.New globs
+// fsys's root, not subdirectories). Apply it under its own version table
+// (migration.WithTable("forge_approval_schema")) — a colliding group name
+// silently skips.
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// Store is the Postgres implementation of approval.Store. The pool's
+// lifecycle is the caller's.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+var _ approval.Store = (*Store)(nil)
+
+// New builds a Postgres approval Store. Apply Migrations first.
+func New(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const cols = `id, kind, tenant, requester, reason, status, version, payload, decisions, meta, claimed_by, created_at, expires_at, claimed_at, decided_at`
+
+const createSQL = `
+INSERT INTO forge_approval_requests (` + cols + `)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`
+
+// Create inserts r. A colliding id yields approval.ErrDuplicate.
+func (s *Store) Create(ctx context.Context, r approval.Request) error {
+	decisions, meta, err := encodeState(r)
+	if err != nil {
+		return err
+	}
+	_, err = s.pool.Exec(ctx, createSQL,
+		r.ID, r.Kind, r.Tenant, r.Requester, r.Reason, int16(r.Status), r.Version,
+		[]byte(r.Payload), decisions, meta, r.ClaimedBy,
+		r.CreatedAt, nullTime(r.ExpiresAt), nullTime(r.ClaimedAt), nullTime(r.DecidedAt))
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
+		return approval.ErrDuplicate
+	}
+	return err
+}
+
+// Get returns the request for reqID, or approval.ErrNotFound.
+func (s *Store) Get(ctx context.Context, reqID id.UUID) (approval.Request, error) {
+	return scanRequest(s.pool.QueryRow(ctx,
+		`SELECT `+cols+` FROM forge_approval_requests WHERE id = $1`, reqID))
+}
+
+const updateSQL = `
+UPDATE forge_approval_requests
+SET kind = $2, tenant = $3, requester = $4, reason = $5, status = $6,
+    version = version + 1, payload = $7, decisions = $8, meta = $9,
+    claimed_by = $10, created_at = $11, expires_at = $12, claimed_at = $13,
+    decided_at = $14
+WHERE id = $1 AND version = $15`
+
+// Update persists r only when the stored version matches expect. Zero rows
+// affected means either the id is gone or another writer moved the version;
+// a follow-up existence check tells those apart, because the Manager
+// retries one and gives up on the other.
+func (s *Store) Update(ctx context.Context, r approval.Request, expect int64) error {
+	decisions, meta, err := encodeState(r)
+	if err != nil {
+		return err
+	}
+	tag, err := s.pool.Exec(ctx, updateSQL,
+		r.ID, r.Kind, r.Tenant, r.Requester, r.Reason, int16(r.Status),
+		[]byte(r.Payload), decisions, meta, r.ClaimedBy,
+		r.CreatedAt, nullTime(r.ExpiresAt), nullTime(r.ClaimedAt), nullTime(r.DecidedAt),
+		expect)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() > 0 {
+		return nil
+	}
+	var exists bool
+	if err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM forge_approval_requests WHERE id = $1)`, r.ID,
+	).Scan(&exists); err != nil {
+		return err
+	}
+	if !exists {
+		return approval.ErrNotFound
+	}
+	return approval.ErrConflict
+}
+
+const listSQL = `
+SELECT ` + cols + ` FROM forge_approval_requests
+WHERE ($1 = '' OR tenant = $1)
+  AND ($2 = '' OR kind = $2)
+  AND ($3 = '' OR requester = $3)
+  AND (cardinality($4::smallint[]) = 0 OR status = ANY($4))
+  AND ($5::timestamptz IS NULL OR (expires_at IS NOT NULL AND expires_at < $5))
+ORDER BY id DESC
+LIMIT $6`
+
+// List returns requests matching f, newest first (UUIDv7 ids are
+// time-ordered, so id DESC is creation order).
+func (s *Store) List(ctx context.Context, f approval.Filter) ([]approval.Request, error) {
+	statuses := make([]int16, 0, len(f.Statuses))
+	for _, st := range f.Statuses {
+		statuses = append(statuses, int16(st))
+	}
+	limit := f.Limit
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	rows, err := s.pool.Query(ctx, listSQL,
+		f.Tenant, f.Kind, f.Requester, statuses, nullTime(f.ExpiresBefore), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	// Non-nil empty on zero rows, matching the memory store.
+	out := []approval.Request{}
+	for rows.Next() {
+		r, err := scanRequest(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// defaultLimit caps an unbounded List so a large table cannot be pulled
+// into memory by a zero-valued Filter.
+const defaultLimit = 100
+
+// row is satisfied by both pgx.Row and pgx.Rows.
+type row interface{ Scan(dest ...any) error }
+
+func scanRequest(rw row) (approval.Request, error) {
+	var (
+		r         approval.Request
+		status    int16
+		payload   []byte
+		decisions []byte
+		exp       *time.Time
+		claimed   *time.Time
+		decided   *time.Time
+	)
+	err := rw.Scan(&r.ID, &r.Kind, &r.Tenant, &r.Requester, &r.Reason, &status,
+		&r.Version, &payload, &decisions, &r.Meta, &r.ClaimedBy,
+		&r.CreatedAt, &exp, &claimed, &decided)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return approval.Request{}, approval.ErrNotFound
+	}
+	if err != nil {
+		return approval.Request{}, err
+	}
+	r.Status = approval.Status(status)
+	r.Payload = json.RawMessage(payload)
+	if err := json.Unmarshal(decisions, &r.Decisions); err != nil {
+		return approval.Request{}, err
+	}
+	r.CreatedAt = r.CreatedAt.UTC()
+	if exp != nil {
+		r.ExpiresAt = exp.UTC()
+	}
+	if claimed != nil {
+		r.ClaimedAt = claimed.UTC()
+	}
+	if decided != nil {
+		r.DecidedAt = decided.UTC()
+	}
+	return r, nil
+}
+
+// encodeState marshals the two JSON columns, normalizing nil to an empty
+// array and an empty object so a reader never has to special-case null.
+func encodeState(r approval.Request) (decisions []byte, meta map[string]string, err error) {
+	d := r.Decisions
+	if d == nil {
+		d = []approval.Decision{}
+	}
+	decisions, err = json.Marshal(d)
+	if err != nil {
+		return nil, nil, err
+	}
+	meta = r.Meta
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	return decisions, meta, nil
+}
+
+// nullTime maps a zero time to SQL NULL.
+func nullTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+```
+
+Create `ops/approval/pgstore/doc.go` with a package comment mirroring `auth/apikey/pgstore/doc.go`'s shape: what it persists, that `Migrations` must be applied first under its own version table, and that the pool's lifecycle is the caller's.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-integration ./ops/approval/...`
+Expected: PASS — the same conformance suite the memory store passes, now against Postgres, plus `TestConcurrentUpdatesConflict` reporting exactly one winner.
+
+Run it twice in a row without dropping the database:
+`just test-integration ./ops/approval/... && just test-integration ./ops/approval/...`
+Expected: PASS both times. A failure on the second run means fixtures are not namespaced and the suite is reading a previous run's rows.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ops/approval/
+git commit -m "feat(approval): postgres store with CAS update and covering indexes"
+```
+
+---
+
+## Task 13: Benchmarks and the optimization pass
+
+**Files:**
+- Create: `ops/approval/bench_test.go`
+- Modify: whatever the profile proves hot (nothing, if nothing is)
+
+**Interfaces:**
+- Consumes: the whole public API.
+- Produces: benchmark numbers for the PR body.
+
+Benchmarks are required for every forge package, and any perf-motivated complexity requires a benchmark proving it. Measured wins only — do not "optimize" anything the numbers do not flag.
+
+- [ ] **Step 1: Write the benchmarks**
+
+Create `ops/approval/bench_test.go`:
+
+```go
+package approval_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+func benchManager(b *testing.B, p approval.Policy, opts ...approval.Option) *approval.Manager {
+	b.Helper()
+	all := append([]approval.Option{
+		approval.WithKind(kindPayout, p),
+		approval.WithClock(clock.NewMock(fixedNow)),
+	}, opts...)
+	return approval.New(approval.NewMemoryStore(), all...)
+}
+
+func BenchmarkSubmit(b *testing.B) {
+	m := benchManager(b, approval.Policy{Quorum: 2, TTL: 24 * time.Hour})
+	ctx := context.Background()
+	payload := payoutPayload{PayoutID: "po_88", Amount: 250000}
+	p := approval.SubmitParams{Requester: "alice", Reason: "invoice"}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := approval.Submit(ctx, m, kindPayout, payload, p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchmarkApprove(b *testing.B, quorum int) {
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		b.StopTimer()
+		m := benchManager(b, approval.Policy{Quorum: quorum})
+		r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+			approval.SubmitParams{Requester: "alice"})
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+
+		if _, err := m.Approve(ctx, r.ID, actor("bob")); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkApproveQuorum2(b *testing.B) { benchmarkApprove(b, 2) }
+func BenchmarkApproveQuorum5(b *testing.B) { benchmarkApprove(b, 5) }
+
+func BenchmarkApproveContended(b *testing.B) {
+	m := benchManager(b, approval.Policy{Quorum: 100}, approval.WithMaxRetries(1000))
+	ctx := context.Background()
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			i++
+			// Distinct approver ids; ErrAlreadyVoted/ErrNotPending are the
+			// expected steady state once quorum is met, so ignore errors and
+			// measure the CAS path itself.
+			_, _ = m.Approve(ctx, r.ID, actor("approver-"+strconv.Itoa(i)))
+		}
+	})
+}
+
+func BenchmarkGet(b *testing.B) {
+	m := benchManager(b, approval.Policy{Quorum: 2, TTL: 24 * time.Hour})
+	ctx := context.Background()
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := m.Get(ctx, r.ID); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkList100(b *testing.B) {
+	m := benchManager(b, approval.Policy{Quorum: 2, TTL: 24 * time.Hour})
+	ctx := context.Background()
+	for range 100 {
+		if _, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+			approval.SubmitParams{Requester: "alice"}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	f := approval.Filter{Statuses: []approval.Status{approval.Pending}}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := m.List(ctx, f); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPayloadOf(b *testing.B) {
+	m := benchManager(b, approval.Policy{Quorum: 2})
+	r, err := approval.Submit(context.Background(), m, kindPayout,
+		payoutPayload{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice"})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := approval.PayloadOf(kindPayout, r); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkApproveWithDecider(b *testing.B) {
+	allow := access.DeciderFunc(func(context.Context, access.Subject, access.Action, access.Resource) (access.Decision, error) {
+		return access.Allow.Because("bench"), nil
+	})
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		b.StopTimer()
+		m := benchManager(b, approval.Policy{Quorum: 2}, approval.WithDecider(allow))
+		r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+			approval.SubmitParams{Requester: "alice"})
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+
+		if _, err := m.Approve(ctx, r.ID, actor("bob")); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+```
+
+Add `"strconv"` to the imports.
+
+- [ ] **Step 2: Capture the baseline**
+
+Run: `just bench ./ops/approval/... | tee docs/superpowers/specs/2026-07-21-approval-bench-baseline.txt`
+Expected: every benchmark reports ns/op and allocs/op.
+
+- [ ] **Step 3: Optimize only what the numbers flag**
+
+Read the baseline and look for these specific suspects, in order:
+
+1. **`BenchmarkGet` allocating more than the store's clone requires.** `applyExpiry` must be allocation-free — it is pure timestamp comparison. If `Get` shows unexpected allocs, they are the memory store's `cloneRequest`, which is correct and required.
+2. **`BenchmarkList100` allocating a second slice.** `List` filters in place with `kept := out[:0]`; if the profile shows a second backing array, the in-place filter was lost in a refactor.
+3. **`BenchmarkApproveQuorum5` growing `Decisions` repeatedly.** `Submit` preallocates to `cap = Quorum`, so appends up to quorum must not reallocate. If they do, the preallocation is wrong.
+4. **`BenchmarkPayloadOf`** is dominated by `encoding/json` — that is expected and not worth optimizing. Leave it.
+
+If a fix is warranted, make it, rerun, and record the delta. If nothing is flagged, change nothing and say so in the PR. Do not add complexity for an unmeasured win.
+
+Run: `just bench ./ops/approval/... | tee docs/superpowers/specs/2026-07-21-approval-bench-after.txt`
+
+- [ ] **Step 4: Verify nothing regressed**
+
+Run: `just test ./ops/approval/...`
+Expected: PASS — optimization must not change behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ops/approval/ docs/superpowers/specs/
+git commit -m "test(approval): benchmarks and measured optimization pass"
+```
+
+---
+
+## Task 14: Package documentation and catalog removal
+
+**Files:**
+- Create: `ops/approval/doc.go`
+- Modify: `docs/packages.md` (delete the `ops/approval` entry)
+- Test: `ops/approval/example_test.go`
+
+**Interfaces:**
+- Consumes: the whole public API.
+- Produces: godoc and a compiling runnable example.
+
+- [ ] **Step 1: Write the runnable example**
+
+Create `ops/approval/example_test.go`. It must compile and its output must match, so it is a real test of the documented flow:
+
+```go
+package approval_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+type releasePayout struct {
+	PayoutID string `json:"payout_id"`
+	Amount   int64  `json:"amount"`
+}
+
+var kindRelease = approval.NewKind[releasePayout]("payout.release")
+
+func Example() {
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindRelease, approval.Policy{Quorum: 2}))
+	ctx := context.Background()
+
+	// The maker submits.
+	req, err := approval.Submit(ctx, m, kindRelease,
+		releasePayout{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice", Reason: "vendor invoice #4471"})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("submitted:", req.Status)
+
+	// The maker cannot be a checker.
+	_, err = m.Approve(ctx, req.ID, approval.Actor{Subject: access.Subject{ID: "alice"}})
+	fmt.Println("self-approval:", err)
+
+	// Two checkers approve.
+	got, _ := m.Approve(ctx, req.ID, approval.Actor{Subject: access.Subject{ID: "bob"}})
+	fmt.Println("one of two:", got.Status)
+	got, _ = m.Approve(ctx, req.ID, approval.Actor{Subject: access.Subject{ID: "carol"}})
+	fmt.Println("two of two:", got.Status)
+
+	// Exactly one executor runs the action.
+	done, err := m.Execute(ctx, req.ID, "worker-1", func(ctx context.Context, r approval.Request) error {
+		p, err := approval.PayloadOf(kindRelease, r)
+		if err != nil {
+			return err
+		}
+		fmt.Println("releasing:", p.PayoutID)
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("finished:", done.Status)
+
+	// Output:
+	// submitted: pending
+	// self-approval: approval: requester cannot decide own request
+	// one of two: pending
+	// two of two: approved
+	// releasing: po_88
+	// finished: executed
+}
+```
+
+- [ ] **Step 2: Run the example to verify it fails**
+
+Run: `just test ./ops/approval/...`
+Expected: FAIL if any output line mismatches — fix the example or the code until it matches exactly.
+
+- [ ] **Step 3: Write doc.go**
+
+Create `ops/approval/doc.go`:
+
+```go
+// Package approval implements maker-checker dual control: a privileged
+// action is recorded as a request, a second person approves or rejects it,
+// and exactly one executor carries it out.
+//
+//	var KindReleasePayout = approval.NewKind[ReleasePayout]("payout.release")
+//
+//	m := approval.New(approval.NewMemoryStore(), // pgstore.New(pool) in production
+//		approval.WithKind(KindReleasePayout, approval.Policy{Quorum: 2, TTL: 24 * time.Hour}))
+//
+//	req, err := approval.Submit(ctx, m, KindReleasePayout,
+//		ReleasePayout{PayoutID: "po_88", Amount: amount},
+//		approval.SubmitParams{Requester: "alice", Reason: "vendor invoice #4471"})
+//
+// Checkers vote with Approve and Reject. The quorum-th distinct approval
+// moves the request to Approved; a single rejection is terminal.
+//
+//	req, err := m.Approve(ctx, req.ID, approval.Actor{
+//		Subject: access.Subject{ID: "bob"}, Reason: "matched to invoice"})
+//
+// Three rules are structural and cannot be configured off: the requester
+// may never decide their own request (at any quorum — Quorum 1 is still
+// dual control), an approver counts once however many times they vote, and
+// a rejected request never becomes approved.
+//
+// # Executing once
+//
+// Reaching Approved does not run anything. For actions where running twice
+// is the real danger — releasing a payout, booking a calendar entry — claim
+// the request first: Claim moves it to Executing atomically, so two
+// operators or two racing webhook deliveries produce one winner and one
+// ErrAlreadyClaimed.
+//
+//	done, err := m.Execute(ctx, req.ID, "worker-1", func(ctx context.Context, r approval.Request) error {
+//		p, err := approval.PayloadOf(KindReleasePayout, r)
+//		if err != nil {
+//			return err
+//		}
+//		return payouts.Release(ctx, p.PayoutID, p.Amount)
+//	})
+//
+// Execute wraps Claim, then Complete or Fail. Call them directly when the
+// action spans processes. By default a claim never expires, so an executor
+// that dies mid-action wedges the request until Release is called — the
+// safe default for money. Policy.ClaimTTL opts into automatic takeover, and
+// with it the action must be idempotent.
+//
+// Requests that nobody acts on expire after Policy.TTL. Expiry is derived
+// on read, not swept: a Pending or Approved request past its deadline
+// reports Expired and refuses every transition, with no background
+// goroutine anywhere.
+//
+// # Eligibility, audit, and tenancy
+//
+// WithDecider gates who may vote through the auth/access decision seam,
+// asking "<kind>:decide" with the request's kind, requester, and raw
+// payload as attributes — enough for relational rules ("must be the
+// requester's manager") and value-aware ones. It fails closed: a decider
+// that errors refuses the vote.
+//
+// WithAuditor writes every transition to an ops/auditlog Recorder,
+// including attempts the decider denied. WithScope confines every operation
+// to a context-derived tenant, failing closed when none is available;
+// single-tenant applications pay no ceremony.
+//
+//	m := approval.New(store,
+//		approval.WithKind(KindReleasePayout, approval.Policy{Quorum: 2}),
+//		approval.WithDecider(roles),
+//		approval.WithAuditor(rec),
+//		approval.WithScope(tenantFromContext))
+//
+// State lives behind the Store interface. NewMemoryStore is for tests and
+// development; approval/pgstore persists to Postgres.
+package approval
+```
+
+- [ ] **Step 4: Verify docs and remove the catalog entry**
+
+Run: `just test ./ops/approval/... && go doc ./ops/approval | head -40`
+Expected: PASS, and the package synopsis renders.
+
+Delete the `**ops/approval**` entry from `docs/packages.md` — the catalog lists only unbuilt packages, and a shipped package's godoc is its reference. Then check for stale cross-references:
+
+Run: `grep -n "ops/approval" docs/packages.md`
+Expected: only the `auth/impersonation` dependency mention remains. Update its "(both planned)" note, since `ops/approval` is no longer planned.
+
+- [ ] **Step 5: Full verification and commit**
+
+Run: `just fmt ./ops/approval/... && just lint && just test ./ops/approval/...`
+Expected: all clean. `nilaway` must be clean — it ignores `nolint` directives, so fix findings rather than suppressing them. If `nilaway` OOMs in CI, that is a known runner flake: rerun it.
+
+```bash
+git add ops/approval/ docs/packages.md
+git commit -m "docs(approval): package documentation and catalog removal"
+```
+
+---
+
+## Final verification
+
+- [ ] `just fmt ./ops/approval/...` — clean
+- [ ] `just lint` — clean, including the integration-tagged pass
+- [ ] `just test ./ops/approval/...` — all green under `-race`
+- [ ] `go test -race -count=20 -run "TestConcurrent" ./ops/approval/` — 20 consecutive passes
+- [ ] `just test-integration ./ops/approval/...` — green with Docker
+- [ ] `just bench ./ops/approval/...` — numbers captured for the PR body
+- [ ] `docs/packages.md` no longer lists `ops/approval` as unbuilt
+- [ ] PR body carries before/after benchmark numbers and notes which optimizations were measured wins (or that none were warranted)

--- a/docs/superpowers/specs/2026-07-21-approval-bench-after.txt
+++ b/docs/superpowers/specs/2026-07-21-approval-bench-after.txt
@@ -1,0 +1,104 @@
+# ops/approval benchmark results — AFTER review-fix pass on Task 13
+# Baseline: docs/superpowers/specs/2026-07-21-approval-bench-baseline.txt
+# (commit 28c535a). This file's commit is the one that adds it, landed
+# together with the bench_test.go fix described below (test-only; see
+# `git log --oneline -- ops/approval/bench_test.go` for the exact SHA).
+# Apple M3 Max, darwin/arm64, go1.26.5, macOS 15.7.7
+# Captured: 2026-07-21 via `go test -run=^$ -bench=. -benchmem -benchtime=1s ./ops/approval/`
+# In-memory store only (approval.NewMemoryStore); pgstore has its own suite.
+# Single-sample (-count=1) for the full-suite run below; the contention
+# redesign is additionally backed by repeated, multi-scale samples further
+# down, since a single sample cannot demonstrate sustained-across-scale
+# behavior on its own.
+
+## No production code changed — this is a benchmark-only fix
+#
+# ops/approval production code is untouched by this task. Comparing every
+# benchmark EXCEPT BenchmarkApproveContended against the baseline file:
+# every number below sits within ordinary run-to-run noise of its baseline
+# counterpart (B/op and allocs/op are identical or off by rounding; ns/op
+# varies by the same shared-machine-load amount you'd see re-running the
+# baseline twice in a row). There is no optimization to report here, and
+# none was attempted — this file exists so the numbers ship with the PR
+# per the task brief, not to claim a perf win that didn't happen.
+
+pkg: github.com/dmitrymomot/forge/ops/approval
+BenchmarkSubmit-14                	 2169258	       556.6 ns/op	     639 B/op	       5 allocs/op
+BenchmarkApproveQuorum2-14        	 2492959	       504.7 ns/op	     480 B/op	       5 allocs/op
+BenchmarkApproveQuorum5-14        	 2845634	       493.6 ns/op	     480 B/op	       5 allocs/op
+BenchmarkApproveContended-14      	 1330050	       917.8 ns/op	    1157 B/op	       9 allocs/op
+BenchmarkGet-14                   	13912840	        86.08 ns/op	      32 B/op	       1 allocs/op
+BenchmarkList100-14               	   72523	     16875 ns/op	   30824 B/op	     104 allocs/op
+BenchmarkPayloadOf-14             	 2707274	       434.5 ns/op	     248 B/op	       6 allocs/op
+BenchmarkApproveWithDecider-14    	 1676247	       777.1 ns/op	     944 B/op	      12 allocs/op
+PASS
+ok  	github.com/dmitrymomot/forge/ops/approval	18.977s
+
+# ===========================================================================
+# BenchmarkApproveContended: redesigned, not optimized — this IS a real
+# before/after, but of the benchmark's methodology, not of production code
+# ===========================================================================
+#
+# The baseline's BenchmarkApproveContended (one Pending request, Quorum: 100)
+# stops sustaining contention after ~100 votes: every later call in the run
+# is a cheap Get+early-reject, not a real CAS race (see baseline file for
+# the reproduced 6981 vs 6872 B/op flatness at a 100x iteration spread).
+#
+# Fix: BenchmarkApproveContended now pre-creates a pool of many low-quorum
+# (Quorum: 4) Pending requests, sized to b.N/quorum plus headroom, and every
+# parallel worker routes through one shared "current" index. All live
+# workers hammer the SAME request at once (quorum 4 is far below the
+# 14-way worker count, so simultaneous CAS conflicts are close to
+# guaranteed), and the instant it fills, whichever worker notices advances
+# the shared index so every worker rotates onto a fresh Pending request
+# together. Because the pool is sized off b.N, this keeps the ENTIRE run
+# inside the contended CAS path regardless of -benchtime, instead of
+# degenerating into cheap rejects after the first ~100 votes.
+#
+# Proof the redesign genuinely sustains contention across scale (the same
+# 100x spread used to catch the original bug, plus a -count=3 repeat at
+# each scale to separate signal from machine-load noise):
+#
+# Command: go test -run=^$ -bench='^BenchmarkApproveContended$' -benchmem -benchtime=2000x -count=3 ./ops/approval/
+#   BenchmarkApproveContended-14    2000    1215 ns/op    1210 B/op    9 allocs/op
+#   BenchmarkApproveContended-14    2000    1073 ns/op    1174 B/op    9 allocs/op
+#   BenchmarkApproveContended-14    2000     897.2 ns/op  1172 B/op    9 allocs/op
+#
+# Command: go test -run=^$ -bench='^BenchmarkApproveContended$' -benchmem -benchtime=200000x -count=3 ./ops/approval/
+#   BenchmarkApproveContended-14  200000    1045 ns/op    1172 B/op    9 allocs/op
+#   BenchmarkApproveContended-14  200000     979.7 ns/op  1131 B/op    9 allocs/op
+#   BenchmarkApproveContended-14  200000    1538 ns/op    1039 B/op    8 allocs/op
+#
+# B/op: 1039-1217 across BOTH scales (100x spread in iteration count) and
+# allocs/op: 8-9 throughout. This is the same shape of stability the
+# baseline showed (~6.9KB flat) but for the OPPOSITE reason: here it is
+# flat because the pool scales with b.N so every iteration keeps doing the
+# same genuinely-contended work, not because most iterations degenerated
+# into a cheap reject tail. The distinguishing evidence against the
+# baseline's degenerate flatness is the elevated, stable cost itself:
+#
+# Command: go test -run=^$ -bench='^BenchmarkApproveQuorum2$' -benchmem -benchtime=200000x ./ops/approval/
+#   BenchmarkApproveQuorum2-14     200000     924.1 ns/op    480 B/op    5 allocs/op   (uncontended control: one Approve, no racing goroutines)
+#
+# BenchmarkApproveContended's 1039-1217 B/op and 8-9 allocs/op are ~2.2-2.5x
+# the bytes and ~1.6-1.8x the allocations of the uncontended control, at
+# BOTH the 2000x and 200000x scale - consistent with the extra Get+clone
+# cycles mutate's retry loop performs when it actually re-reads after a
+# losing CAS, and inconsistent with the baseline's regime where almost
+# every call at large N was a single cheap Get+reject indistinguishable
+# from the uncontended path's cost shape.
+#
+# Also re-ran the full suite under `-race` at -benchtime=200x to confirm no
+# hang/panic in the new rotating-pool design (the b.RunParallel + shared
+# atomic index is new concurrent code, even though it's test-only):
+#
+# Command: go test -run=^$ -bench=. -benchmem -benchtime=200x -race ./ops/approval/
+#   BenchmarkApproveContended-14    200    9649 ns/op    1226 B/op    9 allocs/op
+# PASS, no race detected.
+#
+# CORRECTED CLAIM replacing the Task 13 report's inaccurate one: the report
+# previously described BenchmarkApproveContended as "parallel Approve calls
+# racing on one request's CAS (mutate's optimistic-concurrency retry loop)
+# under Quorum: 100" without noting that this design only contends for the
+# first ~100 votes of any run. It does NOT measure sustained contention as
+# shipped in 28c535a. The redesign above is what makes that name accurate.

--- a/docs/superpowers/specs/2026-07-21-approval-bench-baseline.txt
+++ b/docs/superpowers/specs/2026-07-21-approval-bench-baseline.txt
@@ -1,0 +1,52 @@
+# ops/approval benchmark baseline — bench suite as originally landed (Task 13)
+# Commit: 28c535a (test(approval): add benchmarks for Submit/Approve/Get/List/PayloadOf)
+# Apple M3 Max, darwin/arm64, go1.26.5, macOS 15.7.7
+# Captured: 2026-07-21 via `go test -run=^$ -bench=. -benchmem -benchtime=1s ./ops/approval/`
+# In-memory store only (approval.NewMemoryStore); pgstore has its own suite.
+# Single-sample (-count=1), indicative only, no external services required.
+
+pkg: github.com/dmitrymomot/forge/ops/approval
+BenchmarkSubmit-14                	 2073648	       598.6 ns/op	     643 B/op	       5 allocs/op
+BenchmarkApproveQuorum2-14        	 2244069	       556.0 ns/op	     480 B/op	       5 allocs/op
+BenchmarkApproveQuorum5-14        	 2365843	       660.2 ns/op	     480 B/op	       5 allocs/op
+BenchmarkApproveContended-14      	  760786	      3820 ns/op	    6872 B/op	       5 allocs/op
+BenchmarkGet-14                   	 9205342	       122.3 ns/op	      32 B/op	       1 allocs/op
+BenchmarkList100-14               	   22922	     43681 ns/op	   30824 B/op	     104 allocs/op
+BenchmarkPayloadOf-14             	 1926427	       589.8 ns/op	     248 B/op	       6 allocs/op
+BenchmarkApproveWithDecider-14    	 1562392	       826.0 ns/op	     944 B/op	      12 allocs/op
+PASS
+ok  	github.com/dmitrymomot/forge/ops/approval	20.982s
+
+# ===========================================================================
+# KNOWN DEFECT in this baseline's BenchmarkApproveContended (review finding,
+# fixed in the commit that adds -after.txt; see that file for the redesign)
+# ===========================================================================
+#
+# This benchmark's name and its own doc comment claim it measures sustained
+# CAS-retry contention: many goroutines racing to approve one Pending
+# request under Quorum: 100. It does not sustain that. Approve -> vote ->
+# mutate always does a store.Get (a full Request clone) BEFORE checking
+# r.Status != Pending. Once ~100 distinct approvers push the single request
+# to Approved, every later call in the run pays only a cheap Get+clone+
+# immediate-reject - real CAS retries happen only during the initial ~100-
+# vote window, regardless of how many total iterations the run has.
+#
+# Reproduced directly against this commit's code (not just quoted from the
+# review): a 100x spread in iteration count produces a statistically flat
+# B/op, which is only possible if the contended ramp-up is a negligible
+# fraction of both runs -
+#
+# BenchmarkApproveContended-14  (-benchtime=2000x)    6981 B/op   5 allocs/op
+# BenchmarkApproveContended-14  (-benchtime=200000x)  6872 B/op   5 allocs/op
+#
+# If contention were actually sustained across the run, B/op should fall
+# substantially as N grows (the ~100-vote ramp-up cost gets amortized over
+# far more iterations at 200000x than at 2000x). It does not move outside
+# noise. The dominant per-call cost at BOTH scales is cloning a Request
+# whose Decisions slice is frozen at ~100 entries by the cheap-reject tail,
+# not genuine contended CAS work.
+#
+# See docs/superpowers/specs/2026-07-21-approval-bench-after.txt for the
+# redesign (a rotating pool of many low-quorum Pending requests, sized off
+# b.N, so the whole run stays inside the contended CAS path) and the data
+# proving it.

--- a/docs/superpowers/specs/2026-07-21-ops-approval-design.md
+++ b/docs/superpowers/specs/2026-07-21-ops-approval-design.md
@@ -1,0 +1,477 @@
+# ops/approval — Maker-Checker Dual Control
+
+Status: approved design, ready for implementation plan.
+
+Catalog entry (`docs/packages.md` → ops/approval): typed approval requests (action + payload) a second person approves or rejects over a storage-agnostic Store; decisions emit `auditlog` events and approver eligibility rides the `auth/access` decision seam. Deps: `auth/access`; `ops/auditlog`.
+
+## Purpose
+
+One sentence: **`ops/approval` records a privileged action, collects the second (or third) person's decision on it, and hands the approved action to exactly one executor.** The two-person rule for payouts, limit overrides, config changes, and manager sign-off.
+
+The package never runs consumer code. It owns the *record* and the *transitions*; the consumer owns the action.
+
+## Scope
+
+In scope:
+
+- Typed request submission (action name + payload), one `Kind[T]` per action type.
+- Quorum-based approval, single-reject-is-terminal rejection, cancellation.
+- Structural dual-control invariants: no self-approval, one vote per approver.
+- Approver eligibility via the `auth/access` decision seam.
+- Lazy expiry of unacted requests.
+- Execute-once claim/complete/fail lease so an approved action runs once.
+- Audit trail via `ops/auditlog`.
+- Storage-agnostic `Store` + in-memory implementation + `approval/pgstore`.
+- Optional fail-closed tenant scoping.
+
+Out of scope (deliberate):
+
+- Executing the approved action. No handler registry, no dispatch, no retries — that is `async/workflow`/`async/queue` territory. The package's `Execute` helper is a closure wrapper over its own three transitions, not a registry.
+- Notification of approvers (email/Slack). Consumers read `List` and notify.
+- A background sweeper goroutine. Expiry is lazy; consumers sweep on their own schedule.
+- Approval *chains* / multi-stage escalation ("manager, then VP"). A single quorum per kind. Multi-stage is a consumer composing two requests, or a later addition once a real consumer needs it.
+- Delegation / out-of-office proxy approvers. Consumer's decider concern.
+
+## Architecture
+
+```
+consumer ──Submit[T]──► Manager ──CAS──► Store ──► memory | pgstore
+                          │
+                          ├──eligibility──► access.Decider   (optional)
+                          ├──trail────────► auditlog.Recorder (optional)
+                          └──tenant───────► WithScope hook    (optional)
+```
+
+`Manager` is non-generic and holds the kind registry, the policies, and the seams. Type safety lives in package-level generic functions (`Submit`, `PayloadOf`, `WithKind`) — the `async/queue` `Kind[T]` precedent. This keeps one Manager per application rather than one per payload type.
+
+### Files
+
+| File | Contents |
+| --- | --- |
+| `doc.go` | Package doc + runnable example |
+| `approval.go` | `Request`, `Decision`, `Status`, `Vote`, `Kind[T]`, `SubmitParams`, `Actor`, `Filter` |
+| `policy.go` | `Policy`, kind registry entry, validation |
+| `manager.go` | `New`, transitions, CAS retry loop, lazy expiry, scope resolution |
+| `eligibility.go` | access.Decider invocation and fail-closed mapping |
+| `audit.go` | auditlog event emission |
+| `store.go` | `Store` interface |
+| `memory.go` | In-memory `Store` |
+| `options.go` | `type Option func(*config)`, `WithKind`, `WithDecider`, `WithAuditor`, `WithScope`, `WithClock`, `WithMaxRetries` |
+| `errors.go` | `errors.Is`-matchable single-line sentinels |
+| `bench_test.go` | Required benchmarks (see Performance) |
+| `pgstore/` | Postgres driver + goose migrations + integration tests |
+
+Target ~700–850 LOC for the core package, inside the single-responsibility band.
+
+## Types
+
+```go
+type Status uint8
+
+const (
+    Pending   Status = iota // awaiting decisions
+    Approved                // quorum met, awaiting claim (or terminal for the consumer)
+    Rejected                // a checker rejected; terminal
+    Cancelled               // requester or admin withdrew; terminal
+    Expired                 // TTL elapsed while Pending or Approved; terminal (derived)
+    Executing               // claimed by an executor
+    Executed                // executor reported success; terminal
+    Failed                  // executor reported failure; terminal
+)
+
+func (s Status) String() string
+func (s Status) Terminal() bool // Rejected, Cancelled, Expired, Executed, Failed
+
+type Vote uint8
+
+const (
+    VoteApprove Vote = iota + 1
+    VoteReject
+)
+```
+
+`Status` is a `uint8` with a `String()` — not a string type — to keep `Request` small and comparisons cheap. The store persists the numeric value; `pgstore` maps it to a `smallint`.
+
+```go
+// Kind binds an approval action name to its payload type T. Declare one
+// package-level Kind per action and share it between submitters and approvers.
+type Kind[T any] struct{ name string }
+
+func NewKind[T any](name string) Kind[T] // panics on empty name
+func (k Kind[T]) Name() string
+
+// Policy is the per-kind rule set. Registered at construction, never
+// supplied by the caller at submit time — an attacker who controls the
+// submit call must not be able to weaken the gate.
+type Policy struct {
+    // Quorum is the number of distinct approvals required. Must be >= 1.
+    Quorum int
+    // TTL is how long a request stays actionable after submission.
+    // Zero means it never expires.
+    TTL time.Duration
+    // ClaimTTL is how long an executor's claim is held before another
+    // executor may take it. Zero (default) means the claim never expires:
+    // a dead executor wedges the request until Release is called. Setting
+    // it non-zero opts into at-least-once execution.
+    ClaimTTL time.Duration
+}
+```
+
+```go
+// Request is one privileged action awaiting dual control.
+type Request struct {
+    CreatedAt time.Time
+    ExpiresAt time.Time // zero = never expires
+    ClaimedAt time.Time // zero = unclaimed
+    DecidedAt time.Time // when it reached a terminal or Approved status
+
+    Decisions []Decision
+    Meta      map[string]string
+    Payload   json.RawMessage
+
+    Kind      string
+    Tenant    string
+    Requester string
+    ClaimedBy string
+
+    ID      id.UUID
+    Version int64
+    Status  Status
+}
+
+// Decision is one checker's vote. Append-only within a Request.
+type Decision struct {
+    At       time.Time
+    Approver string
+    Reason   string
+    Vote     Vote
+}
+```
+
+Field order above is illustrative; `betteralign` (via `just lint`) is authoritative for the final layout.
+
+All timestamps are UTC and **truncated to microseconds** before persistence so records survive a Postgres round-trip unchanged (the `finance/ledger` replay trap — `timestamptz` is microsecond-precision, Go's `time.Time` is nanosecond).
+
+```go
+type SubmitParams struct {
+    Meta      map[string]string // free-form context, cloned on submit
+    Requester string            // required — the maker
+    Tenant    string            // optional; must agree with WithScope when set
+    Reason    string            // why the action is being requested
+}
+
+// Actor is the human acting on a request — the checker casting a decision,
+// or the party cancelling. It carries an access.Subject rather than a bare
+// id so the decider has real attributes to judge on. Executors are machines
+// and pass a plain executor string instead.
+type Actor struct {
+    Subject access.Subject
+    Reason  string
+}
+
+type Filter struct {
+    // Statuses matches the STORED status. Expired is never stored (it is
+    // derived on read), so listing it matches nothing — query
+    // Statuses: []Status{Pending, Approved} with ExpiresBefore instead.
+    Statuses      []Status
+    ExpiresBefore time.Time // zero = no bound
+    Kind          string
+    Tenant        string
+    Requester     string
+    Limit         int // 0 = store default
+}
+```
+
+## API
+
+```go
+func New(store Store, opts ...Option) *Manager
+
+// Typed edges.
+func Submit[T any](ctx context.Context, m *Manager, k Kind[T], payload T, p SubmitParams) (Request, error)
+func PayloadOf[T any](k Kind[T], r Request) (T, error)
+
+// Reads.
+func (m *Manager) Get(ctx context.Context, reqID id.UUID) (Request, error)
+func (m *Manager) List(ctx context.Context, f Filter) ([]Request, error)
+
+// Decisions.
+func (m *Manager) Approve(ctx context.Context, reqID id.UUID, a Actor) (Request, error)
+func (m *Manager) Reject(ctx context.Context, reqID id.UUID, a Actor) (Request, error)
+func (m *Manager) Cancel(ctx context.Context, reqID id.UUID, a Actor) (Request, error)
+
+// Execute-once lease. Executors are machines, so these take a plain
+// executor id rather than an Actor.
+func (m *Manager) Claim(ctx context.Context, reqID id.UUID, executor string) (Request, error)
+func (m *Manager) Complete(ctx context.Context, reqID id.UUID, executor string) (Request, error)
+func (m *Manager) Fail(ctx context.Context, reqID id.UUID, executor, reason string) (Request, error)
+
+// Release is the administrative escape hatch for a request wedged in
+// Executing by a dead executor. It is deliberately NOT holder-checked —
+// the holder is the party that cannot call it. Consumers gate access to
+// it; every call is audited.
+func (m *Manager) Release(ctx context.Context, reqID id.UUID, a Actor) (Request, error)
+
+// Execute wraps Claim -> fn -> Complete/Fail so the trio cannot be miswired.
+// A non-nil fn error transitions to Failed and is returned joined with any
+// transition error. ErrAlreadyClaimed is returned as-is: another executor won.
+func (m *Manager) Execute(ctx context.Context, reqID id.UUID, executor string, fn func(context.Context, Request) error) (Request, error)
+```
+
+`New` panics on: nil store, duplicate kind name, `Quorum < 1`, negative `TTL`/`ClaimTTL`. These are startup wiring bugs, matching `apikey.New`'s nil-store panic and `guard.New`'s nil-verifier panic.
+
+### Options
+
+```go
+func WithKind[T any](k Kind[T], p Policy) Option // accumulating; generic func returning Option
+func WithDecider(d access.Decider) Option
+func WithAuditor(rec *auditlog.Recorder) Option
+func WithScope(fn func(context.Context) (string, error)) Option
+func WithClock(c clock.Clock) Option
+func WithMaxRetries(n int) Option // CAS retry attempts, default 3
+```
+
+`WithKind` is a generic function returning a plain `Option`, so kinds enter `New` as accumulating options rather than a post-construction `Register` method. This follows the `abac` `WithRules` ruling: builder values enter `New` via accumulating options, never a mutating builder on a live object. It also means the registry is immutable after `New` and needs no lock on the read path.
+
+## State machine
+
+```
+                    ┌──────────► Rejected      (a single VoteReject; terminal)
+                    │
+                    ├──────────► Cancelled     (requester/admin; terminal)
+                    │
+  submit ──► Pending┤
+                    │
+                    ├──────────► Expired       (TTL elapsed; derived on read)
+                    │
+                    └─quorum──► Approved
+                                   │
+                                   ├──► Expired    (TTL elapsed before claim)
+                                   │
+                                   └─Claim──► Executing ──Complete──► Executed
+                                                    │
+                                                    ├──Fail─────────► Failed
+                                                    │
+                                                    └──Release──────► Approved
+```
+
+Transition rules:
+
+1. **Votes are legal only from `Pending`.** Any other status → `ErrNotPending`.
+2. **A single `Reject` is terminal.** No reject quorum. One checker saying no ends it.
+3. **Quorum counts distinct approvers.** The Nth distinct `VoteApprove` sets `Approved` and stamps `DecidedAt`.
+4. **`Cancel` is legal from `Pending` and `Approved`.** Not from `Executing` — an in-flight action is not cancellable; use `Fail`. The requester may always cancel their own request; any other actor is gated on `<kind>:cancel` when a decider is set (see Eligibility).
+5. **`Claim` is legal only from `Approved`.** From `Executing`, it succeeds only when the existing claim is stale (`ClaimTTL > 0` and `ClaimedAt + ClaimTTL <= now`) — otherwise `ErrAlreadyClaimed`.
+6. **`Complete`/`Fail` are legal only from `Executing`** (`ErrNotExecuting` otherwise) **and only for the current `ClaimedBy` holder** (`ErrNotClaimHolder` otherwise).
+7. **`Release` is legal only from `Executing`** (`ErrNotExecuting` otherwise) and is **not** holder-checked — it exists precisely for the case where the holder is dead. It returns the request to `Approved` and clears `ClaimedBy`/`ClaimedAt`.
+
+### Structural invariants (not configurable off)
+
+- **No self-approval.** `Actor.Subject.ID == Request.Requester` → `ErrSelfApproval`, for both `Approve` and `Reject`. This holds at `Quorum: 1` too — which is precisely why `Quorum: 1` is still dual control and must be documented as such.
+- **One vote per approver.** A second decision from the same `Subject.ID` → `ErrAlreadyVoted`, whichever way they voted the first time.
+- **A rejected request never becomes approved.** Guaranteed by rule 1 + rule 2.
+
+## Eligibility
+
+When `WithDecider` is set, every `Approve` and `Reject` first asks the decision seam:
+
+```go
+dec, err := access.Authorize(ctx, decider, a.Subject,
+    access.Action(r.Kind+":decide"),
+    access.Resource{
+        Type:   "approval",
+        ID:     r.ID.String(),
+        Tenant: r.Tenant,
+        Attrs: map[string]any{
+            "kind":      r.Kind,
+            "requester": r.Requester,
+            "payload":   r.Payload, // json.RawMessage; decoded only if a rule cares
+        },
+    })
+```
+
+- **One action, `<kind>:decide`, for both votes.** Being a checker is the privilege; which way the checker votes is not a separate grant. Rejection is gated too — an ungated reject lets anyone DoS the approval queue.
+- **`Cancel` by a non-requester uses `<kind>:cancel`,** a distinct action: withdrawing someone else's request is a different privilege from judging it, and a policy that grants one need not grant the other. The requester short-circuits this check — withdrawing your own request is never gated.
+- **`Attrs` carries `requester` and the raw `payload`.** `requester` enables relational policies ("must be the requester's manager"); the raw payload enables value-aware policies ("over 10 days needs the department head") without forcing a decode on rules that don't care.
+- **Fail closed.** `Deny` → `ErrNotEligible`. A decider *error* → `ErrNotEligible` with the underlying error wrapped (`access.Authorize` already collapses errors to Deny). The decider's `Reason` may carry internal detail and must not be echoed to clients verbatim — same warning `access.Decision` documents.
+- **The decider runs last.** Check order is: load → expiry → status → self-approval → already-voted → eligibility → CAS. Cheap local invariants reject first; the decider may hit a database or an org chart, so it only runs once the vote is otherwise legal. Every attempt that reaches the decider and is denied is audited.
+
+Without `WithDecider`, any non-requester may vote. That is the correct single-team default and is documented as such: the structural invariants still hold.
+
+## Expiry
+
+Lazy, evaluated on read — no background goroutine.
+
+- `Submit` stamps `ExpiresAt = now + Policy.TTL` (zero TTL → zero `ExpiresAt`, never expires).
+- Any load of a `Pending` or `Approved` request whose `ExpiresAt` is non-zero and `<= now` reports `Status: Expired`. Every transition on it fails with `ErrExpired`.
+- Expiry is **derived, not written**. The stored row keeps its last written status; the effective status is computed on read. This avoids a write on the read path and keeps expiry correct without a sweeper.
+- `Executing` does **not** expire — an in-flight action is governed by `ClaimTTL`, not `TTL`.
+- Consumers who want expired rows materialized, or who want to nudge approvers before expiry, use `Filter.ExpiresBefore` on their own schedule.
+
+**`List` semantics with lazy expiry:** `Filter.Statuses` matches the *stored* status in the store query. The Manager applies expiry to each returned record and then drops records whose effective status no longer matches the requested set. Consequence: `List` returns *up to* `Limit` records, and a `Statuses: [Pending]` query may return fewer than the store matched. This is documented on `Filter`.
+
+## Store
+
+```go
+// Store persists approval requests. Implementations must be safe for
+// concurrent use.
+type Store interface {
+    // Create persists a new request. ErrDuplicate when the ID exists.
+    Create(ctx context.Context, r Request) error
+
+    // Get loads one request. ErrNotFound for unknown ids.
+    Get(ctx context.Context, reqID id.UUID) (Request, error)
+
+    // List returns matching requests, newest first (UUIDv7 id order).
+    List(ctx context.Context, f Filter) ([]Request, error)
+
+    // Update persists r only when the stored Version equals expect,
+    // otherwise ErrConflict. Implementations persist r with Version
+    // expect+1. This is the package's only concurrency primitive.
+    Update(ctx context.Context, r Request, expect int64) error
+}
+```
+
+Rationale for whole-record CAS over first-class decision rows: one primitive is the smallest thing a third-party store author can implement correctly, the quorum math stays in the package where it is tested, and "did this vote tip us to Approved" needs its own CAS regardless. Decisions ride a JSON column. Maker-checker volumes are single-digit approvers per request, so the read-modify-write is cheap; the benchmark proves it.
+
+Implementations may normalize nil vs. empty `Decisions`/`Meta` in either direction; callers must not depend on which form comes back.
+
+### CAS retry loop
+
+Every mutating transition is:
+
+```
+for attempt := 0; attempt <= maxRetries; attempt++ {
+    r := load(ctx, reqID)          // fresh read each attempt
+    applyExpiry(&r)
+    validate(r)                    // status, self-approval, already-voted — re-checked every attempt
+    next := transition(r)
+    if err := store.Update(ctx, next, r.Version); errors.Is(err, ErrConflict) {
+        continue
+    }
+    return next, err
+}
+return Request{}, ErrConflict
+```
+
+Re-validating inside the loop is load-bearing: without it, a retry after a lost race could apply a second vote from an approver whose first vote landed in the winning write, or push a request past quorum.
+
+### memory.go
+
+Mutex-guarded `map[id.UUID]Request`. Stores deep copies (`slices.Clone` on `Decisions`, `maps.Clone` on `Meta`) on the way in and out so callers cannot mutate stored state through a returned `Request` — the aliasing bug this package cannot afford. Suitable for tests and single-process dev; not durable.
+
+### pgstore
+
+Table `forge_approval_requests`:
+
+```sql
+CREATE TABLE forge_approval_requests (
+    id          uuid PRIMARY KEY,
+    kind        text NOT NULL,
+    tenant      text NOT NULL DEFAULT '',
+    requester   text NOT NULL,
+    status      smallint NOT NULL,
+    version     bigint NOT NULL DEFAULT 1,
+    payload     json NOT NULL,
+    decisions   json NOT NULL DEFAULT '[]'::json,
+    meta        jsonb NOT NULL DEFAULT '{}'::jsonb,
+    claimed_by  text NOT NULL DEFAULT '',
+    created_at  timestamptz NOT NULL,
+    expires_at  timestamptz,
+    claimed_at  timestamptz,
+    decided_at  timestamptz
+);
+
+CREATE INDEX forge_approval_requests_list_idx
+    ON forge_approval_requests (tenant, kind, status, id DESC);
+
+CREATE INDEX forge_approval_requests_expiry_idx
+    ON forge_approval_requests (status, expires_at)
+    WHERE expires_at IS NOT NULL;
+```
+
+- `payload` and `decisions` are `json`, not `jsonb`: byte-exact round-trip, no reparse/rewrite cost, and neither is queried by content (the `async/workflow` state ruling). `meta` is `jsonb` — it is small and consumers may want to index it.
+- The list index covers the `Filter` WHERE columns in filter order (the `async/outbox` claim-index lesson: an index that does not cover the filter is not used).
+- `Update` is `UPDATE ... SET ..., version = version + 1 WHERE id = $1 AND version = $2`; zero rows affected → distinguish `ErrConflict` from `ErrNotFound` with a follow-up existence check.
+- Migrations follow the `apikey/pgstore` shape: `//go:embed migrations/*.sql`, `fs.Sub` rooting, applied under its own version table `forge_approval_schema` (a distinct group name — colliding groups silently skip).
+
+## Tenancy
+
+Standard forge seam. `WithScope(fn)` derives the tenant from context:
+
+- `Submit` stamps the scoped tenant; an explicitly-passed `SubmitParams.Tenant` must be empty or equal to it.
+- `Get` and every transition report `ErrNotFound` for other tenants' requests — not `ErrScope`, so the API does not confirm the existence of out-of-tenant records.
+- `List` is confined to the scoped tenant.
+- Fail closed: a hook error or an empty scoped tenant aborts with `ErrScope`.
+- Without the hook, single-tenant use pays zero ceremony and `Tenant` stays `""`.
+
+## Audit
+
+`WithAuditor(rec)` emits one `auditlog.Event` per state-changing call:
+
+| Call | Action | Outcome |
+| --- | --- | --- |
+| `Submit` | `approval.submit` | success |
+| `Approve` | `approval.approve` | success |
+| `Reject` | `approval.reject` | success |
+| ineligible vote attempt | `approval.approve` / `approval.reject` | **denied** |
+| `Cancel` | `approval.cancel` | success |
+| ineligible cancel attempt | `approval.cancel` | **denied** |
+| `Claim` | `approval.claim` | success |
+| `Complete` | `approval.complete` | success |
+| `Fail` | `approval.fail` | failure |
+| `Release` | `approval.release` | success |
+
+- `Actor` = the voter/executor/requester id. `Resource` = `"approval:<uuid>"`. `Tenant` = the request's tenant. `Meta` carries `kind`, `status` (the resulting effective status), and `quorum`/`approvals` on vote events.
+- **Denied attempts are audited.** An ineligible approver trying to push a payout through is the single most security-relevant event this package sees; it must not be invisible.
+- **No event on lazily-observed expiry.** Expiry is derived on every read; emitting there would write an audit event per `Get`.
+- **Ordering: store update first, then audit.** A failed audit write returns the updated `Request` alongside an `ErrAuditFailed`-wrapped error. The transition is durable; the trail write is not, and the caller can `errors.Is` it to page someone. Auditing before the CAS would record transitions that never happened; swallowing the error would be a silent failure in a compliance package.
+
+## Errors
+
+`errors.go`, single-line `errors.Is`-matchable sentinels:
+
+```
+ErrNotFound          ErrDuplicate         ErrConflict
+ErrUnknownKind       ErrKindMismatch      ErrRequesterRequired
+ErrSelfApproval      ErrAlreadyVoted      ErrNotPending
+ErrExpired           ErrNotApproved       ErrAlreadyClaimed
+ErrNotClaimHolder    ErrNotExecuting      ErrNotEligible
+ErrScope             ErrAuditFailed
+```
+
+`ErrNotFound`, `ErrDuplicate`, and `ErrConflict` are the Store contract's sentinels, defined here and returned by every implementation.
+
+## Testing
+
+Black-box (`package approval_test`) throughout; no white-box files anticipated.
+
+- **State machine:** every legal transition, and every illegal one asserted against its specific sentinel. Table-driven over the status matrix.
+- **Structural invariants:** self-approval at `Quorum: 1` and `Quorum: 2`; double-vote from one approver in both directions; reject-after-approve; approve-after-reject.
+- **Concurrency:** N goroutines approving the same request with `Quorum: 2` — exactly two decisions recorded, status `Approved` exactly once, no torn state. Same for `Claim`: N executors, exactly one winner. Run under `-race`.
+- **CAS retry:** a store wrapper that injects `ErrConflict` on the first K attempts proves the retry loop re-validates rather than blindly reapplying — specifically, a vote that lost a race must not be double-recorded.
+- **Expiry:** lazy status on `Get`/`List`; every transition on an expired request; `Approved` expiring before claim; `Executing` *not* expiring under `TTL`.
+- **Claim lease:** stale re-claim with `ClaimTTL > 0`; wedge (no re-claim) with `ClaimTTL == 0`; `Complete`/`Fail` from a non-holder → `ErrNotClaimHolder`; `Release` from a non-holder *succeeds* (the escape hatch) and returns the request to `Approved` for re-claim.
+- **Eligibility:** allow, deny, and decider-error (fail closed); action string and `Attrs` contents asserted via a recording decider; denied attempt audited.
+- **Audit:** event per transition asserted against a memory sink; `ErrAuditFailed` returned with a durable transition when the sink fails.
+- **Tenancy:** cross-tenant `Get`/transition → `ErrNotFound`; `List` confinement; hook error and empty tenant → `ErrScope`; explicit-tenant disagreement rejected.
+- **Store contract:** a shared conformance suite run against `memory` and (integration-tagged) `pgstore`, so both prove the same `ErrConflict`/`ErrNotFound`/`ErrDuplicate` semantics.
+- **pgstore:** `//go:build integration`, testcontainers via `testkit/pgtest`, per-package container. Includes a real concurrent-vote test through Postgres.
+- **Fuzz:** `PayloadOf` against arbitrary stored bytes (must error, never panic).
+
+## Performance
+
+Benchmarks required in `bench_test.go`, with a post-benchmark optimization pass and before/after numbers in the PR:
+
+- `BenchmarkSubmit` — payload marshal + create.
+- `BenchmarkApprove` — the vote path at `Quorum: 2` and at `Quorum: 5`, uncontended.
+- `BenchmarkApproveContended` — parallel voters through the CAS retry loop.
+- `BenchmarkGet` — read + lazy expiry evaluation (the hot read; the approvals inbox hits it per row).
+- `BenchmarkList` — 100 records with status post-filtering.
+- `BenchmarkPayloadOf` — typed decode.
+
+Allocation notes carried into implementation: preallocate `Decisions` to `Quorum` capacity on submit; do not re-marshal the payload on any read path (it is stored and returned as raw bytes); the kind registry is a plain map read without a lock because it is immutable after `New`; `applyExpiry` is a pure timestamp comparison with no allocation.
+
+## Documentation
+
+`doc.go` carries a runnable example of the full payout flow (submit → two approvals → claim → complete) plus the multi-tenant and relational-eligibility variants shown during design. `docs/packages.md` loses its `ops/approval` entry on merge — the catalog lists only unbuilt packages.

--- a/docs/superpowers/specs/2026-07-21-ops-approval-design.md
+++ b/docs/superpowers/specs/2026-07-21-ops-approval-design.md
@@ -51,7 +51,10 @@ consumer ──Submit[T]──► Manager ──CAS──► Store ──► mem
 | `doc.go` | Package doc + runnable example |
 | `approval.go` | `Request`, `Decision`, `Status`, `Vote`, `Kind[T]`, `SubmitParams`, `Actor`, `Filter` |
 | `policy.go` | `Policy`, kind registry entry, validation |
-| `manager.go` | `New`, transitions, CAS retry loop, lazy expiry, scope resolution |
+| `manager.go` | `New`, `Get`, `List`, CAS retry loop, lazy expiry, scope resolution |
+| `submit.go` | `Submit[T]`, `PayloadOf[T]` |
+| `decide.go` | `Approve`, `Reject`, `Cancel` |
+| `execute.go` | `Claim`, `Complete`, `Fail`, `Release`, `Execute` |
 | `eligibility.go` | access.Decider invocation and fail-closed mapping |
 | `audit.go` | auditlog event emission |
 | `store.go` | `Store` interface |
@@ -59,6 +62,7 @@ consumer ──Submit[T]──► Manager ──CAS──► Store ──► mem
 | `options.go` | `type Option func(*config)`, `WithKind`, `WithDecider`, `WithAuditor`, `WithScope`, `WithClock`, `WithMaxRetries` |
 | `errors.go` | `errors.Is`-matchable single-line sentinels |
 | `bench_test.go` | Required benchmarks (see Performance) |
+| `approvaltest/` | Exported Store conformance suite, shared by memory and pgstore |
 | `pgstore/` | Postgres driver + goose migrations + integration tests |
 
 Target ~700–850 LOC for the core package, inside the single-responsibility band.
@@ -133,6 +137,9 @@ type Request struct {
     Tenant    string
     Requester string
     ClaimedBy string
+    // Reason is the maker's justification, captured at submit and shown to
+    // checkers deciding on the request.
+    Reason string
 
     ID      id.UUID
     Version int64
@@ -373,6 +380,7 @@ CREATE TABLE forge_approval_requests (
     status      smallint NOT NULL,
     version     bigint NOT NULL DEFAULT 1,
     payload     json NOT NULL,
+    reason      text NOT NULL DEFAULT '',
     decisions   json NOT NULL DEFAULT '[]'::json,
     meta        jsonb NOT NULL DEFAULT '{}'::jsonb,
     claimed_by  text NOT NULL DEFAULT '',

--- a/ops/approval/approval.go
+++ b/ops/approval/approval.go
@@ -198,7 +198,8 @@ type Filter struct {
 	// derived on read), so listing it matches nothing — query
 	// []Status{Pending, Approved} with ExpiresBefore instead.
 	Statuses []Status
-	// Limit caps the number of records returned. Zero means the store's
-	// default.
+	// Limit caps the number of records returned. Zero defaults to 100; every
+	// Store implementation must apply the same default so swapping stores
+	// cannot silently truncate results.
 	Limit int
 }

--- a/ops/approval/approval.go
+++ b/ops/approval/approval.go
@@ -1,0 +1,204 @@
+package approval
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Status is the lifecycle state of an approval request.
+type Status uint8
+
+// Request statuses. Expired is derived on read from ExpiresAt and is never
+// persisted — see Manager.Get.
+const (
+	Pending   Status = iota // awaiting decisions
+	Approved                // quorum met, awaiting claim
+	Rejected                // a checker rejected it
+	Cancelled               // withdrawn before execution
+	Expired                 // TTL elapsed while Pending or Approved
+	Executing               // claimed by an executor
+	Executed                // executor reported success
+	Failed                  // executor reported failure
+)
+
+// String renders the status for logs, audit metadata, and errors.
+func (s Status) String() string {
+	switch s {
+	case Pending:
+		return "pending"
+	case Approved:
+		return "approved"
+	case Rejected:
+		return "rejected"
+	case Cancelled:
+		return "cancelled"
+	case Expired:
+		return "expired"
+	case Executing:
+		return "executing"
+	case Executed:
+		return "executed"
+	case Failed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+// Terminal reports whether the status admits no further transitions.
+func (s Status) Terminal() bool {
+	switch s {
+	case Rejected, Cancelled, Expired, Executed, Failed:
+		return true
+	default:
+		return false
+	}
+}
+
+// Vote is the direction of a checker's decision.
+type Vote uint8
+
+// Vote directions. The zero value is invalid so an unset Vote cannot pass
+// for an approval.
+const (
+	VoteApprove Vote = iota + 1
+	VoteReject
+)
+
+// String renders the vote for audit metadata.
+func (v Vote) String() string {
+	switch v {
+	case VoteApprove:
+		return "approve"
+	case VoteReject:
+		return "reject"
+	default:
+		return "unknown"
+	}
+}
+
+// Kind binds an approval action name to its payload type T. Declare one
+// package-level Kind per action and share it between the code that submits
+// and the code that executes: the name exists in exactly one place, and
+// payload type drift becomes a compile error.
+//
+//	var KindReleasePayout = approval.NewKind[ReleasePayout]("payout.release")
+type Kind[T any] struct {
+	name string
+}
+
+// NewKind creates a Kind for payload type T. Panics on an empty name:
+// kinds are package-level wiring, not runtime data.
+func NewKind[T any](name string) Kind[T] {
+	if name == "" {
+		panic("approval: NewKind requires a non-empty name")
+	}
+	return Kind[T]{name: name}
+}
+
+// Name returns the action name.
+func (k Kind[T]) Name() string { return k.name }
+
+// Decision is one checker's vote on a request. Decisions are append-only.
+type Decision struct {
+	// At is when the decision was cast, UTC, microsecond precision.
+	At time.Time `json:"at"`
+	// Approver is the deciding subject's id.
+	Approver string `json:"approver"`
+	// Reason is the checker's free-form justification.
+	Reason string `json:"reason,omitempty"`
+	// Vote is the direction of the decision.
+	Vote Vote `json:"vote"`
+}
+
+// Request is one privileged action awaiting dual control.
+type Request struct {
+	// CreatedAt is when the request was submitted.
+	CreatedAt time.Time `json:"created_at"`
+	// ExpiresAt is when the request stops being actionable. Zero means it
+	// never expires.
+	ExpiresAt time.Time `json:"expires_at,omitzero"`
+	// ClaimedAt is when the current executor claimed it. Zero when
+	// unclaimed.
+	ClaimedAt time.Time `json:"claimed_at,omitzero"`
+	// DecidedAt is when the request reached Approved or a terminal status.
+	DecidedAt time.Time `json:"decided_at,omitzero"`
+	// Meta carries free-form submitter context.
+	Meta map[string]string `json:"meta,omitempty"`
+	// Kind is the registered action name.
+	Kind string `json:"kind"`
+	// Tenant is the owning tenant; empty in single-tenant applications.
+	Tenant string `json:"tenant,omitempty"`
+	// Requester is the maker — the principal that submitted the request.
+	Requester string `json:"requester"`
+	// Reason is the maker's justification, shown to checkers.
+	Reason string `json:"reason,omitempty"`
+	// ClaimedBy is the executor currently holding the claim.
+	ClaimedBy string `json:"claimed_by,omitempty"`
+	// Decisions holds every vote cast, in the order cast.
+	Decisions []Decision `json:"decisions,omitempty"`
+	// Payload is the JSON-encoded action payload. Decode it with PayloadOf.
+	Payload json.RawMessage `json:"payload"`
+	// Version is the optimistic-concurrency counter. Store.Update accepts a
+	// write only when the stored value matches.
+	Version int64 `json:"version"`
+	// ID is a time-ordered UUIDv7 assigned at submit.
+	ID id.UUID `json:"id"`
+	// Status is the lifecycle state.
+	Status Status `json:"status"`
+}
+
+// Approvals counts the approving votes cast so far.
+func (r Request) Approvals() int {
+	n := 0
+	for i := range r.Decisions {
+		if r.Decisions[i].Vote == VoteApprove {
+			n++
+		}
+	}
+	return n
+}
+
+// SubmitParams carries the maker's side of a submission.
+type SubmitParams struct {
+	// Meta is free-form context, cloned on submit.
+	Meta map[string]string
+	// Requester is the maker's principal id. Required.
+	Requester string
+	// Tenant is optional; under WithScope it must be empty or equal to the
+	// scoped tenant.
+	Tenant string
+	// Reason is the maker's justification, persisted on the request.
+	Reason string
+}
+
+// Actor is the human acting on a request — a checker casting a decision, or
+// the party cancelling. It carries an access.Subject rather than a bare id
+// so a decider has real attributes to judge on. Executors are machines and
+// pass a plain executor id instead.
+type Actor struct {
+	Reason  string
+	Subject access.Subject
+}
+
+// Filter selects requests for List.
+type Filter struct {
+	// ExpiresBefore bounds ExpiresAt, selecting requests that have expired
+	// or are about to. Zero means no bound. Requests with no expiry are
+	// never matched by it.
+	ExpiresBefore time.Time
+	// Kind, Tenant, and Requester are exact matches; empty means "any".
+	Kind      string
+	Tenant    string
+	Requester string
+	// Statuses matches the STORED status. Expired is never stored (it is
+	// derived on read), so listing it matches nothing — query
+	// []Status{Pending, Approved} with ExpiresBefore instead.
+	Statuses []Status
+	// Limit caps the number of records returned. Zero means the store's
+	// default.
+	Limit int
+}

--- a/ops/approval/approval.go
+++ b/ops/approval/approval.go
@@ -184,6 +184,12 @@ type Actor struct {
 	Subject access.Subject
 }
 
+// DefaultListLimit is the cap List applies when Filter.Limit is zero, so an
+// unbounded filter cannot pull an unbounded result set into memory. Every
+// Store implementation must apply exactly this default — see
+// approvaltest.Run's ListDefaultLimitIsFixed case.
+const DefaultListLimit = 100
+
 // Filter selects requests for List.
 type Filter struct {
 	// ExpiresBefore bounds ExpiresAt, selecting requests that have expired
@@ -198,8 +204,8 @@ type Filter struct {
 	// derived on read), so listing it matches nothing — query
 	// []Status{Pending, Approved} with ExpiresBefore instead.
 	Statuses []Status
-	// Limit caps the number of records returned. Zero defaults to 100; every
-	// Store implementation must apply the same default so swapping stores
-	// cannot silently truncate results.
+	// Limit caps the number of records returned. Zero defaults to
+	// DefaultListLimit; every Store implementation must apply the same
+	// default so swapping stores cannot silently truncate results.
 	Limit int
 }

--- a/ops/approval/approval_test.go
+++ b/ops/approval/approval_test.go
@@ -1,0 +1,52 @@
+package approval_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+func TestStatusString(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		want string
+		s    approval.Status
+	}{
+		{"pending", approval.Pending},
+		{"approved", approval.Approved},
+		{"rejected", approval.Rejected},
+		{"cancelled", approval.Cancelled},
+		{"expired", approval.Expired},
+		{"executing", approval.Executing},
+		{"executed", approval.Executed},
+		{"failed", approval.Failed},
+		{"unknown", approval.Status(99)},
+	} {
+		assert.Equal(t, tc.want, tc.s.String())
+	}
+}
+
+func TestStatusTerminal(t *testing.T) {
+	t.Parallel()
+	terminal := []approval.Status{
+		approval.Rejected, approval.Cancelled, approval.Expired,
+		approval.Executed, approval.Failed,
+	}
+	for _, s := range terminal {
+		assert.True(t, s.Terminal(), "%s must be terminal", s)
+	}
+	nonTerminal := []approval.Status{approval.Pending, approval.Approved, approval.Executing}
+	for _, s := range nonTerminal {
+		assert.False(t, s.Terminal(), "%s must not be terminal", s)
+	}
+}
+
+func TestNewKind(t *testing.T) {
+	t.Parallel()
+	k := approval.NewKind[struct{ A int }]("payout.release")
+	require.Equal(t, "payout.release", k.Name())
+	assert.Panics(t, func() { approval.NewKind[int]("") }, "empty name is a wiring bug")
+}

--- a/ops/approval/approval_test.go
+++ b/ops/approval/approval_test.go
@@ -50,3 +50,41 @@ func TestNewKind(t *testing.T) {
 	require.Equal(t, "payout.release", k.Name())
 	assert.Panics(t, func() { approval.NewKind[int]("") }, "empty name is a wiring bug")
 }
+
+func TestRequestApprovals(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no decisions", func(t *testing.T) {
+		t.Parallel()
+		r := approval.Request{}
+		assert.Equal(t, 0, r.Approvals())
+	})
+
+	t.Run("approvals only", func(t *testing.T) {
+		t.Parallel()
+		r := approval.Request{Decisions: []approval.Decision{
+			{Approver: "bob", Vote: approval.VoteApprove},
+			{Approver: "carol", Vote: approval.VoteApprove},
+		}}
+		assert.Equal(t, 2, r.Approvals())
+	})
+
+	t.Run("rejections only", func(t *testing.T) {
+		t.Parallel()
+		r := approval.Request{Decisions: []approval.Decision{
+			{Approver: "bob", Vote: approval.VoteReject},
+			{Approver: "carol", Vote: approval.VoteReject},
+		}}
+		assert.Equal(t, 0, r.Approvals())
+	})
+
+	t.Run("mixed counts only approvals", func(t *testing.T) {
+		t.Parallel()
+		r := approval.Request{Decisions: []approval.Decision{
+			{Approver: "bob", Vote: approval.VoteApprove},
+			{Approver: "carol", Vote: approval.VoteReject},
+			{Approver: "dave", Vote: approval.VoteApprove},
+		}}
+		assert.Equal(t, 2, r.Approvals())
+	})
+}

--- a/ops/approval/approvaltest/approvaltest.go
+++ b/ops/approval/approvaltest/approvaltest.go
@@ -123,6 +123,13 @@ func Run(t *testing.T, factory func(t *testing.T) approval.Store) {
 		require.Len(t, got.Decisions, 1)
 		assert.Equal(t, "bob", got.Decisions[0].Approver,
 			"a caller must not be able to rewrite a persisted vote")
+
+		got.Decisions[0].Approver = "mallory" // mutate the Get-returned slice too
+		got2, err := s.Get(ctx, r.ID)
+		require.NoError(t, err)
+		require.Len(t, got2.Decisions, 1)
+		assert.Equal(t, "bob", got2.Decisions[0].Approver,
+			"mutating a Get-returned slice must not corrupt the stored copy — read-side isolation")
 	})
 
 	t.Run("DecisionsRoundTrip", func(t *testing.T) {

--- a/ops/approval/approvaltest/approvaltest.go
+++ b/ops/approval/approvaltest/approvaltest.go
@@ -218,13 +218,13 @@ func Run(t *testing.T, factory func(t *testing.T) approval.Store) {
 
 	t.Run("ListDefaultLimitIsFixed", func(t *testing.T) {
 		s, n, ctx := factory(t), newNS(), context.Background()
-		for range 105 {
+		for range approval.DefaultListLimit + 5 {
 			require.NoError(t, s.Create(ctx, n.request("alice", approval.Pending)))
 		}
 
 		got, err := s.List(ctx, approval.Filter{Tenant: n.tenant})
 		require.NoError(t, err)
-		assert.Len(t, got, 100,
-			"a zero Filter.Limit must default to exactly 100 across every Store implementation")
+		assert.Len(t, got, approval.DefaultListLimit,
+			"a zero Filter.Limit must default to exactly approval.DefaultListLimit across every Store implementation")
 	})
 }

--- a/ops/approval/approvaltest/approvaltest.go
+++ b/ops/approval/approvaltest/approvaltest.go
@@ -10,6 +10,9 @@ package approvaltest
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -221,6 +224,57 @@ func Run(t *testing.T, factory func(t *testing.T) approval.Store) {
 		require.NoError(t, err)
 		assert.NotNil(t, got, "nil vs empty must not differ across implementations")
 		assert.Empty(t, got)
+	})
+
+	// ConcurrentUpdateHasExactlyOneWinner exercises the package's one
+	// concurrency primitive under real contention: N goroutines all race
+	// Store.Update on the same record from the same expected version. A
+	// non-atomic implementation (e.g. read-then-write without a single
+	// atomic compare-and-swap) could let more than one of them believe it
+	// won, which is exactly the double-counted-vote defect the CAS exists
+	// to prevent — see Store's doc comment. This is the suite's only
+	// direct test of that atomicity; every other case only ever drives
+	// Update sequentially.
+	t.Run("ConcurrentUpdateHasExactlyOneWinner", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		base := n.request("alice", approval.Pending)
+		require.NoError(t, s.Create(ctx, base))
+
+		const workers = 8
+		var wg sync.WaitGroup
+		results := make([]error, workers)
+		for i := range workers {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				r := base
+				r.Meta = map[string]string{"worker": strconv.Itoa(i)}
+				results[i] = s.Update(ctx, r, 1)
+			}(i)
+		}
+		wg.Wait()
+
+		var winners, conflicts int
+		winner := -1
+		for i, err := range results {
+			switch {
+			case err == nil:
+				winners++
+				winner = i
+			case errors.Is(err, approval.ErrConflict):
+				conflicts++
+			default:
+				require.NoError(t, err, "an Update racing on a stale version must fail with ErrConflict, nothing else")
+			}
+		}
+		require.Equal(t, 1, winners, "exactly one concurrent Update on the same expected version must succeed")
+		require.Equal(t, workers-1, conflicts, "every loser must report ErrConflict")
+
+		got, err := s.Get(ctx, base.ID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), got.Version, "the stored Version must be expect+1, not double-incremented")
+		assert.Equal(t, strconv.Itoa(winner), got.Meta["worker"],
+			"the stored record must be exactly the winner's write, not a loser's or a merge of both")
 	})
 
 	t.Run("ListDefaultLimitIsFixed", func(t *testing.T) {

--- a/ops/approval/approvaltest/approvaltest.go
+++ b/ops/approval/approvaltest/approvaltest.go
@@ -1,0 +1,218 @@
+// Package approvaltest is the executable contract for approval.Store
+// implementations. Every driver's test suite must call Run; the in-memory
+// store is the reference implementation.
+//
+// Fixtures are namespaced per subtest with a fresh UUID because a real
+// backend's table outlives the test process: deterministic kinds and
+// tenants would collide with a previous run's rows and inflate List counts.
+package approvaltest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+// ns is a per-subtest namespace keeping fixtures disjoint from every other
+// run against the same backend.
+type ns struct{ kind, tenant string }
+
+func newNS() ns {
+	u := id.NewUUID().String()
+	return ns{kind: "kind-" + u, tenant: "tenant-" + u}
+}
+
+func (n ns) request(requester string, status approval.Status) approval.Request {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	return approval.Request{
+		ID:        id.NewUUID(),
+		Kind:      n.kind,
+		Tenant:    n.tenant,
+		Requester: requester,
+		Status:    status,
+		Version:   1,
+		Payload:   json.RawMessage(`{"amount":100}`),
+		CreatedAt: now,
+	}
+}
+
+// Run executes the Store conformance suite. factory must return a fresh or
+// namespace-isolated store each call. The Manager's CAS retry loop depends
+// on these exact semantics, so an implementation that diverges here breaks
+// dual control.
+func Run(t *testing.T, factory func(t *testing.T) approval.Store) {
+	t.Helper()
+
+	t.Run("CreateGetRoundTrip", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		r := n.request("alice", approval.Pending)
+		require.NoError(t, s.Create(ctx, r))
+
+		got, err := s.Get(ctx, r.ID)
+		require.NoError(t, err)
+		assert.Equal(t, r.ID, got.ID)
+		assert.Equal(t, r.Kind, got.Kind)
+		assert.Equal(t, r.Requester, got.Requester)
+		assert.Equal(t, approval.Pending, got.Status)
+		assert.Equal(t, int64(1), got.Version)
+		assert.JSONEq(t, string(r.Payload), string(got.Payload))
+		assert.True(t, r.CreatedAt.Equal(got.CreatedAt), "timestamps survive the round-trip")
+	})
+
+	t.Run("CreateRejectsDuplicateID", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		r := n.request("alice", approval.Pending)
+		require.NoError(t, s.Create(ctx, r))
+		assert.ErrorIs(t, s.Create(ctx, r), approval.ErrDuplicate)
+	})
+
+	t.Run("GetReportsNotFound", func(t *testing.T) {
+		s := factory(t)
+		_, err := s.Get(context.Background(), id.NewUUID())
+		assert.ErrorIs(t, err, approval.ErrNotFound)
+	})
+
+	t.Run("UpdateAdvancesVersion", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		r := n.request("alice", approval.Pending)
+		require.NoError(t, s.Create(ctx, r))
+
+		r.Status = approval.Approved
+		require.NoError(t, s.Update(ctx, r, 1))
+
+		got, err := s.Get(ctx, r.ID)
+		require.NoError(t, err)
+		assert.Equal(t, approval.Approved, got.Status)
+		assert.Equal(t, int64(2), got.Version, "store sets version to expect+1")
+	})
+
+	t.Run("UpdateConflictsOnStaleVersion", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		r := n.request("alice", approval.Pending)
+		require.NoError(t, s.Create(ctx, r))
+		require.NoError(t, s.Update(ctx, r, 1))
+
+		// A second writer still believing the version is 1 must lose.
+		assert.ErrorIs(t, s.Update(ctx, r, 1), approval.ErrConflict)
+	})
+
+	t.Run("UpdateReportsNotFound", func(t *testing.T) {
+		s, n := factory(t), newNS()
+		assert.ErrorIs(t, s.Update(context.Background(), n.request("alice", approval.Pending), 1),
+			approval.ErrNotFound)
+	})
+
+	t.Run("StoredStateIsNotAliased", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		r := n.request("alice", approval.Pending)
+		r.Decisions = []approval.Decision{{
+			At: time.Now().UTC().Truncate(time.Microsecond), Approver: "bob", Vote: approval.VoteApprove,
+		}}
+		require.NoError(t, s.Create(ctx, r))
+
+		r.Decisions[0].Approver = "mallory" // mutate the caller's slice
+		got, err := s.Get(ctx, r.ID)
+		require.NoError(t, err)
+		require.Len(t, got.Decisions, 1)
+		assert.Equal(t, "bob", got.Decisions[0].Approver,
+			"a caller must not be able to rewrite a persisted vote")
+	})
+
+	t.Run("DecisionsRoundTrip", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		at := time.Now().UTC().Truncate(time.Microsecond)
+		r := n.request("alice", approval.Pending)
+		r.Decisions = []approval.Decision{
+			{At: at, Approver: "bob", Reason: "checked", Vote: approval.VoteApprove},
+			{At: at, Approver: "carol", Vote: approval.VoteReject},
+		}
+		require.NoError(t, s.Create(ctx, r))
+
+		got, err := s.Get(ctx, r.ID)
+		require.NoError(t, err)
+		require.Len(t, got.Decisions, 2)
+		assert.Equal(t, "bob", got.Decisions[0].Approver)
+		assert.Equal(t, "checked", got.Decisions[0].Reason)
+		assert.Equal(t, approval.VoteApprove, got.Decisions[0].Vote)
+		assert.Equal(t, approval.VoteReject, got.Decisions[1].Vote)
+		assert.True(t, at.Equal(got.Decisions[0].At))
+	})
+
+	t.Run("ListFilters", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		pending := n.request("alice", approval.Pending)
+		approved := n.request("alice", approval.Approved)
+		otherRequester := n.request("carol", approval.Pending)
+		for _, r := range []approval.Request{pending, approved, otherRequester} {
+			require.NoError(t, s.Create(ctx, r))
+		}
+		// A same-kind row in a different tenant must never leak in.
+		foreign := n.request("alice", approval.Pending)
+		foreign.Tenant = "tenant-" + id.NewUUID().String()
+		require.NoError(t, s.Create(ctx, foreign))
+
+		got, err := s.List(ctx, approval.Filter{
+			Statuses:  []approval.Status{approval.Pending},
+			Kind:      n.kind,
+			Tenant:    n.tenant,
+			Requester: "alice",
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, pending.ID, got[0].ID)
+	})
+
+	t.Run("ListFiltersByExpiryBound", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		now := time.Now().UTC().Truncate(time.Microsecond)
+
+		soon := n.request("alice", approval.Pending)
+		soon.ExpiresAt = now.Add(time.Minute)
+		late := n.request("alice", approval.Pending)
+		late.ExpiresAt = now.Add(time.Hour)
+		never := n.request("alice", approval.Pending)
+		for _, r := range []approval.Request{soon, late, never} {
+			require.NoError(t, s.Create(ctx, r))
+		}
+
+		got, err := s.List(ctx, approval.Filter{
+			Tenant:        n.tenant,
+			ExpiresBefore: now.Add(10 * time.Minute),
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1, "never-expiring rows are excluded from an expiry bound")
+		assert.Equal(t, soon.ID, got[0].ID)
+	})
+
+	t.Run("ListLimitAndOrder", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		var ids []id.UUID
+		for range 5 {
+			r := n.request("alice", approval.Pending)
+			require.NoError(t, s.Create(ctx, r))
+			ids = append(ids, r.ID)
+			time.Sleep(2 * time.Millisecond) // UUIDv7 order is millisecond-grained
+		}
+
+		got, err := s.List(ctx, approval.Filter{Tenant: n.tenant, Limit: 2})
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.Equal(t, ids[4], got[0].ID, "newest first")
+		assert.Equal(t, ids[3], got[1].ID)
+	})
+
+	t.Run("ListReturnsNonNilEmpty", func(t *testing.T) {
+		s := factory(t)
+		got, err := s.List(context.Background(), approval.Filter{Kind: "kind-" + id.NewUUID().String()})
+		require.NoError(t, err)
+		assert.NotNil(t, got, "nil vs empty must not differ across implementations")
+		assert.Empty(t, got)
+	})
+}

--- a/ops/approval/approvaltest/approvaltest.go
+++ b/ops/approval/approvaltest/approvaltest.go
@@ -215,4 +215,16 @@ func Run(t *testing.T, factory func(t *testing.T) approval.Store) {
 		assert.NotNil(t, got, "nil vs empty must not differ across implementations")
 		assert.Empty(t, got)
 	})
+
+	t.Run("ListDefaultLimitIsFixed", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		for range 105 {
+			require.NoError(t, s.Create(ctx, n.request("alice", approval.Pending)))
+		}
+
+		got, err := s.List(ctx, approval.Filter{Tenant: n.tenant})
+		require.NoError(t, err)
+		assert.Len(t, got, 100,
+			"a zero Filter.Limit must default to exactly 100 across every Store implementation")
+	})
 }

--- a/ops/approval/audit.go
+++ b/ops/approval/audit.go
@@ -51,7 +51,11 @@ func (m *Manager) audit(ctx context.Context, r Request, action, actor, outcome, 
 // auditDenied records a refused attempt. An ineligible actor trying to push
 // a request through is the most security-relevant event this package sees,
 // so it is never invisible — even though no state changed.
-func (m *Manager) auditDenied(ctx context.Context, reqID id.UUID, action, actor string, cause error) error {
+//
+// tenant is the request's own tenant (empty when unscoped), not the
+// caller's — that's what lets a denied event be attributed to the right
+// tenant in the trail.
+func (m *Manager) auditDenied(ctx context.Context, reqID id.UUID, action, actor, tenant string, cause error) error {
 	if m.cfg.auditor == nil {
 		return nil
 	}
@@ -60,6 +64,7 @@ func (m *Manager) auditDenied(ctx context.Context, reqID id.UUID, action, actor 
 		Action:   action,
 		Resource: "approval:" + reqID.String(),
 		Outcome:  auditlog.OutcomeDenied,
+		Tenant:   tenant,
 		Meta:     map[string]string{"cause": cause.Error()},
 	})
 	if err != nil {

--- a/ops/approval/audit.go
+++ b/ops/approval/audit.go
@@ -1,0 +1,69 @@
+package approval
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/auditlog"
+)
+
+// audit records a completed transition.
+//
+// It runs AFTER the store write, never before: auditing first would record
+// transitions that a lost CAS race then discarded. The cost of that
+// ordering is that a failed trail write cannot undo a durable transition,
+// so the caller gets the updated Request AND an ErrAuditFailed-wrapped
+// error. Match it with errors.Is and alert — in a dual-control package a
+// silent gap in the trail is the failure mode that matters.
+func (m *Manager) audit(ctx context.Context, r Request, action, actor, outcome, reason string) error {
+	if m.cfg.auditor == nil {
+		return nil
+	}
+	meta := map[string]string{
+		"kind":   r.Kind,
+		"status": r.Status.String(),
+	}
+	if reason != "" {
+		meta["reason"] = reason
+	}
+	if action == actionApprove || action == actionReject {
+		if pol, ok := m.policyFor(r.Kind); ok {
+			meta["quorum"] = strconv.Itoa(pol.Quorum)
+			meta["approvals"] = strconv.Itoa(r.Approvals())
+		}
+	}
+	_, err := m.cfg.auditor.Record(ctx, auditlog.Event{
+		Actor:    actor,
+		Action:   action,
+		Resource: "approval:" + r.ID.String(),
+		Outcome:  auditlog.Outcome(outcome),
+		Tenant:   r.Tenant,
+		Meta:     meta,
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrAuditFailed, err)
+	}
+	return nil
+}
+
+// auditDenied records a refused attempt. An ineligible actor trying to push
+// a request through is the most security-relevant event this package sees,
+// so it is never invisible — even though no state changed.
+func (m *Manager) auditDenied(ctx context.Context, reqID id.UUID, action, actor string, cause error) error {
+	if m.cfg.auditor == nil {
+		return nil
+	}
+	_, err := m.cfg.auditor.Record(ctx, auditlog.Event{
+		Actor:    actor,
+		Action:   action,
+		Resource: "approval:" + reqID.String(),
+		Outcome:  auditlog.OutcomeDenied,
+		Meta:     map[string]string{"cause": cause.Error()},
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrAuditFailed, err)
+	}
+	return nil
+}

--- a/ops/approval/audit.go
+++ b/ops/approval/audit.go
@@ -75,7 +75,7 @@ func (m *Manager) auditDenied(ctx context.Context, reqID id.UUID, action, actor,
 		Meta:     map[string]string{"cause": cause.Error()},
 	})
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrAuditFailed, err)
+		return fmt.Errorf("%w for %s: %w", ErrAuditFailed, action, err)
 	}
 	return nil
 }

--- a/ops/approval/audit.go
+++ b/ops/approval/audit.go
@@ -33,6 +33,9 @@ func (m *Manager) audit(ctx context.Context, r Request, action, actor, outcome, 
 			meta["quorum"] = strconv.Itoa(pol.Quorum)
 			meta["approvals"] = strconv.Itoa(r.Approvals())
 		}
+		if n := len(r.Decisions); n > 0 {
+			meta["vote"] = r.Decisions[n-1].Vote.String()
+		}
 	}
 	_, err := m.cfg.auditor.Record(ctx, auditlog.Event{
 		Actor:    actor,

--- a/ops/approval/audit.go
+++ b/ops/approval/audit.go
@@ -46,7 +46,11 @@ func (m *Manager) audit(ctx context.Context, r Request, action, actor, outcome, 
 		Meta:     meta,
 	})
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrAuditFailed, err)
+		// action is folded in so that two ErrAuditFailed wrappings joined
+		// together (e.g. Execute's claim write and its Complete/Fail write
+		// both failing) remain distinguishable in the error text — see
+		// TestExecuteJoinsDistinctAuditFailures.
+		return fmt.Errorf("%w for %s: %w", ErrAuditFailed, action, err)
 	}
 	return nil
 }

--- a/ops/approval/audit_test.go
+++ b/ops/approval/audit_test.go
@@ -23,10 +23,10 @@ func (failingSink) Write(context.Context, auditlog.Event) error {
 func TestAuditRecordsEveryTransition(t *testing.T) {
 	t.Parallel()
 	sink := auditlog.NewMemorySink()
-	m, r := submitted(t, approval.Policy{Quorum: 1},
-		approval.WithAuditor(auditlog.New(sink)))
+	auditor := auditlog.New(sink)
 	ctx := context.Background()
 
+	m, r := submitted(t, approval.Policy{Quorum: 1}, approval.WithAuditor(auditor))
 	_, err := m.Approve(ctx, r.ID, actor("bob"))
 	require.NoError(t, err)
 	_, err = m.Claim(ctx, r.ID, "worker-1")
@@ -46,11 +46,43 @@ func TestAuditRecordsEveryTransition(t *testing.T) {
 	assert.Equal(t, "approval.approve", events[1].Action)
 	assert.Equal(t, "bob", events[1].Actor)
 	assert.Equal(t, "approved", events[1].Meta["status"])
+	assert.Equal(t, "approve", events[1].Meta["vote"])
 
 	assert.Equal(t, "approval.claim", events[2].Action)
 	assert.Equal(t, "worker-1", events[2].Actor)
 
 	assert.Equal(t, "approval.complete", events[3].Action)
+
+	// A second flow, on its own request, covers Fail.
+	m2, r2 := submitted(t, approval.Policy{Quorum: 1}, approval.WithAuditor(auditor))
+	_, err = m2.Approve(ctx, r2.ID, actor("bob"))
+	require.NoError(t, err)
+	_, err = m2.Claim(ctx, r2.ID, "worker-2")
+	require.NoError(t, err)
+	_, err = m2.Fail(ctx, r2.ID, "worker-2", "gateway down")
+	require.NoError(t, err)
+
+	events = sink.Events()
+	require.Len(t, events, 8)
+	assert.Equal(t, "approval.fail", events[7].Action)
+	assert.Equal(t, "worker-2", events[7].Actor)
+	assert.Equal(t, auditlog.OutcomeFailure, events[7].Outcome)
+	assert.Equal(t, "gateway down", events[7].Meta["reason"])
+
+	// A third flow, on its own request, covers Release.
+	m3, r3 := submitted(t, approval.Policy{Quorum: 1}, approval.WithAuditor(auditor))
+	_, err = m3.Approve(ctx, r3.ID, actor("bob"))
+	require.NoError(t, err)
+	_, err = m3.Claim(ctx, r3.ID, "worker-3")
+	require.NoError(t, err)
+	_, err = m3.Release(ctx, r3.ID, actor("ops-oncall"))
+	require.NoError(t, err)
+
+	events = sink.Events()
+	require.Len(t, events, 12)
+	assert.Equal(t, "approval.release", events[11].Action)
+	assert.Equal(t, "ops-oncall", events[11].Actor)
+	assert.Equal(t, auditlog.OutcomeSuccess, events[11].Outcome)
 }
 
 func TestAuditRecordsDeniedAttempts(t *testing.T) {

--- a/ops/approval/audit_test.go
+++ b/ops/approval/audit_test.go
@@ -1,0 +1,110 @@
+package approval_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/ops/approval"
+	"github.com/dmitrymomot/forge/ops/auditlog"
+)
+
+// failingSink rejects every write.
+type failingSink struct{}
+
+func (failingSink) Write(context.Context, auditlog.Event) error {
+	return errors.New("sink unavailable")
+}
+
+func TestAuditRecordsEveryTransition(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	m, r := submitted(t, approval.Policy{Quorum: 1},
+		approval.WithAuditor(auditlog.New(sink)))
+	ctx := context.Background()
+
+	_, err := m.Approve(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+	_, err = m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+	_, err = m.Complete(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	events := sink.Events()
+	require.Len(t, events, 4)
+
+	assert.Equal(t, "approval.submit", events[0].Action)
+	assert.Equal(t, "alice", events[0].Actor)
+	assert.Equal(t, auditlog.OutcomeSuccess, events[0].Outcome)
+	assert.Equal(t, "approval:"+r.ID.String(), events[0].Resource)
+	assert.Equal(t, "payout.release", events[0].Meta["kind"])
+
+	assert.Equal(t, "approval.approve", events[1].Action)
+	assert.Equal(t, "bob", events[1].Actor)
+	assert.Equal(t, "approved", events[1].Meta["status"])
+
+	assert.Equal(t, "approval.claim", events[2].Action)
+	assert.Equal(t, "worker-1", events[2].Actor)
+
+	assert.Equal(t, "approval.complete", events[3].Action)
+}
+
+func TestAuditRecordsDeniedAttempts(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	d := &recordingDecider{effect: access.Deny}
+	m, r := submitted(t, approval.Policy{Quorum: 1},
+		approval.WithDecider(d), approval.WithAuditor(auditlog.New(sink)))
+
+	_, err := m.Approve(context.Background(), r.ID, actor("mallory"))
+	require.ErrorIs(t, err, approval.ErrNotEligible)
+
+	events := sink.Events()
+	require.Len(t, events, 2, "submit + the denied attempt")
+	denied := events[1]
+	assert.Equal(t, "approval.approve", denied.Action)
+	assert.Equal(t, auditlog.OutcomeDenied, denied.Outcome)
+	assert.Equal(t, "mallory", denied.Actor)
+	assert.Equal(t, "approval:"+r.ID.String(), denied.Resource)
+}
+
+// TestAuditFailureReturnsDurableRequest deviates from the task brief's
+// literal test body: the brief built the fixture via submitted(), which
+// asserts require.NoError on Submit — but Submit itself audits, so a sink
+// that fails every write also fails submission, and the helper's own
+// assertion trips before Approve is ever reached. Submitting directly here
+// exercises the identical durable-request-survives-a-failed-trail-write
+// contract, just proven at both transitions (Submit and Approve) instead of
+// only the second.
+func TestAuditFailureReturnsDurableRequest(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 1},
+		approval.WithAuditor(auditlog.New(failingSink{})))
+	ctx := context.Background()
+
+	r, err := approval.Submit(ctx, m, kindPayout,
+		payoutPayload{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice", Reason: "invoice #4471"})
+	require.ErrorIs(t, err, approval.ErrAuditFailed)
+	require.False(t, r.ID.IsZero(), "the request is durable even though the trail write failed")
+
+	got, err := m.Approve(ctx, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrAuditFailed)
+	assert.Equal(t, approval.Approved, got.Status,
+		"the transition is durable even though the trail write failed")
+
+	stored, gerr := m.Get(ctx, r.ID)
+	require.NoError(t, gerr)
+	assert.Equal(t, approval.Approved, stored.Status, "and it really is persisted")
+}
+
+func TestNoAuditorIsSilent(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 1})
+	_, err := m.Approve(context.Background(), r.ID, actor("bob"))
+	assert.NoError(t, err, "the auditor seam is optional")
+}

--- a/ops/approval/audit_test.go
+++ b/ops/approval/audit_test.go
@@ -102,6 +102,50 @@ func TestAuditFailureReturnsDurableRequest(t *testing.T) {
 	assert.Equal(t, approval.Approved, stored.Status, "and it really is persisted")
 }
 
+// TestDeniedVoteAndFailingSinkJoinsBothErrors covers the vote path (backing
+// Approve/Reject): when the decider denies AND the audit sink is down, the
+// caller must still see the original ErrNotEligible alongside ErrAuditFailed
+// — not have it masked entirely.
+func TestDeniedVoteAndFailingSinkJoinsBothErrors(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Deny}
+	m := newManager(t, approval.Policy{Quorum: 1},
+		approval.WithDecider(d), approval.WithAuditor(auditlog.New(failingSink{})))
+	ctx := context.Background()
+
+	r, err := approval.Submit(ctx, m, kindPayout,
+		payoutPayload{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice", Reason: "invoice #4471"})
+	require.ErrorIs(t, err, approval.ErrAuditFailed)
+	require.False(t, r.ID.IsZero())
+
+	_, err = m.Approve(ctx, r.ID, actor("mallory"))
+	assert.ErrorIs(t, err, approval.ErrNotEligible,
+		"the business-rule denial must survive the audit sink also failing")
+	assert.ErrorIs(t, err, approval.ErrAuditFailed)
+}
+
+// TestCancelDeniedAndFailingSinkJoinsBothErrors covers the same defect on
+// the Cancel path.
+func TestCancelDeniedAndFailingSinkJoinsBothErrors(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Deny}
+	m := newManager(t, approval.Policy{Quorum: 2},
+		approval.WithDecider(d), approval.WithAuditor(auditlog.New(failingSink{})))
+	ctx := context.Background()
+
+	r, err := approval.Submit(ctx, m, kindPayout,
+		payoutPayload{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice", Reason: "invoice #4471"})
+	require.ErrorIs(t, err, approval.ErrAuditFailed)
+	require.False(t, r.ID.IsZero())
+
+	_, err = m.Cancel(ctx, r.ID, actor("ops-oncall"))
+	assert.ErrorIs(t, err, approval.ErrNotEligible,
+		"the business-rule denial must survive the audit sink also failing")
+	assert.ErrorIs(t, err, approval.ErrAuditFailed)
+}
+
 func TestNoAuditorIsSilent(t *testing.T) {
 	t.Parallel()
 	m, r := submitted(t, approval.Policy{Quorum: 1})

--- a/ops/approval/bench_test.go
+++ b/ops/approval/bench_test.go
@@ -1,0 +1,176 @@
+package approval_test
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+func benchManager(b *testing.B, p approval.Policy, opts ...approval.Option) *approval.Manager {
+	b.Helper()
+	all := append([]approval.Option{
+		approval.WithKind(kindPayout, p),
+		approval.WithClock(clock.NewMock(fixedNow)),
+	}, opts...)
+	return approval.New(approval.NewMemoryStore(), all...)
+}
+
+func BenchmarkSubmit(b *testing.B) {
+	m := benchManager(b, approval.Policy{Quorum: 2, TTL: 24 * time.Hour})
+	ctx := context.Background()
+	payload := payoutPayload{PayoutID: "po_88", Amount: 250000}
+	p := approval.SubmitParams{Requester: "alice", Reason: "invoice"}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := approval.Submit(ctx, m, kindPayout, payload, p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// benchmarkApprove times a single Approve call on an otherwise-fresh Pending
+// request. Every request it approves must be distinct — approving the same
+// request twice with the same actor hits ErrAlreadyVoted — so the b.N
+// requests are submitted up front and only the Approve calls are timed.
+//
+// This uses the classic b.N loop rather than b.Loop(), because b.N must be
+// known before the timed loop starts to size that fixture pool. Gating the
+// setup with b.StopTimer/b.StartTimer per iteration instead measured mostly
+// timer overhead: on this toolchain that combination inside a b.Loop() loop
+// turned a sub-second benchmark into one that did not finish in minutes.
+func benchmarkApprove(b *testing.B, quorum int) {
+	ctx := context.Background()
+	m := benchManager(b, approval.Policy{Quorum: quorum})
+	reqs := make([]approval.Request, b.N)
+	for i := range reqs {
+		r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+			approval.SubmitParams{Requester: "alice"})
+		if err != nil {
+			b.Fatal(err)
+		}
+		reqs[i] = r
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := m.Approve(ctx, reqs[i].ID, actor("bob")); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkApproveQuorum2(b *testing.B) { benchmarkApprove(b, 2) }
+func BenchmarkApproveQuorum5(b *testing.B) { benchmarkApprove(b, 5) }
+
+func BenchmarkApproveContended(b *testing.B) {
+	m := benchManager(b, approval.Policy{Quorum: 100}, approval.WithMaxRetries(1000))
+	ctx := context.Background()
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	var next atomic.Int64
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// A shared counter keeps approver ids distinct across goroutines,
+			// not just within one. ErrAlreadyVoted/ErrNotPending are the
+			// expected steady state once quorum is met, so ignore errors and
+			// measure the CAS path itself.
+			i := next.Add(1)
+			_, _ = m.Approve(ctx, r.ID, actor("approver-"+strconv.FormatInt(i, 10)))
+		}
+	})
+}
+
+func BenchmarkGet(b *testing.B) {
+	m := benchManager(b, approval.Policy{Quorum: 2, TTL: 24 * time.Hour})
+	ctx := context.Background()
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := m.Get(ctx, r.ID); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkList100(b *testing.B) {
+	m := benchManager(b, approval.Policy{Quorum: 2, TTL: 24 * time.Hour})
+	ctx := context.Background()
+	for range 100 {
+		if _, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+			approval.SubmitParams{Requester: "alice"}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	f := approval.Filter{Statuses: []approval.Status{approval.Pending}}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := m.List(ctx, f); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPayloadOf(b *testing.B) {
+	m := benchManager(b, approval.Policy{Quorum: 2})
+	r, err := approval.Submit(context.Background(), m, kindPayout,
+		payoutPayload{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice"})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := approval.PayloadOf(kindPayout, r); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkApproveWithDecider mirrors benchmarkApprove's fixture-pool
+// approach: b.N Pending requests are submitted up front so only the
+// decider-gated Approve calls are timed.
+func BenchmarkApproveWithDecider(b *testing.B) {
+	allow := access.DeciderFunc(func(context.Context, access.Subject, access.Action, access.Resource) (access.Decision, error) {
+		return access.Allow.Because("bench"), nil
+	})
+	ctx := context.Background()
+	m := benchManager(b, approval.Policy{Quorum: 2}, approval.WithDecider(allow))
+	reqs := make([]approval.Request, b.N)
+	for i := range reqs {
+		r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+			approval.SubmitParams{Requester: "alice"})
+		if err != nil {
+			b.Fatal(err)
+		}
+		reqs[i] = r
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := m.Approve(ctx, reqs[i].ID, actor("bob")); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/ops/approval/bench_test.go
+++ b/ops/approval/bench_test.go
@@ -2,6 +2,7 @@ package approval_test
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/dmitrymomot/forge/auth/access"
 	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/id"
 	"github.com/dmitrymomot/forge/ops/approval"
 )
 
@@ -70,26 +72,68 @@ func benchmarkApprove(b *testing.B, quorum int) {
 func BenchmarkApproveQuorum2(b *testing.B) { benchmarkApprove(b, 2) }
 func BenchmarkApproveQuorum5(b *testing.B) { benchmarkApprove(b, 5) }
 
+// BenchmarkApproveContended measures Approve's CAS-retry path (mutate's
+// optimistic-concurrency loop) under contention that is SUSTAINED across the
+// whole run, not just an initial ramp-up.
+//
+// A single Pending request cannot sustain this alone: once its quorum is
+// met it goes terminal, and every later Approve call on it costs only a
+// cheap Get+early-reject — no CAS, no retry. That was this benchmark's
+// original shape (one request, Quorum: 100) and it does not measure what
+// its name claims: B/op at -benchtime=2000x (7016 B/op) was statistically
+// indistinguishable from a 1,000,000-iteration run (6872 B/op), which is
+// only possible if the ~100-vote contended ramp-up is a negligible sliver
+// of both runs and nearly every iteration in either run was the cheap
+// rejected path, not a real CAS race.
+//
+// Fix: pre-create a pool of many low-quorum Pending requests, sized to
+// b.N/quorum plus headroom, and route every parallel worker through one
+// shared "current" index. All live workers hammer the SAME request at
+// once — quorum is far below the worker count, so simultaneous CAS
+// conflicts are all but guaranteed — and the instant it fills, whichever
+// worker notices advances the shared index so every worker rotates onto a
+// fresh Pending request together. Because the pool is sized off b.N, this
+// keeps the entire run inside the contended CAS path regardless of
+// -benchtime, instead of degenerating into cheap rejects after ~100 votes.
 func BenchmarkApproveContended(b *testing.B) {
-	m := benchManager(b, approval.Policy{Quorum: 100}, approval.WithMaxRetries(1000))
+	const quorum = 4 // well below the worker count: guarantees real simultaneous CAS conflicts per request
+	m := benchManager(b, approval.Policy{Quorum: quorum}, approval.WithMaxRetries(1000))
 	ctx := context.Background()
-	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
-		approval.SubmitParams{Requester: "alice"})
-	if err != nil {
-		b.Fatal(err)
+
+	poolSize := b.N/quorum + 64 // headroom absorbs tail races so the pool never runs dry mid-run
+	reqs := make([]id.UUID, poolSize)
+	for i := range reqs {
+		r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+			approval.SubmitParams{Requester: "alice"})
+		if err != nil {
+			b.Fatal(err)
+		}
+		reqs[i] = r.ID
 	}
 
-	var next atomic.Int64
+	var cur atomic.Int64 // index into reqs of the request every worker is currently contending
+	var approverSeq atomic.Int64
 
 	b.ReportAllocs()
+	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			// A shared counter keeps approver ids distinct across goroutines,
-			// not just within one. ErrAlreadyVoted/ErrNotPending are the
-			// expected steady state once quorum is met, so ignore errors and
-			// measure the CAS path itself.
-			i := next.Add(1)
-			_, _ = m.Approve(ctx, r.ID, actor("approver-"+strconv.FormatInt(i, 10)))
+			approver := actor("approver-" + strconv.FormatInt(approverSeq.Add(1), 10))
+			for {
+				i := cur.Load()
+				if i >= int64(len(reqs)) {
+					break // pool exhausted; headroom keeps this vanishingly rare
+				}
+				_, err := m.Approve(ctx, reqs[i], approver)
+				if err == nil {
+					break
+				}
+				if errors.Is(err, approval.ErrNotPending) || errors.Is(err, approval.ErrExpired) {
+					cur.CompareAndSwap(i, i+1) // whoever notices first rotates every worker forward together
+					continue
+				}
+				b.Fatal(err)
+			}
 		}
 	})
 }

--- a/ops/approval/cancel_test.go
+++ b/ops/approval/cancel_test.go
@@ -1,0 +1,55 @@
+package approval_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+func TestCancelFromPending(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2})
+
+	got, err := m.Cancel(context.Background(), r.ID,
+		approval.Actor{Subject: access.Subject{ID: "alice"}, Reason: "wrong vendor"})
+	require.NoError(t, err)
+	assert.Equal(t, approval.Cancelled, got.Status)
+	assert.True(t, fixedNow.Equal(got.DecidedAt))
+}
+
+func TestCancelFromApproved(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+
+	_, err := m.Approve(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+
+	got, err := m.Cancel(ctx, r.ID, actor("alice"))
+	require.NoError(t, err)
+	assert.Equal(t, approval.Cancelled, got.Status, "approved but unexecuted is still cancellable")
+}
+
+func TestCancelRejectedOnTerminalRequest(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2})
+	ctx := context.Background()
+
+	_, err := m.Reject(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+
+	_, err = m.Cancel(ctx, r.ID, actor("alice"))
+	assert.ErrorIs(t, err, approval.ErrNotCancellable)
+}
+
+func TestCancelRequiresActorID(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2})
+	_, err := m.Cancel(context.Background(), r.ID, approval.Actor{})
+	assert.ErrorIs(t, err, approval.ErrActorRequired)
+}

--- a/ops/approval/cancel_test.go
+++ b/ops/approval/cancel_test.go
@@ -53,3 +53,29 @@ func TestCancelRequiresActorID(t *testing.T) {
 	_, err := m.Cancel(context.Background(), r.ID, approval.Actor{})
 	assert.ErrorIs(t, err, approval.ErrActorRequired)
 }
+
+func TestCancelRejectedWhileExecuting(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	_, err = m.Cancel(ctx, r.ID, actor("alice"))
+	assert.ErrorIs(t, err, approval.ErrNotCancellable, "an in-flight action is not cancellable")
+}
+
+func TestCancelRejectedOnExecutedRequest(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+	_, err = m.Complete(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	_, err = m.Cancel(ctx, r.ID, actor("alice"))
+	assert.ErrorIs(t, err, approval.ErrNotCancellable)
+}

--- a/ops/approval/conflictstore_test.go
+++ b/ops/approval/conflictstore_test.go
@@ -1,0 +1,36 @@
+package approval_test
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+// conflictStore wraps a Store and returns ErrConflict from Update for the
+// first n calls, then delegates. It is a deterministic stand-in for a real
+// CAS race, letting mutate's retry loop be tested without relying on
+// goroutine scheduling.
+//
+// before, if set, runs exactly once — right when the injected calls run
+// out — letting a test commit a "winning" write to the wrapped Store
+// between the losing attempt and the retry that must observe it.
+type conflictStore struct {
+	approval.Store
+	before func()
+	calls  int
+	left   int
+}
+
+func (s *conflictStore) Update(ctx context.Context, r approval.Request, expect int64) error {
+	s.calls++
+	if s.left <= 0 {
+		return s.Store.Update(ctx, r, expect)
+	}
+	s.left--
+	if s.before != nil {
+		before := s.before
+		s.before = nil
+		before()
+	}
+	return approval.ErrConflict
+}

--- a/ops/approval/decide.go
+++ b/ops/approval/decide.go
@@ -2,6 +2,7 @@ package approval
 
 import (
 	"context"
+	"errors"
 
 	"github.com/dmitrymomot/forge/core/id"
 )
@@ -76,11 +77,11 @@ func (m *Manager) vote(ctx context.Context, reqID id.UUID, a Actor, v Vote) (Req
 	if err != nil {
 		if denied {
 			// An ineligible actor trying to push a request through is the
-			// most security-relevant event this package sees. Record it,
-			// and let the audit error win only if the caller has no error
-			// of their own to act on.
+			// most security-relevant event this package sees. Record it, and
+			// join the audit error with the caller's own: errors.Is must still
+			// hold for both the original sentinel and ErrAuditFailed.
 			if aerr := m.auditDenied(ctx, reqID, action, a.Subject.ID, err); aerr != nil {
-				return Request{}, aerr
+				return Request{}, errors.Join(err, aerr)
 			}
 		}
 		return Request{}, err
@@ -121,8 +122,10 @@ func (m *Manager) Cancel(ctx context.Context, reqID id.UUID, a Actor) (Request, 
 	})
 	if err != nil {
 		if denied {
+			// Join, don't drop: the actor's denial and the audit failure are
+			// distinct facts and both must survive errors.Is.
 			if aerr := m.auditDenied(ctx, reqID, actionCancel, a.Subject.ID, err); aerr != nil {
-				return Request{}, aerr
+				return Request{}, errors.Join(err, aerr)
 			}
 		}
 		return Request{}, err

--- a/ops/approval/decide.go
+++ b/ops/approval/decide.go
@@ -1,0 +1,89 @@
+package approval
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Approve records an approving decision from a. When it is the quorum-th
+// distinct approval the request becomes Approved.
+//
+// It refuses the request's own requester (ErrSelfApproval) at every quorum
+// — including quorum 1, which is still dual control — and refuses a second
+// decision from an approver who has already voted (ErrAlreadyVoted).
+func (m *Manager) Approve(ctx context.Context, reqID id.UUID, a Actor) (Request, error) {
+	return m.vote(ctx, reqID, a, VoteApprove)
+}
+
+// Reject records a rejecting decision from a. A single rejection is
+// terminal: there is no reject quorum, because one checker seeing a problem
+// is reason enough to stop.
+func (m *Manager) Reject(ctx context.Context, reqID id.UUID, a Actor) (Request, error) {
+	return m.vote(ctx, reqID, a, VoteReject)
+}
+
+func (m *Manager) vote(ctx context.Context, reqID id.UUID, a Actor, v Vote) (Request, error) {
+	if a.Subject.ID == "" {
+		return Request{}, ErrActorRequired
+	}
+	action := actionApprove
+	if v == VoteReject {
+		action = actionReject
+	}
+
+	var denied bool
+	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		if r.Status != Pending {
+			return statusErr(r.Status)
+		}
+		if r.Requester == a.Subject.ID {
+			return ErrSelfApproval
+		}
+		for i := range r.Decisions {
+			if r.Decisions[i].Approver == a.Subject.ID {
+				return ErrAlreadyVoted
+			}
+		}
+		// The decider runs last: it may hit a database or an org chart, so
+		// it only pays off once the vote is otherwise legal.
+		if err := m.eligible(ctx, *r, a, verbDecide); err != nil {
+			denied = true
+			return err
+		}
+
+		now := m.now()
+		r.Decisions = append(r.Decisions, Decision{
+			At:       now,
+			Approver: a.Subject.ID,
+			Reason:   a.Reason,
+			Vote:     v,
+		})
+		pol, ok := m.policyFor(r.Kind)
+		if !ok {
+			return ErrUnknownKind
+		}
+		switch {
+		case v == VoteReject:
+			r.Status = Rejected
+			r.DecidedAt = now
+		case r.Approvals() >= pol.Quorum:
+			r.Status = Approved
+			r.DecidedAt = now
+		}
+		return nil
+	})
+	if err != nil {
+		if denied {
+			// An ineligible actor trying to push a request through is the
+			// most security-relevant event this package sees. Record it,
+			// and let the audit error win only if the caller has no error
+			// of their own to act on.
+			if aerr := m.auditDenied(ctx, reqID, action, a.Subject.ID, err); aerr != nil {
+				return Request{}, aerr
+			}
+		}
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, action, a.Subject.ID, outcomeSuccess, a.Reason)
+}

--- a/ops/approval/decide.go
+++ b/ops/approval/decide.go
@@ -34,7 +34,9 @@ func (m *Manager) vote(ctx context.Context, reqID id.UUID, a Actor, v Vote) (Req
 	}
 
 	var denied bool
+	var tenant string
 	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		tenant = r.Tenant
 		if r.Status != Pending {
 			return statusErr(r.Status)
 		}
@@ -80,7 +82,7 @@ func (m *Manager) vote(ctx context.Context, reqID id.UUID, a Actor, v Vote) (Req
 			// most security-relevant event this package sees. Record it, and
 			// join the audit error with the caller's own: errors.Is must still
 			// hold for both the original sentinel and ErrAuditFailed.
-			if aerr := m.auditDenied(ctx, reqID, action, a.Subject.ID, err); aerr != nil {
+			if aerr := m.auditDenied(ctx, reqID, action, a.Subject.ID, tenant, err); aerr != nil {
 				return Request{}, errors.Join(err, aerr)
 			}
 		}
@@ -103,7 +105,9 @@ func (m *Manager) Cancel(ctx context.Context, reqID id.UUID, a Actor) (Request, 
 	}
 
 	var denied bool
+	var tenant string
 	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		tenant = r.Tenant
 		if r.Status != Pending && r.Status != Approved {
 			if r.Status == Expired {
 				return ErrExpired
@@ -124,7 +128,7 @@ func (m *Manager) Cancel(ctx context.Context, reqID id.UUID, a Actor) (Request, 
 		if denied {
 			// Join, don't drop: the actor's denial and the audit failure are
 			// distinct facts and both must survive errors.Is.
-			if aerr := m.auditDenied(ctx, reqID, actionCancel, a.Subject.ID, err); aerr != nil {
+			if aerr := m.auditDenied(ctx, reqID, actionCancel, a.Subject.ID, tenant, err); aerr != nil {
 				return Request{}, errors.Join(err, aerr)
 			}
 		}

--- a/ops/approval/decide.go
+++ b/ops/approval/decide.go
@@ -87,3 +87,45 @@ func (m *Manager) vote(ctx context.Context, reqID id.UUID, a Actor, v Vote) (Req
 	}
 	return r, m.audit(ctx, r, action, a.Subject.ID, outcomeSuccess, a.Reason)
 }
+
+// Cancel withdraws a request before it executes. It is legal from Pending
+// and Approved but not from Executing — an in-flight action is not
+// cancellable; the executor reports the outcome with Complete or Fail.
+//
+// The requester may always cancel their own request. Any other actor is
+// gated on "<kind>:cancel" when a decider is configured: withdrawing
+// someone else's request is a different privilege from judging it, and a
+// policy that grants one need not grant the other.
+func (m *Manager) Cancel(ctx context.Context, reqID id.UUID, a Actor) (Request, error) {
+	if a.Subject.ID == "" {
+		return Request{}, ErrActorRequired
+	}
+
+	var denied bool
+	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		if r.Status != Pending && r.Status != Approved {
+			if r.Status == Expired {
+				return ErrExpired
+			}
+			return ErrNotCancellable
+		}
+		if r.Requester != a.Subject.ID {
+			if err := m.eligible(ctx, *r, a, verbCancel); err != nil {
+				denied = true
+				return err
+			}
+		}
+		r.Status = Cancelled
+		r.DecidedAt = m.now()
+		return nil
+	})
+	if err != nil {
+		if denied {
+			if aerr := m.auditDenied(ctx, reqID, actionCancel, a.Subject.ID, err); aerr != nil {
+				return Request{}, aerr
+			}
+		}
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, actionCancel, a.Subject.ID, outcomeSuccess, a.Reason)
+}

--- a/ops/approval/decide.go
+++ b/ops/approval/decide.go
@@ -55,6 +55,10 @@ func (m *Manager) vote(ctx context.Context, reqID id.UUID, a Actor, v Vote) (Req
 			return err
 		}
 
+		pol, ok := m.policyFor(r.Kind)
+		if !ok {
+			return ErrUnknownKind
+		}
 		now := m.now()
 		r.Decisions = append(r.Decisions, Decision{
 			At:       now,
@@ -62,10 +66,6 @@ func (m *Manager) vote(ctx context.Context, reqID id.UUID, a Actor, v Vote) (Req
 			Reason:   a.Reason,
 			Vote:     v,
 		})
-		pol, ok := m.policyFor(r.Kind)
-		if !ok {
-			return ErrUnknownKind
-		}
 		switch {
 		case v == VoteReject:
 			r.Status = Rejected

--- a/ops/approval/decide_test.go
+++ b/ops/approval/decide_test.go
@@ -1,0 +1,171 @@
+package approval_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+// actor builds an Actor for subject id.
+func actor(id string) approval.Actor {
+	return approval.Actor{Subject: access.Subject{ID: id}}
+}
+
+// submitted returns a fresh manager and one Pending request.
+func submitted(t *testing.T, p approval.Policy, extra ...approval.Option) (*approval.Manager, approval.Request) {
+	t.Helper()
+	m := newManager(t, p, extra...)
+	r, err := approval.Submit(context.Background(), m, kindPayout,
+		payoutPayload{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice", Reason: "invoice #4471"})
+	require.NoError(t, err)
+	return m, r
+}
+
+func TestApproveReachesQuorum(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2})
+	ctx := context.Background()
+
+	got, err := m.Approve(ctx, r.ID, approval.Actor{
+		Subject: access.Subject{ID: "bob"}, Reason: "matched to invoice"})
+	require.NoError(t, err)
+	assert.Equal(t, approval.Pending, got.Status, "1 of 2")
+	require.Len(t, got.Decisions, 1)
+	assert.Equal(t, "bob", got.Decisions[0].Approver)
+	assert.Equal(t, approval.VoteApprove, got.Decisions[0].Vote)
+	assert.Equal(t, "matched to invoice", got.Decisions[0].Reason)
+	assert.True(t, got.DecidedAt.IsZero(), "not decided until quorum")
+
+	got, err = m.Approve(ctx, r.ID, actor("carol"))
+	require.NoError(t, err)
+	assert.Equal(t, approval.Approved, got.Status, "2 of 2")
+	assert.Len(t, got.Decisions, 2)
+	assert.True(t, fixedNow.Equal(got.DecidedAt))
+	assert.Equal(t, int64(3), got.Version, "one version bump per vote")
+}
+
+func TestRejectIsTerminalAtOneVote(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 3})
+	ctx := context.Background()
+
+	got, err := m.Reject(ctx, r.ID, approval.Actor{
+		Subject: access.Subject{ID: "bob"}, Reason: "duplicate payment"})
+	require.NoError(t, err)
+	assert.Equal(t, approval.Rejected, got.Status, "one reject ends it regardless of quorum")
+	assert.Equal(t, "duplicate payment", got.Decisions[0].Reason)
+
+	_, err = m.Approve(ctx, r.ID, actor("carol"))
+	assert.ErrorIs(t, err, approval.ErrNotPending, "a rejected request never becomes approved")
+}
+
+func TestSelfApprovalRejected(t *testing.T) {
+	t.Parallel()
+	for _, quorum := range []int{1, 2} {
+		m, r := submitted(t, approval.Policy{Quorum: quorum})
+		_, err := m.Approve(context.Background(), r.ID, actor("alice"))
+		assert.ErrorIs(t, err, approval.ErrSelfApproval,
+			"quorum %d: the maker is never a checker", quorum)
+
+		_, err = m.Reject(context.Background(), r.ID, actor("alice"))
+		assert.ErrorIs(t, err, approval.ErrSelfApproval, "quorum %d: nor may they reject", quorum)
+	}
+}
+
+func TestDoubleVoteRejected(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 3})
+	ctx := context.Background()
+
+	_, err := m.Approve(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrAlreadyVoted)
+
+	_, err = m.Reject(ctx, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrAlreadyVoted, "cannot switch a vote either")
+}
+
+func TestVoteRequiresActorID(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2})
+	_, err := m.Approve(context.Background(), r.ID, approval.Actor{})
+	assert.ErrorIs(t, err, approval.ErrActorRequired)
+}
+
+func TestVoteOnExpiredRequest(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2, TTL: time.Hour}),
+		approval.WithClock(clk))
+	ctx := context.Background()
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	clk.Set(fixedNow.Add(2 * time.Hour))
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrExpired)
+}
+
+func TestVoteOnUnknownRequest(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 2})
+	_, err := m.Approve(context.Background(), id.NewUUID(), actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrNotFound)
+}
+
+// TestConcurrentApprovalsRespectQuorum is the test this whole package
+// exists for: many checkers voting at once must produce exactly one
+// Approved transition and exactly one recorded vote per approver.
+func TestConcurrentApprovalsRespectQuorum(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2},
+		approval.WithMaxRetries(20))
+	ctx := context.Background()
+
+	approvers := []string{"bob", "carol", "dave", "erin", "frank"}
+	var wg sync.WaitGroup
+	errs := make([]error, len(approvers))
+	for i, name := range approvers {
+		wg.Go(func() {
+			_, errs[i] = m.Approve(ctx, r.ID, actor(name))
+		})
+	}
+	wg.Wait()
+
+	got, err := m.Get(ctx, r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, approval.Approved, got.Status)
+	assert.Len(t, got.Decisions, 2, "voting stops at quorum; late voters are refused")
+
+	seen := map[string]bool{}
+	for _, d := range got.Decisions {
+		assert.False(t, seen[d.Approver], "approver %s counted twice", d.Approver)
+		seen[d.Approver] = true
+	}
+
+	var ok, refused int
+	for _, err := range errs {
+		switch {
+		case err == nil:
+			ok++
+		case assert.ErrorIs(t, err, approval.ErrNotPending):
+			refused++
+		}
+	}
+	assert.Equal(t, 2, ok, "exactly quorum many votes succeed")
+	assert.Equal(t, len(approvers)-2, refused)
+}

--- a/ops/approval/doc.go
+++ b/ops/approval/doc.go
@@ -19,8 +19,9 @@
 //
 // Three rules are structural and cannot be configured off: the requester
 // may never decide their own request (at any quorum — Quorum 1 is still
-// dual control), an approver counts once however many times they vote, and
-// a rejected request never becomes approved.
+// dual control), a second decision from an approver who already voted is
+// rejected with ErrAlreadyVoted, and a rejected request never becomes
+// approved.
 //
 // # Executing once
 //

--- a/ops/approval/doc.go
+++ b/ops/approval/doc.go
@@ -1,0 +1,73 @@
+// Package approval implements maker-checker dual control: a privileged
+// action is recorded as a request, a second person approves or rejects it,
+// and exactly one executor carries it out.
+//
+//	var KindReleasePayout = approval.NewKind[ReleasePayout]("payout.release")
+//
+//	m := approval.New(approval.NewMemoryStore(), // pgstore.New(pool) in production
+//		approval.WithKind(KindReleasePayout, approval.Policy{Quorum: 2, TTL: 24 * time.Hour}))
+//
+//	req, err := approval.Submit(ctx, m, KindReleasePayout,
+//		ReleasePayout{PayoutID: "po_88", Amount: amount},
+//		approval.SubmitParams{Requester: "alice", Reason: "vendor invoice #4471"})
+//
+// Checkers vote with Approve and Reject. The quorum-th distinct approval
+// moves the request to Approved; a single rejection is terminal.
+//
+//	req, err := m.Approve(ctx, req.ID, approval.Actor{
+//		Subject: access.Subject{ID: "bob"}, Reason: "matched to invoice"})
+//
+// Three rules are structural and cannot be configured off: the requester
+// may never decide their own request (at any quorum — Quorum 1 is still
+// dual control), an approver counts once however many times they vote, and
+// a rejected request never becomes approved.
+//
+// # Executing once
+//
+// Reaching Approved does not run anything. For actions where running twice
+// is the real danger — releasing a payout, booking a calendar entry — claim
+// the request first: Claim moves it to Executing atomically, so two
+// operators or two racing webhook deliveries produce one winner and one
+// ErrAlreadyClaimed.
+//
+//	done, err := m.Execute(ctx, req.ID, "worker-1", func(ctx context.Context, r approval.Request) error {
+//		p, err := approval.PayloadOf(KindReleasePayout, r)
+//		if err != nil {
+//			return err
+//		}
+//		return payouts.Release(ctx, p.PayoutID, p.Amount)
+//	})
+//
+// Execute wraps Claim, then Complete or Fail. Call them directly when the
+// action spans processes. By default a claim never expires, so an executor
+// that dies mid-action wedges the request until Release is called — the
+// safe default for money. Policy.ClaimTTL opts into automatic takeover, and
+// with it the action must be idempotent.
+//
+// Requests that nobody acts on expire after Policy.TTL. Expiry is derived
+// on read, not swept: a Pending or Approved request past its deadline
+// reports Expired and refuses every transition, with no background
+// goroutine anywhere.
+//
+// # Eligibility, audit, and tenancy
+//
+// WithDecider gates who may vote through the auth/access decision seam,
+// asking "<kind>:decide" with the request's kind, requester, and raw
+// payload as attributes — enough for relational rules ("must be the
+// requester's manager") and value-aware ones. It fails closed: a decider
+// that errors refuses the vote.
+//
+// WithAuditor writes every transition to an ops/auditlog Recorder,
+// including attempts the decider denied. WithScope confines every operation
+// to a context-derived tenant, failing closed when none is available;
+// single-tenant applications pay no ceremony.
+//
+//	m := approval.New(store,
+//		approval.WithKind(KindReleasePayout, approval.Policy{Quorum: 2}),
+//		approval.WithDecider(roles),
+//		approval.WithAuditor(rec),
+//		approval.WithScope(tenantFromContext))
+//
+// State lives behind the Store interface. NewMemoryStore is for tests and
+// development; approval/pgstore persists to Postgres.
+package approval

--- a/ops/approval/eligibility.go
+++ b/ops/approval/eligibility.go
@@ -1,0 +1,47 @@
+package approval
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/auth/access"
+)
+
+// eligible asks the decision seam whether a may act on r.
+//
+// The action is "<kind>:<verb>" — "payout.release:decide" for a vote,
+// "payout.release:cancel" for a third-party withdrawal. Both votes share
+// one verb: being a checker is the privilege, and which way a checker votes
+// is not a separate grant.
+//
+// It fails closed. access.Authorize already collapses Abstain and decider
+// errors into Deny, so anything short of an explicit Allow refuses the
+// action. A decider that cannot reach its data must never let a payout
+// through.
+func (m *Manager) eligible(ctx context.Context, r Request, a Actor, verb string) error {
+	if m.cfg.decider == nil {
+		return nil
+	}
+	res := access.Resource{
+		Type:   "approval",
+		ID:     r.ID.String(),
+		Tenant: r.Tenant,
+		Attrs: map[string]any{
+			"kind":      r.Kind,
+			"requester": r.Requester,
+			// The raw payload, not a decoded map: value-aware rules decode
+			// it themselves, and rules that ignore it pay nothing.
+			"payload": r.Payload,
+		},
+	}
+	dec, err := access.Authorize(ctx, m.cfg.decider, a.Subject, access.Action(r.Kind+":"+verb), res)
+	if err != nil {
+		// Never surface the decider's raw error to the caller: it may carry
+		// internal detail, and the caller sees a generic refusal either way.
+		return fmt.Errorf("%w: %s", ErrNotEligible, "eligibility could not be established")
+	}
+	if dec.Effect != access.Allow {
+		return ErrNotEligible
+	}
+	return nil
+}

--- a/ops/approval/eligibility_test.go
+++ b/ops/approval/eligibility_test.go
@@ -1,0 +1,121 @@
+package approval_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+// recordingDecider captures what the manager asked, and answers with effect.
+type recordingDecider struct {
+	gotAction   access.Action
+	gotResource access.Resource
+	gotSubject  access.Subject
+	effect      access.Effect
+	err         error
+}
+
+func (d *recordingDecider) Decide(_ context.Context, s access.Subject, a access.Action, r access.Resource) (access.Decision, error) {
+	d.gotSubject, d.gotAction, d.gotResource = s, a, r
+	if d.err != nil {
+		return access.Decision{}, d.err
+	}
+	return access.Decision{Effect: d.effect, Reason: "test"}, nil
+}
+
+func TestEligibilityAllows(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Allow}
+	m, r := submitted(t, approval.Policy{Quorum: 1}, approval.WithDecider(d))
+
+	got, err := m.Approve(context.Background(), r.ID, approval.Actor{
+		Subject: access.Subject{ID: "bob", Roles: []string{"finance"}}})
+	require.NoError(t, err)
+	assert.Equal(t, approval.Approved, got.Status)
+
+	assert.Equal(t, access.Action("payout.release:decide"), d.gotAction)
+	assert.Equal(t, "bob", d.gotSubject.ID)
+	assert.Equal(t, []string{"finance"}, d.gotSubject.Roles)
+	assert.Equal(t, "approval", d.gotResource.Type)
+	assert.Equal(t, r.ID.String(), d.gotResource.ID)
+	assert.Equal(t, "payout.release", d.gotResource.Attrs["kind"])
+	assert.Equal(t, "alice", d.gotResource.Attrs["requester"],
+		"relational policies need the requester")
+
+	raw, ok := d.gotResource.Attrs["payload"].(json.RawMessage)
+	require.True(t, ok, "value-aware policies need the raw payload")
+	assert.JSONEq(t, `{"payout_id":"po_88","amount":250000}`, string(raw))
+}
+
+func TestEligibilityDenies(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Deny}
+	m, r := submitted(t, approval.Policy{Quorum: 1}, approval.WithDecider(d))
+
+	_, err := m.Approve(context.Background(), r.ID, actor("dave"))
+	assert.ErrorIs(t, err, approval.ErrNotEligible)
+
+	got, err := m.Get(context.Background(), r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, approval.Pending, got.Status, "a denied vote leaves no trace on the record")
+	assert.Empty(t, got.Decisions)
+}
+
+func TestEligibilityFailsClosedOnDeciderError(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{err: errors.New("org chart unreachable")}
+	m, r := submitted(t, approval.Policy{Quorum: 1}, approval.WithDecider(d))
+
+	_, err := m.Approve(context.Background(), r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrNotEligible,
+		"an unavailable decider must never grant approval")
+}
+
+func TestEligibilityGatesRejectToo(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Deny}
+	m, r := submitted(t, approval.Policy{Quorum: 2}, approval.WithDecider(d))
+
+	_, err := m.Reject(context.Background(), r.ID, actor("mallory"))
+	assert.ErrorIs(t, err, approval.ErrNotEligible,
+		"an ungated reject lets anyone DoS the approval queue")
+	assert.Equal(t, access.Action("payout.release:decide"), d.gotAction)
+}
+
+func TestEligibilityRunsAfterCheapInvariants(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Allow}
+	m, r := submitted(t, approval.Policy{Quorum: 2}, approval.WithDecider(d))
+
+	_, err := m.Approve(context.Background(), r.ID, actor("alice"))
+	require.ErrorIs(t, err, approval.ErrSelfApproval)
+	assert.Empty(t, d.gotAction, "self-approval is refused without consulting the decider")
+}
+
+func TestCancelUsesCancelVerbForNonRequester(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Allow}
+	m, r := submitted(t, approval.Policy{Quorum: 2}, approval.WithDecider(d))
+
+	_, err := m.Cancel(context.Background(), r.ID, actor("ops-oncall"))
+	require.NoError(t, err)
+	assert.Equal(t, access.Action("payout.release:cancel"), d.gotAction)
+}
+
+func TestCancelByRequesterSkipsTheDecider(t *testing.T) {
+	t.Parallel()
+	d := &recordingDecider{effect: access.Deny}
+	m, r := submitted(t, approval.Policy{Quorum: 2}, approval.WithDecider(d))
+
+	got, err := m.Cancel(context.Background(), r.ID, actor("alice"))
+	require.NoError(t, err, "withdrawing your own request is never gated")
+	assert.Equal(t, approval.Cancelled, got.Status)
+	assert.Empty(t, d.gotAction)
+}

--- a/ops/approval/errors.go
+++ b/ops/approval/errors.go
@@ -1,0 +1,84 @@
+package approval
+
+import "errors"
+
+var (
+	// ErrNotFound is returned by a Store when no request matches, and by
+	// Manager operations for other tenants' requests under WithScope (so
+	// cross-tenant existence cannot be probed).
+	ErrNotFound = errors.New("approval: request not found")
+
+	// ErrDuplicate is returned by Store.Create when the ID already exists.
+	ErrDuplicate = errors.New("approval: duplicate request")
+
+	// ErrConflict is returned by Store.Update when the stored Version no
+	// longer matches the expected one. The Manager retries on it.
+	ErrConflict = errors.New("approval: version conflict")
+
+	// ErrUnknownKind rejects a submission for a kind that was not
+	// registered with WithKind.
+	ErrUnknownKind = errors.New("approval: unknown kind")
+
+	// ErrKindMismatch rejects PayloadOf when the Kind does not match the
+	// request's kind — the payload would decode into the wrong type.
+	ErrKindMismatch = errors.New("approval: kind mismatch")
+
+	// ErrRequesterRequired rejects SubmitParams with an empty Requester.
+	ErrRequesterRequired = errors.New("approval: requester required")
+
+	// ErrActorRequired rejects a decision from an Actor with an empty
+	// Subject.ID — an anonymous checker cannot satisfy dual control.
+	ErrActorRequired = errors.New("approval: actor required")
+
+	// ErrExecutorRequired rejects a claim with an empty executor id.
+	ErrExecutorRequired = errors.New("approval: executor required")
+
+	// ErrSelfApproval enforces the maker-checker rule: the requester may
+	// never decide their own request, at any quorum.
+	ErrSelfApproval = errors.New("approval: requester cannot decide own request")
+
+	// ErrAlreadyVoted rejects a second decision from an approver who has
+	// already voted, whichever way they voted first.
+	ErrAlreadyVoted = errors.New("approval: approver already voted")
+
+	// ErrNotPending rejects a decision on a request that is no longer
+	// awaiting one.
+	ErrNotPending = errors.New("approval: request not pending")
+
+	// ErrExpired rejects every transition on a request past its TTL.
+	ErrExpired = errors.New("approval: request expired")
+
+	// ErrNotApproved rejects a claim on a request that has not reached
+	// quorum.
+	ErrNotApproved = errors.New("approval: request not approved")
+
+	// ErrAlreadyClaimed rejects a claim held by another executor whose
+	// lease has not gone stale.
+	ErrAlreadyClaimed = errors.New("approval: request already claimed")
+
+	// ErrNotExecuting rejects Complete, Fail, or Release on a request that
+	// is not currently claimed.
+	ErrNotExecuting = errors.New("approval: request not executing")
+
+	// ErrNotClaimHolder rejects Complete or Fail from an executor other
+	// than the one holding the claim. Release is deliberately exempt.
+	ErrNotClaimHolder = errors.New("approval: executor does not hold the claim")
+
+	// ErrNotCancellable rejects Cancel on a request that is executing or
+	// already terminal.
+	ErrNotCancellable = errors.New("approval: request not cancellable")
+
+	// ErrNotEligible rejects a decision from an actor the decider denied,
+	// or whose eligibility could not be established (fail closed).
+	ErrNotEligible = errors.New("approval: actor not eligible")
+
+	// ErrScope is the fail-closed result of a WithScope hook that errored
+	// or returned an empty tenant, or of a request tenant that disagrees
+	// with the scoped one.
+	ErrScope = errors.New("approval: tenant scope unavailable")
+
+	// ErrAuditFailed reports that a transition was persisted but its audit
+	// event could not be written. The returned Request is durable; the
+	// trail is not. Match it with errors.Is and alert — never swallow it.
+	ErrAuditFailed = errors.New("approval: audit write failed")
+)

--- a/ops/approval/errors.go
+++ b/ops/approval/errors.go
@@ -65,7 +65,8 @@ var (
 	ErrNotClaimHolder = errors.New("approval: executor does not hold the claim")
 
 	// ErrNotCancellable rejects Cancel on a request that is executing or
-	// already terminal.
+	// has already reached a terminal status other than Expired — an expired
+	// request is rejected with ErrExpired instead.
 	ErrNotCancellable = errors.New("approval: request not cancellable")
 
 	// ErrNotEligible rejects a decision from an actor the decider denied,

--- a/ops/approval/example_test.go
+++ b/ops/approval/example_test.go
@@ -1,0 +1,63 @@
+package approval_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+type releasePayout struct {
+	PayoutID string `json:"payout_id"`
+	Amount   int64  `json:"amount"`
+}
+
+var kindRelease = approval.NewKind[releasePayout]("payout.release")
+
+func Example() {
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindRelease, approval.Policy{Quorum: 2}))
+	ctx := context.Background()
+
+	// The maker submits.
+	req, err := approval.Submit(ctx, m, kindRelease,
+		releasePayout{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice", Reason: "vendor invoice #4471"})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("submitted:", req.Status)
+
+	// The maker cannot be a checker.
+	_, err = m.Approve(ctx, req.ID, approval.Actor{Subject: access.Subject{ID: "alice"}})
+	fmt.Println("self-approval:", err)
+
+	// Two checkers approve.
+	got, _ := m.Approve(ctx, req.ID, approval.Actor{Subject: access.Subject{ID: "bob"}})
+	fmt.Println("one of two:", got.Status)
+	got, _ = m.Approve(ctx, req.ID, approval.Actor{Subject: access.Subject{ID: "carol"}})
+	fmt.Println("two of two:", got.Status)
+
+	// Exactly one executor runs the action.
+	done, err := m.Execute(ctx, req.ID, "worker-1", func(ctx context.Context, r approval.Request) error {
+		p, err := approval.PayloadOf(kindRelease, r)
+		if err != nil {
+			return err
+		}
+		fmt.Println("releasing:", p.PayoutID)
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("finished:", done.Status)
+
+	// Output:
+	// submitted: pending
+	// self-approval: approval: requester cannot decide own request
+	// one of two: pending
+	// two of two: approved
+	// releasing: po_88
+	// finished: executed
+}

--- a/ops/approval/execute.go
+++ b/ops/approval/execute.go
@@ -109,10 +109,12 @@ func (m *Manager) Fail(ctx context.Context, reqID id.UUID, executor, reason stri
 //
 // Release does not touch ExpiresAt. A request released past its kind's TTL
 // goes back to Approved in the stored row, but the next read still derives
-// Expired from the unchanged ExpiresAt (see Manager.applyExpiry) and every
-// further transition refuses with ErrExpired — the rescue hatch quietly
-// no-ops for exactly the long-wedged requests it exists for. There is no
-// workaround: submit a new request instead.
+// Expired from the unchanged ExpiresAt (see Manager.applyExpiry): Claim,
+// vote, and Cancel all refuse it with ErrExpired, while Complete, Fail, and
+// Release itself refuse it with ErrNotExecuting because it is no longer
+// Executing — either way the rescue hatch quietly no-ops for exactly the
+// long-wedged requests it exists for. There is no workaround: submit a new
+// request instead.
 func (m *Manager) Release(ctx context.Context, reqID id.UUID, a Actor) (Request, error) {
 	if a.Subject.ID == "" {
 		return Request{}, ErrActorRequired

--- a/ops/approval/execute.go
+++ b/ops/approval/execute.go
@@ -17,6 +17,11 @@ import (
 // has gone stale under the kind's ClaimTTL. With ClaimTTL 0 — the default —
 // a claim is never stale, so an executor that dies mid-action wedges the
 // request until Release is called.
+//
+// Claim is not idempotent for the current holder: retrying after an
+// ambiguous response (e.g. a timeout that hid a successful write) returns
+// ErrAlreadyClaimed rather than reconfirming the caller's own claim, so
+// that error alone does not mean another executor has it.
 func (m *Manager) Claim(ctx context.Context, reqID id.UUID, executor string) (Request, error) {
 	if executor == "" {
 		return Request{}, ErrExecutorRequired
@@ -96,7 +101,10 @@ func (m *Manager) Fail(ctx context.Context, reqID id.UUID, executor, reason stri
 // take it. It is the administrative escape hatch for a request wedged by a
 // dead executor, so it is deliberately NOT holder-checked — the holder is
 // precisely the party that cannot call it. Gate access to it in your own
-// application; every call is audited.
+// application: releasing a live executor's claim lets another executor
+// re-claim and re-run the action — genuine double execution — and the true
+// holder's later Complete then returns ErrNotExecuting, silently discarding
+// a successful completion. Every call is audited.
 func (m *Manager) Release(ctx context.Context, reqID id.UUID, a Actor) (Request, error) {
 	if a.Subject.ID == "" {
 		return Request{}, ErrActorRequired
@@ -128,6 +136,10 @@ func (m *Manager) Release(ctx context.Context, reqID id.UUID, a Actor) (Request,
 // fn runs exactly once per successful claim. Under a non-zero ClaimTTL a
 // stale claim can be taken over, so fn may run more than once across
 // executor deaths — make it idempotent, or leave ClaimTTL at 0.
+//
+// There is no panic recovery: if fn panics, the request stays wedged in
+// Executing (consistent with the crashed-executor philosophy — Release or
+// a ClaimTTL takeover is what recovers it).
 func (m *Manager) Execute(ctx context.Context, reqID id.UUID, executor string, fn func(context.Context, Request) error) (Request, error) {
 	r, err := m.Claim(ctx, reqID, executor)
 	if err != nil {

--- a/ops/approval/execute.go
+++ b/ops/approval/execute.go
@@ -133,6 +133,12 @@ func (m *Manager) Release(ctx context.Context, reqID id.UUID, a Actor) (Request,
 // with any transition error. ErrAlreadyClaimed is returned unwrapped when
 // another executor holds the claim, and fn never runs.
 //
+// A claim that is durable but whose own audit write failed is not a claim
+// failure: fn still runs against the claimed Request, and Complete or Fail
+// still applies normally. The returned error is joined with ErrAuditFailed
+// so the gap in the trail stays visible via errors.Is instead of being
+// silently swallowed by treating the claim as if it had never happened.
+//
 // fn runs exactly once per successful claim. Under a non-zero ClaimTTL a
 // stale claim can be taken over, so fn may run more than once across
 // executor deaths — make it idempotent, or leave ClaimTTL at 0.
@@ -141,15 +147,16 @@ func (m *Manager) Release(ctx context.Context, reqID id.UUID, a Actor) (Request,
 // Executing (consistent with the crashed-executor philosophy — Release or
 // a ClaimTTL takeover is what recovers it).
 func (m *Manager) Execute(ctx context.Context, reqID id.UUID, executor string, fn func(context.Context, Request) error) (Request, error) {
-	r, err := m.Claim(ctx, reqID, executor)
-	if err != nil {
-		return Request{}, err
+	r, claimErr := m.Claim(ctx, reqID, executor)
+	if claimErr != nil && !errors.Is(claimErr, ErrAuditFailed) {
+		return Request{}, claimErr
 	}
 	if err := fn(ctx, r); err != nil {
 		failed, ferr := m.Fail(ctx, reqID, executor, err.Error())
-		return failed, errors.Join(err, ferr)
+		return failed, errors.Join(err, ferr, claimErr)
 	}
-	return m.Complete(ctx, reqID, executor)
+	completed, err := m.Complete(ctx, reqID, executor)
+	return completed, errors.Join(err, claimErr)
 }
 
 // checkHolder gates Complete and Fail on the claim.

--- a/ops/approval/execute.go
+++ b/ops/approval/execute.go
@@ -1,0 +1,152 @@
+package approval
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Claim takes exclusive ownership of an approved request so its action runs
+// once. It is the transition that makes double execution impossible: two
+// operators clicking the same button, or two webhook deliveries racing,
+// produce exactly one winner and one ErrAlreadyClaimed.
+//
+// It is legal only from Approved, or from Executing when the current claim
+// has gone stale under the kind's ClaimTTL. With ClaimTTL 0 — the default —
+// a claim is never stale, so an executor that dies mid-action wedges the
+// request until Release is called.
+func (m *Manager) Claim(ctx context.Context, reqID id.UUID, executor string) (Request, error) {
+	if executor == "" {
+		return Request{}, ErrExecutorRequired
+	}
+	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		switch r.Status {
+		case Approved:
+			// claimable
+		case Executing:
+			pol, ok := m.policyFor(r.Kind)
+			if !ok {
+				return ErrUnknownKind
+			}
+			if pol.ClaimTTL <= 0 {
+				return ErrAlreadyClaimed
+			}
+			if m.now().Before(r.ClaimedAt.Add(pol.ClaimTTL)) {
+				return ErrAlreadyClaimed
+			}
+		case Expired:
+			return ErrExpired
+		default:
+			return ErrNotApproved
+		}
+		r.Status = Executing
+		r.ClaimedBy = executor
+		r.ClaimedAt = m.now()
+		return nil
+	})
+	if err != nil {
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, actionClaim, executor, outcomeSuccess, "")
+}
+
+// Complete records that the claimed action succeeded. Only the executor
+// holding the claim may call it.
+func (m *Manager) Complete(ctx context.Context, reqID id.UUID, executor string) (Request, error) {
+	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		if err := checkHolder(*r, executor); err != nil {
+			return err
+		}
+		r.Status = Executed
+		r.DecidedAt = m.now()
+		return nil
+	})
+	if err != nil {
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, actionComplete, executor, outcomeSuccess, "")
+}
+
+// Fail records that the claimed action failed, storing reason under the
+// "failure" meta key. Only the claim holder may call it. The request is
+// terminal afterwards: re-running it means submitting a new request, which
+// means asking for approval again.
+func (m *Manager) Fail(ctx context.Context, reqID id.UUID, executor, reason string) (Request, error) {
+	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		if err := checkHolder(*r, executor); err != nil {
+			return err
+		}
+		r.Status = Failed
+		r.DecidedAt = m.now()
+		if r.Meta == nil {
+			r.Meta = make(map[string]string, 1)
+		}
+		r.Meta["failure"] = reason
+		return nil
+	})
+	if err != nil {
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, actionFail, executor, outcomeFailure, reason)
+}
+
+// Release returns a claimed request to Approved so another executor can
+// take it. It is the administrative escape hatch for a request wedged by a
+// dead executor, so it is deliberately NOT holder-checked — the holder is
+// precisely the party that cannot call it. Gate access to it in your own
+// application; every call is audited.
+func (m *Manager) Release(ctx context.Context, reqID id.UUID, a Actor) (Request, error) {
+	if a.Subject.ID == "" {
+		return Request{}, ErrActorRequired
+	}
+	r, err := m.mutate(ctx, reqID, func(r *Request) error {
+		if r.Status != Executing {
+			return ErrNotExecuting
+		}
+		r.Status = Approved
+		r.ClaimedBy = ""
+		r.ClaimedAt = time.Time{}
+		return nil
+	})
+	if err != nil {
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, actionRelease, a.Subject.ID, outcomeSuccess, a.Reason)
+}
+
+// Execute claims the request, runs fn, and reports the outcome — the
+// Claim/Complete/Fail trio wired correctly so that forgetting the failure
+// path cannot wedge a request.
+//
+// fn receives the claimed request; decode its payload with PayloadOf. A
+// non-nil fn error transitions the request to Failed and is returned joined
+// with any transition error. ErrAlreadyClaimed is returned unwrapped when
+// another executor holds the claim, and fn never runs.
+//
+// fn runs exactly once per successful claim. Under a non-zero ClaimTTL a
+// stale claim can be taken over, so fn may run more than once across
+// executor deaths — make it idempotent, or leave ClaimTTL at 0.
+func (m *Manager) Execute(ctx context.Context, reqID id.UUID, executor string, fn func(context.Context, Request) error) (Request, error) {
+	r, err := m.Claim(ctx, reqID, executor)
+	if err != nil {
+		return Request{}, err
+	}
+	if err := fn(ctx, r); err != nil {
+		failed, ferr := m.Fail(ctx, reqID, executor, err.Error())
+		return failed, errors.Join(err, ferr)
+	}
+	return m.Complete(ctx, reqID, executor)
+}
+
+// checkHolder gates Complete and Fail on the claim.
+func checkHolder(r Request, executor string) error {
+	if r.Status != Executing {
+		return ErrNotExecuting
+	}
+	if r.ClaimedBy != executor {
+		return ErrNotClaimHolder
+	}
+	return nil
+}

--- a/ops/approval/execute.go
+++ b/ops/approval/execute.go
@@ -105,6 +105,13 @@ func (m *Manager) Fail(ctx context.Context, reqID id.UUID, executor, reason stri
 // re-claim and re-run the action — genuine double execution — and the true
 // holder's later Complete then returns ErrNotExecuting, silently discarding
 // a successful completion. Every call is audited.
+//
+// Release does not touch ExpiresAt. A request released past its kind's TTL
+// goes back to Approved in the stored row, but the next read still derives
+// Expired from the unchanged ExpiresAt (see Manager.applyExpiry) and every
+// further transition refuses with ErrExpired — the rescue hatch quietly
+// no-ops for exactly the long-wedged requests it exists for. There is no
+// workaround: submit a new request instead.
 func (m *Manager) Release(ctx context.Context, reqID id.UUID, a Actor) (Request, error) {
 	if a.Subject.ID == "" {
 		return Request{}, ErrActorRequired

--- a/ops/approval/execute.go
+++ b/ops/approval/execute.go
@@ -75,9 +75,10 @@ func (m *Manager) Complete(ctx context.Context, reqID id.UUID, executor string) 
 }
 
 // Fail records that the claimed action failed, storing reason under the
-// "failure" meta key. Only the claim holder may call it. The request is
-// terminal afterwards: re-running it means submitting a new request, which
-// means asking for approval again.
+// "approval.failure" meta key — namespaced so it cannot silently overwrite
+// a submitter-supplied "failure" key in the request's own Meta. Only the
+// claim holder may call it. The request is terminal afterwards: re-running
+// it means submitting a new request, which means asking for approval again.
 func (m *Manager) Fail(ctx context.Context, reqID id.UUID, executor, reason string) (Request, error) {
 	r, err := m.mutate(ctx, reqID, func(r *Request) error {
 		if err := checkHolder(*r, executor); err != nil {
@@ -88,7 +89,7 @@ func (m *Manager) Fail(ctx context.Context, reqID id.UUID, executor, reason stri
 		if r.Meta == nil {
 			r.Meta = make(map[string]string, 1)
 		}
-		r.Meta["failure"] = reason
+		r.Meta["approval.failure"] = reason
 		return nil
 	})
 	if err != nil {

--- a/ops/approval/execute_test.go
+++ b/ops/approval/execute_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/ops/approval"
+	"github.com/dmitrymomot/forge/ops/auditlog"
 )
 
 // approved returns a manager and a request that has reached quorum.
@@ -239,6 +240,42 @@ func TestExecuteFailsOnActionError(t *testing.T) {
 		func(context.Context, approval.Request) error { return boom })
 	assert.ErrorIs(t, err, boom)
 	assert.Equal(t, approval.Failed, got.Status, "the failure is recorded, not swallowed")
+}
+
+// TestExecuteRunsFnWhenClaimAuditFails guards the fix: Claim returns
+// (r, m.audit(...)), so a durable claim whose trail write failed used to
+// look like a failed claim to Execute, which returned Request{} without
+// ever calling fn — wedging the request in Executing with no way for the
+// caller to recover it. fn must still run and Complete must still apply,
+// with ErrAuditFailed surfacing on the final error rather than vanishing.
+func TestExecuteRunsFnWhenClaimAuditFails(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 1},
+		approval.WithAuditor(auditlog.New(failingSink{})))
+	ctx := context.Background()
+
+	r, err := approval.Submit(ctx, m, kindPayout,
+		payoutPayload{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice"})
+	require.ErrorIs(t, err, approval.ErrAuditFailed)
+
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	require.ErrorIs(t, err, approval.ErrAuditFailed)
+
+	var ran bool
+	var sawPayload payoutPayload
+	got, err := m.Execute(ctx, r.ID, "worker-1", func(_ context.Context, req approval.Request) error {
+		ran = true
+		p, perr := approval.PayloadOf(kindPayout, req)
+		sawPayload = p
+		return perr
+	})
+	assert.ErrorIs(t, err, approval.ErrAuditFailed,
+		"a durable claim whose own audit write failed must stay visible, not vanish")
+	assert.True(t, ran, "fn must run even though the claim's own audit write failed")
+	assert.Equal(t, approval.Executed, got.Status,
+		"the claim was durable, so Complete must still have applied")
+	assert.Equal(t, "po_88", sawPayload.PayoutID)
 }
 
 func TestExecuteYieldsToTheClaimHolder(t *testing.T) {

--- a/ops/approval/execute_test.go
+++ b/ops/approval/execute_test.go
@@ -1,0 +1,258 @@
+package approval_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+// approved returns a manager and a request that has reached quorum.
+func approved(t *testing.T, p approval.Policy, extra ...approval.Option) (*approval.Manager, approval.Request) {
+	t.Helper()
+	m, r := submitted(t, p, extra...)
+	got, err := m.Approve(context.Background(), r.ID, actor("bob"))
+	require.NoError(t, err)
+	require.Equal(t, approval.Approved, got.Status)
+	return m, got
+}
+
+func TestClaimAndComplete(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+
+	got, err := m.Claim(ctx, r.ID, "worker-3")
+	require.NoError(t, err)
+	assert.Equal(t, approval.Executing, got.Status)
+	assert.Equal(t, "worker-3", got.ClaimedBy)
+	assert.True(t, fixedNow.Equal(got.ClaimedAt))
+
+	got, err = m.Complete(ctx, r.ID, "worker-3")
+	require.NoError(t, err)
+	assert.Equal(t, approval.Executed, got.Status)
+	assert.True(t, got.Status.Terminal())
+}
+
+func TestClaimIsExclusive(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	_, err = m.Claim(ctx, r.ID, "worker-2")
+	assert.ErrorIs(t, err, approval.ErrAlreadyClaimed)
+}
+
+func TestClaimRequiresApproved(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 2})
+	_, err := m.Claim(context.Background(), r.ID, "worker-1")
+	assert.ErrorIs(t, err, approval.ErrNotApproved, "a pending request is not executable")
+}
+
+func TestClaimRequiresExecutorID(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	_, err := m.Claim(context.Background(), r.ID, "")
+	assert.ErrorIs(t, err, approval.ErrExecutorRequired)
+}
+
+func TestZeroClaimTTLWedgesUntilRelease(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m, r := approved(t, approval.Policy{Quorum: 1}, approval.WithClock(clk))
+	ctx := context.Background()
+
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	clk.Set(fixedNow.Add(365 * 24 * time.Hour))
+	_, err = m.Claim(ctx, r.ID, "worker-2")
+	assert.ErrorIs(t, err, approval.ErrAlreadyClaimed,
+		"ClaimTTL 0 never lets a second executor in — the safe default for money")
+
+	// Release is the escape hatch, and it is deliberately not holder-checked.
+	got, err := m.Release(ctx, r.ID, actor("ops-oncall"))
+	require.NoError(t, err)
+	assert.Equal(t, approval.Approved, got.Status)
+	assert.Empty(t, got.ClaimedBy)
+	assert.True(t, got.ClaimedAt.IsZero())
+
+	got, err = m.Claim(ctx, r.ID, "worker-2")
+	require.NoError(t, err)
+	assert.Equal(t, "worker-2", got.ClaimedBy)
+}
+
+func TestStaleClaimIsReclaimable(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m, r := approved(t, approval.Policy{Quorum: 1, ClaimTTL: 5 * time.Minute},
+		approval.WithClock(clk))
+	ctx := context.Background()
+
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	clk.Set(fixedNow.Add(time.Minute))
+	_, err = m.Claim(ctx, r.ID, "worker-2")
+	assert.ErrorIs(t, err, approval.ErrAlreadyClaimed, "lease still held")
+
+	clk.Set(fixedNow.Add(5 * time.Minute))
+	got, err := m.Claim(ctx, r.ID, "worker-2")
+	require.NoError(t, err, "lease expired at exactly ClaimTTL")
+	assert.Equal(t, "worker-2", got.ClaimedBy)
+}
+
+func TestCompleteAndFailAreHolderChecked(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	_, err = m.Complete(ctx, r.ID, "worker-2")
+	assert.ErrorIs(t, err, approval.ErrNotClaimHolder)
+
+	_, err = m.Fail(ctx, r.ID, "worker-2", "nope")
+	assert.ErrorIs(t, err, approval.ErrNotClaimHolder)
+}
+
+func TestCompleteRequiresExecuting(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	_, err := m.Complete(context.Background(), r.ID, "worker-1")
+	assert.ErrorIs(t, err, approval.ErrNotExecuting)
+}
+
+func TestFailRecordsReason(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	got, err := m.Fail(ctx, r.ID, "worker-1", "gateway rejected: insufficient funds")
+	require.NoError(t, err)
+	assert.Equal(t, approval.Failed, got.Status)
+	assert.Equal(t, "gateway rejected: insufficient funds", got.Meta["failure"])
+}
+
+func TestApprovedRequestExpiresBeforeClaim(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 1, TTL: time.Hour}),
+		approval.WithClock(clk))
+	ctx := context.Background()
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+
+	clk.Set(fixedNow.Add(2 * time.Hour))
+	_, err = m.Claim(ctx, r.ID, "worker-1")
+	assert.ErrorIs(t, err, approval.ErrExpired, "an approved-but-unexecuted request is not immortal")
+}
+
+func TestExecutingDoesNotExpire(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 1, TTL: time.Hour}),
+		approval.WithClock(clk))
+	ctx := context.Background()
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+	_, err = m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	clk.Set(fixedNow.Add(2 * time.Hour))
+	got, err := m.Complete(ctx, r.ID, "worker-1")
+	require.NoError(t, err, "TTL does not reap an in-flight action; ClaimTTL governs it")
+	assert.Equal(t, approval.Executed, got.Status)
+}
+
+// TestConcurrentClaimsHaveOneWinner is the execute-once guarantee.
+func TestConcurrentClaimsHaveOneWinner(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1}, approval.WithMaxRetries(20))
+	ctx := context.Background()
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, workers)
+	for i := range workers {
+		wg.Go(func() {
+			_, errs[i] = m.Claim(ctx, r.ID, "worker")
+		})
+	}
+	wg.Wait()
+
+	var won int
+	for _, err := range errs {
+		if err == nil {
+			won++
+		} else {
+			assert.ErrorIs(t, err, approval.ErrAlreadyClaimed)
+		}
+	}
+	assert.Equal(t, 1, won, "exactly one executor claims the action")
+}
+
+func TestExecuteWrapsTheTrio(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+
+	var sawPayload payoutPayload
+	got, err := m.Execute(ctx, r.ID, "worker-1", func(ctx context.Context, req approval.Request) error {
+		p, err := approval.PayloadOf(kindPayout, req)
+		require.NoError(t, err)
+		sawPayload = p
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, approval.Executed, got.Status)
+	assert.Equal(t, "po_88", sawPayload.PayoutID)
+}
+
+func TestExecuteFailsOnActionError(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	boom := errors.New("gateway down")
+
+	got, err := m.Execute(context.Background(), r.ID, "worker-1",
+		func(context.Context, approval.Request) error { return boom })
+	assert.ErrorIs(t, err, boom)
+	assert.Equal(t, approval.Failed, got.Status, "the failure is recorded, not swallowed")
+}
+
+func TestExecuteYieldsToTheClaimHolder(t *testing.T) {
+	t.Parallel()
+	m, r := approved(t, approval.Policy{Quorum: 1})
+	ctx := context.Background()
+	_, err := m.Claim(ctx, r.ID, "worker-1")
+	require.NoError(t, err)
+
+	var ran bool
+	_, err = m.Execute(ctx, r.ID, "worker-2", func(context.Context, approval.Request) error {
+		ran = true
+		return nil
+	})
+	assert.ErrorIs(t, err, approval.ErrAlreadyClaimed)
+	assert.False(t, ran, "the action must not run without the claim")
+}

--- a/ops/approval/execute_test.go
+++ b/ops/approval/execute_test.go
@@ -278,6 +278,38 @@ func TestExecuteRunsFnWhenClaimAuditFails(t *testing.T) {
 	assert.Equal(t, "po_88", sawPayload.PayoutID)
 }
 
+// TestExecuteJoinsDistinctAuditFailures covers the ambiguity fix: when
+// BOTH the claim's audit write and the subsequent Complete audit write
+// fail, the joined error must carry two ErrAuditFailed wrappings that are
+// textually distinguishable — a caller reading the error string alone
+// must be able to tell the claim's trail entry and the completion's
+// trail entry apart, not see the same message twice with no way to know
+// which transition lost its record.
+func TestExecuteJoinsDistinctAuditFailures(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 1},
+		approval.WithAuditor(auditlog.New(failingSink{})))
+	ctx := context.Background()
+
+	r, err := approval.Submit(ctx, m, kindPayout,
+		payoutPayload{PayoutID: "po_88"}, approval.SubmitParams{Requester: "alice"})
+	require.ErrorIs(t, err, approval.ErrAuditFailed)
+
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	require.ErrorIs(t, err, approval.ErrAuditFailed)
+
+	got, err := m.Execute(ctx, r.ID, "worker-1",
+		func(context.Context, approval.Request) error { return nil })
+	require.ErrorIs(t, err, approval.ErrAuditFailed)
+	assert.Equal(t, approval.Executed, got.Status, "both durable transitions still applied")
+
+	msg := err.Error()
+	assert.Contains(t, msg, "approval.claim",
+		"the claim's own audit failure must name its transition")
+	assert.Contains(t, msg, "approval.complete",
+		"the completion's audit failure must name its transition, distinctly from the claim's")
+}
+
 func TestExecuteYieldsToTheClaimHolder(t *testing.T) {
 	t.Parallel()
 	m, r := approved(t, approval.Policy{Quorum: 1})

--- a/ops/approval/execute_test.go
+++ b/ops/approval/execute_test.go
@@ -145,7 +145,7 @@ func TestFailRecordsReason(t *testing.T) {
 	got, err := m.Fail(ctx, r.ID, "worker-1", "gateway rejected: insufficient funds")
 	require.NoError(t, err)
 	assert.Equal(t, approval.Failed, got.Status)
-	assert.Equal(t, "gateway rejected: insufficient funds", got.Meta["failure"])
+	assert.Equal(t, "gateway rejected: insufficient funds", got.Meta["approval.failure"])
 }
 
 func TestApprovedRequestExpiresBeforeClaim(t *testing.T) {

--- a/ops/approval/expiry_test.go
+++ b/ops/approval/expiry_test.go
@@ -1,0 +1,81 @@
+package approval_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+func TestGetAppliesLazyExpiry(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2, TTL: time.Hour}),
+		approval.WithClock(clk))
+	ctx := context.Background()
+
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	got, err := m.Get(ctx, r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, approval.Pending, got.Status)
+
+	clk.Set(fixedNow.Add(time.Hour)) // exactly at ExpiresAt
+	got, err = m.Get(ctx, r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, approval.Expired, got.Status, "expiry is inclusive of ExpiresAt")
+}
+
+func TestZeroTTLNeverExpires(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2}),
+		approval.WithClock(clk))
+	ctx := context.Background()
+
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	clk.Set(fixedNow.Add(10 * 365 * 24 * time.Hour))
+	got, err := m.Get(ctx, r.ID)
+	require.NoError(t, err)
+	assert.Equal(t, approval.Pending, got.Status)
+}
+
+func TestListDropsRecordsExpiredOutOfTheFilter(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMock(fixedNow)
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2, TTL: time.Hour}),
+		approval.WithClock(clk))
+	ctx := context.Background()
+
+	_, err := approval.Submit(ctx, m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	got, err := m.List(ctx, approval.Filter{Statuses: []approval.Status{approval.Pending}})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	clk.Set(fixedNow.Add(2 * time.Hour))
+	got, err = m.List(ctx, approval.Filter{Statuses: []approval.Status{approval.Pending}})
+	require.NoError(t, err)
+	assert.Empty(t, got, "the stored row is still Pending but reads as Expired")
+
+	// Unfiltered, it still comes back — carrying the derived status.
+	got, err = m.List(ctx, approval.Filter{})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, approval.Expired, got[0].Status)
+}

--- a/ops/approval/fuzz_test.go
+++ b/ops/approval/fuzz_test.go
@@ -1,0 +1,29 @@
+package approval_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+func FuzzPayloadOf(f *testing.F) {
+	f.Add([]byte(`{"payout_id":"po_1","amount":100}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(``))
+	f.Add([]byte(`{"amount":"not-a-number"}`))
+	f.Add([]byte(`[1,2,3]`))
+	f.Add([]byte("\x00\x01\x02"))
+
+	f.Fuzz(func(t *testing.T, payload []byte) {
+		r := approval.Request{
+			ID:      id.NewUUID(),
+			Kind:    kindPayout.Name(),
+			Payload: json.RawMessage(payload),
+		}
+		// Must never panic; an error is a perfectly good outcome.
+		_, _ = approval.PayloadOf(kindPayout, r)
+	})
+}

--- a/ops/approval/manager.go
+++ b/ops/approval/manager.go
@@ -65,7 +65,12 @@ const (
 	actionApprove  = "approval.approve"
 	actionReject   = "approval.reject"
 	actionCancel   = "approval.cancel"
+	actionClaim    = "approval.claim"
+	actionComplete = "approval.complete"
+	actionFail     = "approval.fail"
+	actionRelease  = "approval.release"
 	outcomeSuccess = "success"
+	outcomeFailure = "failure"
 )
 
 // Eligibility verbs, appended to a kind name to form the access.Action.

--- a/ops/approval/manager.go
+++ b/ops/approval/manager.go
@@ -79,12 +79,6 @@ const (
 	verbCancel = "cancel"
 )
 
-// eligible checks the actor against the decider seam. Landed in Task 9;
-// until then every actor is eligible.
-func (m *Manager) eligible(_ context.Context, _ Request, _ Actor, _ string) error {
-	return nil
-}
-
 // auditDenied records a refused attempt. Landed in Task 10.
 func (m *Manager) auditDenied(_ context.Context, _ id.UUID, _, _ string, _ error) error {
 	return nil

--- a/ops/approval/manager.go
+++ b/ops/approval/manager.go
@@ -2,6 +2,8 @@ package approval
 
 import (
 	"context"
+	"errors"
+	"slices"
 
 	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/core/id"
@@ -91,4 +93,90 @@ func (m *Manager) applyExpiry(r *Request) {
 		return
 	}
 	r.Status = Expired
+}
+
+// List returns requests matching f, newest first, with expiry applied to
+// each record.
+//
+// Filter.Statuses matches the STORED status, so a record that has expired
+// out of the requested set is dropped after the fact: List returns UP TO
+// Limit records, and a Statuses filter may yield fewer than the store
+// matched. Query with no Statuses to see expired records with their derived
+// status.
+func (m *Manager) List(ctx context.Context, f Filter) ([]Request, error) {
+	tenant, err := m.scoped(ctx, f.Tenant)
+	if err != nil {
+		return nil, err
+	}
+	f.Tenant = tenant
+
+	out, err := m.store.List(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+	kept := out[:0]
+	for i := range out {
+		m.applyExpiry(&out[i])
+		if len(f.Statuses) > 0 && !slices.Contains(f.Statuses, out[i].Status) {
+			continue
+		}
+		kept = append(kept, out[i])
+	}
+	return kept, nil
+}
+
+// mutate is the one concurrency primitive every transition rides: read the
+// current record, derive its effective status, let fn validate and apply
+// the transition, then compare-and-swap it back.
+//
+// fn is re-run from a FRESH read on every conflict retry — never from the
+// previous attempt's copy. That re-validation is load-bearing: without it a
+// vote that lost a race could be applied a second time on top of the
+// winner's write, pushing a request past quorum with one approver counted
+// twice.
+//
+//nolint:unused // consumed by Approve/Reject/Cancel/Claim/Complete/Fail/Release, added in Tasks 6-8 of this package's build.
+func (m *Manager) mutate(ctx context.Context, reqID id.UUID, fn func(r *Request) error) (Request, error) {
+	tenant, err := m.scoped(ctx, "")
+	if err != nil {
+		return Request{}, err
+	}
+	for attempt := 0; ; attempt++ {
+		r, err := m.store.Get(ctx, reqID)
+		if err != nil {
+			return Request{}, err
+		}
+		// Report a foreign-tenant request as missing rather than forbidden,
+		// so cross-tenant existence cannot be probed.
+		if tenant != "" && r.Tenant != tenant {
+			return Request{}, ErrNotFound
+		}
+		expect := r.Version
+		m.applyExpiry(&r)
+
+		if err := fn(&r); err != nil {
+			return Request{}, err
+		}
+
+		err = m.store.Update(ctx, r, expect)
+		switch {
+		case err == nil:
+			r.Version = expect + 1
+			return r, nil
+		case !errors.Is(err, ErrConflict):
+			return Request{}, err
+		case attempt >= m.cfg.maxRetries:
+			return Request{}, ErrConflict
+		}
+	}
+}
+
+// statusErr maps a non-Pending status to the sentinel that explains it.
+//
+//nolint:unused // consumed by Tasks 6-8's transitions.
+func statusErr(s Status) error {
+	if s == Expired {
+		return ErrExpired
+	}
+	return ErrNotPending
 }

--- a/ops/approval/manager.go
+++ b/ops/approval/manager.go
@@ -62,8 +62,24 @@ func (m *Manager) audit(_ context.Context, _ Request, _, _, _, _ string) error {
 // Audit action names and outcomes.
 const (
 	actionSubmit   = "approval.submit"
+	actionApprove  = "approval.approve"
+	actionReject   = "approval.reject"
 	outcomeSuccess = "success"
 )
+
+// Eligibility verbs, appended to a kind name to form the access.Action.
+const verbDecide = "decide"
+
+// eligible checks the actor against the decider seam. Landed in Task 9;
+// until then every actor is eligible.
+func (m *Manager) eligible(_ context.Context, _ Request, _ Actor, _ string) error {
+	return nil
+}
+
+// auditDenied records a refused attempt. Landed in Task 10.
+func (m *Manager) auditDenied(_ context.Context, _ id.UUID, _, _ string, _ error) error {
+	return nil
+}
 
 // Get loads one request, with expiry applied: a Pending or Approved
 // request past its ExpiresAt reports Status Expired even though the stored
@@ -134,8 +150,6 @@ func (m *Manager) List(ctx context.Context, f Filter) ([]Request, error) {
 // vote that lost a race could be applied a second time on top of the
 // winner's write, pushing a request past quorum with one approver counted
 // twice.
-//
-//nolint:unused // consumed by Approve/Reject/Cancel/Claim/Complete/Fail/Release, added in Tasks 6-8 of this package's build.
 func (m *Manager) mutate(ctx context.Context, reqID id.UUID, fn func(r *Request) error) (Request, error) {
 	tenant, err := m.scoped(ctx, "")
 	if err != nil {
@@ -172,8 +186,6 @@ func (m *Manager) mutate(ctx context.Context, reqID id.UUID, fn func(r *Request)
 }
 
 // statusErr maps a non-Pending status to the sentinel that explains it.
-//
-//nolint:unused // consumed by Tasks 6-8's transitions.
 func statusErr(s Status) error {
 	if s == Expired {
 		return ErrExpired

--- a/ops/approval/manager.go
+++ b/ops/approval/manager.go
@@ -1,0 +1,78 @@
+package approval
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Manager records approval requests, collects decisions on them, and hands
+// approved requests to exactly one executor. Safe for concurrent use.
+type Manager struct {
+	store Store
+	cfg   config
+}
+
+// New builds a Manager over store. Register at least one kind with
+// WithKind.
+//
+// It panics on a nil store, on a Manager with no registered kinds, and on
+// any invalid policy — wiring bugs caught at startup rather than on the
+// first payout, matching apikey.New's nil-store panic.
+func New(store Store, opts ...Option) *Manager {
+	if store == nil {
+		panic("approval: nil store")
+	}
+	cfg := config{
+		clk:        clock.System(),
+		kinds:      make(map[string]Policy),
+		maxRetries: 3,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if len(cfg.kinds) == 0 {
+		panic("approval: no kinds registered; every submission would fail with ErrUnknownKind")
+	}
+	return &Manager{store: store, cfg: cfg}
+}
+
+// policyFor returns the policy registered for kind. The registry is
+// immutable after New, so this read needs no lock.
+//
+//nolint:unused // consumed by Submit, added in Task 4 of this package's build.
+func (m *Manager) policyFor(kind string) (Policy, bool) {
+	p, ok := m.cfg.kinds[kind]
+	return p, ok
+}
+
+// Get loads one request, with expiry applied: a Pending or Approved
+// request past its ExpiresAt reports Status Expired even though the stored
+// row still carries its last written status.
+func (m *Manager) Get(ctx context.Context, reqID id.UUID) (Request, error) {
+	r, err := m.store.Get(ctx, reqID)
+	if err != nil {
+		return Request{}, err
+	}
+	m.applyExpiry(&r)
+	return r, nil
+}
+
+// applyExpiry derives the effective status of r. Expiry is never written:
+// the stored row keeps its last written status and the effective status is
+// computed on every read, so no sweeper is needed for correctness. Only
+// Pending and Approved expire — an Executing request is governed by its
+// claim lease, not by TTL.
+func (m *Manager) applyExpiry(r *Request) {
+	if r.ExpiresAt.IsZero() {
+		return
+	}
+	if r.Status != Pending && r.Status != Approved {
+		return
+	}
+	if m.cfg.clk.Now().Before(r.ExpiresAt) {
+		return
+	}
+	r.Status = Expired
+}

--- a/ops/approval/manager.go
+++ b/ops/approval/manager.go
@@ -3,6 +3,7 @@ package approval
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/dmitrymomot/forge/core/clock"
@@ -48,10 +49,28 @@ func (m *Manager) policyFor(kind string) (Policy, bool) {
 	return p, ok
 }
 
-// scoped resolves the tenant an operation is confined to. Tenancy lands in
-// Task 11; until then it passes the requested tenant through.
-func (m *Manager) scoped(_ context.Context, requested string) (string, error) {
-	return requested, nil
+// scoped resolves the tenant an operation is confined to.
+//
+// With no WithScope hook it passes the requested tenant through, so
+// single-tenant applications pay nothing. With one, it fails closed: a hook
+// error or an empty tenant aborts with ErrScope rather than silently
+// operating across every tenant, and an explicitly requested tenant must
+// agree with the scoped one.
+func (m *Manager) scoped(ctx context.Context, requested string) (string, error) {
+	if m.cfg.scope == nil {
+		return requested, nil
+	}
+	tenant, err := m.cfg.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrScope, err)
+	}
+	if tenant == "" {
+		return "", ErrScope
+	}
+	if requested != "" && requested != tenant {
+		return "", fmt.Errorf("%w: requested tenant %q is outside scope %q", ErrScope, requested, tenant)
+	}
+	return tenant, nil
 }
 
 // Audit action names and outcomes.
@@ -77,10 +96,20 @@ const (
 // Get loads one request, with expiry applied: a Pending or Approved
 // request past its ExpiresAt reports Status Expired even though the stored
 // row still carries its last written status.
+//
+// Under WithScope, another tenant's request reports ErrNotFound rather than
+// a forbidden error, so cross-tenant existence cannot be probed.
 func (m *Manager) Get(ctx context.Context, reqID id.UUID) (Request, error) {
+	tenant, err := m.scoped(ctx, "")
+	if err != nil {
+		return Request{}, err
+	}
 	r, err := m.store.Get(ctx, reqID)
 	if err != nil {
 		return Request{}, err
+	}
+	if tenant != "" && r.Tenant != tenant {
+		return Request{}, ErrNotFound
 	}
 	m.applyExpiry(&r)
 	return r, nil

--- a/ops/approval/manager.go
+++ b/ops/approval/manager.go
@@ -64,11 +64,15 @@ const (
 	actionSubmit   = "approval.submit"
 	actionApprove  = "approval.approve"
 	actionReject   = "approval.reject"
+	actionCancel   = "approval.cancel"
 	outcomeSuccess = "success"
 )
 
 // Eligibility verbs, appended to a kind name to form the access.Action.
-const verbDecide = "decide"
+const (
+	verbDecide = "decide"
+	verbCancel = "cancel"
+)
 
 // eligible checks the actor against the decider seam. Landed in Task 9;
 // until then every actor is eligible.

--- a/ops/approval/manager.go
+++ b/ops/approval/manager.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/auditlog"
 )
 
 // Manager records approval requests, collects decisions on them, and hands
@@ -53,12 +54,6 @@ func (m *Manager) scoped(_ context.Context, requested string) (string, error) {
 	return requested, nil
 }
 
-// audit records a state change. The auditlog seam lands in Task 10; until
-// then it is a no-op.
-func (m *Manager) audit(_ context.Context, _ Request, _, _, _, _ string) error {
-	return nil
-}
-
 // Audit action names and outcomes.
 const (
 	actionSubmit   = "approval.submit"
@@ -69,8 +64,8 @@ const (
 	actionComplete = "approval.complete"
 	actionFail     = "approval.fail"
 	actionRelease  = "approval.release"
-	outcomeSuccess = "success"
-	outcomeFailure = "failure"
+	outcomeSuccess = string(auditlog.OutcomeSuccess)
+	outcomeFailure = string(auditlog.OutcomeFailure)
 )
 
 // Eligibility verbs, appended to a kind name to form the access.Action.
@@ -78,11 +73,6 @@ const (
 	verbDecide = "decide"
 	verbCancel = "cancel"
 )
-
-// auditDenied records a refused attempt. Landed in Task 10.
-func (m *Manager) auditDenied(_ context.Context, _ id.UUID, _, _ string, _ error) error {
-	return nil
-}
 
 // Get loads one request, with expiry applied: a Pending or Approved
 // request past its ExpiresAt reports Status Expired even though the stored

--- a/ops/approval/manager.go
+++ b/ops/approval/manager.go
@@ -40,12 +40,28 @@ func New(store Store, opts ...Option) *Manager {
 
 // policyFor returns the policy registered for kind. The registry is
 // immutable after New, so this read needs no lock.
-//
-//nolint:unused // consumed by Submit, added in Task 4 of this package's build.
 func (m *Manager) policyFor(kind string) (Policy, bool) {
 	p, ok := m.cfg.kinds[kind]
 	return p, ok
 }
+
+// scoped resolves the tenant an operation is confined to. Tenancy lands in
+// Task 11; until then it passes the requested tenant through.
+func (m *Manager) scoped(_ context.Context, requested string) (string, error) {
+	return requested, nil
+}
+
+// audit records a state change. The auditlog seam lands in Task 10; until
+// then it is a no-op.
+func (m *Manager) audit(_ context.Context, _ Request, _, _, _, _ string) error {
+	return nil
+}
+
+// Audit action names and outcomes.
+const (
+	actionSubmit   = "approval.submit"
+	outcomeSuccess = "success"
+)
 
 // Get loads one request, with expiry applied: a Pending or Approved
 // request past its ExpiresAt reports Status Expired even though the stored

--- a/ops/approval/manager_retry_test.go
+++ b/ops/approval/manager_retry_test.go
@@ -121,21 +121,21 @@ func TestMaxRetriesZeroIsSingleAttempt(t *testing.T) {
 	assert.Equal(t, 1, cs.calls, "WithMaxRetries(0) means a single attempt, no retry")
 }
 
-// TestMaxRetriesNegativeClampsToZero proves a negative WithMaxRetries
-// clamps to zero rather than, say, disabling the retry bound.
-func TestMaxRetriesNegativeClampsToZero(t *testing.T) {
-	t.Parallel()
-	p := approval.Policy{Quorum: 1}
-	real := approval.NewMemoryStore()
-	ctx := context.Background()
-	cs := &conflictStore{Store: real, left: 1}
-	m := approval.New(cs, approval.WithKind(kindPayout, p), approval.WithClock(clock.NewMock(fixedNow)),
-		approval.WithMaxRetries(-5))
-
-	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{}, approval.SubmitParams{Requester: "alice"})
-	require.NoError(t, err)
-
-	_, err = m.Approve(ctx, r.ID, actor("bob"))
-	assert.ErrorIs(t, err, approval.ErrConflict)
-	assert.Equal(t, 1, cs.calls, "a negative WithMaxRetries clamps to zero — still a single attempt")
-}
+// There is intentionally no TestMaxRetriesNegativeClampsToZero here.
+//
+// mutate's exhaustion check is `case attempt >= m.cfg.maxRetries` with
+// attempt starting at 0, so for ANY maxRetries <= 0 — clamped to 0 by
+// options.go, or left raw at -5 without that clamp — the very first
+// conflict already satisfies `0 >= maxRetries` and mutate stops after
+// exactly one Update call. That holds for every possible number of
+// injected conflicts, so no black-box assertion on call count, error, or
+// outcome can ever distinguish "clamped to zero" from "left negative":
+// grep confirms cfg.maxRetries is read nowhere else in the package. A
+// test asserting this indistinguishable behavior would pass identically
+// whether options.go's `if n < 0 { n = 0 }` clamp exists or not — proven
+// by temporarily deleting that clamp and re-running the old version of
+// this test, which still passed unchanged. The clamp itself stays (it is
+// still the documented contract on WithMaxRetries and would matter the
+// moment maxRetries is ever read from a second call site), but a test
+// that cannot fail when the thing it guards is removed is worse than no
+// test: it was deleted rather than kept as false assurance.

--- a/ops/approval/manager_retry_test.go
+++ b/ops/approval/manager_retry_test.go
@@ -1,0 +1,141 @@
+package approval_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+// TestRetryReReadsFreshStateNotStaleCopy proves mutate's most load-bearing
+// property deterministically: on a conflict retry, fn is re-run against a
+// FRESH read rather than blindly reapplying the previous attempt's copy.
+// carol's vote is committed for real, through a second Manager sharing the
+// same underlying store, in the gap between bob's losing Update and his
+// retry — the retry must observe it and merge with it, not overwrite it.
+func TestRetryReReadsFreshStateNotStaleCopy(t *testing.T) {
+	t.Parallel()
+	p := approval.Policy{Quorum: 2}
+	real := approval.NewMemoryStore()
+	ctx := context.Background()
+	m2 := approval.New(real, approval.WithKind(kindPayout, p), approval.WithClock(clock.NewMock(fixedNow)))
+
+	r, err := approval.Submit(ctx, m2, kindPayout, payoutPayload{PayoutID: "po_88"},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	cs := &conflictStore{Store: real, left: 1, before: func() {
+		_, err := m2.Approve(ctx, r.ID, actor("carol"))
+		require.NoError(t, err)
+	}}
+	m := approval.New(cs, approval.WithKind(kindPayout, p), approval.WithClock(clock.NewMock(fixedNow)),
+		approval.WithMaxRetries(5))
+
+	got, err := m.Approve(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+	assert.Equal(t, approval.Approved, got.Status,
+		"quorum is reached by carol's real vote plus bob's retried one")
+	require.Len(t, got.Decisions, 2, "the retry must merge with carol's vote, not overwrite it")
+	seen := map[string]bool{}
+	for _, d := range got.Decisions {
+		seen[d.Approver] = true
+	}
+	assert.True(t, seen["carol"] && seen["bob"], "both votes must survive")
+	assert.Equal(t, 2, cs.calls, "one losing Update, one winning retry")
+}
+
+// TestDoubleVoteLosesRaceStillRejected closes the deferred finding: a
+// same-approver double vote that loses the CAS race must be rejected with
+// ErrAlreadyVoted on retry, never recorded a second time.
+func TestDoubleVoteLosesRaceStillRejected(t *testing.T) {
+	t.Parallel()
+	p := approval.Policy{Quorum: 2}
+	real := approval.NewMemoryStore()
+	ctx := context.Background()
+	m2 := approval.New(real, approval.WithKind(kindPayout, p), approval.WithClock(clock.NewMock(fixedNow)))
+
+	r, err := approval.Submit(ctx, m2, kindPayout, payoutPayload{PayoutID: "po_88"},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	cs := &conflictStore{Store: real, left: 1, before: func() {
+		// bob's own vote, committed for real, wins the race against his own
+		// retried attempt below.
+		_, err := m2.Approve(ctx, r.ID, actor("bob"))
+		require.NoError(t, err)
+	}}
+	m := approval.New(cs, approval.WithKind(kindPayout, p), approval.WithClock(clock.NewMock(fixedNow)),
+		approval.WithMaxRetries(5))
+
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrAlreadyVoted,
+		"a vote that lost the race must be refused on retry, not recorded a second time")
+
+	got, gerr := m2.Get(ctx, r.ID)
+	require.NoError(t, gerr)
+	require.Len(t, got.Decisions, 1, "bob's vote must be recorded exactly once")
+	assert.Equal(t, "bob", got.Decisions[0].Approver)
+}
+
+// TestRetryExhaustionSurfacesErrConflict proves the previously-uncovered
+// manager.go exhaustion branch: once maxRetries is used up, mutate returns
+// ErrConflict rather than looping forever.
+func TestRetryExhaustionSurfacesErrConflict(t *testing.T) {
+	t.Parallel()
+	p := approval.Policy{Quorum: 1}
+	real := approval.NewMemoryStore()
+	ctx := context.Background()
+	cs := &conflictStore{Store: real, left: 100}
+	m := approval.New(cs, approval.WithKind(kindPayout, p), approval.WithClock(clock.NewMock(fixedNow)),
+		approval.WithMaxRetries(2))
+
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{}, approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err, "Submit uses Create, not Update — unaffected by the injected conflicts")
+
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrConflict,
+		"retries exhausted must surface ErrConflict rather than loop forever")
+	assert.Equal(t, 3, cs.calls, "maxRetries=2 allows attempts 0, 1, and 2 — three Update calls total")
+}
+
+// TestMaxRetriesZeroIsSingleAttempt proves WithMaxRetries(0) means exactly
+// one attempt: no retry after the first conflict.
+func TestMaxRetriesZeroIsSingleAttempt(t *testing.T) {
+	t.Parallel()
+	p := approval.Policy{Quorum: 1}
+	real := approval.NewMemoryStore()
+	ctx := context.Background()
+	cs := &conflictStore{Store: real, left: 1}
+	m := approval.New(cs, approval.WithKind(kindPayout, p), approval.WithClock(clock.NewMock(fixedNow)),
+		approval.WithMaxRetries(0))
+
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{}, approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrConflict)
+	assert.Equal(t, 1, cs.calls, "WithMaxRetries(0) means a single attempt, no retry")
+}
+
+// TestMaxRetriesNegativeClampsToZero proves a negative WithMaxRetries
+// clamps to zero rather than, say, disabling the retry bound.
+func TestMaxRetriesNegativeClampsToZero(t *testing.T) {
+	t.Parallel()
+	p := approval.Policy{Quorum: 1}
+	real := approval.NewMemoryStore()
+	ctx := context.Background()
+	cs := &conflictStore{Store: real, left: 1}
+	m := approval.New(cs, approval.WithKind(kindPayout, p), approval.WithClock(clock.NewMock(fixedNow)),
+		approval.WithMaxRetries(-5))
+
+	r, err := approval.Submit(ctx, m, kindPayout, payoutPayload{}, approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrConflict)
+	assert.Equal(t, 1, cs.calls, "a negative WithMaxRetries clamps to zero — still a single attempt")
+}

--- a/ops/approval/manager_test.go
+++ b/ops/approval/manager_test.go
@@ -24,28 +24,28 @@ func TestNewPanics(t *testing.T) {
 		approval.New(nil, approval.WithKind(kindPayout, approval.Policy{Quorum: 2}))
 	})
 
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, `approval: kind "payout.release": quorum must be >= 1, got 0`, func() {
 		approval.New(approval.NewMemoryStore(),
 			approval.WithKind(kindPayout, approval.Policy{Quorum: 0}))
 	}, "quorum below 1 is a wiring bug")
 
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, "approval: duplicate kind payout.release", func() {
 		approval.New(approval.NewMemoryStore(),
 			approval.WithKind(kindPayout, approval.Policy{Quorum: 2}),
 			approval.WithKind(kindPayout, approval.Policy{Quorum: 3}))
 	}, "duplicate kind registration is a wiring bug")
 
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, `approval: kind "payout.release": negative TTL -1h0m0s`, func() {
 		approval.New(approval.NewMemoryStore(),
 			approval.WithKind(kindPayout, approval.Policy{Quorum: 2, TTL: -time.Hour}))
 	}, "negative TTL is a wiring bug")
 
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, `approval: kind "payout.release": negative ClaimTTL -1h0m0s`, func() {
 		approval.New(approval.NewMemoryStore(),
 			approval.WithKind(kindPayout, approval.Policy{Quorum: 2, ClaimTTL: -time.Hour}))
 	}, "negative ClaimTTL is a wiring bug")
 
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, "approval: no kinds registered; every submission would fail with ErrUnknownKind", func() {
 		approval.New(approval.NewMemoryStore())
 	}, "a manager with no registered kinds can never accept a submission")
 }

--- a/ops/approval/manager_test.go
+++ b/ops/approval/manager_test.go
@@ -1,0 +1,58 @@
+package approval_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+type payoutPayload struct {
+	PayoutID string `json:"payout_id"`
+	Amount   int64  `json:"amount"`
+}
+
+var kindPayout = approval.NewKind[payoutPayload]("payout.release")
+
+func TestNewPanics(t *testing.T) {
+	t.Parallel()
+
+	assert.PanicsWithValue(t, "approval: nil store", func() {
+		approval.New(nil, approval.WithKind(kindPayout, approval.Policy{Quorum: 2}))
+	})
+
+	assert.Panics(t, func() {
+		approval.New(approval.NewMemoryStore(),
+			approval.WithKind(kindPayout, approval.Policy{Quorum: 0}))
+	}, "quorum below 1 is a wiring bug")
+
+	assert.Panics(t, func() {
+		approval.New(approval.NewMemoryStore(),
+			approval.WithKind(kindPayout, approval.Policy{Quorum: 2}),
+			approval.WithKind(kindPayout, approval.Policy{Quorum: 3}))
+	}, "duplicate kind registration is a wiring bug")
+
+	assert.Panics(t, func() {
+		approval.New(approval.NewMemoryStore(),
+			approval.WithKind(kindPayout, approval.Policy{Quorum: 2, TTL: -time.Hour}))
+	}, "negative TTL is a wiring bug")
+
+	assert.Panics(t, func() {
+		approval.New(approval.NewMemoryStore(),
+			approval.WithKind(kindPayout, approval.Policy{Quorum: 2, ClaimTTL: -time.Hour}))
+	}, "negative ClaimTTL is a wiring bug")
+
+	assert.Panics(t, func() {
+		approval.New(approval.NewMemoryStore())
+	}, "a manager with no registered kinds can never accept a submission")
+}
+
+func TestNewAcceptsValidWiring(t *testing.T) {
+	t.Parallel()
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2, TTL: 24 * time.Hour}))
+	require.NotNil(t, m)
+}

--- a/ops/approval/memory.go
+++ b/ops/approval/memory.go
@@ -1,10 +1,10 @@
 package approval
 
 import (
+	"bytes"
 	"context"
 	"maps"
 	"slices"
-	"sort"
 	"sync"
 
 	"github.com/dmitrymomot/forge/core/id"
@@ -79,8 +79,8 @@ func (s *memoryStore) List(_ context.Context, f Filter) ([]Request, error) {
 	s.mu.RUnlock()
 
 	// UUIDv7 ids are time-ordered, so descending id order is newest-first.
-	sort.Slice(out, func(i, j int) bool {
-		return string(out[i].ID[:]) > string(out[j].ID[:])
+	slices.SortFunc(out, func(a, b Request) int {
+		return bytes.Compare(b.ID[:], a.ID[:])
 	})
 	limit := f.Limit
 	if limit <= 0 {

--- a/ops/approval/memory.go
+++ b/ops/approval/memory.go
@@ -84,18 +84,13 @@ func (s *memoryStore) List(_ context.Context, f Filter) ([]Request, error) {
 	})
 	limit := f.Limit
 	if limit <= 0 {
-		limit = defaultLimit
+		limit = DefaultListLimit
 	}
 	if len(out) > limit {
 		out = out[:limit]
 	}
 	return out, nil
 }
-
-// defaultLimit caps an unbounded List so a zero Filter.Limit cannot pull an
-// unbounded result set into memory. Every Store implementation defaults to
-// the same value — see approvaltest.Run's ListDefaultLimitIsFixed case.
-const defaultLimit = 100
 
 func matches(r Request, f Filter) bool {
 	if f.Kind != "" && r.Kind != f.Kind {

--- a/ops/approval/memory.go
+++ b/ops/approval/memory.go
@@ -82,11 +82,20 @@ func (s *memoryStore) List(_ context.Context, f Filter) ([]Request, error) {
 	sort.Slice(out, func(i, j int) bool {
 		return string(out[i].ID[:]) > string(out[j].ID[:])
 	})
-	if f.Limit > 0 && len(out) > f.Limit {
-		out = out[:f.Limit]
+	limit := f.Limit
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	if len(out) > limit {
+		out = out[:limit]
 	}
 	return out, nil
 }
+
+// defaultLimit caps an unbounded List so a zero Filter.Limit cannot pull an
+// unbounded result set into memory. Every Store implementation defaults to
+// the same value — see approvaltest.Run's ListDefaultLimitIsFixed case.
+const defaultLimit = 100
 
 func matches(r Request, f Filter) bool {
 	if f.Kind != "" && r.Kind != f.Kind {

--- a/ops/approval/memory.go
+++ b/ops/approval/memory.go
@@ -1,0 +1,111 @@
+package approval
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sort"
+	"sync"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+type memoryStore struct {
+	byID map[id.UUID]Request
+	mu   sync.RWMutex
+}
+
+// NewMemoryStore returns an in-memory Store for tests and development. It
+// is not durable: process exit loses every request.
+func NewMemoryStore() Store {
+	return &memoryStore{byID: make(map[id.UUID]Request)}
+}
+
+// cloneRequest copies the reference fields so callers cannot mutate stored
+// state through a shared slice or map, and vice versa. Aliased Decisions
+// would be a dual-control hole: a caller could rewrite a persisted vote.
+func cloneRequest(r Request) Request {
+	r.Decisions = slices.Clone(r.Decisions)
+	r.Meta = maps.Clone(r.Meta)
+	r.Payload = slices.Clone(r.Payload)
+	return r
+}
+
+func (s *memoryStore) Create(_ context.Context, r Request) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.byID[r.ID]; ok {
+		return ErrDuplicate
+	}
+	s.byID[r.ID] = cloneRequest(r)
+	return nil
+}
+
+func (s *memoryStore) Get(_ context.Context, reqID id.UUID) (Request, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.byID[reqID]
+	if !ok {
+		return Request{}, ErrNotFound
+	}
+	return cloneRequest(r), nil
+}
+
+func (s *memoryStore) Update(_ context.Context, r Request, expect int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cur, ok := s.byID[r.ID]
+	if !ok {
+		return ErrNotFound
+	}
+	if cur.Version != expect {
+		return ErrConflict
+	}
+	next := cloneRequest(r)
+	next.Version = expect + 1
+	s.byID[r.ID] = next
+	return nil
+}
+
+func (s *memoryStore) List(_ context.Context, f Filter) ([]Request, error) {
+	s.mu.RLock()
+	out := make([]Request, 0, len(s.byID))
+	for _, r := range s.byID {
+		if !matches(r, f) {
+			continue
+		}
+		out = append(out, cloneRequest(r))
+	}
+	s.mu.RUnlock()
+
+	// UUIDv7 ids are time-ordered, so descending id order is newest-first.
+	sort.Slice(out, func(i, j int) bool {
+		return string(out[i].ID[:]) > string(out[j].ID[:])
+	})
+	if f.Limit > 0 && len(out) > f.Limit {
+		out = out[:f.Limit]
+	}
+	return out, nil
+}
+
+func matches(r Request, f Filter) bool {
+	if f.Kind != "" && r.Kind != f.Kind {
+		return false
+	}
+	if f.Tenant != "" && r.Tenant != f.Tenant {
+		return false
+	}
+	if f.Requester != "" && r.Requester != f.Requester {
+		return false
+	}
+	if len(f.Statuses) > 0 && !slices.Contains(f.Statuses, r.Status) {
+		return false
+	}
+	if !f.ExpiresBefore.IsZero() {
+		// Rows with no expiry never match an expiry bound.
+		if r.ExpiresAt.IsZero() || !r.ExpiresAt.Before(f.ExpiresBefore) {
+			return false
+		}
+	}
+	return true
+}

--- a/ops/approval/options.go
+++ b/ops/approval/options.go
@@ -3,11 +3,13 @@ package approval
 import (
 	"github.com/dmitrymomot/forge/auth/access"
 	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/auditlog"
 )
 
 type config struct {
 	clk        clock.Clock
 	decider    access.Decider
+	auditor    *auditlog.Recorder
 	kinds      map[string]Policy
 	maxRetries int
 }
@@ -69,4 +71,15 @@ func WithMaxRetries(n int) Option {
 // one vote per approver) hold either way.
 func WithDecider(d access.Decider) Option {
 	return func(c *config) { c.decider = d }
+}
+
+// WithAuditor records every state change to the audit trail: submissions,
+// decisions, cancellations, claims, and outcomes — plus every attempt a
+// decider refused, as OutcomeDenied.
+//
+// The trail is written after the state change is durable. If the sink
+// fails, the transition still happened and the operation returns
+// ErrAuditFailed alongside the updated request.
+func WithAuditor(rec *auditlog.Recorder) Option {
+	return func(c *config) { c.auditor = rec }
 }

--- a/ops/approval/options.go
+++ b/ops/approval/options.go
@@ -95,6 +95,11 @@ func WithAuditor(rec *auditlog.Recorder) Option {
 // Fail-closed: a hook error or an empty tenant fails the operation with
 // ErrScope. A nil fn leaves the manager unscoped, which is the correct
 // single-tenant default.
+//
+// A disagreement between the requested and scoped tenant wraps ErrScope
+// with text naming both tenant ids. That text is diagnostic-only — match
+// the error with errors.Is and return callers something opaque, not the
+// wrapped message.
 func WithScope(fn func(context.Context) (string, error)) Option {
 	return func(c *config) { c.scope = fn }
 }

--- a/ops/approval/options.go
+++ b/ops/approval/options.go
@@ -1,0 +1,56 @@
+package approval
+
+import (
+	"github.com/dmitrymomot/forge/core/clock"
+)
+
+type config struct {
+	clk        clock.Clock
+	kinds      map[string]Policy
+	maxRetries int
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithKind registers an action name and the policy that governs it. It is
+// the only way a kind enters a Manager — the registry is immutable after
+// New, so the read path needs no lock and no caller can register a weaker
+// policy at runtime. Repeat it once per action.
+//
+// New panics on a duplicate name, a quorum below 1, or a negative duration.
+func WithKind[T any](k Kind[T], p Policy) Option {
+	return func(c *config) {
+		name := k.Name()
+		if _, dup := c.kinds[name]; dup {
+			panic("approval: duplicate kind " + name)
+		}
+		if err := p.validate(name); err != nil {
+			panic(err.Error())
+		}
+		c.kinds[name] = p
+	}
+}
+
+// WithClock injects a clock for deterministic tests. Defaults to
+// clock.System().
+func WithClock(clk clock.Clock) Option {
+	return func(c *config) {
+		if clk != nil {
+			c.clk = clk
+		}
+	}
+}
+
+// WithMaxRetries caps how many times a transition re-reads and retries
+// after losing a version race (default 3). Each retry re-validates from a
+// fresh read, so a retry can still legitimately fail with ErrAlreadyVoted.
+// Values below zero are clamped to zero (a single attempt).
+func WithMaxRetries(n int) Option {
+	return func(c *config) {
+		if n < 0 {
+			n = 0
+		}
+		c.maxRetries = n
+	}
+}

--- a/ops/approval/options.go
+++ b/ops/approval/options.go
@@ -1,6 +1,8 @@
 package approval
 
 import (
+	"context"
+
 	"github.com/dmitrymomot/forge/auth/access"
 	"github.com/dmitrymomot/forge/core/clock"
 	"github.com/dmitrymomot/forge/ops/auditlog"
@@ -10,6 +12,7 @@ type config struct {
 	clk        clock.Clock
 	decider    access.Decider
 	auditor    *auditlog.Recorder
+	scope      func(context.Context) (string, error)
 	kinds      map[string]Policy
 	maxRetries int
 }
@@ -82,4 +85,16 @@ func WithDecider(d access.Decider) Option {
 // ErrAuditFailed alongside the updated request.
 func WithAuditor(rec *auditlog.Recorder) Option {
 	return func(c *config) { c.auditor = rec }
+}
+
+// WithScope derives the tenant from context for every operation: Submit
+// stamps it, List is confined to it, and Get and every transition report
+// ErrNotFound for other tenants' requests — not a forbidden error, so
+// cross-tenant existence cannot be probed.
+//
+// Fail-closed: a hook error or an empty tenant fails the operation with
+// ErrScope. A nil fn leaves the manager unscoped, which is the correct
+// single-tenant default.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) { c.scope = fn }
 }

--- a/ops/approval/options.go
+++ b/ops/approval/options.go
@@ -1,11 +1,13 @@
 package approval
 
 import (
+	"github.com/dmitrymomot/forge/auth/access"
 	"github.com/dmitrymomot/forge/core/clock"
 )
 
 type config struct {
 	clk        clock.Clock
+	decider    access.Decider
 	kinds      map[string]Policy
 	maxRetries int
 }
@@ -53,4 +55,18 @@ func WithMaxRetries(n int) Option {
 		}
 		c.maxRetries = n
 	}
+}
+
+// WithDecider gates who may decide on a request. The manager asks it
+// "<kind>:decide" before recording any vote and "<kind>:cancel" before a
+// non-requester cancellation, passing the request's kind, requester, and
+// raw payload as resource attributes so relational rules ("must be the
+// requester's manager") and value-aware rules ("over 10 days needs the
+// department head") both work.
+//
+// Without it, any principal other than the requester may decide — the
+// correct single-team default. The structural invariants (no self-approval,
+// one vote per approver) hold either way.
+func WithDecider(d access.Decider) Option {
+	return func(c *config) { c.decider = d }
 }

--- a/ops/approval/options.go
+++ b/ops/approval/options.go
@@ -69,6 +69,11 @@ func WithMaxRetries(n int) Option {
 // requester's manager") and value-aware rules ("over 10 days needs the
 // department head") both work.
 //
+// The decider may be consulted more than once per call: eligible() re-runs
+// on every mutate CAS retry, so a decider that hits a database is called
+// once per retry, not once per Approve/Reject/Cancel. Do not build a rate
+// limiter or any other side-effecting hook into a decider.
+//
 // Without it, any principal other than the requester may decide — the
 // correct single-team default. The structural invariants (no self-approval,
 // one vote per approver) hold either way.

--- a/ops/approval/pgstore/doc.go
+++ b/ops/approval/pgstore/doc.go
@@ -1,0 +1,13 @@
+// Package pgstore is the Postgres approval.Store driver over pgx. The DDL
+// (forge_approval_requests) ships as an embedded goose migration in
+// Migrations; apply it via data/migration under its own version table
+// before first use:
+//
+//	_ = migration.New(pgstore.Migrations, migration.WithTable("forge_approval_schema")).Up(ctx, db)
+//
+// Update is a compare-and-swap enforced by Postgres itself (an UPDATE ...
+// WHERE id = $1 AND version = $2), not by an in-process lock, so it holds
+// under concurrent transactions from separate processes. payload and
+// decisions are stored as json, not jsonb, so a payload a caller hashes
+// round-trips byte-identical. The pool's lifecycle is the caller's.
+package pgstore

--- a/ops/approval/pgstore/migrations/00001_create_forge_approval_requests.sql
+++ b/ops/approval/pgstore/migrations/00001_create_forge_approval_requests.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+CREATE TABLE forge_approval_requests (
+    id          uuid PRIMARY KEY,
+    kind        text NOT NULL,
+    tenant      text NOT NULL DEFAULT '',
+    requester   text NOT NULL,
+    reason      text NOT NULL DEFAULT '',
+    status      smallint NOT NULL,
+    version     bigint NOT NULL DEFAULT 1,
+    payload     json NOT NULL,
+    decisions   json NOT NULL DEFAULT '[]'::json,
+    meta        jsonb NOT NULL DEFAULT '{}'::jsonb,
+    claimed_by  text NOT NULL DEFAULT '',
+    created_at  timestamptz NOT NULL,
+    expires_at  timestamptz,
+    claimed_at  timestamptz,
+    decided_at  timestamptz
+);
+
+-- Covers the Filter WHERE columns in filter order, then id for the
+-- newest-first ordering. An index that does not cover the filter is an
+-- index Postgres will not use.
+CREATE INDEX forge_approval_requests_list_idx
+    ON forge_approval_requests (tenant, kind, status, id DESC);
+
+-- Partial: rows with no expiry are never selected by an expiry bound, so
+-- they do not belong in this index.
+CREATE INDEX forge_approval_requests_expiry_idx
+    ON forge_approval_requests (status, expires_at)
+    WHERE expires_at IS NOT NULL;
+
+-- +goose Down
+DROP TABLE forge_approval_requests;

--- a/ops/approval/pgstore/migrations/00001_create_forge_approval_requests.sql
+++ b/ops/approval/pgstore/migrations/00001_create_forge_approval_requests.sql
@@ -29,5 +29,11 @@ CREATE INDEX forge_approval_requests_expiry_idx
     ON forge_approval_requests (status, expires_at)
     WHERE expires_at IS NOT NULL;
 
+-- Covers a List filtered by Requester alone (or Requester plus Tenant),
+-- which forge_approval_requests_list_idx cannot serve since it leads with
+-- kind and status.
+CREATE INDEX forge_approval_requests_requester_idx
+    ON forge_approval_requests (tenant, requester, id DESC);
+
 -- +goose Down
 DROP TABLE forge_approval_requests;

--- a/ops/approval/pgstore/migrations/00001_create_forge_approval_requests.sql
+++ b/ops/approval/pgstore/migrations/00001_create_forge_approval_requests.sql
@@ -29,9 +29,11 @@ CREATE INDEX forge_approval_requests_expiry_idx
     ON forge_approval_requests (status, expires_at)
     WHERE expires_at IS NOT NULL;
 
--- Covers a List filtered by Requester alone (or Requester plus Tenant),
--- which forge_approval_requests_list_idx cannot serve since it leads with
--- kind and status.
+-- Covers a List filtered by Requester within a Tenant, which
+-- forge_approval_requests_list_idx cannot serve since it leads with kind and
+-- status. A single-tenant deployment (tenant uniformly '') gets no benefit:
+-- the optional-filter idiom leaves the leading column unqualified, so
+-- Postgres cannot use requester as a search key.
 CREATE INDEX forge_approval_requests_requester_idx
     ON forge_approval_requests (tenant, requester, id DESC);
 

--- a/ops/approval/pgstore/pgstore.go
+++ b/ops/approval/pgstore/pgstore.go
@@ -1,0 +1,228 @@
+package pgstore
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_approval_requests,
+// rooted so its .sql files sit at fsys root (data/migration.New globs
+// fsys's root, not subdirectories). Apply it under its own version table
+// (migration.WithTable("forge_approval_schema")) — a colliding group name
+// silently skips.
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// Store is the Postgres implementation of approval.Store. The pool's
+// lifecycle is the caller's.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+var _ approval.Store = (*Store)(nil)
+
+// New builds a Postgres approval Store. Apply Migrations first.
+func New(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const cols = `id, kind, tenant, requester, reason, status, version, payload, decisions, meta, claimed_by, created_at, expires_at, claimed_at, decided_at`
+
+const createSQL = `
+INSERT INTO forge_approval_requests (` + cols + `)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`
+
+// Create inserts r. A colliding id yields approval.ErrDuplicate.
+func (s *Store) Create(ctx context.Context, r approval.Request) error {
+	decisions, meta, err := encodeState(r)
+	if err != nil {
+		return err
+	}
+	_, err = s.pool.Exec(ctx, createSQL,
+		r.ID, r.Kind, r.Tenant, r.Requester, r.Reason, int16(r.Status), r.Version,
+		[]byte(r.Payload), decisions, meta, r.ClaimedBy,
+		r.CreatedAt, nullTime(r.ExpiresAt), nullTime(r.ClaimedAt), nullTime(r.DecidedAt))
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
+		return approval.ErrDuplicate
+	}
+	return err
+}
+
+// Get returns the request for reqID, or approval.ErrNotFound.
+func (s *Store) Get(ctx context.Context, reqID id.UUID) (approval.Request, error) {
+	return scanRequest(s.pool.QueryRow(ctx,
+		`SELECT `+cols+` FROM forge_approval_requests WHERE id = $1`, reqID))
+}
+
+const updateSQL = `
+UPDATE forge_approval_requests
+SET kind = $2, tenant = $3, requester = $4, reason = $5, status = $6,
+    version = version + 1, payload = $7, decisions = $8, meta = $9,
+    claimed_by = $10, created_at = $11, expires_at = $12, claimed_at = $13,
+    decided_at = $14
+WHERE id = $1 AND version = $15`
+
+// Update persists r only when the stored version matches expect. Zero rows
+// affected means either the id is gone or another writer moved the version;
+// a follow-up existence check tells those apart, because the Manager
+// retries one and gives up on the other.
+func (s *Store) Update(ctx context.Context, r approval.Request, expect int64) error {
+	decisions, meta, err := encodeState(r)
+	if err != nil {
+		return err
+	}
+	tag, err := s.pool.Exec(ctx, updateSQL,
+		r.ID, r.Kind, r.Tenant, r.Requester, r.Reason, int16(r.Status),
+		[]byte(r.Payload), decisions, meta, r.ClaimedBy,
+		r.CreatedAt, nullTime(r.ExpiresAt), nullTime(r.ClaimedAt), nullTime(r.DecidedAt),
+		expect)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() > 0 {
+		return nil
+	}
+	var exists bool
+	if err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM forge_approval_requests WHERE id = $1)`, r.ID,
+	).Scan(&exists); err != nil {
+		return err
+	}
+	if !exists {
+		return approval.ErrNotFound
+	}
+	return approval.ErrConflict
+}
+
+const listSQL = `
+SELECT ` + cols + ` FROM forge_approval_requests
+WHERE ($1 = '' OR tenant = $1)
+  AND ($2 = '' OR kind = $2)
+  AND ($3 = '' OR requester = $3)
+  AND (cardinality($4::smallint[]) = 0 OR status = ANY($4))
+  AND ($5::timestamptz IS NULL OR (expires_at IS NOT NULL AND expires_at < $5))
+ORDER BY id DESC
+LIMIT $6`
+
+// List returns requests matching f, newest first (UUIDv7 ids are
+// time-ordered, so id DESC is creation order). A zero f.Limit defaults to
+// defaultLimit, matching the memory store.
+func (s *Store) List(ctx context.Context, f approval.Filter) ([]approval.Request, error) {
+	statuses := make([]int16, 0, len(f.Statuses))
+	for _, st := range f.Statuses {
+		statuses = append(statuses, int16(st))
+	}
+	limit := f.Limit
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	rows, err := s.pool.Query(ctx, listSQL,
+		f.Tenant, f.Kind, f.Requester, statuses, nullTime(f.ExpiresBefore), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	// Non-nil empty on zero rows, matching the memory store.
+	out := []approval.Request{}
+	for rows.Next() {
+		r, err := scanRequest(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// defaultLimit caps an unbounded List so a large table cannot be pulled
+// into memory by a zero-valued Filter. The memory store defaults to the
+// same value, so swapping stores cannot silently truncate results.
+const defaultLimit = 100
+
+// row is satisfied by both pgx.Row and pgx.Rows.
+type row interface{ Scan(dest ...any) error }
+
+func scanRequest(rw row) (approval.Request, error) {
+	var (
+		r         approval.Request
+		status    int16
+		payload   []byte
+		decisions []byte
+		exp       *time.Time
+		claimed   *time.Time
+		decided   *time.Time
+	)
+	err := rw.Scan(&r.ID, &r.Kind, &r.Tenant, &r.Requester, &r.Reason, &status,
+		&r.Version, &payload, &decisions, &r.Meta, &r.ClaimedBy,
+		&r.CreatedAt, &exp, &claimed, &decided)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return approval.Request{}, approval.ErrNotFound
+	}
+	if err != nil {
+		return approval.Request{}, err
+	}
+	r.Status = approval.Status(status)
+	r.Payload = json.RawMessage(payload)
+	if err := json.Unmarshal(decisions, &r.Decisions); err != nil {
+		return approval.Request{}, err
+	}
+	r.CreatedAt = r.CreatedAt.UTC()
+	if exp != nil {
+		r.ExpiresAt = exp.UTC()
+	}
+	if claimed != nil {
+		r.ClaimedAt = claimed.UTC()
+	}
+	if decided != nil {
+		r.DecidedAt = decided.UTC()
+	}
+	return r, nil
+}
+
+// encodeState marshals the two JSON columns, normalizing nil to an empty
+// array and an empty object so a reader never has to special-case null.
+func encodeState(r approval.Request) (decisions []byte, meta map[string]string, err error) {
+	d := r.Decisions
+	if d == nil {
+		d = []approval.Decision{}
+	}
+	decisions, err = json.Marshal(d)
+	if err != nil {
+		return nil, nil, err
+	}
+	meta = r.Meta
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	return decisions, meta, nil
+}
+
+// nullTime maps a zero time to SQL NULL.
+func nullTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}

--- a/ops/approval/pgstore/pgstore.go
+++ b/ops/approval/pgstore/pgstore.go
@@ -128,7 +128,7 @@ LIMIT $6`
 
 // List returns requests matching f, newest first (UUIDv7 ids are
 // time-ordered, so id DESC is creation order). A zero f.Limit defaults to
-// defaultLimit, matching the memory store.
+// approval.DefaultListLimit, matching the memory store.
 func (s *Store) List(ctx context.Context, f approval.Filter) ([]approval.Request, error) {
 	statuses := make([]int16, 0, len(f.Statuses))
 	for _, st := range f.Statuses {
@@ -136,7 +136,7 @@ func (s *Store) List(ctx context.Context, f approval.Filter) ([]approval.Request
 	}
 	limit := f.Limit
 	if limit <= 0 {
-		limit = defaultLimit
+		limit = approval.DefaultListLimit
 	}
 	rows, err := s.pool.Query(ctx, listSQL,
 		f.Tenant, f.Kind, f.Requester, statuses, nullTime(f.ExpiresBefore), limit)
@@ -155,11 +155,6 @@ func (s *Store) List(ctx context.Context, f approval.Filter) ([]approval.Request
 	}
 	return out, rows.Err()
 }
-
-// defaultLimit caps an unbounded List so a large table cannot be pulled
-// into memory by a zero-valued Filter. The memory store defaults to the
-// same value, so swapping stores cannot silently truncate results.
-const defaultLimit = 100
 
 // row is satisfied by both pgx.Row and pgx.Rows.
 type row interface{ Scan(dest ...any) error }

--- a/ops/approval/pgstore/pgstore_test.go
+++ b/ops/approval/pgstore/pgstore_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+
+package pgstore_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+	"github.com/dmitrymomot/forge/ops/approval"
+	"github.com/dmitrymomot/forge/ops/approval/approvaltest"
+	"github.com/dmitrymomot/forge/ops/approval/pgstore"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+)
+
+var _ approval.Store = (*pgstore.Store)(nil)
+
+func newPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	cfg := postgres.DefaultConfig()
+	cfg.URL = pgtest.DSN(t)
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgstore.Migrations,
+		migration.WithTable("forge_approval_schema")).Up(context.Background(), db))
+	return pool
+}
+
+// TestPgStoreContract runs the same suite the memory store passes. The
+// table outlives the process, so the suite namespaces its own fixtures —
+// nothing here truncates.
+func TestPgStoreContract(t *testing.T) {
+	pool := newPool(t)
+	approvaltest.Run(t, func(t *testing.T) approval.Store {
+		return pgstore.New(pool)
+	})
+}
+
+// TestConcurrentUpdatesConflict proves the CAS is enforced by Postgres
+// itself, not by a mutex the memory store happens to hold.
+func TestConcurrentUpdatesConflict(t *testing.T) {
+	s := pgstore.New(newPool(t))
+	ctx := context.Background()
+
+	r := approval.Request{
+		ID:        id.NewUUID(),
+		Kind:      "kind-" + id.NewUUID().String(),
+		Tenant:    "tenant-" + id.NewUUID().String(),
+		Requester: "alice",
+		Status:    approval.Pending,
+		Version:   1,
+		Payload:   json.RawMessage(`{}`),
+		CreatedAt: time.Now().UTC().Truncate(time.Microsecond),
+	}
+	require.NoError(t, s.Create(ctx, r))
+
+	const writers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, writers)
+	for i := range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = s.Update(ctx, r, 1)
+		}()
+	}
+	wg.Wait()
+
+	var won int
+	for _, err := range errs {
+		if err == nil {
+			won++
+			continue
+		}
+		require.ErrorIs(t, err, approval.ErrConflict)
+	}
+	require.Equal(t, 1, won, "exactly one CAS wins at a given version")
+}

--- a/ops/approval/policy.go
+++ b/ops/approval/policy.go
@@ -1,0 +1,41 @@
+package approval
+
+import (
+	"fmt"
+	"time"
+)
+
+// Policy is the per-kind rule set. It is registered at construction with
+// WithKind and never supplied by the caller at submit time: a caller who
+// could choose the quorum could weaken the gate on the action they are
+// asking permission for.
+type Policy struct {
+	// TTL is how long a request stays actionable after submission. Zero
+	// means it never expires.
+	TTL time.Duration
+	// ClaimTTL is how long an executor's claim is held before another
+	// executor may take it over. Zero — the default — means the claim never
+	// expires: an executor that dies mid-action wedges the request until
+	// Release is called. That is the safe default for actions that move
+	// money. Setting it non-zero opts into at-least-once execution, so the
+	// action behind it must be idempotent.
+	ClaimTTL time.Duration
+	// Quorum is the number of distinct approvals required. Must be at
+	// least 1. Note that Quorum 1 is still dual control: the requester can
+	// never be the approver.
+	Quorum int
+}
+
+// validate reports why a policy is unusable, or nil.
+func (p Policy) validate(kind string) error {
+	if p.Quorum < 1 {
+		return fmt.Errorf("approval: kind %q: quorum must be >= 1, got %d", kind, p.Quorum)
+	}
+	if p.TTL < 0 {
+		return fmt.Errorf("approval: kind %q: negative TTL %s", kind, p.TTL)
+	}
+	if p.ClaimTTL < 0 {
+		return fmt.Errorf("approval: kind %q: negative ClaimTTL %s", kind, p.ClaimTTL)
+	}
+	return nil
+}

--- a/ops/approval/store.go
+++ b/ops/approval/store.go
@@ -31,7 +31,8 @@ type Store interface {
 
 	// List returns requests matching f, newest first (UUIDv7 id order;
 	// ties within one millisecond are unordered). A zero f.Limit defaults
-	// to 100; every implementation must apply the same fixed default.
+	// to DefaultListLimit; every implementation must apply the same fixed
+	// default.
 	List(ctx context.Context, f Filter) ([]Request, error)
 
 	// Update persists r only when the stored Version equals expect,

--- a/ops/approval/store.go
+++ b/ops/approval/store.go
@@ -30,7 +30,8 @@ type Store interface {
 	Get(ctx context.Context, reqID id.UUID) (Request, error)
 
 	// List returns requests matching f, newest first (UUIDv7 id order;
-	// ties within one millisecond are unordered).
+	// ties within one millisecond are unordered). A zero f.Limit defaults
+	// to 100; every implementation must apply the same fixed default.
 	List(ctx context.Context, f Filter) ([]Request, error)
 
 	// Update persists r only when the stored Version equals expect,

--- a/ops/approval/store.go
+++ b/ops/approval/store.go
@@ -1,0 +1,40 @@
+package approval
+
+import (
+	"context"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Store persists approval requests. Implementations must be safe for
+// concurrent use.
+//
+// Update is the package's only concurrency primitive: every state
+// transition is a compare-and-swap on Version. An implementation that does
+// not enforce it atomically breaks dual control — two checkers voting
+// concurrently could both read quorum-1 approvals and both write, losing a
+// vote or counting one approver twice.
+//
+// Implementations may normalize nil and empty Decisions/Meta in either
+// direction; callers must not depend on which form is returned. List must
+// return a non-nil empty slice rather than nil when nothing matches.
+//
+// approvaltest.Run is the executable contract; every implementation must
+// pass it.
+type Store interface {
+	// Create persists a new request. It returns ErrDuplicate when a
+	// request with the same ID already exists.
+	Create(ctx context.Context, r Request) error
+
+	// Get loads one request. It returns ErrNotFound for unknown ids.
+	Get(ctx context.Context, reqID id.UUID) (Request, error)
+
+	// List returns requests matching f, newest first (UUIDv7 id order;
+	// ties within one millisecond are unordered).
+	List(ctx context.Context, f Filter) ([]Request, error)
+
+	// Update persists r only when the stored Version equals expect,
+	// returning ErrConflict otherwise and ErrNotFound for unknown ids. The
+	// implementation persists r with Version set to expect+1.
+	Update(ctx context.Context, r Request, expect int64) error
+}

--- a/ops/approval/store_test.go
+++ b/ops/approval/store_test.go
@@ -1,0 +1,15 @@
+package approval_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/ops/approval"
+	"github.com/dmitrymomot/forge/ops/approval/approvaltest"
+)
+
+func TestMemoryStoreContract(t *testing.T) {
+	t.Parallel()
+	approvaltest.Run(t, func(t *testing.T) approval.Store {
+		return approval.NewMemoryStore()
+	})
+}

--- a/ops/approval/submit.go
+++ b/ops/approval/submit.go
@@ -1,0 +1,77 @@
+package approval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// now returns the manager's clock time, normalized to what a Postgres
+// timestamptz can hold. Untruncated nanoseconds do not survive the
+// round-trip, so a stored request would not equal the one just returned.
+func (m *Manager) now() time.Time {
+	return m.cfg.clk.Now().UTC().Truncate(time.Microsecond)
+}
+
+// Submit records a new approval request for kind k carrying payload.
+//
+// The returned request is Pending: it becomes actionable to checkers
+// immediately and expires after the kind's policy TTL. Submitting does not
+// authorize anything by itself — the maker's own decision never counts.
+func Submit[T any](ctx context.Context, m *Manager, k Kind[T], payload T, p SubmitParams) (Request, error) {
+	pol, ok := m.policyFor(k.Name())
+	if !ok {
+		return Request{}, ErrUnknownKind
+	}
+	if p.Requester == "" {
+		return Request{}, ErrRequesterRequired
+	}
+	tenant, err := m.scoped(ctx, p.Tenant)
+	if err != nil {
+		return Request{}, err
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return Request{}, fmt.Errorf("approval: marshal payload: %w", err)
+	}
+
+	now := m.now()
+	r := Request{
+		ID:        id.NewUUID(),
+		Kind:      k.Name(),
+		Tenant:    tenant,
+		Requester: p.Requester,
+		Reason:    p.Reason,
+		Status:    Pending,
+		Version:   1,
+		Payload:   raw,
+		Meta:      maps.Clone(p.Meta),
+		Decisions: make([]Decision, 0, pol.Quorum),
+		CreatedAt: now,
+	}
+	if pol.TTL > 0 {
+		r.ExpiresAt = now.Add(pol.TTL)
+	}
+	if err := m.store.Create(ctx, r); err != nil {
+		return Request{}, err
+	}
+	return r, m.audit(ctx, r, actionSubmit, p.Requester, outcomeSuccess, p.Reason)
+}
+
+// PayloadOf decodes r's payload as T. It returns ErrKindMismatch when k is
+// not the kind r was submitted under — decoding another action's payload
+// into T would silently produce a zero-valued struct.
+func PayloadOf[T any](k Kind[T], r Request) (T, error) {
+	var out T
+	if r.Kind != k.Name() {
+		return out, fmt.Errorf("%w: request is %q, kind is %q", ErrKindMismatch, r.Kind, k.Name())
+	}
+	if err := json.Unmarshal(r.Payload, &out); err != nil {
+		return out, fmt.Errorf("approval: unmarshal payload: %w", err)
+	}
+	return out, nil
+}

--- a/ops/approval/submit_test.go
+++ b/ops/approval/submit_test.go
@@ -2,6 +2,7 @@ package approval_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -82,6 +83,32 @@ func TestSubmitClonesMeta(t *testing.T) {
 
 	meta["request_id"] = "tampered"
 	assert.Equal(t, "req_1", r.Meta["request_id"], "meta is cloned at submit")
+}
+
+// unmarshalablePayload cannot be encoded by encoding/json — a chan field
+// always fails Marshal.
+type unmarshalablePayload struct {
+	Ch chan int
+}
+
+func TestSubmitMarshalFailureLeavesNothingPersisted(t *testing.T) {
+	t.Parallel()
+	kind := approval.NewKind[unmarshalablePayload]("test.submit-marshal-failure")
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kind, approval.Policy{Quorum: 1}),
+		approval.WithClock(clock.NewMock(fixedNow)))
+	ctx := context.Background()
+
+	_, err := approval.Submit(ctx, m, kind, unmarshalablePayload{Ch: make(chan int)},
+		approval.SubmitParams{Requester: "alice"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal payload")
+	var jsonErr *json.UnsupportedTypeError
+	assert.ErrorAs(t, err, &jsonErr, "the underlying json error must surface, not be swallowed")
+
+	got, lerr := m.List(ctx, approval.Filter{Kind: kind.Name()})
+	require.NoError(t, lerr)
+	assert.Empty(t, got, "a marshal failure must abort before Store.Create — nothing may be persisted")
 }
 
 func TestPayloadOf(t *testing.T) {

--- a/ops/approval/submit_test.go
+++ b/ops/approval/submit_test.go
@@ -1,0 +1,111 @@
+package approval_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/approval"
+)
+
+var fixedNow = time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+
+// newManager builds a Manager with a fixed clock and the payout kind.
+func newManager(t *testing.T, p approval.Policy, extra ...approval.Option) *approval.Manager {
+	t.Helper()
+	opts := append([]approval.Option{
+		approval.WithKind(kindPayout, p),
+		approval.WithClock(clock.NewMock(fixedNow)),
+	}, extra...)
+	return approval.New(approval.NewMemoryStore(), opts...)
+}
+
+func TestSubmit(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 2, TTL: 24 * time.Hour})
+	ctx := context.Background()
+
+	r, err := approval.Submit(ctx, m, kindPayout,
+		payoutPayload{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice", Reason: "invoice #4471"})
+	require.NoError(t, err)
+
+	assert.False(t, r.ID.IsZero())
+	assert.Equal(t, "payout.release", r.Kind)
+	assert.Equal(t, "alice", r.Requester)
+	assert.Equal(t, "invoice #4471", r.Reason)
+	assert.Equal(t, approval.Pending, r.Status)
+	assert.Equal(t, int64(1), r.Version)
+	assert.Empty(t, r.Decisions)
+	assert.True(t, fixedNow.Equal(r.CreatedAt))
+	assert.True(t, fixedNow.Add(24*time.Hour).Equal(r.ExpiresAt))
+}
+
+func TestSubmitZeroTTLNeverExpires(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 1})
+	r, err := approval.Submit(context.Background(), m, kindPayout,
+		payoutPayload{PayoutID: "po_1"}, approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+	assert.True(t, r.ExpiresAt.IsZero())
+}
+
+func TestSubmitRejectsEmptyRequester(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 2})
+	_, err := approval.Submit(context.Background(), m, kindPayout,
+		payoutPayload{}, approval.SubmitParams{})
+	assert.ErrorIs(t, err, approval.ErrRequesterRequired)
+}
+
+func TestSubmitRejectsUnknownKind(t *testing.T) {
+	t.Parallel()
+	unregistered := approval.NewKind[payoutPayload]("payout.unregistered")
+	m := newManager(t, approval.Policy{Quorum: 2})
+	_, err := approval.Submit(context.Background(), m, unregistered,
+		payoutPayload{}, approval.SubmitParams{Requester: "alice"})
+	assert.ErrorIs(t, err, approval.ErrUnknownKind)
+}
+
+func TestSubmitClonesMeta(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 2})
+	meta := map[string]string{"request_id": "req_1"}
+
+	r, err := approval.Submit(context.Background(), m, kindPayout,
+		payoutPayload{}, approval.SubmitParams{Requester: "alice", Meta: meta})
+	require.NoError(t, err)
+
+	meta["request_id"] = "tampered"
+	assert.Equal(t, "req_1", r.Meta["request_id"], "meta is cloned at submit")
+}
+
+func TestPayloadOf(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 2})
+	want := payoutPayload{PayoutID: "po_88", Amount: 250000}
+
+	r, err := approval.Submit(context.Background(), m, kindPayout, want,
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	got, err := approval.PayloadOf(kindPayout, r)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestPayloadOfRejectsWrongKind(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 2})
+	r, err := approval.Submit(context.Background(), m, kindPayout,
+		payoutPayload{PayoutID: "po_88"}, approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	other := approval.NewKind[struct{ Days int }]("hr.vacation")
+	_, err = approval.PayloadOf(other, r)
+	assert.ErrorIs(t, err, approval.ErrKindMismatch)
+}

--- a/ops/approval/tenancy_test.go
+++ b/ops/approval/tenancy_test.go
@@ -1,0 +1,168 @@
+package approval_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/access"
+	"github.com/dmitrymomot/forge/core/clock"
+	"github.com/dmitrymomot/forge/ops/approval"
+	"github.com/dmitrymomot/forge/ops/auditlog"
+)
+
+type tenantKey struct{}
+
+func ctxTenant(t string) context.Context {
+	return context.WithValue(context.Background(), tenantKey{}, t)
+}
+
+func tenantFromCtx(ctx context.Context) (string, error) {
+	t, _ := ctx.Value(tenantKey{}).(string)
+	return t, nil
+}
+
+func scopedManager(t *testing.T, store approval.Store) *approval.Manager {
+	t.Helper()
+	return approval.New(store,
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2}),
+		approval.WithClock(clock.NewMock(fixedNow)),
+		approval.WithScope(tenantFromCtx))
+}
+
+func TestScopeStampsTenantOnSubmit(t *testing.T) {
+	t.Parallel()
+	m := scopedManager(t, approval.NewMemoryStore())
+
+	r, err := approval.Submit(ctxTenant("acme"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+	assert.Equal(t, "acme", r.Tenant)
+}
+
+func TestScopeFailsClosedOnEmptyTenant(t *testing.T) {
+	t.Parallel()
+	m := scopedManager(t, approval.NewMemoryStore())
+
+	_, err := approval.Submit(context.Background(), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	assert.ErrorIs(t, err, approval.ErrScope, "a missing tenant must not fall back to global")
+}
+
+func TestScopeFailsClosedOnHookError(t *testing.T) {
+	t.Parallel()
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2}),
+		approval.WithScope(func(context.Context) (string, error) {
+			return "", errors.New("tenant lookup failed")
+		}))
+
+	_, err := approval.Submit(context.Background(), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	assert.ErrorIs(t, err, approval.ErrScope)
+}
+
+func TestScopeRejectsDisagreeingExplicitTenant(t *testing.T) {
+	t.Parallel()
+	m := scopedManager(t, approval.NewMemoryStore())
+
+	_, err := approval.Submit(ctxTenant("acme"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice", Tenant: "globex"})
+	assert.ErrorIs(t, err, approval.ErrScope)
+
+	// Agreeing is fine.
+	_, err = approval.Submit(ctxTenant("acme"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice", Tenant: "acme"})
+	assert.NoError(t, err)
+}
+
+func TestCrossTenantAccessReportsNotFound(t *testing.T) {
+	t.Parallel()
+	store := approval.NewMemoryStore()
+	m := scopedManager(t, store)
+
+	r, err := approval.Submit(ctxTenant("acme"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	other := ctxTenant("globex")
+	_, err = m.Approve(other, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrNotFound,
+		"not ErrScope — cross-tenant existence must not be probeable")
+
+	_, err = m.Cancel(other, r.ID, actor("bob"))
+	assert.ErrorIs(t, err, approval.ErrNotFound)
+}
+
+func TestListIsConfinedToScope(t *testing.T) {
+	t.Parallel()
+	store := approval.NewMemoryStore()
+	m := scopedManager(t, store)
+
+	_, err := approval.Submit(ctxTenant("acme"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+	_, err = approval.Submit(ctxTenant("globex"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "carol"})
+	require.NoError(t, err)
+
+	got, err := m.List(ctxTenant("acme"), approval.Filter{})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "acme", got[0].Tenant)
+}
+
+func TestUnscopedManagerPaysNoCeremony(t *testing.T) {
+	t.Parallel()
+	m, r := submitted(t, approval.Policy{Quorum: 1})
+	assert.Empty(t, r.Tenant)
+
+	got, err := m.Approve(context.Background(), r.ID, actor("bob"))
+	require.NoError(t, err)
+	assert.Equal(t, approval.Approved, got.Status)
+}
+
+func TestScopedGetReportsNotFoundForOtherTenant(t *testing.T) {
+	t.Parallel()
+	store := approval.NewMemoryStore()
+	m := scopedManager(t, store)
+
+	r, err := approval.Submit(ctxTenant("acme"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	_, err = m.Get(ctxTenant("acme"), r.ID)
+	require.NoError(t, err, "same-tenant Get must still work")
+
+	_, err = m.Get(ctxTenant("globex"), r.ID)
+	assert.ErrorIs(t, err, approval.ErrNotFound,
+		"cross-tenant Get must not leak the record or a distinguishable forbidden error")
+}
+
+func TestDeniedAttemptAuditCarriesTenant(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	d := &recordingDecider{effect: access.Deny}
+	m := approval.New(approval.NewMemoryStore(),
+		approval.WithKind(kindPayout, approval.Policy{Quorum: 2}),
+		approval.WithClock(clock.NewMock(fixedNow)),
+		approval.WithScope(tenantFromCtx),
+		approval.WithDecider(d),
+		approval.WithAuditor(auditlog.New(sink)))
+
+	r, err := approval.Submit(ctxTenant("acme"), m, kindPayout, payoutPayload{},
+		approval.SubmitParams{Requester: "alice"})
+	require.NoError(t, err)
+
+	_, err = m.Approve(ctxTenant("acme"), r.ID, actor("mallory"))
+	require.ErrorIs(t, err, approval.ErrNotEligible)
+
+	events := sink.Events()
+	require.Len(t, events, 2, "submit + the denied attempt")
+	assert.Equal(t, auditlog.OutcomeDenied, events[1].Outcome)
+	assert.Equal(t, "acme", events[1].Tenant,
+		"a denied attempt must be attributable to its tenant in the trail")
+}


### PR DESCRIPTION
Maker-checker dual control: typed approval requests that a second person approves or rejects over a storage-agnostic `Store`, with an execute-once claim so an approved action runs exactly once.

Design: [docs/superpowers/specs/2026-07-21-ops-approval-design.md](docs/superpowers/specs/2026-07-21-ops-approval-design.md) · Plan: [docs/superpowers/plans/2026-07-21-ops-approval.md](docs/superpowers/plans/2026-07-21-ops-approval.md)

## Architecture

A non-generic `Manager` owns a kind→`Policy` registry (immutable after `New`, so the read path needs no lock and no caller can register a weaker policy at runtime) and drives **every** state transition through one concurrency primitive: whole-record compare-and-swap on `Store.Update(ctx, r, expectVersion)`. Type safety lives in package-level generic functions (`Submit`, `PayloadOf`, `WithKind`) over a `Kind[T]` token, mirroring `async/queue`.

Expiry is derived on read and never persisted — no sweeper is needed for correctness. Three optional seams, all fail-closed when configured: `WithDecider` (eligibility via `auth/access`), `WithAuditor` (`ops/auditlog`), `WithScope` (tenancy). Single-tenant, no-seam use pays zero ceremony.

## Invariants

- The requester can never decide their own request, at any quorum — including Quorum 1, and under concurrency.
- An approver cannot vote twice, whichever way they voted first. Decisions are append-only.
- An approved action runs exactly once: two executors never both hold the claim.
- `ClaimTTL: 0` (default) means the claim never expires — a dead executor wedges the request until `Release`, the safe default for actions that move money. Non-zero opts into at-least-once, so the action must be idempotent.
- Under a configured scope, no exported entry point leaks another tenant's data; cross-tenant reads return `ErrNotFound`, indistinguishable from "no such request", so existence cannot be probed.

## Layout

`approval.go` types · `errors.go` sentinels · `policy.go` · `store.go`/`memory.go` · `approvaltest/` (exported Store conformance suite) · `manager.go` (CAS loop, expiry, scope) · `submit.go` · `decide.go` · `execute.go` · `eligibility.go` · `audit.go` · `pgstore/` (Postgres driver, pgx isolated here) · `doc.go`

## Testing

- Unit: **95.3%** coverage with `-race`.
- Integration: `approvaltest.Run` reruns against live Postgres via testcontainers behind the `integration` tag; plus an 8-writer concurrent-CAS test. Default `go test` stays Docker-free.
- Deterministic CAS coverage via a conflict-injecting `Store` decorator: proves the retry loop re-validates from a **fresh** read rather than blindly reapplying (a vote that lost a race is not double-recorded), that exhaustion surfaces `ErrConflict`, and that `WithMaxRetries` clamps.
- Fuzz: `FuzzPayloadOf` (~9M execs, no crashers) — payloads come out of a database and must never panic.
- `just lint` clean (vet, golangci-lint, nilaway, betteralign, modernize, integration pass). Zero `//nolint` directives.

## Benchmarks

`docs/superpowers/specs/2026-07-21-approval-bench-{baseline,after}.txt`. **No production code was changed for performance** — the numbers showed none warranted, and no speculative optimization was made. Apple M3 Max, go1.26.5, in-memory store:

```
BenchmarkSubmit-14                	 2169258	       556.6 ns/op	     639 B/op	       5 allocs/op
BenchmarkApproveQuorum2-14        	 2492959	       504.7 ns/op	     480 B/op	       5 allocs/op
BenchmarkApproveQuorum5-14        	 2845634	       493.6 ns/op	     480 B/op	       5 allocs/op
BenchmarkApproveContended-14      	 1330050	       917.8 ns/op	    1157 B/op	       9 allocs/op
BenchmarkGet-14                   	13912840	        86.08 ns/op	      32 B/op	       1 allocs/op
BenchmarkList100-14               	   72523	     16875 ns/op	   30824 B/op	     104 allocs/op
BenchmarkPayloadOf-14             	 2707274	       434.5 ns/op	     248 B/op	       6 allocs/op
BenchmarkApproveWithDecider-14    	 1676247	       777.1 ns/op	     944 B/op	      12 allocs/op
```

The one real before/after is methodological, not a perf win: `BenchmarkApproveContended` originally stopped contending once quorum was reached (~100 votes), so every later iteration was a cheap early-reject — its flat `B/op` across a 100x `N` spread proved it. Redesigned around a `b.N`-sized rotating pool of low-quorum requests; sustained contention is now shown by cost holding ~2.2–2.5x the uncontended control at every scale.

## Deviations from the plan

- **`Manager.Get` is tenant-scoped.** The plan's own `WithScope` doc promised `Get` returns `ErrNotFound` cross-tenant, but only `mutate` and `List` enforced it — the plan's tests never exercised cross-tenant `Get`, so the gap passed green. Code now matches its documentation.
- **`Filter.Limit` zero-default pinned to 100 in both stores** (was: memory unlimited, pgstore 100). "The store's default" silently truncated results when swapping stores, and the conformance suite — whose purpose is interchangeability — never covered it. Now an exported `approval.DefaultListLimit`, asserted by `approvaltest`.

## Observable changes for trail consumers

- `Fail` writes its reserved meta key as `approval.failure` (was `failure`), so it can no longer silently overwrite a submitter-supplied key.
- Approve/reject audit metadata gains a `vote` key. Additive.

## Known follow-ups (non-blocking)

- `TestMaxRetriesNegativeClampsToZero` passes with or without the clamp — it covers the line but doesn't discriminate.
- `TestNewPanics` uses bare `assert.Panics` for 4 of 5 wiring bugs; a reordering bug firing the wrong check would still pass.
- `pgstore`'s `($1 = '' OR col = $1)` filter idiom limits index usability, and the covering index omits `requester` — both inherited from `auth/apikey/pgstore`; worth fixing repo-wide or not at all.
- `Claim` is not idempotent for the current holder (documented, deliberate — the conservative choice for money).
