### PR TITLE
fix(approval): post-merge review follow-ups — audit structural refusals, nil-payload parity, List index usage

### DIFF
--- a/ops/approval/approvaltest/approvaltest.go
+++ b/ops/approval/approvaltest/approvaltest.go
@@ -76,6 +76,24 @@ func Run(t *testing.T, factory func(t *testing.T) approval.Store) {
 		assert.ErrorIs(t, s.Create(ctx, r), approval.ErrDuplicate)
 	})
 
+	// The Manager always marshals a payload before Create, but the Store
+	// contract does not require one: a driver must accept a nil Payload
+	// rather than surface a backend constraint error, normalizing it to at
+	// most JSON null.
+	t.Run("CreateAcceptsNilPayload", func(t *testing.T) {
+		s, n, ctx := factory(t), newNS(), context.Background()
+		r := n.request("alice", approval.Pending)
+		r.Payload = nil
+		require.NoError(t, s.Create(ctx, r))
+
+		got, err := s.Get(ctx, r.ID)
+		require.NoError(t, err)
+		if len(got.Payload) > 0 {
+			assert.Equal(t, "null", string(got.Payload),
+				"a nil payload may round-trip only as nil, empty, or JSON null")
+		}
+	})
+
 	t.Run("GetReportsNotFound", func(t *testing.T) {
 		s := factory(t)
 		_, err := s.Get(context.Background(), id.NewUUID())

--- a/ops/approval/audit.go
+++ b/ops/approval/audit.go
@@ -55,8 +55,9 @@ func (m *Manager) audit(ctx context.Context, r Request, action, actor, outcome, 
 	return nil
 }
 
-// auditDenied records a refused attempt. An ineligible actor trying to push
-// a request through is the most security-relevant event this package sees,
+// auditDenied records a refused attempt — a decider denial, a self-approval,
+// or a duplicate vote. An actor trying to push a request through without the
+// standing to do so is the most security-relevant event this package sees,
 // so it is never invisible — even though no state changed.
 //
 // tenant is the request's own tenant (empty when unscoped), not the

--- a/ops/approval/audit_test.go
+++ b/ops/approval/audit_test.go
@@ -104,6 +104,62 @@ func TestAuditRecordsDeniedAttempts(t *testing.T) {
 	assert.Equal(t, "approval:"+r.ID.String(), denied.Resource)
 }
 
+// TestAuditRecordsStructuralRefusals covers the refusals that need no
+// decider: a requester deciding their own request and an approver voting
+// twice must land in the trail as OutcomeDenied, exactly like a decider
+// denial — they are attempts to subvert dual control, not benign errors.
+func TestAuditRecordsStructuralRefusals(t *testing.T) {
+	t.Parallel()
+	sink := auditlog.NewMemorySink()
+	m, r := submitted(t, approval.Policy{Quorum: 2}, approval.WithAuditor(auditlog.New(sink)))
+	ctx := context.Background()
+
+	_, err := m.Approve(ctx, r.ID, actor("alice")) // alice is the requester
+	require.ErrorIs(t, err, approval.ErrSelfApproval)
+
+	_, err = m.Approve(ctx, r.ID, actor("bob"))
+	require.NoError(t, err)
+	_, err = m.Reject(ctx, r.ID, actor("bob")) // bob already voted
+	require.ErrorIs(t, err, approval.ErrAlreadyVoted)
+
+	events := sink.Events()
+	require.Len(t, events, 4, "submit + denied self-approval + bob's vote + denied re-vote")
+
+	self := events[1]
+	assert.Equal(t, "approval.approve", self.Action)
+	assert.Equal(t, auditlog.OutcomeDenied, self.Outcome)
+	assert.Equal(t, "alice", self.Actor)
+	assert.Equal(t, "approval:"+r.ID.String(), self.Resource)
+	assert.Contains(t, self.Meta["cause"], "cannot decide own request")
+
+	dup := events[3]
+	assert.Equal(t, "approval.reject", dup.Action)
+	assert.Equal(t, auditlog.OutcomeDenied, dup.Outcome)
+	assert.Equal(t, "bob", dup.Actor)
+	assert.Contains(t, dup.Meta["cause"], "already voted")
+}
+
+// TestSelfApprovalAndFailingSinkJoinsBothErrors pins the same non-masking
+// rule the decider-denial path has: when the structural refusal cannot be
+// audited, the caller still sees ErrSelfApproval, joined with ErrAuditFailed.
+func TestSelfApprovalAndFailingSinkJoinsBothErrors(t *testing.T) {
+	t.Parallel()
+	m := newManager(t, approval.Policy{Quorum: 1},
+		approval.WithAuditor(auditlog.New(failingSink{})))
+	ctx := context.Background()
+
+	r, err := approval.Submit(ctx, m, kindPayout,
+		payoutPayload{PayoutID: "po_88", Amount: 250000},
+		approval.SubmitParams{Requester: "alice", Reason: "invoice #4471"})
+	require.ErrorIs(t, err, approval.ErrAuditFailed)
+	require.False(t, r.ID.IsZero())
+
+	_, err = m.Approve(ctx, r.ID, actor("alice"))
+	assert.ErrorIs(t, err, approval.ErrSelfApproval,
+		"the structural refusal must survive the audit sink failing")
+	assert.ErrorIs(t, err, approval.ErrAuditFailed)
+}
+
 // TestAuditFailureReturnsDurableRequest deviates from the task brief's
 // literal test body: the brief built the fixture via submitted(), which
 // asserts require.NoError on Submit — but Submit itself audits, so a sink

--- a/ops/approval/decide.go
+++ b/ops/approval/decide.go
@@ -41,10 +41,12 @@ func (m *Manager) vote(ctx context.Context, reqID id.UUID, a Actor, v Vote) (Req
 			return statusErr(r.Status)
 		}
 		if r.Requester == a.Subject.ID {
+			denied = true
 			return ErrSelfApproval
 		}
 		for i := range r.Decisions {
 			if r.Decisions[i].Approver == a.Subject.ID {
+				denied = true
 				return ErrAlreadyVoted
 			}
 		}
@@ -78,10 +80,12 @@ func (m *Manager) vote(ctx context.Context, reqID id.UUID, a Actor, v Vote) (Req
 	})
 	if err != nil {
 		if denied {
-			// An ineligible actor trying to push a request through is the
-			// most security-relevant event this package sees. Record it, and
-			// join the audit error with the caller's own: errors.Is must still
-			// hold for both the original sentinel and ErrAuditFailed.
+			// A refused attempt to influence a decision — an ineligible actor,
+			// the requester voting on their own request, or an approver voting
+			// twice — is the most security-relevant event this package sees.
+			// Record it, and join the audit error with the caller's own:
+			// errors.Is must still hold for both the original sentinel and
+			// ErrAuditFailed.
 			if aerr := m.auditDenied(ctx, reqID, action, a.Subject.ID, tenant, err); aerr != nil {
 				return Request{}, errors.Join(err, aerr)
 			}

--- a/ops/approval/doc.go
+++ b/ops/approval/doc.go
@@ -59,7 +59,8 @@
 // that errors refuses the vote.
 //
 // WithAuditor writes every transition to an ops/auditlog Recorder,
-// including attempts the decider denied. WithScope confines every operation
+// including refused decision attempts — decider denials, self-approvals,
+// and duplicate votes. WithScope confines every operation
 // to a context-derived tenant, failing closed when none is available;
 // single-tenant applications pay no ceremony.
 //

--- a/ops/approval/errors.go
+++ b/ops/approval/errors.go
@@ -48,8 +48,9 @@ var (
 	// ErrExpired rejects every transition on a request past its TTL.
 	ErrExpired = errors.New("approval: request expired")
 
-	// ErrNotApproved rejects a claim on a request that has not reached
-	// quorum.
+	// ErrNotApproved rejects a claim on a request that is not in the
+	// Approved status: it has not reached quorum yet, or it has already
+	// moved past claiming (rejected, cancelled, executed, or failed).
 	ErrNotApproved = errors.New("approval: request not approved")
 
 	// ErrAlreadyClaimed rejects a claim held by another executor whose

--- a/ops/approval/options.go
+++ b/ops/approval/options.go
@@ -82,8 +82,9 @@ func WithDecider(d access.Decider) Option {
 }
 
 // WithAuditor records every state change to the audit trail: submissions,
-// decisions, cancellations, claims, and outcomes — plus every attempt a
-// decider refused, as OutcomeDenied.
+// decisions, cancellations, claims, and outcomes — plus every refused
+// attempt to influence a decision, as OutcomeDenied: decider denials,
+// self-approvals, and duplicate votes.
 //
 // The trail is written after the state change is durable. If the sink
 // fails, the transition still happened and the operation returns

--- a/ops/approval/pgstore/migrations/00001_create_forge_approval_requests.sql
+++ b/ops/approval/pgstore/migrations/00001_create_forge_approval_requests.sql
@@ -32,8 +32,8 @@ CREATE INDEX forge_approval_requests_expiry_idx
 -- Covers a List filtered by Requester within a Tenant, which
 -- forge_approval_requests_list_idx cannot serve since it leads with kind and
 -- status. A single-tenant deployment (tenant uniformly '') gets no benefit:
--- the optional-filter idiom leaves the leading column unqualified, so
--- Postgres cannot use requester as a search key.
+-- List omits the tenant predicate entirely, leaving this index's leading
+-- column unqualified, so Postgres cannot use requester as a search key.
 CREATE INDEX forge_approval_requests_requester_idx
     ON forge_approval_requests (tenant, requester, id DESC);
 

--- a/ops/approval/pgstore/pgstore.go
+++ b/ops/approval/pgstore/pgstore.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io/fs"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -116,30 +118,57 @@ func (s *Store) Update(ctx context.Context, r approval.Request, expect int64) er
 	return approval.ErrConflict
 }
 
-const listSQL = `
-SELECT ` + cols + ` FROM forge_approval_requests
-WHERE ($1 = '' OR tenant = $1)
-  AND ($2 = '' OR kind = $2)
-  AND ($3 = '' OR requester = $3)
-  AND (cardinality($4::smallint[]) = 0 OR status = ANY($4))
-  AND ($5::timestamptz IS NULL OR (expires_at IS NOT NULL AND expires_at < $5))
-ORDER BY id DESC
-LIMIT $6`
-
 // List returns requests matching f, newest first (UUIDv7 ids are
 // time-ordered, so id DESC is creation order). A zero f.Limit defaults to
 // approval.DefaultListLimit, matching the memory store.
+//
+// The WHERE clause carries only the filters actually set, rather than the
+// static `($n = ” OR col = $n)` idiom: once a prepared statement switches
+// to a generic plan (pgx prepares every query, and Postgres goes generic
+// after five executions) those ORs cannot be pruned and the planner stops
+// using the indexes. The distinct filter combinations bound the statement
+// cache at 32 entries.
 func (s *Store) List(ctx context.Context, f approval.Filter) ([]approval.Request, error) {
-	statuses := make([]int16, 0, len(f.Statuses))
-	for _, st := range f.Statuses {
-		statuses = append(statuses, int16(st))
+	var (
+		conds []string
+		args  []any
+	)
+	arg := func(v any) string {
+		args = append(args, v)
+		return "$" + strconv.Itoa(len(args))
+	}
+	if f.Tenant != "" {
+		conds = append(conds, "tenant = "+arg(f.Tenant))
+	}
+	if f.Kind != "" {
+		conds = append(conds, "kind = "+arg(f.Kind))
+	}
+	if f.Requester != "" {
+		conds = append(conds, "requester = "+arg(f.Requester))
+	}
+	if len(f.Statuses) > 0 {
+		statuses := make([]int16, 0, len(f.Statuses))
+		for _, st := range f.Statuses {
+			statuses = append(statuses, int16(st))
+		}
+		conds = append(conds, "status = ANY("+arg(statuses)+"::smallint[])")
+	}
+	if !f.ExpiresBefore.IsZero() {
+		// A NULL expires_at never satisfies the comparison, which is exactly
+		// the contract: rows with no expiry never match an expiry bound.
+		conds = append(conds, "expires_at < "+arg(f.ExpiresBefore))
 	}
 	limit := f.Limit
 	if limit <= 0 {
 		limit = approval.DefaultListLimit
 	}
-	rows, err := s.pool.Query(ctx, listSQL,
-		f.Tenant, f.Kind, f.Requester, statuses, nullTime(f.ExpiresBefore), limit)
+	sql := `SELECT ` + cols + ` FROM forge_approval_requests`
+	if len(conds) > 0 {
+		sql += " WHERE " + strings.Join(conds, " AND ")
+	}
+	sql += " ORDER BY id DESC LIMIT " + arg(limit)
+
+	rows, err := s.pool.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/ops/approval/pgstore/pgstore.go
+++ b/ops/approval/pgstore/pgstore.go
@@ -55,13 +55,13 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`
 
 // Create inserts r. A colliding id yields approval.ErrDuplicate.
 func (s *Store) Create(ctx context.Context, r approval.Request) error {
-	decisions, meta, err := encodeState(r)
+	payload, decisions, meta, err := encodeState(r)
 	if err != nil {
 		return err
 	}
 	_, err = s.pool.Exec(ctx, createSQL,
 		r.ID, r.Kind, r.Tenant, r.Requester, r.Reason, int16(r.Status), r.Version,
-		[]byte(r.Payload), decisions, meta, r.ClaimedBy,
+		payload, decisions, meta, r.ClaimedBy,
 		r.CreatedAt, nullTime(r.ExpiresAt), nullTime(r.ClaimedAt), nullTime(r.DecidedAt))
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
@@ -89,13 +89,13 @@ WHERE id = $1 AND version = $15`
 // a follow-up existence check tells those apart, because the Manager
 // retries one and gives up on the other.
 func (s *Store) Update(ctx context.Context, r approval.Request, expect int64) error {
-	decisions, meta, err := encodeState(r)
+	payload, decisions, meta, err := encodeState(r)
 	if err != nil {
 		return err
 	}
 	tag, err := s.pool.Exec(ctx, updateSQL,
 		r.ID, r.Kind, r.Tenant, r.Requester, r.Reason, int16(r.Status),
-		[]byte(r.Payload), decisions, meta, r.ClaimedBy,
+		payload, decisions, meta, r.ClaimedBy,
 		r.CreatedAt, nullTime(r.ExpiresAt), nullTime(r.ClaimedAt), nullTime(r.DecidedAt),
 		expect)
 	if err != nil {
@@ -196,22 +196,29 @@ func scanRequest(rw row) (approval.Request, error) {
 	return r, nil
 }
 
-// encodeState marshals the two JSON columns, normalizing nil to an empty
-// array and an empty object so a reader never has to special-case null.
-func encodeState(r approval.Request) (decisions []byte, meta map[string]string, err error) {
+// encodeState prepares the three JSON columns, normalizing nil Decisions to
+// an empty array and nil Meta to an empty object so a reader never has to
+// special-case null. A nil Payload becomes JSON null: the column is NOT
+// NULL, and the memory store accepts a nil payload, so rejecting it here
+// would make the two stores diverge on the same input.
+func encodeState(r approval.Request) (payload, decisions []byte, meta map[string]string, err error) {
+	payload = []byte(r.Payload)
+	if len(payload) == 0 {
+		payload = []byte("null")
+	}
 	d := r.Decisions
 	if d == nil {
 		d = []approval.Decision{}
 	}
 	decisions, err = json.Marshal(d)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	meta = r.Meta
 	if meta == nil {
 		meta = map[string]string{}
 	}
-	return decisions, meta, nil
+	return payload, decisions, meta, nil
 }
 
 // nullTime maps a zero time to SQL NULL.

--- a/ops/approval/pgstore/pgstore.go
+++ b/ops/approval/pgstore/pgstore.go
@@ -121,14 +121,13 @@ func (s *Store) Update(ctx context.Context, r approval.Request, expect int64) er
 // List returns requests matching f, newest first (UUIDv7 ids are
 // time-ordered, so id DESC is creation order). A zero f.Limit defaults to
 // approval.DefaultListLimit, matching the memory store.
-//
-// The WHERE clause carries only the filters actually set, rather than the
-// static `($n = ” OR col = $n)` idiom: once a prepared statement switches
-// to a generic plan (pgx prepares every query, and Postgres goes generic
-// after five executions) those ORs cannot be pruned and the planner stops
-// using the indexes. The distinct filter combinations bound the statement
-// cache at 32 entries.
 func (s *Store) List(ctx context.Context, f approval.Filter) ([]approval.Request, error) {
+	// The WHERE clause carries only the filters actually set, rather than
+	// the static `($n = '' OR col = $n)` idiom: once a prepared statement
+	// switches to a generic plan (pgx prepares every query, and Postgres
+	// goes generic after five executions) those ORs cannot be pruned and
+	// the planner stops using the indexes. The distinct filter combinations
+	// bound the statement cache at 32 entries.
 	var (
 		conds []string
 		args  []any

--- a/ops/approval/store.go
+++ b/ops/approval/store.go
@@ -16,8 +16,9 @@ import (
 // vote or counting one approver twice.
 //
 // Implementations may normalize nil and empty Decisions/Meta in either
-// direction; callers must not depend on which form is returned. List must
-// return a non-nil empty slice rather than nil when nothing matches.
+// direction, and a nil Payload to JSON null; callers must not depend on
+// which form is returned. List must return a non-nil empty slice rather
+// than nil when nothing matches.
 //
 // approvaltest.Run is the executable contract; every implementation must
 // pass it.


### PR DESCRIPTION
Post-merge review of ops/approval (PR #111) surfaced four issues; this PR fixes all of them.

## 1. Structural refusals are now audited (feat)

A requester approving their own request (`ErrSelfApproval`) or an approver voting twice (`ErrAlreadyVoted`) left no trace in the audit trail — only decider denials did, even though `audit.go` itself calls a refused attempt "the most security-relevant event this package sees", and a requester repeatedly trying to push their own payout through is exactly that. Both now land in the trail as `OutcomeDenied`, and a failing sink joins `ErrAuditFailed` with the original sentinel instead of masking it — same non-masking rule the decider-denial path already had. New tests: `TestAuditRecordsStructuralRefusals`, `TestSelfApprovalAndFailingSinkJoinsBothErrors`.

## 2. pgstore accepts a nil Payload (fix)

The Store contract never required a payload, and the two implementations diverged on the same input: the memory store accepted a nil `Payload` while pgstore surfaced a raw not-null constraint violation from the `json NOT NULL` column. `encodeState` now normalizes an empty payload to JSON `null`, the Store doc names the allowed normalization, and a new conformance case (`CreateAcceptsNilPayload`) pins every implementation — verified against live Postgres.

## 3. List builds its WHERE from only the filters set (perf)

The static optional-filter idiom — `($1 = '' OR tenant = $1)` for every column — defeats the indexes in production: pgx prepares every query, Postgres switches a prepared statement to a generic plan after five executions, and a generic plan cannot prune those ORs, so List degrades to a full sequential scan. The WHERE clause is now built from only the filters actually set, giving the planner plain equality predicates in every plan mode. The distinct filter combinations bound pgx's statement cache at 32 entries.

EXPLAIN ANALYZE under `force_generic_plan`, 200k rows, tenant+kind+status filter, postgres:18:

| shape | plan | buffers | execution |
|---|---|---|---|
| old | Parallel Seq Scan (100k rows removed/worker) | shared hit=2858 | 10.163 ms |
| new | Bitmap Index Scan on `forge_approval_requests_list_idx` | shared hit=3 | 0.017 ms |

The migration's requester-index comment explained single-tenant behavior in terms of the removed idiom; reworded (comment-only, no DDL touched).

## 4. ErrNotApproved doc covers terminal statuses (docs)

Claim returns `ErrNotApproved` for rejected, cancelled, executed, and failed requests too, but the doc claimed the request "has not reached quorum" — untrue for a request already past execution.

## Verification

- `go test -race` ops/approval: pass
- `go test -tags integration` ops/approval/pgstore (testcontainers, live Postgres): pass
- `just lint` (golangci-lint + nilaway + vet, integration tags): 0 issues