### PR TITLE
perf(pgstore): sweep the optional-filter OR idiom that defeats indexes under generic plans

### DIFF
--- a/auth/apikey/pgstore/pgstore.go
+++ b/auth/apikey/pgstore/pgstore.go
@@ -86,14 +86,13 @@ func (s *Store) GetByHash(ctx context.Context, hash string) (apikey.Key, error) 
 
 // List returns records matching f, newest first (UUIDv7 ids are
 // time-ordered, so id DESC is creation order).
-//
-// The WHERE clause carries only the filters actually set, rather than the
-// static `($n = ” OR col = $n)` idiom: once a prepared statement switches
-// to a generic plan (pgx prepares every query, and Postgres goes generic
-// after five executions) those ORs cannot be pruned and the planner stops
-// using forge_api_keys_list_idx. The filter combinations bound the
-// statement cache at 4 shapes.
 func (s *Store) List(ctx context.Context, f apikey.Filter) ([]apikey.Key, error) {
+	// The WHERE clause carries only the filters actually set, rather than
+	// the static `($n = '' OR col = $n)` idiom: once a prepared statement
+	// switches to a generic plan (pgx prepares every query, and Postgres
+	// goes generic after five executions) those ORs cannot be pruned and
+	// the planner stops using forge_api_keys_list_idx. The filter
+	// combinations bound the statement cache at 4 shapes.
 	var (
 		conds []string
 		args  []any

--- a/auth/apikey/pgstore/pgstore.go
+++ b/auth/apikey/pgstore/pgstore.go
@@ -5,6 +5,8 @@ import (
 	"embed"
 	"errors"
 	"io/fs"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -84,11 +86,34 @@ func (s *Store) GetByHash(ctx context.Context, hash string) (apikey.Key, error) 
 
 // List returns records matching f, newest first (UUIDv7 ids are
 // time-ordered, so id DESC is creation order).
+//
+// The WHERE clause carries only the filters actually set, rather than the
+// static `($n = ” OR col = $n)` idiom: once a prepared statement switches
+// to a generic plan (pgx prepares every query, and Postgres goes generic
+// after five executions) those ORs cannot be pruned and the planner stops
+// using forge_api_keys_list_idx. The filter combinations bound the
+// statement cache at 4 shapes.
 func (s *Store) List(ctx context.Context, f apikey.Filter) ([]apikey.Key, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT `+cols+` FROM forge_api_keys
-		 WHERE ($1 = '' OR tenant = $1) AND ($2 = '' OR subject = $2)
-		 ORDER BY id DESC`, f.Tenant, f.Subject)
+	var (
+		conds []string
+		args  []any
+	)
+	arg := func(v any) string {
+		args = append(args, v)
+		return "$" + strconv.Itoa(len(args))
+	}
+	if f.Tenant != "" {
+		conds = append(conds, "tenant = "+arg(f.Tenant))
+	}
+	if f.Subject != "" {
+		conds = append(conds, "subject = "+arg(f.Subject))
+	}
+	sql := `SELECT ` + cols + ` FROM forge_api_keys`
+	if len(conds) > 0 {
+		sql += " WHERE " + strings.Join(conds, " AND ")
+	}
+	sql += " ORDER BY id DESC"
+	rows, err := s.pool.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/oauthserver/pgstore/pgstore.go
+++ b/auth/oauthserver/pgstore/pgstore.go
@@ -85,14 +85,27 @@ func (s *Store) Update(ctx context.Context, c oauthserver.Client) error {
 	return nil
 }
 
-const listSQL = `
+// Two static shapes instead of `($1 = ” OR tenant_id = $1)`: under a
+// generic plan (which pgx-prepared statements reach after five executions)
+// Postgres cannot prune that OR and stops using oauth_clients_tenant_idx.
+const (
+	listSQL = `
 SELECT ` + columns + ` FROM oauth_clients
-WHERE ($1 = '' OR tenant_id = $1)
 ORDER BY created_at, id`
+
+	listTenantSQL = `
+SELECT ` + columns + ` FROM oauth_clients
+WHERE tenant_id = $1
+ORDER BY created_at, id`
+)
 
 // List returns the tenant's clients; tenantID "" returns all.
 func (s *Store) List(ctx context.Context, tenantID string) ([]oauthserver.Client, error) {
-	rows, err := s.pool.Query(ctx, listSQL, tenantID)
+	sql, args := listSQL, []any(nil)
+	if tenantID != "" {
+		sql, args = listTenantSQL, []any{tenantID}
+	}
+	rows, err := s.pool.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/oauthserver/pgstore/pgstore.go
+++ b/auth/oauthserver/pgstore/pgstore.go
@@ -85,9 +85,7 @@ func (s *Store) Update(ctx context.Context, c oauthserver.Client) error {
 	return nil
 }
 
-// Two static shapes instead of `($1 = ” OR tenant_id = $1)`: under a
-// generic plan (which pgx-prepared statements reach after five executions)
-// Postgres cannot prune that OR and stops using oauth_clients_tenant_idx.
+// List statement shapes — see List for why there are two.
 const (
 	listSQL = `
 SELECT ` + columns + ` FROM oauth_clients
@@ -101,6 +99,10 @@ ORDER BY created_at, id`
 
 // List returns the tenant's clients; tenantID "" returns all.
 func (s *Store) List(ctx context.Context, tenantID string) ([]oauthserver.Client, error) {
+	// Two static shapes instead of `($1 = '' OR tenant_id = $1)`: under a
+	// generic plan (which pgx-prepared statements reach after five
+	// executions) Postgres cannot prune that OR and stops using
+	// oauth_clients_tenant_idx.
 	sql, args := listSQL, []any(nil)
 	if tenantID != "" {
 		sql, args = listTenantSQL, []any{tenantID}

--- a/ops/auditlog/pgsink/pgsink.go
+++ b/ops/auditlog/pgsink/pgsink.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -135,27 +137,56 @@ func (s *Sink) List(ctx context.Context, f Filter) ([]auditlog.Event, string, er
 	case limit > 500:
 		limit = 500
 	}
-	var cursor any
+	// The WHERE clause carries only the filters actually set, rather than
+	// the static `($n = '' OR col = $n)` / `($n IS NULL OR ...)` idiom:
+	// once a prepared statement switches to a generic plan (pgx prepares
+	// every query, and Postgres goes generic after five executions) those
+	// ORs cannot be pruned and the planner stops using
+	// forge_audit_events_list_idx. The filter combinations bound the
+	// statement cache at 2^8 shapes.
+	var (
+		conds []string
+		args  []any
+	)
+	arg := func(v any) string {
+		args = append(args, v)
+		return "$" + strconv.Itoa(len(args))
+	}
+	if tenant != "" {
+		conds = append(conds, "tenant = "+arg(tenant))
+	}
+	if f.Actor != "" {
+		conds = append(conds, "actor = "+arg(f.Actor))
+	}
+	if f.Action != "" {
+		conds = append(conds, "action = "+arg(f.Action))
+	}
+	if f.Resource != "" {
+		conds = append(conds, "resource = "+arg(f.Resource))
+	}
+	if f.Outcome != "" {
+		conds = append(conds, "outcome = "+arg(string(f.Outcome)))
+	}
+	if !f.From.IsZero() {
+		conds = append(conds, "occurred_at >= "+arg(f.From))
+	}
+	if !f.To.IsZero() {
+		conds = append(conds, "occurred_at <= "+arg(f.To))
+	}
 	if f.Cursor != "" {
 		u, err := id.ParseUUID(f.Cursor)
 		if err != nil {
 			return nil, "", fmt.Errorf("%w: %w", ErrInvalidCursor, err)
 		}
-		cursor = u
+		conds = append(conds, "id < "+arg(u))
 	}
-	rows, err := s.pool.Query(ctx, `SELECT `+cols+` FROM forge_audit_events
-		WHERE ($1 = '' OR tenant = $1)
-		  AND ($2 = '' OR actor = $2)
-		  AND ($3 = '' OR action = $3)
-		  AND ($4 = '' OR resource = $4)
-		  AND ($5 = '' OR outcome = $5)
-		  AND ($6::timestamptz IS NULL OR occurred_at >= $6)
-		  AND ($7::timestamptz IS NULL OR occurred_at <= $7)
-		  AND ($8::uuid IS NULL OR id < $8)
-		ORDER BY id DESC
-		LIMIT $9`,
-		tenant, f.Actor, f.Action, f.Resource, string(f.Outcome),
-		nullTime(f.From), nullTime(f.To), cursor, limit+1)
+	sql := `SELECT ` + cols + ` FROM forge_audit_events`
+	if len(conds) > 0 {
+		sql += " WHERE " + strings.Join(conds, " AND ")
+	}
+	sql += " ORDER BY id DESC LIMIT " + arg(limit+1)
+
+	rows, err := s.pool.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -198,10 +229,7 @@ func (s *Sink) Verify(ctx context.Context, stream string) (int, string, error) {
 		count int
 	)
 	for {
-		rows, err := s.pool.Query(ctx, `SELECT `+cols+` FROM forge_audit_events
-			WHERE tenant = $1 AND ($2::uuid IS NULL OR id > $2)
-			ORDER BY id ASC
-			LIMIT $3`, tenant, after, verifyBatch)
+		rows, err := s.verifyPage(ctx, tenant, after)
 		if err != nil {
 			return count, prev, err
 		}
@@ -221,6 +249,24 @@ func (s *Sink) Verify(ctx context.Context, stream string) (int, string, error) {
 			return count, prev, nil
 		}
 	}
+}
+
+// verifyPage fetches one ascending batch of the tenant's chain. Two static
+// shapes instead of `($2 IS NULL OR id > $2)`: under a generic plan (which
+// pgx-prepared statements reach after five executions) the keyset bound
+// stops being an index condition, so every batch would rescan the tenant's
+// rows from the chain's genesis and filter — O(N²/batch) over the stream.
+func (s *Sink) verifyPage(ctx context.Context, tenant string, after any) (pgx.Rows, error) {
+	if after == nil {
+		return s.pool.Query(ctx, `SELECT `+cols+` FROM forge_audit_events
+			WHERE tenant = $1
+			ORDER BY id ASC
+			LIMIT $2`, tenant, verifyBatch)
+	}
+	return s.pool.Query(ctx, `SELECT `+cols+` FROM forge_audit_events
+		WHERE tenant = $1 AND id > $2
+		ORDER BY id ASC
+		LIMIT $3`, tenant, after, verifyBatch)
 }
 
 // scoped resolves the effective tenant: the WithScope hook when
@@ -260,12 +306,4 @@ func scanEvents(rows pgx.Rows, capacity int) ([]auditlog.Event, error) {
 		events = append(events, e)
 	}
 	return events, rows.Err()
-}
-
-// nullTime maps the zero time to SQL NULL.
-func nullTime(t time.Time) any {
-	if t.IsZero() {
-		return nil
-	}
-	return t
 }

--- a/ops/auditlog/pgsink/pgsink.go
+++ b/ops/auditlog/pgsink/pgsink.go
@@ -142,8 +142,12 @@ func (s *Sink) List(ctx context.Context, f Filter) ([]auditlog.Event, string, er
 	// once a prepared statement switches to a generic plan (pgx prepares
 	// every query, and Postgres goes generic after five executions) those
 	// ORs cannot be pruned and the planner stops using
-	// forge_audit_events_list_idx. The filter combinations bound the
-	// statement cache at 2^8 shapes.
+	// forge_audit_events_list_idx. The filter combinations bound this
+	// query's contribution to pgx's per-connection statement cache at 2^8 =
+	// 256 entries in the worst case — half the default 512-entry LRU cap,
+	// and only if a connection actually sees all 256 shapes; a typical
+	// paged-UI workload uses a handful. An evicted entry re-prepares on
+	// next use (one extra round-trip), it does not error.
 	var (
 		conds []string
 		args  []any

--- a/web/smartlink/pgstore/pgstore.go
+++ b/web/smartlink/pgstore/pgstore.go
@@ -79,12 +79,11 @@ func (s *Store) Get(ctx context.Context, code string) (smartlink.Link, error) {
 // List returns Links matching f, newest first (created_at descending, code
 // ascending on ties). An empty Filter.Tenant matches every tenant; a zero
 // Filter.Limit applies no cap.
-//
-// The tenant predicate is added only when set, rather than the static
-// `($1 = ” OR tenant = $1)` idiom: under a generic plan (which
-// pgx-prepared statements reach after five executions) Postgres cannot
-// prune that OR and stops using forge_smart_links_tenant_created_idx.
 func (s *Store) List(ctx context.Context, f smartlink.Filter) ([]smartlink.Link, error) {
+	// The tenant predicate is added only when set, rather than the static
+	// `($1 = '' OR tenant = $1)` idiom: under a generic plan (which
+	// pgx-prepared statements reach after five executions) Postgres cannot
+	// prune that OR and stops using forge_smart_links_tenant_created_idx.
 	sql := `SELECT ` + cols + ` FROM forge_smart_links`
 	var args []any
 	if f.Tenant != "" {
@@ -115,10 +114,10 @@ func (s *Store) List(ctx context.Context, f smartlink.Filter) ([]smartlink.Link,
 }
 
 // The point statements come in unscoped/tenant-scoped pairs instead of the
-// `($n = ” OR tenant = $n)` idiom. Perf is not the driver here — code is
-// the primary key, so these are index point lookups under any plan — but
-// the pair keeps the package free of the OR idiom so it cannot be copied
-// back into a query where it does defeat an index (see List).
+// optional-tenant OR idiom List used to share. Perf is not the driver here
+// — code is the primary key, so these are index point lookups under any
+// plan — but the pair keeps the package free of the OR idiom so it cannot
+// be copied back into a query where it does defeat an index (see List).
 const (
 	deactivateSQL       = `UPDATE forge_smart_links SET deactivated_at = $2 WHERE code = $1`
 	deactivateTenantSQL = deactivateSQL + ` AND tenant = $3`

--- a/web/smartlink/pgstore/pgstore.go
+++ b/web/smartlink/pgstore/pgstore.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"strconv"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -78,14 +79,22 @@ func (s *Store) Get(ctx context.Context, code string) (smartlink.Link, error) {
 // List returns Links matching f, newest first (created_at descending, code
 // ascending on ties). An empty Filter.Tenant matches every tenant; a zero
 // Filter.Limit applies no cap.
+//
+// The tenant predicate is added only when set, rather than the static
+// `($1 = ” OR tenant = $1)` idiom: under a generic plan (which
+// pgx-prepared statements reach after five executions) Postgres cannot
+// prune that OR and stops using forge_smart_links_tenant_created_idx.
 func (s *Store) List(ctx context.Context, f smartlink.Filter) ([]smartlink.Link, error) {
-	sql := `SELECT ` + cols + ` FROM forge_smart_links
-	        WHERE ($1 = '' OR tenant = $1)
-	        ORDER BY created_at DESC, code ASC`
-	args := []any{f.Tenant}
+	sql := `SELECT ` + cols + ` FROM forge_smart_links`
+	var args []any
+	if f.Tenant != "" {
+		args = append(args, f.Tenant)
+		sql += ` WHERE tenant = $1`
+	}
+	sql += ` ORDER BY created_at DESC, code ASC`
 	if f.Limit > 0 {
-		sql += ` LIMIT $2`
 		args = append(args, f.Limit)
+		sql += ` LIMIT $` + strconv.Itoa(len(args))
 	}
 	rows, err := s.pool.Query(ctx, sql, args...)
 	if err != nil {
@@ -105,9 +114,15 @@ func (s *Store) List(ctx context.Context, f smartlink.Filter) ([]smartlink.Link,
 	return out, rows.Err()
 }
 
-const deactivateSQL = `
-UPDATE forge_smart_links SET deactivated_at = $3
-WHERE code = $1 AND ($2 = '' OR tenant = $2)`
+// The point statements come in unscoped/tenant-scoped pairs instead of the
+// `($n = ” OR tenant = $n)` idiom. Perf is not the driver here — code is
+// the primary key, so these are index point lookups under any plan — but
+// the pair keeps the package free of the OR idiom so it cannot be copied
+// back into a query where it does defeat an index (see List).
+const (
+	deactivateSQL       = `UPDATE forge_smart_links SET deactivated_at = $2 WHERE code = $1`
+	deactivateTenantSQL = deactivateSQL + ` AND tenant = $3`
+)
 
 // Deactivate sets DeactivatedAt to at on code, scoped to tenant. A zero at
 // is rejected per the Store contract — it would write NULL and silently
@@ -116,28 +131,41 @@ func (s *Store) Deactivate(ctx context.Context, code, tenant string, at time.Tim
 	if at.IsZero() {
 		return fmt.Errorf("%w: Deactivate needs a non-zero time", smartlink.ErrInvalidLink)
 	}
-	return s.exec(ctx, deactivateSQL, code, tenant, at)
+	if tenant == "" {
+		return s.exec(ctx, deactivateSQL, code, at)
+	}
+	return s.exec(ctx, deactivateTenantSQL, code, at, tenant)
 }
 
-const activateSQL = `
-UPDATE forge_smart_links SET deactivated_at = NULL
-WHERE code = $1 AND ($2 = '' OR tenant = $2)`
+const (
+	activateSQL       = `UPDATE forge_smart_links SET deactivated_at = NULL WHERE code = $1`
+	activateTenantSQL = activateSQL + ` AND tenant = $2`
+)
 
 // Activate clears DeactivatedAt on code, scoped to tenant.
 func (s *Store) Activate(ctx context.Context, code, tenant string) error {
-	return s.exec(ctx, activateSQL, code, tenant)
+	if tenant == "" {
+		return s.exec(ctx, activateSQL, code)
+	}
+	return s.exec(ctx, activateTenantSQL, code, tenant)
 }
 
-const deleteSQL = `DELETE FROM forge_smart_links WHERE code = $1 AND ($2 = '' OR tenant = $2)`
+const (
+	deleteSQL       = `DELETE FROM forge_smart_links WHERE code = $1`
+	deleteTenantSQL = deleteSQL + ` AND tenant = $2`
+)
 
 // Delete removes code, scoped to tenant.
 func (s *Store) Delete(ctx context.Context, code, tenant string) error {
-	return s.exec(ctx, deleteSQL, code, tenant)
+	if tenant == "" {
+		return s.exec(ctx, deleteSQL, code)
+	}
+	return s.exec(ctx, deleteTenantSQL, code, tenant)
 }
 
-// exec runs sql and maps a zero-row result to smartlink.ErrNotFound: the
-// tenant predicate is inline in sql, so a mismatch and a missing code are
-// indistinguishable and both surface the same error.
+// exec runs sql and maps a zero-row result to smartlink.ErrNotFound: when a
+// tenant is set its predicate is inline in sql, so a mismatch and a missing
+// code are indistinguishable and both surface the same error.
 func (s *Store) exec(ctx context.Context, sql string, args ...any) error {
 	tag, err := s.pool.Exec(ctx, sql, args...)
 	if err != nil {


### PR DESCRIPTION
Repo-wide sweep of the `($n = '' OR col = $n)` / `($n IS NULL OR ...)` optional-filter SQL idiom, following its removal from ops/approval/pgstore in #112 (commit 0f57e7c).

## Why

pgx prepares every query, and Postgres switches a prepared statement to a **generic plan after five executions**. A generic plan cannot prune the ORs, so every query built with the idiom degrades to a scan that ignores the very indexes the migrations create for it. This bites exactly in production (warmed statements, real table sizes) while staying invisible in tests.

## What changed

| package | query | old (generic plan) | new (generic plan) |
|---|---|---|---|
| auth/apikey/pgstore | List (tenant+subject) | Parallel Seq Scan, 2634 buffers, 10.2ms | Bitmap Index Scan on `forge_api_keys_list_idx`, 406 buffers, 0.29ms |
| auth/oauthserver/pgstore | List (tenant) | Seq Scan, 190k rows filtered, 25.9ms | Bitmap Index Scan on `oauth_clients_tenant_idx`, 17.3ms¹ |
| web/smartlink/pgstore | List (tenant, LIMIT 100) | Parallel Seq Scan, 1517 buffers, 7.3ms | Index Only Scan, 36 buffers, 0.05ms |
| ops/auditlog/pgsink | List (tenant, LIMIT 51) | pkey walk + filter, 1152 buffers, 0.70ms | Index Only Scan on `forge_audit_events_list_idx`, 54 buffers, 0.03ms |
| ops/auditlog/pgsink | Verify batch @ offset 5000 | 5545 buffers, 5001 rows removed by filter — **O(N²/batch) over the stream** | 507 buffers flat, 0.09ms |

¹ both sides return the tenant's full 10k rows; the win grows with table size and shrinks with result size.

All numbers: EXPLAIN (ANALYZE) on postgres:18, 200k rows, `SET plan_cache_mode = force_generic_plan` (the state warmed pgx statements reach), PREPARE/EXECUTE with the exact old vs new query shapes.

## How

- **apikey, pgsink List**: WHERE built from only the filters actually set (the #112 pattern — placeholder positions string-built, all values bound). Statement-cache bound: 4 and 2⁸ shapes respectively.
- **oauthserver, pgsink Verify**: only one optional predicate, so two static statements instead of dynamic SQL. Verify's keyset bound is the important one: as a filter it rescans the chain from genesis every batch; as an index condition each batch starts at the bound.
- **smartlink**: List gets the conditional predicate; the Deactivate/Activate/Delete point statements become unscoped/tenant-scoped pairs. Perf is not the driver for those three — `code` is the primary key, so they are point lookups under any plan — they're included so the package is free of the idiom and it can't be copied back into a query where it does matter.

Not touched: `ops/approval/pgstore` (fixed in #112), and column-level NULL checks like `last_used_at IS NULL OR last_used_at < $3` (auth/totp, async/queue, resilience/ratelimit) — those are genuine SQL semantics on column values, not parameter-driven optional filters, and a generic plan handles them fine.

## Verification

- `go test -race` on all four package trees: pass
- `go test -tags integration -race` (testcontainers, live Postgres) on all four pgstores: pass — behavior pinned identical by each package's existing conformance suites
- `just lint` (golangci-lint + nilaway, integration tags): 0 issues