### PR TITLE
feat(bizcal): core/bizcal business-calendar package

### DIFF
--- a/core/bizcal/bench_test.go
+++ b/core/bizcal/bench_test.go
@@ -1,0 +1,170 @@
+package bizcal_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/bizcal"
+)
+
+// BenchmarkNew measures constructing a workdays calendar with three holiday
+// rules registered (the New() cost, not any lazy year resolution).
+func BenchmarkNew(b *testing.B) {
+	for b.Loop() {
+		_, err := bizcal.New(time.UTC,
+			bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
+			bizcal.WithRule(bizcal.Fixed{Month: time.January, Day: 1}),
+			bizcal.WithRule(bizcal.Fixed{Month: time.July, Day: 4}),
+			bizcal.WithRule(bizcal.NthWeekday{Month: time.November, Weekday: time.Thursday, N: 4}),
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// windowsCalendar builds a Monday-Friday, 09:00-18:00 windows-model
+// calendar used by the instant-op benchmarks below.
+func windowsCalendar(b *testing.B) *bizcal.Calendar {
+	b.Helper()
+	windows := bizcal.MustWindows("09:00-18:00")
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWeekday(time.Monday, windows...),
+		bizcal.WithWeekday(time.Tuesday, windows...),
+		bizcal.WithWeekday(time.Wednesday, windows...),
+		bizcal.WithWeekday(time.Thursday, windows...),
+		bizcal.WithWeekday(time.Friday, windows...),
+		bizcal.WithRule(bizcal.Fixed{Month: time.January, Day: 1}),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return cal
+}
+
+// BenchmarkIsOpen measures IsOpen against an already-resolved year (the
+// resolver's steady-state cost, with no lazy year build in the loop).
+func BenchmarkIsOpen(b *testing.B) {
+	cal := windowsCalendar(b)
+	t := time.Date(2026, time.July, 20, 10, 0, 0, 0, time.UTC)
+	cal.IsOpen(t) // prime the 2026 year plan
+	b.ReportAllocs()
+
+	for b.Loop() {
+		cal.IsOpen(t)
+	}
+}
+
+// BenchmarkNextOpen measures a weekend hop: querying Saturday noon on a
+// Monday-Friday calendar, which must scan forward to Monday 09:00.
+func BenchmarkNextOpen(b *testing.B) {
+	cal := windowsCalendar(b)
+	saturday := time.Date(2026, time.July, 25, 12, 0, 0, 0, time.UTC)
+	if _, err := cal.NextOpen(saturday); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if _, err := cal.NextOpen(saturday); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAdd_Short measures Add with a budget that lands the same day.
+func BenchmarkAdd_Short(b *testing.B) {
+	cal := windowsCalendar(b)
+	start := time.Date(2026, time.July, 20, 9, 0, 0, 0, time.UTC)
+	if _, err := cal.Add(start, 2*time.Hour); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if _, err := cal.Add(start, 2*time.Hour); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAdd_MultiWeek measures Add with an 80h budget spanning multiple
+// weeks and a holiday, exercising the multi-day scan loop.
+func BenchmarkAdd_MultiWeek(b *testing.B) {
+	cal := windowsCalendar(b)
+	start := time.Date(2025, time.December, 29, 9, 0, 0, 0, time.UTC)
+	if _, err := cal.Add(start, 80*time.Hour); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if _, err := cal.Add(start, 80*time.Hour); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkBetween_Day measures Between over a single-day span.
+func BenchmarkBetween_Day(b *testing.B) {
+	cal := windowsCalendar(b)
+	a := time.Date(2026, time.July, 20, 9, 12, 0, 0, time.UTC)
+	bnd := time.Date(2026, time.July, 20, 16, 5, 0, 0, time.UTC)
+	cal.Between(a, bnd)
+	b.ReportAllocs()
+
+	for b.Loop() {
+		cal.Between(a, bnd)
+	}
+}
+
+// BenchmarkBetween_Month measures Between over a roughly month-long span.
+func BenchmarkBetween_Month(b *testing.B) {
+	cal := windowsCalendar(b)
+	a := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	bnd := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	cal.Between(a, bnd)
+	b.ReportAllocs()
+
+	for b.Loop() {
+		cal.Between(a, bnd)
+	}
+}
+
+// BenchmarkScheduledBetween_Year measures ScheduledBetween over a full
+// year on a workdays-model calendar.
+func BenchmarkScheduledBetween_Year(b *testing.B) {
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
+		bizcal.WithRule(bizcal.Fixed{Month: time.January, Day: 1}),
+		bizcal.WithRule(bizcal.Fixed{Month: time.July, Day: 4}),
+		bizcal.WithRule(bizcal.NthWeekday{Month: time.November, Weekday: time.Thursday, N: 4}),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	from := bizcal.MustDate(2026, time.January, 1)
+	to := bizcal.MustDate(2027, time.January, 1)
+	cal.ScheduledBetween(from, to)
+	b.ReportAllocs()
+
+	for b.Loop() {
+		cal.ScheduledBetween(from, to)
+	}
+}
+
+// BenchmarkWindowsBetween_Month measures WindowsBetween over a month span,
+// fully draining the returned iterator on every iteration.
+func BenchmarkWindowsBetween_Month(b *testing.B) {
+	cal := windowsCalendar(b)
+	from := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	for range cal.WindowsBetween(from, to) {
+	}
+	b.ReportAllocs()
+
+	for b.Loop() {
+		for range cal.WindowsBetween(from, to) {
+		}
+	}
+}

--- a/core/bizcal/calendar.go
+++ b/core/bizcal/calendar.go
@@ -1,0 +1,158 @@
+package bizcal
+
+import (
+	"errors"
+	"maps"
+	"sort"
+	"time"
+)
+
+// Calendar is an immutable, goroutine-safe business-calendar built from a
+// base schedule (weekly windows, day-granular workdays, or always-open),
+// holiday rules, per-date exceptions, and rostered shifts. Construct one
+// with New; every field is unexported and normalized at construction time,
+// so a Calendar never aliases any slice or map the caller passed to its
+// Options.
+type Calendar struct {
+	loc            *time.Location
+	exceptions     map[Date]Exception
+	weekly         [7][]Window
+	rules          []Rule
+	shifts         []Interval
+	workdayCap     [7]time.Duration
+	horizon        time.Duration
+	workdaySet     [7]bool
+	usedWeekday    bool
+	usedWorkdays   bool
+	usedAlwaysOpen bool
+}
+
+// New builds a Calendar from loc and opts. loc must be non-nil, else
+// ErrNilLocation. Every Option error and every registered Rule's validation
+// error is collected and returned together via errors.Join.
+//
+// Exactly one base source may be used: WithWeekday, WithWorkdays, or
+// WithAlwaysOpen; combining more than one is a construction error. A
+// Calendar with no base and no shifts is statically closed on every day and
+// is rejected with ErrNeverOpen.
+func New(loc *time.Location, opts ...Option) (*Calendar, error) {
+	var errs []error
+	if loc == nil {
+		errs = append(errs, ErrNilLocation)
+	}
+
+	cfg := &config{horizon: defaultHorizon}
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	baseCount := 0
+	if cfg.usedWeekday {
+		baseCount++
+	}
+	if cfg.usedWorkdays {
+		baseCount++
+	}
+	if cfg.usedAlwaysOpen {
+		baseCount++
+	}
+	if baseCount > 1 {
+		errs = append(errs, errors.New("bizcal: at most one base source (WithWeekday, WithWorkdays, WithAlwaysOpen) may be used"))
+	}
+
+	for _, r := range cfg.rules {
+		if err := validateRule(r); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	hasBase := cfg.usedWeekday || cfg.usedWorkdays || cfg.usedAlwaysOpen
+	if !hasBase && len(cfg.shifts) == 0 {
+		errs = append(errs, ErrNeverOpen)
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	cal := &Calendar{
+		loc:            loc,
+		workdaySet:     cfg.workdaySet,
+		workdayCap:     cfg.workdayCap,
+		usedWeekday:    cfg.usedWeekday,
+		usedWorkdays:   cfg.usedWorkdays,
+		usedAlwaysOpen: cfg.usedAlwaysOpen,
+		rules:          append([]Rule(nil), cfg.rules...),
+		exceptions:     make(map[Date]Exception, len(cfg.exceptions)),
+		shifts:         mergeIntervals(cfg.shifts),
+		horizon:        cfg.horizon,
+	}
+	for i := range cfg.weekly {
+		cal.weekly[i] = mergeWindows(cfg.weekly[i])
+	}
+	maps.Copy(cal.exceptions, cfg.exceptions)
+
+	return cal, nil
+}
+
+// Location returns the *time.Location c interprets civil dates and clock
+// windows in.
+func (c *Calendar) Location() *time.Location {
+	return c.loc
+}
+
+// DateOf converts t to c's zone and returns its civil date there.
+func (c *Calendar) DateOf(t time.Time) Date {
+	return DateOf(t.In(c.loc))
+}
+
+// mergeWindows returns a sorted, non-aliasing copy of ws with overlapping or
+// adjacent windows merged. A nil or empty ws yields nil.
+func mergeWindows(ws []Window) []Window {
+	if len(ws) == 0 {
+		return nil
+	}
+	out := make([]Window, len(ws))
+	copy(out, ws)
+	sort.Slice(out, func(i, j int) bool { return out[i].start < out[j].start })
+
+	merged := out[:1]
+	for _, w := range out[1:] {
+		last := &merged[len(merged)-1]
+		if w.start <= last.end {
+			if w.end > last.end {
+				last.end = w.end
+			}
+			continue
+		}
+		merged = append(merged, w)
+	}
+	return merged
+}
+
+// mergeIntervals returns a sorted, non-aliasing copy of ivs with overlapping
+// or adjacent intervals merged (by absolute time). A nil or empty ivs
+// yields nil.
+func mergeIntervals(ivs []Interval) []Interval {
+	if len(ivs) == 0 {
+		return nil
+	}
+	out := make([]Interval, len(ivs))
+	copy(out, ivs)
+	sort.Slice(out, func(i, j int) bool { return out[i].Start.Before(out[j].Start) })
+
+	merged := out[:1]
+	for _, iv := range out[1:] {
+		last := &merged[len(merged)-1]
+		if !iv.Start.After(last.End) {
+			if iv.End.After(last.End) {
+				last.End = iv.End
+			}
+			continue
+		}
+		merged = append(merged, iv)
+	}
+	return merged
+}

--- a/core/bizcal/calendar.go
+++ b/core/bizcal/calendar.go
@@ -81,7 +81,17 @@ func New(loc *time.Location, opts ...Option) (*Calendar, error) {
 			break
 		}
 	}
-	hasBase := cfg.usedWorkdays || cfg.usedAlwaysOpen || (cfg.usedWeekday && weekdayHasWindows)
+	// A WithWorkdays base only opens the calendar if at least one weekday was
+	// actually supplied; WithWorkdays(perDay) with no weekdays contributes no
+	// open time, so it does not count as a base for the never-open check.
+	workdaysHasDays := false
+	for _, on := range cfg.workdaySet {
+		if on {
+			workdaysHasDays = true
+			break
+		}
+	}
+	hasBase := (cfg.usedWorkdays && workdaysHasDays) || cfg.usedAlwaysOpen || (cfg.usedWeekday && weekdayHasWindows)
 	if !hasBase && len(cfg.shifts) == 0 {
 		errs = append(errs, ErrNeverOpen)
 	}

--- a/core/bizcal/calendar.go
+++ b/core/bizcal/calendar.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"maps"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -16,11 +17,13 @@ import (
 type Calendar struct {
 	loc            *time.Location
 	exceptions     map[Date]Exception
+	years          map[int]*yearPlan
 	weekly         [7][]Window
 	rules          []Rule
 	shifts         []Interval
 	workdayCap     [7]time.Duration
 	horizon        time.Duration
+	mu             sync.RWMutex
 	workdaySet     [7]bool
 	usedWeekday    bool
 	usedWorkdays   bool
@@ -88,6 +91,7 @@ func New(loc *time.Location, opts ...Option) (*Calendar, error) {
 		exceptions:     make(map[Date]Exception, len(cfg.exceptions)),
 		shifts:         mergeIntervals(cfg.shifts),
 		horizon:        cfg.horizon,
+		years:          make(map[int]*yearPlan),
 	}
 	for i := range cfg.weekly {
 		cal.weekly[i] = mergeWindows(cfg.weekly[i])
@@ -106,6 +110,82 @@ func (c *Calendar) Location() *time.Location {
 // DateOf converts t to c's zone and returns its civil date there.
 func (c *Calendar) DateOf(t time.Time) Date {
 	return DateOf(t.In(c.loc))
+}
+
+// IsWorkingDay reports whether d has any open time: a non-zero scheduled
+// capacity or at least one open interval. A workdays-model day-off (or a
+// zero-capacity ShortDay) leaves both empty and is therefore not a working
+// day; a shift rostered onto a holiday makes that date working.
+func (c *Calendar) IsWorkingDay(d Date) bool {
+	p := c.dayPlan(d)
+	return p.capacity > 0 || len(p.intervals) > 0
+}
+
+// WorkingDays counts the working days in the half-open range [from, to). It
+// returns 0 when from is not before to (empty or inverted range).
+func (c *Calendar) WorkingDays(from, to Date) int {
+	if !from.Before(to) {
+		return 0
+	}
+	count := 0
+	for d := from; d.Before(to); d = d.AddDays(1) {
+		if c.IsWorkingDay(d) {
+			count++
+		}
+	}
+	return count
+}
+
+// AddWorkingDays returns the n-th working day strictly after d (n > 0) or
+// strictly before d (n < 0), skipping non-working days. n == 0 returns d
+// unchanged, even when d itself is not a working day. The scan is bounded by
+// the configured horizon (interpreted as a day count of horizon/24h from d);
+// exhausting it returns ErrHorizonExceeded.
+func (c *Calendar) AddWorkingDays(d Date, n int) (Date, error) {
+	if n == 0 {
+		return d, nil
+	}
+	maxDays := int(c.horizon / (24 * time.Hour))
+	step := 1
+	if n < 0 {
+		step = -1
+		n = -n
+	}
+	cur := d
+	for moved := 0; ; {
+		cur = cur.AddDays(step)
+		moved++
+		if moved > maxDays {
+			return Date{}, ErrHorizonExceeded
+		}
+		if c.IsWorkingDay(cur) {
+			if n--; n == 0 {
+				return cur, nil
+			}
+		}
+	}
+}
+
+// DayDuration returns d's scheduled capacity: the duration that counts as the
+// day's expected hours. For the windows model this is the sum of real
+// interval durations (so a DST day may differ from a nominal one); for the
+// workdays model it is the fixed per-day capacity; shift time rostered onto d
+// adds on top.
+func (c *Calendar) DayDuration(d Date) time.Duration {
+	return c.dayPlan(d).capacity
+}
+
+// ScheduledBetween sums DayDuration over the half-open range [from, to). It
+// returns 0 when from is not before to (empty or inverted range).
+func (c *Calendar) ScheduledBetween(from, to Date) time.Duration {
+	if !from.Before(to) {
+		return 0
+	}
+	var total time.Duration
+	for d := from; d.Before(to); d = d.AddDays(1) {
+		total += c.dayPlan(d).capacity
+	}
+	return total
 }
 
 // mergeWindows returns a sorted, non-aliasing copy of ws with overlapping or

--- a/core/bizcal/calendar.go
+++ b/core/bizcal/calendar.go
@@ -71,7 +71,17 @@ func New(loc *time.Location, opts ...Option) (*Calendar, error) {
 		}
 	}
 
-	hasBase := cfg.usedWeekday || cfg.usedWorkdays || cfg.usedAlwaysOpen
+	// A WithWeekday base only opens the calendar if at least one window was
+	// actually supplied; WithWeekday(wd) with no windows contributes no open
+	// time, so it does not count as a base for the never-open check.
+	weekdayHasWindows := false
+	for _, ws := range cfg.weekly {
+		if len(ws) > 0 {
+			weekdayHasWindows = true
+			break
+		}
+	}
+	hasBase := cfg.usedWorkdays || cfg.usedAlwaysOpen || (cfg.usedWeekday && weekdayHasWindows)
 	if !hasBase && len(cfg.shifts) == 0 {
 		errs = append(errs, ErrNeverOpen)
 	}

--- a/core/bizcal/calendar_internal_test.go
+++ b/core/bizcal/calendar_internal_test.go
@@ -1,0 +1,113 @@
+package bizcal
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNew_ClonesCallerSlices pins the variadic-clone/deep-copy invariant
+// directly against Calendar's unexported state: no ops exist yet to observe
+// mutation through behavior (that lands in Task 4), so this white-box test
+// is the only way to verify New does not alias a caller's slice today.
+func TestNew_ClonesCallerSlices(t *testing.T) {
+	windows := MustWindows("09:00-17:00")
+	start := time.Date(2026, time.July, 21, 9, 0, 0, 0, time.UTC)
+	end := time.Date(2026, time.July, 21, 17, 0, 0, 0, time.UTC)
+	shifts := []Interval{{Start: start, End: end}}
+
+	cal, err := New(time.UTC, WithWeekday(time.Monday, windows...), WithShifts(shifts...))
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+
+	var wantWindow Window
+	for _, w := range cal.weekly[time.Monday] {
+		wantWindow = w
+		break
+	}
+	var wantShift Interval
+	for _, iv := range cal.shifts {
+		wantShift = iv
+		break
+	}
+
+	// Mutate the caller's backing arrays after New returns.
+	windows[0] = MustWindows("00:00-01:00")[0]
+	shifts[0].Start = time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	var gotWindow Window
+	for _, w := range cal.weekly[time.Monday] {
+		gotWindow = w
+		break
+	}
+	if gotWindow != wantWindow {
+		t.Fatalf("weekly[Monday][0] = %v after caller mutation, want unchanged %v", gotWindow, wantWindow)
+	}
+	var gotShift Interval
+	for _, iv := range cal.shifts {
+		gotShift = iv
+		break
+	}
+	if gotShift != wantShift {
+		t.Fatalf("shifts[0] = %v after caller mutation, want unchanged %v", gotShift, wantShift)
+	}
+}
+
+// TestMergeWindows verifies sorting and merging of overlapping/adjacent
+// windows, and that the result never aliases the input slice.
+func TestMergeWindows(t *testing.T) {
+	in := MustWindows("14:00-18:00", "09:00-13:00", "12:30-14:00")
+	got := mergeWindows(in)
+
+	// 09:00-13:00 and 12:30-14:00 overlap, and the result touches
+	// 14:00-18:00 exactly at the boundary (adjacent), so all three merge
+	// into a single window.
+	want := MustWindows("09:00-18:00")
+	if len(got) != len(want) {
+		t.Fatalf("mergeWindows(%v) = %v, want %v", in, got, want)
+	}
+	i := 0
+	for _, g := range got {
+		if g != want[i] {
+			t.Fatalf("mergeWindows(%v)[%d] = %v, want %v", in, i, g, want[i])
+		}
+		i++
+	}
+
+	in[0] = MustWindows("00:00-01:00")[0]
+	var last Window
+	for _, g := range got {
+		last = g
+	}
+	if last == in[0] {
+		t.Fatalf("mergeWindows result aliases input slice")
+	}
+}
+
+// TestMergeIntervals verifies sorting and merging of overlapping/adjacent
+// intervals in absolute time, and that the result never aliases the input.
+func TestMergeIntervals(t *testing.T) {
+	day := func(h int) time.Time { return time.Date(2026, time.July, 21, h, 0, 0, 0, time.UTC) }
+	in := []Interval{
+		{Start: day(14), End: day(18)},
+		{Start: day(9), End: day(13)},
+		{Start: day(12), End: day(14)},
+	}
+	got := mergeIntervals(in)
+	want := []Interval{
+		{Start: day(9), End: day(18)},
+	}
+	var first Interval
+	for _, iv := range got {
+		first = iv
+		break
+	}
+	if len(got) != len(want) || first != want[0] {
+		t.Fatalf("mergeIntervals(%v) = %v, want %v", in, got, want)
+	}
+
+	in[0].Start = day(0)
+	if first == in[0] {
+		t.Fatalf("mergeIntervals result aliases input slice")
+	}
+}

--- a/core/bizcal/calendar_test.go
+++ b/core/bizcal/calendar_test.go
@@ -1,0 +1,298 @@
+package bizcal_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/bizcal"
+)
+
+func TestNew_WorkdaysCalendar(t *testing.T) {
+	loc := time.UTC
+	cal, err := bizcal.New(loc,
+		bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+	if cal.Location() != loc {
+		t.Fatalf("Location() = %v, want %v", cal.Location(), loc)
+	}
+}
+
+func TestNew_WeeklyWindowsCalendar(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	windows := bizcal.MustWindows("09:00-13:00", "14:00-18:00")
+	cal, err := bizcal.New(loc,
+		bizcal.WithWeekday(time.Monday, windows...),
+		bizcal.WithWeekday(time.Tuesday, windows...),
+		bizcal.WithWeekday(time.Friday, bizcal.MustWindows("09:00-15:00")...),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+	if cal.Location() != loc {
+		t.Fatalf("Location() = %v, want %v", cal.Location(), loc)
+	}
+}
+
+func TestNew_AlwaysOpen(t *testing.T) {
+	cal, err := bizcal.New(time.UTC, bizcal.WithAlwaysOpen())
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+	if cal == nil {
+		t.Fatal("New() returned nil calendar with nil error")
+	}
+}
+
+func TestNew_ShiftsOnly(t *testing.T) {
+	start := time.Date(2026, time.July, 21, 9, 0, 0, 0, time.UTC)
+	end := time.Date(2026, time.July, 21, 17, 0, 0, 0, time.UTC)
+	cal, err := bizcal.New(time.UTC, bizcal.WithShifts(bizcal.Shift(start, end)))
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+	if cal == nil {
+		t.Fatal("New() returned nil calendar with nil error")
+	}
+}
+
+func TestNew_EmptyCalendar_ErrNeverOpen(t *testing.T) {
+	_, err := bizcal.New(time.UTC)
+	if !errors.Is(err, bizcal.ErrNeverOpen) {
+		t.Fatalf("New() = %v, want ErrNeverOpen", err)
+	}
+}
+
+func TestNew_NilLocation_ErrNilLocation(t *testing.T) {
+	_, err := bizcal.New(nil, bizcal.WithAlwaysOpen())
+	if !errors.Is(err, bizcal.ErrNilLocation) {
+		t.Fatalf("New() = %v, want ErrNilLocation", err)
+	}
+}
+
+func TestNew_TwoBaseSources_Error(t *testing.T) {
+	_, err := bizcal.New(time.UTC,
+		bizcal.WithWorkdays(8*time.Hour, time.Monday),
+		bizcal.WithWeekday(time.Tuesday, bizcal.MustWindows("09:00-17:00")...),
+	)
+	if err == nil {
+		t.Fatal("New() = nil, want a base-source-conflict error")
+	}
+	if errors.Is(err, bizcal.ErrNeverOpen) || errors.Is(err, bizcal.ErrInvalidRule) {
+		t.Fatalf("New() = %v, want a distinct non-sentinel error", err)
+	}
+}
+
+func TestNew_TwoBaseSources_AlwaysOpenAndWorkdays_Error(t *testing.T) {
+	_, err := bizcal.New(time.UTC,
+		bizcal.WithAlwaysOpen(),
+		bizcal.WithWorkdays(8*time.Hour, time.Monday),
+	)
+	if err == nil {
+		t.Fatal("New() = nil, want a base-source-conflict error")
+	}
+}
+
+func TestNew_WithWeekday_InvalidWeekday(t *testing.T) {
+	_, err := bizcal.New(time.UTC, bizcal.WithWeekday(time.Weekday(9)))
+	if !errors.Is(err, bizcal.ErrInvalidWeekday) {
+		t.Fatalf("New() = %v, want ErrInvalidWeekday", err)
+	}
+}
+
+func TestNew_WithWorkdays_InvalidCapacity(t *testing.T) {
+	cases := []struct {
+		name   string
+		perDay time.Duration
+	}{
+		{"zero", 0},
+		{"negative", -time.Hour},
+		{"over 24h", 25 * time.Hour},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := bizcal.New(time.UTC, bizcal.WithWorkdays(c.perDay, time.Monday))
+			if !errors.Is(err, bizcal.ErrInvalidCapacity) {
+				t.Fatalf("New() = %v, want ErrInvalidCapacity", err)
+			}
+		})
+	}
+}
+
+func TestNew_WithWorkdays_InvalidWeekday(t *testing.T) {
+	_, err := bizcal.New(time.UTC, bizcal.WithWorkdays(8*time.Hour, time.Weekday(-1)))
+	if !errors.Is(err, bizcal.ErrInvalidWeekday) {
+		t.Fatalf("New() = %v, want ErrInvalidWeekday", err)
+	}
+}
+
+func TestNew_WithRule_Nil(t *testing.T) {
+	_, err := bizcal.New(time.UTC, bizcal.WithAlwaysOpen(), bizcal.WithRule(nil))
+	if !errors.Is(err, bizcal.ErrInvalidRule) {
+		t.Fatalf("New() = %v, want ErrInvalidRule", err)
+	}
+}
+
+func TestNew_WithRule_InvalidRuleValidatedAtNew(t *testing.T) {
+	_, err := bizcal.New(time.UTC,
+		bizcal.WithAlwaysOpen(),
+		bizcal.WithRule(bizcal.NthWeekday{Month: time.May, Weekday: time.Monday, N: 0}),
+	)
+	if !errors.Is(err, bizcal.ErrInvalidRule) {
+		t.Fatalf("New() = %v, want ErrInvalidRule", err)
+	}
+}
+
+func TestNew_WithRules_BulkForm(t *testing.T) {
+	_, err := bizcal.New(time.UTC,
+		bizcal.WithAlwaysOpen(),
+		bizcal.WithRules(bizcal.Fixed{Month: time.January, Day: 1}, bizcal.Fixed{Month: time.July, Day: 4}),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+}
+
+func TestNew_WithShifts_InvalidShift(t *testing.T) {
+	start := time.Date(2026, time.July, 21, 17, 0, 0, 0, time.UTC)
+	end := time.Date(2026, time.July, 21, 9, 0, 0, 0, time.UTC)
+	_, err := bizcal.New(time.UTC, bizcal.WithShifts(bizcal.Shift(start, end)))
+	if !errors.Is(err, bizcal.ErrInvalidShift) {
+		t.Fatalf("New() = %v, want ErrInvalidShift", err)
+	}
+}
+
+func TestNew_WithShifts_ZeroTimes(t *testing.T) {
+	_, err := bizcal.New(time.UTC, bizcal.WithShifts(bizcal.Interval{}))
+	if !errors.Is(err, bizcal.ErrInvalidShift) {
+		t.Fatalf("New() = %v, want ErrInvalidShift", err)
+	}
+}
+
+func TestNew_MultipleOptionErrors_AllPresent(t *testing.T) {
+	_, err := bizcal.New(time.UTC,
+		bizcal.WithWeekday(time.Weekday(9)),
+		bizcal.WithRule(nil),
+		bizcal.WithShifts(bizcal.Shift(time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC), time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC))),
+	)
+	if !errors.Is(err, bizcal.ErrInvalidWeekday) {
+		t.Fatalf("New() = %v, want ErrInvalidWeekday present", err)
+	}
+	if !errors.Is(err, bizcal.ErrInvalidRule) {
+		t.Fatalf("New() = %v, want ErrInvalidRule present", err)
+	}
+	if !errors.Is(err, bizcal.ErrInvalidShift) {
+		t.Fatalf("New() = %v, want ErrInvalidShift present", err)
+	}
+}
+
+func TestNew_WithExceptions_ShortDay_InvalidCapacity(t *testing.T) {
+	cases := []struct {
+		name     string
+		capacity time.Duration
+	}{
+		{"negative", -time.Minute},
+		{"over 24h", 25 * time.Hour},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := bizcal.New(time.UTC,
+				bizcal.WithAlwaysOpen(),
+				bizcal.WithExceptions(bizcal.ShortDay(bizcal.MustDate(2026, time.December, 31), c.capacity)),
+			)
+			if !errors.Is(err, bizcal.ErrInvalidCapacity) {
+				t.Fatalf("New() = %v, want ErrInvalidCapacity", err)
+			}
+		})
+	}
+}
+
+func TestNew_WithExceptions_ShortDay_ZeroCapacityValid(t *testing.T) {
+	_, err := bizcal.New(time.UTC,
+		bizcal.WithAlwaysOpen(),
+		bizcal.WithExceptions(bizcal.ShortDay(bizcal.MustDate(2026, time.December, 31), 0)),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v, want nil (zero capacity behaves as DayOff)", err)
+	}
+}
+
+func TestNew_WithExceptions_CustomDayEmptyIsDayOff(t *testing.T) {
+	// CustomDay with no windows is documented to behave as DayOff; this is
+	// just a construction smoke test — behavioral verification is Task 4's.
+	_, err := bizcal.New(time.UTC,
+		bizcal.WithAlwaysOpen(),
+		bizcal.WithExceptions(bizcal.CustomDay(bizcal.MustDate(2026, time.July, 21))),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+}
+
+func TestNew_WithHorizon(t *testing.T) {
+	_, err := bizcal.New(time.UTC, bizcal.WithAlwaysOpen(), bizcal.WithHorizon(48*time.Hour))
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+}
+
+func TestNew_WithHorizon_Invalid(t *testing.T) {
+	_, err := bizcal.New(time.UTC, bizcal.WithAlwaysOpen(), bizcal.WithHorizon(0))
+	if !errors.Is(err, bizcal.ErrInvalidCapacity) {
+		t.Fatalf("New() = %v, want ErrInvalidCapacity", err)
+	}
+	_, err = bizcal.New(time.UTC, bizcal.WithAlwaysOpen(), bizcal.WithHorizon(-time.Hour))
+	if !errors.Is(err, bizcal.ErrInvalidCapacity) {
+		t.Fatalf("New() = %v, want ErrInvalidCapacity", err)
+	}
+}
+
+func TestCalendar_DateOf_ConvertsToCalendarZone(t *testing.T) {
+	kyiv, err := time.LoadLocation("Europe/Kyiv")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	cal, err := bizcal.New(kyiv, bizcal.WithAlwaysOpen())
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+
+	// 2026-07-21 00:30 Kyiv (UTC+3 in July) is 2026-07-20 21:30 UTC.
+	instant := time.Date(2026, time.July, 20, 21, 30, 0, 0, time.UTC)
+	got := cal.DateOf(instant)
+	want := bizcal.MustDate(2026, time.July, 21)
+	if got != want {
+		t.Fatalf("DateOf(%v) = %v, want %v", instant, got, want)
+	}
+}
+
+// TestNew_MutationSafety_ConstructionLevel is the construction-level half of
+// the mutation-safety requirement: options must not alias the caller's
+// slices. It only verifies New succeeds and is unaffected by post-New
+// mutation of the caller's inputs at the API surface available today
+// (Location/DateOf); once day/instant ops exist (Task 4) this should be
+// extended to assert the resolved schedule is unchanged too. See also the
+// white-box TestNew_ClonesCallerSlices in calendar_internal_test.go, which
+// pins the same invariant directly against unexported state.
+func TestNew_MutationSafety_ConstructionLevel(t *testing.T) {
+	windows := bizcal.MustWindows("09:00-17:00")
+	loc := time.UTC
+
+	cal, err := bizcal.New(loc, bizcal.WithWeekday(time.Monday, windows...))
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+
+	// Mutate the caller's backing slice after New returns.
+	windows[0] = bizcal.MustWindows("00:00-01:00")[0]
+
+	if cal.Location() != loc {
+		t.Fatalf("Location() = %v, want %v (calendar corrupted by post-New mutation)", cal.Location(), loc)
+	}
+}

--- a/core/bizcal/calendar_test.go
+++ b/core/bizcal/calendar_test.go
@@ -95,6 +95,32 @@ func TestNew_WeekdayNoWindows_WithShifts_Valid(t *testing.T) {
 	}
 }
 
+func TestNew_WorkdaysNoWeekdays_ErrNeverOpen(t *testing.T) {
+	// A workdays base with no weekdays supplied opens no time: the calendar
+	// is structurally never open and must be rejected at New.
+	_, err := bizcal.New(time.UTC, bizcal.WithWorkdays(8*time.Hour))
+	if !errors.Is(err, bizcal.ErrNeverOpen) {
+		t.Fatalf("New() = %v, want ErrNeverOpen", err)
+	}
+}
+
+func TestNew_WorkdaysNoWeekdays_WithShifts_Valid(t *testing.T) {
+	// A weekdays-empty workdays base combined with shifts is still open: the
+	// shifts supply the open time, so construction must succeed.
+	start := time.Date(2026, time.July, 20, 9, 0, 0, 0, time.UTC)
+	end := time.Date(2026, time.July, 20, 17, 0, 0, 0, time.UTC)
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWorkdays(8*time.Hour),
+		bizcal.WithShifts(bizcal.Shift(start, end)),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+	if !cal.IsWorkingDay(bizcal.MustDate(2026, time.July, 20)) {
+		t.Fatal("IsWorkingDay(shift day) = false, want true")
+	}
+}
+
 func TestNew_WithWeekday_SameWeekdayAppends(t *testing.T) {
 	// Repeated WithWeekday for the same weekday appends windows rather than
 	// replacing; overlapping windows merge. A Monday configured with a

--- a/core/bizcal/calendar_test.go
+++ b/core/bizcal/calendar_test.go
@@ -69,6 +69,57 @@ func TestNew_EmptyCalendar_ErrNeverOpen(t *testing.T) {
 	}
 }
 
+func TestNew_WeekdayNoWindows_ErrNeverOpen(t *testing.T) {
+	// A weekday base with no windows and nothing else opens no time: the
+	// calendar is structurally never open and must be rejected at New.
+	_, err := bizcal.New(time.UTC, bizcal.WithWeekday(time.Monday))
+	if !errors.Is(err, bizcal.ErrNeverOpen) {
+		t.Fatalf("New() = %v, want ErrNeverOpen", err)
+	}
+}
+
+func TestNew_WeekdayNoWindows_WithShifts_Valid(t *testing.T) {
+	// A windows-empty weekday base combined with shifts is still open: the
+	// shifts supply the open time, so construction must succeed.
+	start := time.Date(2026, time.July, 20, 9, 0, 0, 0, time.UTC)
+	end := time.Date(2026, time.July, 20, 17, 0, 0, 0, time.UTC)
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWeekday(time.Monday),
+		bizcal.WithShifts(bizcal.Shift(start, end)),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+	if !cal.IsWorkingDay(bizcal.MustDate(2026, time.July, 20)) {
+		t.Fatal("IsWorkingDay(shift day) = false, want true")
+	}
+}
+
+func TestNew_WithWeekday_SameWeekdayAppends(t *testing.T) {
+	// Repeated WithWeekday for the same weekday appends windows rather than
+	// replacing; overlapping windows merge. A Monday configured with a
+	// morning window in one call and an overlapping-into-afternoon window in
+	// another must be open across the union.
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWeekday(time.Monday, bizcal.MustWindows("09:00-13:00")...),
+		bizcal.WithWeekday(time.Monday, bizcal.MustWindows("12:00-18:00")...),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+	monday := bizcal.MustDate(2026, time.July, 20) // a Monday
+	if got, want := cal.DayDuration(monday), 9*time.Hour; got != want {
+		t.Fatalf("DayDuration(Monday) = %s, want %s (merged 09-18)", got, want)
+	}
+	// A point inside each original window is open; the merge spans both.
+	for _, hm := range []struct{ h, m int }{{10, 0}, {12, 30}, {17, 0}} {
+		at := time.Date(2026, time.July, 20, hm.h, hm.m, 0, 0, time.UTC)
+		if !cal.IsOpen(at) {
+			t.Fatalf("IsOpen(%02d:%02d) = false, want true", hm.h, hm.m)
+		}
+	}
+}
+
 func TestNew_NilLocation_ErrNilLocation(t *testing.T) {
 	_, err := bizcal.New(nil, bizcal.WithAlwaysOpen())
 	if !errors.Is(err, bizcal.ErrNilLocation) {

--- a/core/bizcal/date.go
+++ b/core/bizcal/date.go
@@ -1,0 +1,102 @@
+package bizcal
+
+import (
+	"fmt"
+	"time"
+)
+
+// Date is a civil (calendar) date: a year, month, and day with no time-of-day
+// or location component. The zero value is not a valid date; use NewDate,
+// MustDate, or DateOf to construct one.
+type Date struct {
+	Year  int
+	Month time.Month
+	Day   int
+}
+
+// NewDate validates and constructs a Date. It rejects impossible dates
+// (e.g. 2026-02-30, month 13) by round-tripping through time.Date in UTC
+// and checking the components survive unchanged.
+func NewDate(year int, month time.Month, day int) (Date, error) {
+	t := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	if t.Year() != year || t.Month() != month || t.Day() != day {
+		return Date{}, fmt.Errorf("%w: %04d-%02d-%02d", ErrInvalidDate, year, month, day)
+	}
+	return Date{Year: year, Month: month, Day: day}, nil
+}
+
+// MustDate is like NewDate but panics if the date is invalid. Intended for
+// literals known to be valid at compile time (tests, constants).
+func MustDate(year int, month time.Month, day int) Date {
+	d, err := NewDate(year, month, day)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+// DateOf returns the civil date of t, read in t's own location. To convert
+// an instant into a particular zone first, call t.In(loc) before DateOf.
+func DateOf(t time.Time) Date {
+	y, m, d := t.Date()
+	return Date{Year: y, Month: m, Day: d}
+}
+
+// AddDays returns the date n civil days after d (n may be negative or zero).
+// Arithmetic is performed via time.Date in UTC, which normalizes overflowing
+// month/day components (including leap years) automatically.
+func (d Date) AddDays(n int) Date {
+	t := time.Date(d.Year, d.Month, d.Day+n, 0, 0, 0, 0, time.UTC)
+	return DateOf(t)
+}
+
+// Weekday returns the day of the week for d. This is a pure civil
+// computation independent of any time zone.
+func (d Date) Weekday() time.Weekday {
+	t := time.Date(d.Year, d.Month, d.Day, 0, 0, 0, 0, time.UTC)
+	return t.Weekday()
+}
+
+// Before reports whether d is strictly before o.
+func (d Date) Before(o Date) bool {
+	return d.Compare(o) < 0
+}
+
+// After reports whether d is strictly after o.
+func (d Date) After(o Date) bool {
+	return d.Compare(o) > 0
+}
+
+// Compare returns -1, 0, or +1 depending on whether d is before, equal to,
+// or after o.
+func (d Date) Compare(o Date) int {
+	switch {
+	case d.Year != o.Year:
+		return cmp(d.Year, o.Year)
+	case d.Month != o.Month:
+		return cmp(int(d.Month), int(o.Month))
+	default:
+		return cmp(d.Day, o.Day)
+	}
+}
+
+func cmp(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// IsZero reports whether d is the zero Date value.
+func (d Date) IsZero() bool {
+	return d == Date{}
+}
+
+// String formats d as "2026-07-21" (RFC 3339 date, zero-padded).
+func (d Date) String() string {
+	return fmt.Sprintf("%04d-%02d-%02d", d.Year, d.Month, d.Day)
+}

--- a/core/bizcal/date_test.go
+++ b/core/bizcal/date_test.go
@@ -1,0 +1,151 @@
+package bizcal_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/bizcal"
+)
+
+func TestNewDate_Valid(t *testing.T) {
+	d, err := bizcal.NewDate(2026, time.July, 21)
+	if err != nil {
+		t.Fatalf("NewDate: unexpected error: %v", err)
+	}
+	if d.Year != 2026 || d.Month != time.July || d.Day != 21 {
+		t.Fatalf("NewDate: got %+v", d)
+	}
+}
+
+func TestNewDate_RejectsImpossibleDayOfMonth(t *testing.T) {
+	_, err := bizcal.NewDate(2026, time.February, 30)
+	if !errors.Is(err, bizcal.ErrInvalidDate) {
+		t.Fatalf("NewDate(2026-02-30): got err=%v, want ErrInvalidDate", err)
+	}
+}
+
+func TestNewDate_RejectsInvalidMonth(t *testing.T) {
+	_, err := bizcal.NewDate(2026, time.Month(13), 1)
+	if !errors.Is(err, bizcal.ErrInvalidDate) {
+		t.Fatalf("NewDate(month=13): got err=%v, want ErrInvalidDate", err)
+	}
+}
+
+func TestMustDate_PanicsOnInvalid(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("MustDate: expected panic on invalid date")
+		}
+	}()
+	bizcal.MustDate(2026, time.February, 30)
+}
+
+func TestMustDate_ReturnsValid(t *testing.T) {
+	d := bizcal.MustDate(2026, time.July, 21)
+	if d.String() != "2026-07-21" {
+		t.Fatalf("MustDate: got %s, want 2026-07-21", d.String())
+	}
+}
+
+func TestDateOf_HonorsInstantOwnZone(t *testing.T) {
+	kyiv, err := time.LoadLocation("Europe/Kyiv")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+
+	// 2026-07-21T00:30 in Kyiv (UTC+3 in July) is 2026-07-20T21:30 UTC.
+	// DateOf must read the instant in its own zone, so both must report July 21.
+	kyivTime := time.Date(2026, time.July, 21, 0, 30, 0, 0, kyiv)
+	utcTime := kyivTime.UTC()
+
+	gotKyiv := bizcal.DateOf(kyivTime)
+	wantKyiv := bizcal.MustDate(2026, time.July, 21)
+	if gotKyiv != wantKyiv {
+		t.Fatalf("DateOf(kyivTime) = %s, want %s", gotKyiv, wantKyiv)
+	}
+
+	gotUTC := bizcal.DateOf(utcTime)
+	wantUTC := bizcal.MustDate(2026, time.July, 20)
+	if gotUTC != wantUTC {
+		t.Fatalf("DateOf(utcTime) = %s, want %s", gotUTC, wantUTC)
+	}
+}
+
+func TestAddDays_AcrossMonthAndYearEnds(t *testing.T) {
+	cases := []struct {
+		start Date
+		n     int
+		want  Date
+	}{
+		{bizcal.MustDate(2026, time.January, 31), 1, bizcal.MustDate(2026, time.February, 1)},
+		{bizcal.MustDate(2026, time.December, 31), 1, bizcal.MustDate(2027, time.January, 1)},
+		{bizcal.MustDate(2027, time.January, 1), -1, bizcal.MustDate(2026, time.December, 31)},
+		{bizcal.MustDate(2026, time.July, 21), 0, bizcal.MustDate(2026, time.July, 21)},
+		{bizcal.MustDate(2028, time.March, 1), -1, bizcal.MustDate(2028, time.February, 29)}, // leap year
+	}
+	for _, c := range cases {
+		got := c.start.AddDays(c.n)
+		if got != c.want {
+			t.Errorf("%s.AddDays(%d) = %s, want %s", c.start, c.n, got, c.want)
+		}
+	}
+}
+
+func TestWeekday_KnownDates(t *testing.T) {
+	d := bizcal.MustDate(2026, time.July, 21)
+	if d.Weekday() != time.Tuesday {
+		t.Fatalf("Weekday(2026-07-21) = %v, want Tuesday", d.Weekday())
+	}
+}
+
+func TestCompareBeforeAfter_Ordering(t *testing.T) {
+	a := bizcal.MustDate(2026, time.July, 21)
+	b := bizcal.MustDate(2026, time.July, 22)
+
+	if !a.Before(b) {
+		t.Fatal("a.Before(b) = false, want true")
+	}
+	if a.After(b) {
+		t.Fatal("a.After(b) = true, want false")
+	}
+	if b.Before(a) {
+		t.Fatal("b.Before(a) = true, want false")
+	}
+	if !b.After(a) {
+		t.Fatal("b.After(a) = false, want true")
+	}
+	if a.Compare(b) >= 0 {
+		t.Fatalf("a.Compare(b) = %d, want negative", a.Compare(b))
+	}
+	if b.Compare(a) <= 0 {
+		t.Fatalf("b.Compare(a) = %d, want positive", b.Compare(a))
+	}
+	if a.Compare(a) != 0 {
+		t.Fatalf("a.Compare(a) = %d, want 0", a.Compare(a))
+	}
+	if a.Before(a) || a.After(a) {
+		t.Fatal("a.Before(a)/a.After(a) must both be false")
+	}
+}
+
+func TestIsZero(t *testing.T) {
+	var zero Date
+	if !zero.IsZero() {
+		t.Fatal("zero Date.IsZero() = false, want true")
+	}
+	d := bizcal.MustDate(2026, time.July, 21)
+	if d.IsZero() {
+		t.Fatal("non-zero Date.IsZero() = true, want false")
+	}
+}
+
+func TestDate_String_ZeroPads(t *testing.T) {
+	d := bizcal.MustDate(2026, time.January, 5)
+	if d.String() != "2026-01-05" {
+		t.Fatalf("String() = %s, want 2026-01-05", d.String())
+	}
+}
+
+// Date is a local alias to bizcal.Date to keep table declarations concise.
+type Date = bizcal.Date

--- a/core/bizcal/dayops_test.go
+++ b/core/bizcal/dayops_test.go
@@ -203,20 +203,62 @@ func TestAddWorkingDays_HorizonExceeded(t *testing.T) {
 }
 
 func TestRule_OutOfYearDatesIgnored(t *testing.T) {
-	// A rule that only ever returns next-year dates must not affect the
-	// queried year: 2026-01-01 (a Thursday) stays a working day.
-	outOfYear := bizcal.RuleFunc(func(year int) []bizcal.Date {
-		return []bizcal.Date{bizcal.MustDate(year+1, time.January, 1)}
+	// A rule that always returns the same far-year date regardless of the
+	// queried year must only close that date in its own year. buildYear now
+	// evaluates each rule for years y-1, y, and y+1, so 2030-06-18 (a Tuesday)
+	// is produced when building 2029, 2030, and 2031; only 2030's plan may
+	// keep it. This pins the defensive out-of-year filter: 2029-06-18 (Monday)
+	// and 2031-06-18 (Wednesday), both workdays, stay working days.
+	fixedFar := bizcal.RuleFunc(func(int) []bizcal.Date {
+		return []bizcal.Date{bizcal.MustDate(2030, time.June, 18)}
 	})
 	cal, err := bizcal.New(time.UTC,
 		bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
-		bizcal.WithRule(outOfYear),
+		bizcal.WithRule(fixedFar),
 	)
 	if err != nil {
 		t.Fatalf("New() = %v", err)
 	}
-	if !cal.IsWorkingDay(bizcal.MustDate(2026, time.January, 1)) {
-		t.Fatal("IsWorkingDay(2026-01-01) = false, want true (out-of-year rule date must be ignored)")
+	if cal.IsWorkingDay(bizcal.MustDate(2030, time.June, 18)) {
+		t.Fatal("IsWorkingDay(2030-06-18) = true, want false (rule closes its own year)")
+	}
+	if !cal.IsWorkingDay(bizcal.MustDate(2029, time.June, 18)) {
+		t.Fatal("IsWorkingDay(2029-06-18) = false, want true (out-of-year rule date must be ignored)")
+	}
+	if !cal.IsWorkingDay(bizcal.MustDate(2031, time.June, 18)) {
+		t.Fatal("IsWorkingDay(2031-06-18) = false, want true (out-of-year rule date must be ignored)")
+	}
+}
+
+func TestRule_ObservedShiftBackwardAcrossYearBoundary(t *testing.T) {
+	// Observed(Fixed{Jan 1}): in 2022 Jan 1 is a Saturday, so the observance
+	// shifts back to Friday 2021-12-31, which lands in the prior year's plan.
+	// buildYear(2021) must honor it even though the rule was defined for 2022.
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
+		bizcal.WithRule(bizcal.Observed(bizcal.Fixed{Month: time.January, Day: 1})),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	if cal.IsWorkingDay(bizcal.MustDate(2021, time.December, 31)) {
+		t.Fatal("IsWorkingDay(2021-12-31) = true, want false (observed New Year shifted back)")
+	}
+}
+
+func TestRule_ObservedShiftForwardAcrossYearBoundary(t *testing.T) {
+	// Observed(Fixed{Dec 31}): in 2023 Dec 31 is a Sunday, so the observance
+	// shifts forward to Monday 2024-01-01, landing in the next year's plan.
+	// buildYear(2024) must honor it even though the rule was defined for 2023.
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
+		bizcal.WithRule(bizcal.Observed(bizcal.Fixed{Month: time.December, Day: 31})),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	if cal.IsWorkingDay(bizcal.MustDate(2024, time.January, 1)) {
+		t.Fatal("IsWorkingDay(2024-01-01) = true, want false (observed Dec 31 shifted forward)")
 	}
 }
 

--- a/core/bizcal/dayops_test.go
+++ b/core/bizcal/dayops_test.go
@@ -1,0 +1,376 @@
+package bizcal_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/bizcal"
+)
+
+// --- fixture calendars ---------------------------------------------------
+
+// calA is the HR workdays fixture: Mon-Fri 8h in Europe/Kyiv with New
+// Year's Day as a holiday, 2026-07-24 taken as a day off, and 2026-12-31 a
+// short (4h) day.
+func calA(t *testing.T) *bizcal.Calendar {
+	t.Helper()
+	kyiv, err := time.LoadLocation("Europe/Kyiv")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	cal, err := bizcal.New(kyiv,
+		bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
+		bizcal.WithRule(bizcal.Fixed{Month: time.January, Day: 1}),
+		bizcal.WithExceptions(
+			bizcal.DayOff(bizcal.MustDate(2026, time.July, 24)),
+			bizcal.ShortDay(bizcal.MustDate(2026, time.December, 31), 4*time.Hour),
+		),
+	)
+	if err != nil {
+		t.Fatalf("New(calA) = %v", err)
+	}
+	return cal
+}
+
+// calB is the weekly-windows fixture: Mon-Thu 09-13 + 14-18, Fri 09-15, in
+// America/New_York.
+func calB(t *testing.T) *bizcal.Calendar {
+	t.Helper()
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	split := bizcal.MustWindows("09:00-13:00", "14:00-18:00")
+	cal, err := bizcal.New(ny,
+		bizcal.WithWeekday(time.Monday, split...),
+		bizcal.WithWeekday(time.Tuesday, split...),
+		bizcal.WithWeekday(time.Wednesday, split...),
+		bizcal.WithWeekday(time.Thursday, split...),
+		bizcal.WithWeekday(time.Friday, bizcal.MustWindows("09:00-15:00")...),
+	)
+	if err != nil {
+		t.Fatalf("New(calB) = %v", err)
+	}
+	return cal
+}
+
+// calC is the shifts-only roster fixture: no base schedule, a New Year's
+// holiday rule, one cross-midnight shift (2026-07-20 22:00 -> 07-21 02:00
+// UTC) and one shift landing on the holiday (2026-01-01 09:00-17:00 UTC).
+func calC(t *testing.T) *bizcal.Calendar {
+	t.Helper()
+	cross := bizcal.Shift(
+		time.Date(2026, time.July, 20, 22, 0, 0, 0, time.UTC),
+		time.Date(2026, time.July, 21, 2, 0, 0, 0, time.UTC),
+	)
+	onHoliday := bizcal.Shift(
+		time.Date(2026, time.January, 1, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, time.January, 1, 17, 0, 0, 0, time.UTC),
+	)
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithRule(bizcal.Fixed{Month: time.January, Day: 1}),
+		bizcal.WithShifts(cross, onHoliday),
+	)
+	if err != nil {
+		t.Fatalf("New(calC) = %v", err)
+	}
+	return cal
+}
+
+// calD is the always-open fixture.
+func calD(t *testing.T) *bizcal.Calendar {
+	t.Helper()
+	cal, err := bizcal.New(time.UTC, bizcal.WithAlwaysOpen())
+	if err != nil {
+		t.Fatalf("New(calD) = %v", err)
+	}
+	return cal
+}
+
+// --- IsWorkingDay --------------------------------------------------------
+
+func TestIsWorkingDay(t *testing.T) {
+	a := calA(t)
+	c := calC(t)
+	d := calD(t)
+
+	cases := []struct {
+		name string
+		cal  *bizcal.Calendar
+		date bizcal.Date
+		want bool
+	}{
+		{"workdays weekday", a, bizcal.MustDate(2026, time.July, 22), true},  // Wed
+		{"workdays weekend", a, bizcal.MustDate(2026, time.July, 25), false}, // Sat
+		{"workdays dayoff exception", a, bizcal.MustDate(2026, time.July, 24), false},
+		{"workdays holiday", a, bizcal.MustDate(2026, time.January, 1), false},
+		{"workdays shortday", a, bizcal.MustDate(2026, time.December, 31), true},
+		{"shift on holiday", c, bizcal.MustDate(2026, time.January, 1), true},
+		{"shift cross-midnight tail", c, bizcal.MustDate(2026, time.July, 21), true},
+		{"roster empty day", c, bizcal.MustDate(2026, time.July, 15), false},
+		{"always open", d, bizcal.MustDate(2026, time.July, 25), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cal.IsWorkingDay(tc.date); got != tc.want {
+				t.Fatalf("IsWorkingDay(%s) = %v, want %v", tc.date, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- WorkingDays ---------------------------------------------------------
+
+func TestWorkingDays_JulyWorkdays(t *testing.T) {
+	a := calA(t)
+	// July 2026 has 23 weekdays; 07-24 is a day-off exception, leaving 22.
+	got := a.WorkingDays(bizcal.MustDate(2026, time.July, 1), bizcal.MustDate(2026, time.August, 1))
+	if got != 22 {
+		t.Fatalf("WorkingDays(Jul) = %d, want 22", got)
+	}
+}
+
+func TestWorkingDays_EmptyAndInverted(t *testing.T) {
+	a := calA(t)
+	jul1 := bizcal.MustDate(2026, time.July, 1)
+	aug1 := bizcal.MustDate(2026, time.August, 1)
+	if got := a.WorkingDays(jul1, jul1); got != 0 {
+		t.Fatalf("WorkingDays(empty) = %d, want 0", got)
+	}
+	if got := a.WorkingDays(aug1, jul1); got != 0 {
+		t.Fatalf("WorkingDays(inverted) = %d, want 0", got)
+	}
+}
+
+// --- AddWorkingDays ------------------------------------------------------
+
+func TestAddWorkingDays(t *testing.T) {
+	a := calA(t)
+	cases := []struct {
+		name string
+		from bizcal.Date
+		n    int
+		want bizcal.Date
+	}{
+		// 07-23 Thu +1: 07-24 is off, 07-25/26 weekend, so 07-27 Mon.
+		{"skip weekend and holiday", bizcal.MustDate(2026, time.July, 23), 1, bizcal.MustDate(2026, time.July, 27)},
+		// 07-27 Mon -1: back over weekend + 07-24 off to 07-23 Thu.
+		{"negative walks back", bizcal.MustDate(2026, time.July, 27), -1, bizcal.MustDate(2026, time.July, 23)},
+		// n==0 is identity even on a non-working day.
+		{"zero identity on dayoff", bizcal.MustDate(2026, time.July, 24), 0, bizcal.MustDate(2026, time.July, 24)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := a.AddWorkingDays(tc.from, tc.n)
+			if err != nil {
+				t.Fatalf("AddWorkingDays(%s, %d) = %v", tc.from, tc.n, err)
+			}
+			if got != tc.want {
+				t.Fatalf("AddWorkingDays(%s, %d) = %s, want %s", tc.from, tc.n, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAddWorkingDays_HorizonExceeded(t *testing.T) {
+	// A calendar whose rule closes every day of every year: no working day
+	// is ever reachable, so AddWorkingDays must exhaust the horizon.
+	allDays := bizcal.RuleFunc(func(year int) []bizcal.Date {
+		var ds []bizcal.Date
+		d := bizcal.MustDate(year, time.January, 1)
+		end := bizcal.MustDate(year+1, time.January, 1)
+		for d.Before(end) {
+			ds = append(ds, d)
+			d = d.AddDays(1)
+		}
+		return ds
+	})
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
+		bizcal.WithRule(allDays),
+		bizcal.WithHorizon(10*24*time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	if _, err := cal.AddWorkingDays(bizcal.MustDate(2026, time.July, 1), 1); !errors.Is(err, bizcal.ErrHorizonExceeded) {
+		t.Fatalf("AddWorkingDays() = %v, want ErrHorizonExceeded", err)
+	}
+	if _, err := cal.AddWorkingDays(bizcal.MustDate(2026, time.July, 1), -1); !errors.Is(err, bizcal.ErrHorizonExceeded) {
+		t.Fatalf("AddWorkingDays(backward) = %v, want ErrHorizonExceeded", err)
+	}
+}
+
+func TestRule_OutOfYearDatesIgnored(t *testing.T) {
+	// A rule that only ever returns next-year dates must not affect the
+	// queried year: 2026-01-01 (a Thursday) stays a working day.
+	outOfYear := bizcal.RuleFunc(func(year int) []bizcal.Date {
+		return []bizcal.Date{bizcal.MustDate(year+1, time.January, 1)}
+	})
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
+		bizcal.WithRule(outOfYear),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	if !cal.IsWorkingDay(bizcal.MustDate(2026, time.January, 1)) {
+		t.Fatal("IsWorkingDay(2026-01-01) = false, want true (out-of-year rule date must be ignored)")
+	}
+}
+
+// --- DayDuration ---------------------------------------------------------
+
+func TestDayDuration_Workdays(t *testing.T) {
+	a := calA(t)
+	cases := []struct {
+		name string
+		date bizcal.Date
+		want time.Duration
+	}{
+		{"weekday", bizcal.MustDate(2026, time.July, 22), 8 * time.Hour},
+		{"weekend", bizcal.MustDate(2026, time.July, 25), 0},
+		{"shortday", bizcal.MustDate(2026, time.December, 31), 4 * time.Hour},
+		{"holiday", bizcal.MustDate(2026, time.January, 1), 0},
+		{"dayoff", bizcal.MustDate(2026, time.July, 24), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := a.DayDuration(tc.date); got != tc.want {
+				t.Fatalf("DayDuration(%s) = %s, want %s", tc.date, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDayDuration_Windows(t *testing.T) {
+	b := calB(t)
+	cases := []struct {
+		name string
+		date bizcal.Date
+		want time.Duration
+	}{
+		{"monday split", bizcal.MustDate(2026, time.July, 6), 8 * time.Hour}, // 09-13 + 14-18
+		{"friday", bizcal.MustDate(2026, time.July, 3), 6 * time.Hour},       // 09-15
+		{"saturday", bizcal.MustDate(2026, time.July, 4), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := b.DayDuration(tc.date); got != tc.want {
+				t.Fatalf("DayDuration(%s) = %s, want %s", tc.date, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDayDuration_DST(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	// A window straddling the 02:00 transition: 00:00-06:00 on Sundays.
+	straddle, err := bizcal.New(ny, bizcal.WithWeekday(time.Sunday, bizcal.MustWindows("00:00-06:00")...))
+	if err != nil {
+		t.Fatalf("New(straddle) = %v", err)
+	}
+	// A window entirely after the 02:00 transition: 09:00-17:00 on Sundays.
+	outside, err := bizcal.New(ny, bizcal.WithWeekday(time.Sunday, bizcal.MustWindows("09:00-17:00")...))
+	if err != nil {
+		t.Fatalf("New(outside) = %v", err)
+	}
+
+	cases := []struct {
+		name string
+		cal  *bizcal.Calendar
+		date bizcal.Date
+		want time.Duration
+	}{
+		{"spring forward shrinks 1h", straddle, bizcal.MustDate(2026, time.March, 8), 5 * time.Hour},
+		{"fall back grows 1h", straddle, bizcal.MustDate(2026, time.November, 1), 7 * time.Hour},
+		{"normal sunday", straddle, bizcal.MustDate(2026, time.March, 15), 6 * time.Hour},
+		{"window outside transition unaffected", outside, bizcal.MustDate(2026, time.March, 8), 8 * time.Hour},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cal.DayDuration(tc.date); got != tc.want {
+				t.Fatalf("DayDuration(%s) = %s, want %s", tc.date, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDayDuration_CrossMidnightShiftSplits(t *testing.T) {
+	c := calC(t)
+	// The 22:00->02:00 shift contributes 2h to each of the two civil dates.
+	if got := c.DayDuration(bizcal.MustDate(2026, time.July, 20)); got != 2*time.Hour {
+		t.Fatalf("DayDuration(07-20) = %s, want 2h", got)
+	}
+	if got := c.DayDuration(bizcal.MustDate(2026, time.July, 21)); got != 2*time.Hour {
+		t.Fatalf("DayDuration(07-21) = %s, want 2h", got)
+	}
+	// The shift landing on the holiday still counts as capacity.
+	if got := c.DayDuration(bizcal.MustDate(2026, time.January, 1)); got != 8*time.Hour {
+		t.Fatalf("DayDuration(01-01) = %s, want 8h", got)
+	}
+}
+
+// --- ScheduledBetween ----------------------------------------------------
+
+func TestScheduledBetween_July(t *testing.T) {
+	a := calA(t)
+	// 22 working days at 8h each.
+	got := a.ScheduledBetween(bizcal.MustDate(2026, time.July, 1), bizcal.MustDate(2026, time.August, 1))
+	if got != 176*time.Hour {
+		t.Fatalf("ScheduledBetween(Jul) = %s, want 176h", got)
+	}
+}
+
+func TestScheduledBetween_EmptyAndInverted(t *testing.T) {
+	a := calA(t)
+	jul1 := bizcal.MustDate(2026, time.July, 1)
+	aug1 := bizcal.MustDate(2026, time.August, 1)
+	if got := a.ScheduledBetween(jul1, jul1); got != 0 {
+		t.Fatalf("ScheduledBetween(empty) = %s, want 0", got)
+	}
+	if got := a.ScheduledBetween(aug1, jul1); got != 0 {
+		t.Fatalf("ScheduledBetween(inverted) = %s, want 0", got)
+	}
+}
+
+// --- mutation safety (behavioral half, deferred from Task 3) -------------
+
+func TestMutationSafety_Behavioral(t *testing.T) {
+	windows := bizcal.MustWindows("09:00-17:00")
+	// A Tue->Wed cross-midnight shift; neither date carries a Monday base
+	// window, so the shift's capacity is observable in isolation.
+	start := time.Date(2026, time.July, 21, 22, 0, 0, 0, time.UTC)
+	end := time.Date(2026, time.July, 22, 2, 0, 0, 0, time.UTC)
+	shifts := []bizcal.Interval{bizcal.Shift(start, end)}
+
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWeekday(time.Monday, windows...),
+		bizcal.WithShifts(shifts...),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	// Mutate the caller's backing arrays after New returns.
+	windows[0] = bizcal.MustWindows("00:00-01:00")[0]
+	shifts[0] = bizcal.Shift(
+		time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(1999, time.January, 1, 1, 0, 0, 0, time.UTC),
+	)
+
+	// Monday window is unchanged (8h), and the shift still splits 2h/2h.
+	if got := cal.DayDuration(bizcal.MustDate(2026, time.July, 6)); got != 8*time.Hour {
+		t.Fatalf("DayDuration(Mon) = %s, want 8h (mutation leaked)", got)
+	}
+	if got := cal.DayDuration(bizcal.MustDate(2026, time.July, 21)); got != 2*time.Hour {
+		t.Fatalf("DayDuration(07-21) = %s, want 2h (shift mutation leaked)", got)
+	}
+	if got := cal.DayDuration(bizcal.MustDate(2026, time.July, 22)); got != 2*time.Hour {
+		t.Fatalf("DayDuration(07-22) = %s, want 2h (shift mutation leaked)", got)
+	}
+}

--- a/core/bizcal/doc.go
+++ b/core/bizcal/doc.go
@@ -1,0 +1,89 @@
+// Package bizcal provides stdlib-only, data-free business-calendar
+// arithmetic. Consumer-declared schedules (per-weekday clock windows,
+// day-granular workdays, rostered shifts, or always-open) plus holiday
+// rules and per-date exceptions compose into an immutable, goroutine-safe
+// Calendar answering instant questions (open? next open? add business
+// duration; business time between two instants) and day questions
+// (working day? count; add working days; scheduled hours) — DST-correct
+// throughout. No embedded country/holiday tables: holiday data is always
+// consumer-supplied.
+//
+// Build one Calendar per tenant or per policy and cache the instance —
+// New is the only construction cost, a Calendar never mutates after it
+// returns, and every method is safe to call from multiple goroutines at
+// once. Rebuild (and swap the cached pointer) only when the underlying
+// policy changes; a version-keyed cache never needs invalidation.
+//
+// # HR: workdays calendar and salary math
+//
+// The workdays model (WithWorkdays) matches an HR schedule row exactly:
+// a set of weekdays, each open the whole civil day with a fixed capacity,
+// no invented clock windows. Combine it with a holiday Rule and per-date
+// Exceptions for the employee's short days and days off:
+//
+//	loc, _ := time.LoadLocation("Europe/Kyiv")
+//	cal, err := bizcal.New(loc,
+//		bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
+//		bizcal.WithRule(bizcal.Fixed{Month: time.January, Day: 1}),
+//		bizcal.WithExceptions(bizcal.ShortDay(bizcal.MustDate(2026, time.December, 31), 4*time.Hour)),
+//	)
+//
+// Salary formulas fall out of the day and instant ops: expected hours for
+// a pay period is ScheduledBetween(periodStart, periodEnd); payable
+// in-schedule time for one shift is Between(clockIn, clockOut); undertime
+// is DayDuration(day) minus worked; overtime is worked minus
+// DayDuration(day). Leave math uses AddWorkingDays to land n working days
+// after a request date, skipping weekends and holidays automatically.
+//
+// Between on a workdays calendar counts whole-day-open wall-clock span,
+// not clipped to any nominal shift: Between(Tue 09:12, Tue 16:05) returns
+// 6h53m regardless of what the employee's expected hours are, because the
+// whole day is open. Scheduled capacity for that day stays the fixed
+// perDay value (8h above) no matter how long the employee actually
+// clocked in or out, and no matter what DST does that day — a workdays
+// day's capacity never changes.
+//
+// # SLA: windows or always-open with rostered shifts
+//
+// The windows model (WithWeekday) and WithAlwaysOpen give clock-accurate
+// SLA arithmetic: real interval durations, not fixed per-day capacity.
+// Add a support ticket's opened instant plus its response budget to get
+// the deadline:
+//
+//	sla, err := bizcal.New(loc,
+//		bizcal.WithWeekday(time.Monday, bizcal.MustWindows("09:00-18:00")...),
+//		bizcal.WithWeekday(time.Tuesday, bizcal.MustWindows("09:00-18:00")...),
+//	)
+//	deadline, err := sla.Add(opened, 8*time.Hour)
+//
+// A 24/7 desk uses WithAlwaysOpen instead, and an on-call rota layers
+// WithShifts on top of either base (or with no base at all) to add
+// rostered coverage windows; shift time adds on top of whatever the base
+// resolved a day to, so a shift rostered onto a holiday still counts as
+// open. DayDuration on a day carrying both a base window and an
+// overlapping shift sums the shift's capacity in addition to the base
+// window's, even across the overlap — capacity is an additive count of
+// scheduled coverage, not a measure of the open-interval union, so a
+// double-covered hour is deliberately counted twice.
+//
+// # DST
+//
+// Windows-model and always-open capacity is a real absolute duration: a
+// spring-forward day loses the skipped hour (23h span) and a fall-back
+// day gains the repeated one (25h span), and Between/Add measure the same
+// elapsed absolute time, so an SLA spanning a transition is never over-
+// or under-counted. Workdays-model capacity is the fixed perDay value
+// from WithWorkdays and is unaffected by DST — an 8h expectation stays
+// 8h on a transition day.
+//
+// # Horizon
+//
+// NextOpen, Add, and AddWorkingDays scan forward or backward from their
+// anchor and are bounded by a configured horizon (WithHorizon, default 5
+// years of calendar time); exhausting it returns ErrHorizonExceeded. This
+// guards against a holiday Rule that closes every day forever. Between
+// and WindowsBetween carry no horizon guard: their cost is proportional
+// to the day span between the two instants the caller passed in, so
+// callers are expected to pass already-bounded ranges (a pay period, a
+// ticket's lifetime) rather than open-ended ones.
+package bizcal

--- a/core/bizcal/errors.go
+++ b/core/bizcal/errors.go
@@ -1,4 +1,3 @@
-// Package bizcal provides stdlib-only business-calendar arithmetic.
 package bizcal
 
 import "errors"

--- a/core/bizcal/errors.go
+++ b/core/bizcal/errors.go
@@ -1,0 +1,34 @@
+// Package bizcal provides stdlib-only business-calendar arithmetic.
+package bizcal
+
+import "errors"
+
+// Sentinel errors for the bizcal package, all errors.Is-matchable.
+var (
+	// ErrInvalidDate is returned when a civil date does not exist on the calendar (e.g. 2026-02-30, month 13).
+	ErrInvalidDate = errors.New("bizcal: invalid date")
+
+	// ErrInvalidWindow is returned when a Window's bounds are malformed, inverted, or out of range.
+	ErrInvalidWindow = errors.New("bizcal: invalid window")
+
+	// ErrInvalidWeekday is returned when a time.Weekday value falls outside Sunday through Saturday.
+	ErrInvalidWeekday = errors.New("bizcal: invalid weekday")
+
+	// ErrInvalidRule is returned when a holiday Rule is constructed with invalid parameters.
+	ErrInvalidRule = errors.New("bizcal: invalid rule")
+
+	// ErrInvalidShift is returned when a shift Interval has an end at or before its start.
+	ErrInvalidShift = errors.New("bizcal: invalid shift")
+
+	// ErrInvalidCapacity is returned when a scheduled capacity duration is negative.
+	ErrInvalidCapacity = errors.New("bizcal: invalid capacity")
+
+	// ErrNilLocation is returned when a Calendar is constructed with a nil *time.Location.
+	ErrNilLocation = errors.New("bizcal: nil location")
+
+	// ErrNeverOpen is returned when a Calendar is statically closed on every day (no base, no shifts).
+	ErrNeverOpen = errors.New("bizcal: calendar never open")
+
+	// ErrHorizonExceeded is returned when a search for an open instant or working day exceeds the configured horizon.
+	ErrHorizonExceeded = errors.New("bizcal: search horizon exceeded")
+)

--- a/core/bizcal/example_test.go
+++ b/core/bizcal/example_test.go
@@ -1,0 +1,40 @@
+package bizcal_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/bizcal"
+)
+
+// ExampleNew builds an HR workdays calendar (Monday-Friday, 8h/day), then
+// derives a pay-period expected total via ScheduledBetween, a single day's
+// worked time via Between, and the resulting undertime against that day's
+// scheduled capacity.
+func ExampleNew() {
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
+	)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	monday := bizcal.MustDate(2026, time.July, 20)
+	saturday := bizcal.MustDate(2026, time.July, 25)
+	expected := cal.ScheduledBetween(monday, saturday)
+
+	clockIn := time.Date(2026, time.July, 20, 9, 12, 0, 0, time.UTC)
+	clockOut := time.Date(2026, time.July, 20, 16, 5, 0, 0, time.UTC)
+	worked := cal.Between(clockIn, clockOut)
+	undertime := cal.DayDuration(monday) - worked
+
+	fmt.Println(expected)
+	fmt.Println(worked)
+	fmt.Println(undertime)
+
+	// Output:
+	// 40h0m0s
+	// 6h53m0s
+	// 1h7m0s
+}

--- a/core/bizcal/fuzz_test.go
+++ b/core/bizcal/fuzz_test.go
@@ -1,0 +1,126 @@
+package bizcal_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/bizcal"
+)
+
+// maxFuzzOffsetSec bounds Between/Add fuzz offsets so a pathological large
+// int64 doesn't turn the day-by-day walk inside Between/Add into a
+// multi-million-iteration scan; 90 days is generous headroom over the
+// property tests' 30-day budget while staying fast under -fuzz.
+const maxFuzzOffsetSec = 90 * 24 * 3600
+
+// boundedOffset folds an arbitrary int64 into [0, maxFuzzOffsetSec).
+func boundedOffset(v int64) int64 {
+	if v < 0 {
+		v = -v
+	}
+	return v % maxFuzzOffsetSec
+}
+
+// FuzzParseWindow checks that ParseWindow never panics on arbitrary input,
+// and that every value it successfully parses round-trips through String:
+// re-parsing the formatted output yields an equal Window.
+func FuzzParseWindow(f *testing.F) {
+	seeds := []string{
+		"09:00-17:30",
+		"9:00-17:00",
+		"00:00-24:00",
+		"",
+		"09:00",
+		"17:00-09:00",
+		"09:60-10:00",
+		"09:00-25:00",
+		"garbage",
+		"09:00-17:00-extra",
+		"-17:00",
+		"09-17",
+		"24:00-24:00",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		w, err := bizcal.ParseWindow(s)
+		if err != nil {
+			return
+		}
+		w2, err := bizcal.ParseWindow(w.String())
+		if err != nil {
+			t.Fatalf("ParseWindow(%q) = %v, err=nil; but re-parsing its String() %q failed: %v", s, w, w.String(), err)
+		}
+		if w2 != w {
+			t.Fatalf("ParseWindow(%q) = %v; round-trip through String() %q gave %v", s, w, w.String(), w2)
+		}
+	})
+}
+
+// FuzzBetweenSymmetry fuzzes Between on fixture (b) with a random base
+// instant and two forward offsets, checking signed symmetry, additivity
+// across the midpoint, and that business time never exceeds the wall span.
+func FuzzBetweenSymmetry(f *testing.F) {
+	// DST instants for fixture (b)'s zone (America/New_York): 2026 spring
+	// forward (2nd Sunday of March) and fall back (1st Sunday of November).
+	spring := time.Date(2026, time.March, 8, 1, 30, 0, 0, time.UTC).Unix()
+	fall := time.Date(2026, time.November, 1, 5, 30, 0, 0, time.UTC).Unix()
+	f.Add(spring, int64(3600), int64(7200))
+	f.Add(fall, int64(3600), int64(7200))
+	f.Add(int64(1751500800), int64(0), int64(0))
+
+	f.Fuzz(func(t *testing.T, unixSec int64, off1, off2 int64) {
+		b := calB(t)
+		loc := b.Location()
+		a := time.Unix(unixSec, 0).In(loc)
+		mid := a.Add(time.Duration(boundedOffset(off1)) * time.Second)
+		z := mid.Add(time.Duration(boundedOffset(off2)) * time.Second)
+
+		fwd := b.Between(a, z)
+		rev := b.Between(z, a)
+		if fwd != -rev {
+			t.Fatalf("Between not signed-symmetric: a=%s z=%s fwd=%s rev=%s", a, z, fwd, rev)
+		}
+
+		if sum := b.Between(a, mid) + b.Between(mid, z); sum != fwd {
+			t.Fatalf("Between not additive: a=%s mid=%s z=%s Between(a,z)=%s sum=%s", a, mid, z, fwd, sum)
+		}
+
+		wall := z.Sub(a)
+		if fwd < 0 || fwd > wall {
+			t.Fatalf("Between(a,z)=%s exceeds wall span %s: a=%s z=%s", fwd, wall, a, z)
+		}
+	})
+}
+
+// FuzzAddRoundTrip fuzzes Add on fixture (b) with a random start instant and
+// a random non-negative budget, checking that whenever Add succeeds its
+// result round-trips through Between against NextOpen(start).
+func FuzzAddRoundTrip(f *testing.F) {
+	spring := time.Date(2026, time.March, 8, 1, 30, 0, 0, time.UTC).Unix()
+	fall := time.Date(2026, time.November, 1, 5, 30, 0, 0, time.UTC).Unix()
+	f.Add(spring, int64(3600))
+	f.Add(fall, int64(3600))
+	f.Add(int64(1751500800), int64(0))
+
+	f.Fuzz(func(t *testing.T, unixSec int64, budgetSec int64) {
+		b := calB(t)
+		loc := b.Location()
+		start := time.Unix(unixSec, 0).In(loc)
+		d := time.Duration(boundedOffset(budgetSec)) * time.Second
+
+		result, err := b.Add(start, d)
+		if err != nil {
+			return // horizon exceeded is not a fuzz violation
+		}
+		anchor, err := b.NextOpen(start)
+		if err != nil {
+			t.Fatalf("NextOpen(start) errored after Add succeeded: start=%s err=%v", start, err)
+		}
+		if got := b.Between(anchor, result); got != d {
+			t.Fatalf("Add round-trip broke: start=%s d=%s anchor=%s result=%s Between=%s", start, d, anchor, result, got)
+		}
+	})
+}

--- a/core/bizcal/instant.go
+++ b/core/bizcal/instant.go
@@ -1,0 +1,255 @@
+package bizcal
+
+import (
+	"iter"
+	"slices"
+	"time"
+)
+
+// IsOpen reports whether the calendar is open at instant t: whether t falls in
+// one of t's civil date's open intervals, with the interval start inclusive
+// and its end exclusive. A cross-midnight shift is stored split across the two
+// civil dates it covers, so instants on either side of the midnight it
+// straddles both resolve open.
+func (c *Calendar) IsOpen(t time.Time) bool {
+	for _, iv := range c.dayIntervals(c.DateOf(t)) {
+		if !t.Before(iv.Start) && t.Before(iv.End) {
+			return true
+		}
+	}
+	return false
+}
+
+// NextOpen returns the earliest open instant at or after t. If t is already
+// open it returns t unchanged. The forward scan is bounded by the configured
+// horizon (interpreted as a day count of horizon/24h); exhausting it returns
+// ErrHorizonExceeded.
+func (c *Calendar) NextOpen(t time.Time) (time.Time, error) {
+	maxDays := c.horizonDays()
+	d := c.DateOf(t)
+	for scanned := 0; ; scanned++ {
+		if scanned > maxDays {
+			return time.Time{}, ErrHorizonExceeded
+		}
+		for _, iv := range c.dayIntervals(d) {
+			if !iv.End.After(t) {
+				continue // interval ends at or before t
+			}
+			if iv.Start.After(t) {
+				return iv.Start, nil
+			}
+			return t, nil // t is inside [start, end)
+		}
+		d = d.AddDays(1)
+	}
+}
+
+// Add advances t by d of business time and returns the resulting instant. A
+// negative d walks backward. Add(t, 0) equals NextOpen(t). When the budget is
+// exhausted exactly at a window edge the result is that boundary instant (the
+// closing edge walking forward, the opening edge walking backward), which
+// keeps Add a clean inverse of Between. The scan is horizon-bounded and
+// returns ErrHorizonExceeded when no reachable instant satisfies the budget.
+func (c *Calendar) Add(t time.Time, d time.Duration) (time.Time, error) {
+	if d >= 0 {
+		anchor, err := c.NextOpen(t)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return c.addForward(anchor, d)
+	}
+	anchor, err := c.prevOpen(t)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return c.addBackward(anchor, -d)
+}
+
+// Between returns the signed business time in the half-open span [a, b): the
+// sum of open-interval durations clipped to the span, measured in absolute
+// time so DST transitions are counted exactly. Between(a, a) is zero and
+// Between(a, b) equals -Between(b, a).
+func (c *Calendar) Between(a, b time.Time) time.Duration {
+	if a.Equal(b) {
+		return 0
+	}
+	if a.After(b) {
+		return -c.Between(b, a)
+	}
+	var total time.Duration
+	end := c.DateOf(b)
+	for day := c.DateOf(a); !day.After(end); day = day.AddDays(1) {
+		for _, iv := range c.dayIntervals(day) {
+			s, e := iv.Start, iv.End
+			if s.Before(a) {
+				s = a
+			}
+			if e.After(b) {
+				e = b
+			}
+			if e.After(s) {
+				total += e.Sub(s)
+			}
+		}
+	}
+	return total
+}
+
+// WindowsBetween yields the calendar's open intervals overlapping [from, to),
+// clipped to that span and in ascending order, with intervals adjacent across
+// a civil-date boundary (a cross-midnight shift, or consecutive whole-day-open
+// days) merged into one. A from at or after to yields nothing.
+func (c *Calendar) WindowsBetween(from, to time.Time) iter.Seq[Interval] {
+	return func(yield func(Interval) bool) {
+		if !from.Before(to) {
+			return
+		}
+		var pend Interval
+		var has bool
+		flush := func() bool {
+			if !has {
+				return true
+			}
+			has = false
+			s, e := pend.Start, pend.End
+			if s.Before(from) {
+				s = from
+			}
+			if e.After(to) {
+				e = to
+			}
+			if e.After(s) {
+				return yield(Interval{Start: s, End: e})
+			}
+			return true
+		}
+
+		end := c.DateOf(to)
+		for day := c.DateOf(from); !day.After(end); day = day.AddDays(1) {
+			for _, iv := range c.dayIntervals(day) {
+				if !iv.End.After(from) {
+					continue // fully before the span
+				}
+				if !iv.Start.Before(to) {
+					// The first interval at or after to ends the walk; nothing
+					// later can overlap the span.
+					if !flush() {
+						return
+					}
+					return
+				}
+				switch {
+				case !has:
+					pend, has = iv, true
+				case !iv.Start.After(pend.End):
+					if iv.End.After(pend.End) {
+						pend.End = iv.End
+					}
+				default:
+					if !flush() {
+						return
+					}
+					pend, has = iv, true
+				}
+			}
+		}
+		flush()
+	}
+}
+
+// dayIntervals returns date d's resolved open intervals: sorted, merged, and
+// within-day non-adjacent (adjacency only ever occurs across a civil-date
+// boundary).
+func (c *Calendar) dayIntervals(d Date) []Interval {
+	return c.dayPlan(d).intervals
+}
+
+// horizonDays converts the configured horizon into a whole-day scan cap,
+// matching AddWorkingDays' interpretation.
+func (c *Calendar) horizonDays() int {
+	return int(c.horizon / (24 * time.Hour))
+}
+
+// prevOpen returns the anchor for a backward walk from t: the latest open
+// instant at or before t, or the closing boundary of the last interval that
+// ends at or before t when t lies in a closed gap. It is the mirror of
+// NextOpen and is horizon-bounded.
+func (c *Calendar) prevOpen(t time.Time) (time.Time, error) {
+	maxDays := c.horizonDays()
+	d := c.DateOf(t)
+	for scanned := 0; ; scanned++ {
+		if scanned > maxDays {
+			return time.Time{}, ErrHorizonExceeded
+		}
+		for _, iv := range slices.Backward(c.dayIntervals(d)) {
+			if !iv.Start.Before(t) {
+				continue // interval starts at or after t
+			}
+			if t.Before(iv.End) {
+				return t, nil // t is inside [start, end)
+			}
+			return iv.End, nil // t is in the gap after this interval
+		}
+		d = d.AddDays(-1)
+	}
+}
+
+// addForward consumes budget of business time starting at the open instant
+// anchor and returns the landing instant, at a closing boundary when the
+// budget exhausts exactly at a window end.
+func (c *Calendar) addForward(anchor time.Time, budget time.Duration) (time.Time, error) {
+	maxDays := c.horizonDays()
+	t := anchor
+	d := c.DateOf(t)
+	for scanned := 0; ; scanned++ {
+		if scanned > maxDays {
+			return time.Time{}, ErrHorizonExceeded
+		}
+		for _, iv := range c.dayIntervals(d) {
+			if !iv.End.After(t) {
+				continue
+			}
+			start := iv.Start
+			if start.Before(t) {
+				start = t
+			}
+			avail := iv.End.Sub(start)
+			if budget <= avail {
+				return start.Add(budget), nil
+			}
+			budget -= avail
+			t = iv.End
+		}
+		d = d.AddDays(1)
+	}
+}
+
+// addBackward consumes budget of business time walking backward from the
+// anchor and returns the landing instant, at an opening boundary when the
+// budget exhausts exactly at a window start.
+func (c *Calendar) addBackward(anchor time.Time, budget time.Duration) (time.Time, error) {
+	maxDays := c.horizonDays()
+	t := anchor
+	d := c.DateOf(t)
+	for scanned := 0; ; scanned++ {
+		if scanned > maxDays {
+			return time.Time{}, ErrHorizonExceeded
+		}
+		for _, iv := range slices.Backward(c.dayIntervals(d)) {
+			if !iv.Start.Before(t) {
+				continue
+			}
+			end := iv.End
+			if end.After(t) {
+				end = t
+			}
+			avail := end.Sub(iv.Start)
+			if budget <= avail {
+				return end.Add(-budget), nil
+			}
+			budget -= avail
+			t = iv.Start
+		}
+		d = d.AddDays(-1)
+	}
+}

--- a/core/bizcal/instant_test.go
+++ b/core/bizcal/instant_test.go
@@ -1,0 +1,415 @@
+package bizcal_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/bizcal"
+)
+
+// nyTime builds an America/New_York wall-clock instant for the calB fixture.
+func nyTime(t *testing.T, y int, m time.Month, d, hh, mm int) time.Time {
+	t.Helper()
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	return time.Date(y, m, d, hh, mm, 0, 0, ny)
+}
+
+// --- IsOpen --------------------------------------------------------------
+
+func TestIsOpen(t *testing.T) {
+	b := calB(t)
+	cases := []struct {
+		name string
+		t    time.Time
+		want bool
+	}{
+		{"inside morning window", nyTime(t, 2026, time.July, 6, 10, 0), true}, // Mon
+		{"exactly at start inclusive", nyTime(t, 2026, time.July, 6, 9, 0), true},
+		{"exactly at end exclusive", nyTime(t, 2026, time.July, 6, 13, 0), false},
+		{"in lunch gap", nyTime(t, 2026, time.July, 6, 13, 30), false},
+		{"inside afternoon window", nyTime(t, 2026, time.July, 6, 15, 0), true},
+		{"after close", nyTime(t, 2026, time.July, 6, 18, 0), false},
+		{"weekend", nyTime(t, 2026, time.July, 4, 10, 0), false}, // Sat
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := b.IsOpen(tc.t); got != tc.want {
+				t.Fatalf("IsOpen(%s) = %v, want %v", tc.t, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsOpen_CrossMidnightShift(t *testing.T) {
+	c := calC(t)
+	// Cross-midnight shift 2026-07-20 22:00 -> 07-21 02:00 UTC: open on both
+	// sides of the civil midnight it straddles.
+	before := time.Date(2026, time.July, 20, 23, 0, 0, 0, time.UTC)
+	after := time.Date(2026, time.July, 21, 1, 0, 0, 0, time.UTC)
+	atMidnight := time.Date(2026, time.July, 21, 0, 0, 0, 0, time.UTC)
+	if !c.IsOpen(before) {
+		t.Fatal("IsOpen(pre-midnight) = false, want true")
+	}
+	if !c.IsOpen(after) {
+		t.Fatal("IsOpen(post-midnight) = false, want true")
+	}
+	if !c.IsOpen(atMidnight) {
+		t.Fatal("IsOpen(midnight) = false, want true")
+	}
+	// The shift landing on the holiday is open despite the holiday rule.
+	onHoliday := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	if !c.IsOpen(onHoliday) {
+		t.Fatal("IsOpen(holiday shift) = false, want true")
+	}
+}
+
+// --- NextOpen ------------------------------------------------------------
+
+func TestNextOpen(t *testing.T) {
+	b := calB(t)
+	cases := []struct {
+		name string
+		from time.Time
+		want time.Time
+	}{
+		{"saturday to monday open", nyTime(t, 2026, time.July, 4, 10, 0), nyTime(t, 2026, time.July, 6, 9, 0)},
+		{"mid-lunch to afternoon", nyTime(t, 2026, time.July, 6, 13, 30), nyTime(t, 2026, time.July, 6, 14, 0)},
+		{"already open returns itself", nyTime(t, 2026, time.July, 6, 10, 0), nyTime(t, 2026, time.July, 6, 10, 0)},
+		{"before open to open", nyTime(t, 2026, time.July, 6, 8, 0), nyTime(t, 2026, time.July, 6, 9, 0)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := b.NextOpen(tc.from)
+			if err != nil {
+				t.Fatalf("NextOpen(%s) = %v", tc.from, err)
+			}
+			if !got.Equal(tc.want) {
+				t.Fatalf("NextOpen(%s) = %s, want %s", tc.from, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNextOpen_AlwaysOpen(t *testing.T) {
+	d := calD(t)
+	at := time.Date(2026, time.July, 4, 3, 15, 0, 0, time.UTC)
+	got, err := d.NextOpen(at)
+	if err != nil {
+		t.Fatalf("NextOpen = %v", err)
+	}
+	if !got.Equal(at) {
+		t.Fatalf("NextOpen(always-open) = %s, want %s", got, at)
+	}
+}
+
+// --- Add -----------------------------------------------------------------
+
+func TestAdd_ForwardAcrossWeekend(t *testing.T) {
+	b := calB(t)
+	// Fri closes 15:00: Fri 14:00 + 1h reaches close, remaining 3h -> Mon
+	// 09:00 + 3h = Mon 12:00.
+	from := nyTime(t, 2026, time.July, 3, 14, 0)
+	want := nyTime(t, 2026, time.July, 6, 12, 0)
+	got, err := b.Add(from, 4*time.Hour)
+	if err != nil {
+		t.Fatalf("Add = %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("Add(Fri 14:00, 4h) = %s, want %s", got, want)
+	}
+}
+
+func TestAdd_LandsAtClosingBoundary(t *testing.T) {
+	b := calB(t)
+	// Budget exhausting exactly at a window end lands on the closing boundary
+	// instant, not the next window start.
+	from := nyTime(t, 2026, time.July, 6, 9, 0)
+	want := nyTime(t, 2026, time.July, 6, 13, 0)
+	got, err := b.Add(from, 4*time.Hour)
+	if err != nil {
+		t.Fatalf("Add = %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("Add(Mon 09:00, 4h) = %s, want %s (closing boundary)", got, want)
+	}
+	// Round-trips with Between.
+	if d := b.Between(from, got); d != 4*time.Hour {
+		t.Fatalf("Between(Mon 09:00, Mon 13:00) = %s, want 4h", d)
+	}
+}
+
+func TestAdd_Backward(t *testing.T) {
+	b := calB(t)
+	// Mirror of the forward weekend case: Mon 12:00 - 4h -> Fri 14:00.
+	from := nyTime(t, 2026, time.July, 6, 12, 0)
+	want := nyTime(t, 2026, time.July, 3, 14, 0)
+	got, err := b.Add(from, -4*time.Hour)
+	if err != nil {
+		t.Fatalf("Add = %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("Add(Mon 12:00, -4h) = %s, want %s", got, want)
+	}
+}
+
+func TestAdd_ZeroEqualsNextOpen(t *testing.T) {
+	b := calB(t)
+	from := nyTime(t, 2026, time.July, 6, 13, 30) // lunch gap
+	add0, err := b.Add(from, 0)
+	if err != nil {
+		t.Fatalf("Add(_,0) = %v", err)
+	}
+	next, err := b.NextOpen(from)
+	if err != nil {
+		t.Fatalf("NextOpen = %v", err)
+	}
+	if !add0.Equal(next) {
+		t.Fatalf("Add(t,0) = %s, want NextOpen = %s", add0, next)
+	}
+}
+
+func TestAdd_AlwaysOpenIsPlainDuration(t *testing.T) {
+	d := calD(t)
+	at := time.Date(2026, time.July, 4, 20, 0, 0, 0, time.UTC)
+	got, err := d.Add(at, 8*time.Hour)
+	if err != nil {
+		t.Fatalf("Add = %v", err)
+	}
+	if !got.Equal(at.Add(8 * time.Hour)) {
+		t.Fatalf("Add(always-open, 8h) = %s, want %s", got, at.Add(8*time.Hour))
+	}
+}
+
+// --- Between -------------------------------------------------------------
+
+func TestBetween_SignedSymmetry(t *testing.T) {
+	b := calB(t)
+	a := nyTime(t, 2026, time.July, 6, 10, 0)
+	z := nyTime(t, 2026, time.July, 6, 16, 0)
+	fwd := b.Between(a, z)
+	rev := b.Between(z, a)
+	if fwd != -rev {
+		t.Fatalf("Between not signed-symmetric: fwd=%s rev=%s", fwd, rev)
+	}
+	// [10:00,16:00): 10-13 (3h) + 14-16 (2h) = 5h.
+	if fwd != 5*time.Hour {
+		t.Fatalf("Between(10:00,16:00) = %s, want 5h", fwd)
+	}
+	if b.Between(a, a) != 0 {
+		t.Fatalf("Between(a,a) = %s, want 0", b.Between(a, a))
+	}
+}
+
+func TestBetween_ClosedWeekendIsZero(t *testing.T) {
+	b := calB(t)
+	sat := nyTime(t, 2026, time.July, 4, 0, 0)
+	mon := nyTime(t, 2026, time.July, 6, 0, 0)
+	if got := b.Between(sat, mon); got != 0 {
+		t.Fatalf("Between(Sat,Mon) = %s, want 0", got)
+	}
+}
+
+func TestBetween_WorkdaysWallSpan(t *testing.T) {
+	a := calA(t)
+	kyiv, err := time.LoadLocation("Europe/Kyiv")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	// Whole-day-open workdays model: business time equals wall span within a
+	// single working day. 2026-07-21 is a Tuesday.
+	from := time.Date(2026, time.July, 21, 9, 12, 0, 0, kyiv)
+	to := time.Date(2026, time.July, 21, 16, 5, 0, 0, kyiv)
+	if got := a.Between(from, to); got != 6*time.Hour+53*time.Minute {
+		t.Fatalf("Between(Tue 09:12, Tue 16:05) = %s, want 6h53m", got)
+	}
+	// Spanning a weekend counts only the weekday wall time: Fri 07-17 full day
+	// (8h capacity but whole-day-open => 24h wall) is not what we assert here;
+	// instead assert the weekend itself contributes nothing.
+	satMid := time.Date(2026, time.July, 25, 0, 0, 0, 0, kyiv)
+	monMid := time.Date(2026, time.July, 27, 0, 0, 0, 0, kyiv)
+	if got := a.Between(satMid, monMid); got != 0 {
+		t.Fatalf("Between(Sat,Mon) = %s, want 0", got)
+	}
+}
+
+// --- DST correctness -----------------------------------------------------
+
+func kyivSundayCal(t *testing.T) *bizcal.Calendar {
+	t.Helper()
+	kyiv, err := time.LoadLocation("Europe/Kyiv")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	cal, err := bizcal.New(kyiv, bizcal.WithWeekday(time.Sunday, bizcal.MustWindows("00:00-06:00")...))
+	if err != nil {
+		t.Fatalf("New(kyivSunday) = %v", err)
+	}
+	return cal
+}
+
+func TestBetween_DST(t *testing.T) {
+	cal := kyivSundayCal(t)
+	kyiv := cal.Location()
+	// Spring-forward 2026-03-29: 03:00 -> 04:00 skip, so the 00:00-06:00 wall
+	// window is only 5 absolute hours.
+	springFrom := time.Date(2026, time.March, 29, 0, 0, 0, 0, kyiv)
+	springTo := time.Date(2026, time.March, 29, 6, 0, 0, 0, kyiv)
+	if got := cal.Between(springFrom, springTo); got != 5*time.Hour {
+		t.Fatalf("Between(spring-forward wall day) = %s, want 5h", got)
+	}
+	// Fall-back 2026-10-25: 04:00 -> 03:00 repeat, so the window is 7 hours.
+	fallFrom := time.Date(2026, time.October, 25, 0, 0, 0, 0, kyiv)
+	fallTo := time.Date(2026, time.October, 25, 6, 0, 0, 0, kyiv)
+	if got := cal.Between(fallFrom, fallTo); got != 7*time.Hour {
+		t.Fatalf("Between(fall-back wall day) = %s, want 7h", got)
+	}
+}
+
+func TestAdd_DSTDurationExact(t *testing.T) {
+	cal := kyivSundayCal(t)
+	kyiv := cal.Location()
+	// SLA add across spring-forward stays absolute-duration exact: 4 in-window
+	// hours from 01:00 land at the 06:00 close, 4 absolute hours later.
+	from := time.Date(2026, time.March, 29, 1, 0, 0, 0, kyiv)
+	got, err := cal.Add(from, 4*time.Hour)
+	if err != nil {
+		t.Fatalf("Add = %v", err)
+	}
+	if got.Sub(from) != 4*time.Hour {
+		t.Fatalf("Add across spring-forward: elapsed %s, want 4h absolute", got.Sub(from))
+	}
+	want := time.Date(2026, time.March, 29, 6, 0, 0, 0, kyiv)
+	if !got.Equal(want) {
+		t.Fatalf("Add(01:00, 4h) = %s, want %s", got, want)
+	}
+}
+
+// --- WindowsBetween ------------------------------------------------------
+
+func collect(seq func(func(bizcal.Interval) bool)) []bizcal.Interval {
+	var out []bizcal.Interval
+	seq(func(iv bizcal.Interval) bool {
+		out = append(out, iv)
+		return true
+	})
+	return out
+}
+
+func TestWindowsBetween_Windows(t *testing.T) {
+	b := calB(t)
+	// A single Monday: two split windows, both fully inside the range.
+	from := nyTime(t, 2026, time.July, 6, 0, 0)
+	to := nyTime(t, 2026, time.July, 7, 0, 0)
+	got := collect(b.WindowsBetween(from, to))
+	if len(got) != 2 {
+		t.Fatalf("WindowsBetween(Mon) yielded %d intervals, want 2", len(got))
+	}
+	if !got[0].Start.Equal(nyTime(t, 2026, time.July, 6, 9, 0)) || !got[0].End.Equal(nyTime(t, 2026, time.July, 6, 13, 0)) {
+		t.Fatalf("first interval = %v", got[0])
+	}
+	if !got[1].Start.Equal(nyTime(t, 2026, time.July, 6, 14, 0)) || !got[1].End.Equal(nyTime(t, 2026, time.July, 6, 18, 0)) {
+		t.Fatalf("second interval = %v", got[1])
+	}
+}
+
+func TestWindowsBetween_ClipsBothEdges(t *testing.T) {
+	b := calB(t)
+	// Clip inside the morning window at the from edge and inside the afternoon
+	// window at the to edge.
+	from := nyTime(t, 2026, time.July, 6, 10, 0)
+	to := nyTime(t, 2026, time.July, 6, 15, 0)
+	got := collect(b.WindowsBetween(from, to))
+	if len(got) != 2 {
+		t.Fatalf("WindowsBetween(clipped) yielded %d, want 2", len(got))
+	}
+	if !got[0].Start.Equal(from) {
+		t.Fatalf("first clipped start = %s, want %s", got[0].Start, from)
+	}
+	if !got[1].End.Equal(to) {
+		t.Fatalf("last clipped end = %s, want %s", got[1].End, to)
+	}
+}
+
+func TestWindowsBetween_MergesCrossMidnightShift(t *testing.T) {
+	c := calC(t)
+	// The 22:00 -> 02:00 shift is split across two civil dates internally but
+	// must emerge as one merged interval.
+	from := time.Date(2026, time.July, 20, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, time.July, 22, 0, 0, 0, 0, time.UTC)
+	got := collect(c.WindowsBetween(from, to))
+	if len(got) != 1 {
+		t.Fatalf("WindowsBetween(shift) yielded %d, want 1 merged", len(got))
+	}
+	wantStart := time.Date(2026, time.July, 20, 22, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, time.July, 21, 2, 0, 0, 0, time.UTC)
+	if !got[0].Start.Equal(wantStart) || !got[0].End.Equal(wantEnd) {
+		t.Fatalf("merged shift = %v, want [%s,%s)", got[0], wantStart, wantEnd)
+	}
+}
+
+func TestWindowsBetween_AlwaysOpenSingleInterval(t *testing.T) {
+	d := calD(t)
+	from := time.Date(2026, time.July, 4, 6, 0, 0, 0, time.UTC)
+	to := time.Date(2026, time.July, 9, 18, 0, 0, 0, time.UTC)
+	got := collect(d.WindowsBetween(from, to))
+	if len(got) != 1 {
+		t.Fatalf("WindowsBetween(always-open) yielded %d, want 1", len(got))
+	}
+	if !got[0].Start.Equal(from) || !got[0].End.Equal(to) {
+		t.Fatalf("always-open merged = %v, want [%s,%s)", got[0], from, to)
+	}
+}
+
+func TestWindowsBetween_EmptyWhenInverted(t *testing.T) {
+	b := calB(t)
+	from := nyTime(t, 2026, time.July, 6, 12, 0)
+	to := nyTime(t, 2026, time.July, 6, 9, 0)
+	if got := collect(b.WindowsBetween(from, to)); len(got) != 0 {
+		t.Fatalf("WindowsBetween(from>=to) yielded %d, want 0", len(got))
+	}
+}
+
+// --- Horizon -------------------------------------------------------------
+
+// alwaysClosedCal builds a calendar with a base but a rule that closes every
+// day of every year, so no open instant is ever reachable.
+func alwaysClosedCal(t *testing.T, horizon time.Duration) *bizcal.Calendar {
+	t.Helper()
+	allDays := bizcal.RuleFunc(func(year int) []bizcal.Date {
+		var ds []bizcal.Date
+		d := bizcal.MustDate(year, time.January, 1)
+		end := bizcal.MustDate(year+1, time.January, 1)
+		for d.Before(end) {
+			ds = append(ds, d)
+			d = d.AddDays(1)
+		}
+		return ds
+	})
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
+		bizcal.WithRule(allDays),
+		bizcal.WithHorizon(horizon),
+	)
+	if err != nil {
+		t.Fatalf("New(alwaysClosed) = %v", err)
+	}
+	return cal
+}
+
+func TestHorizonExceeded(t *testing.T) {
+	cal := alwaysClosedCal(t, 48*time.Hour)
+	at := time.Date(2026, time.July, 1, 9, 0, 0, 0, time.UTC)
+	if _, err := cal.NextOpen(at); !errors.Is(err, bizcal.ErrHorizonExceeded) {
+		t.Fatalf("NextOpen = %v, want ErrHorizonExceeded", err)
+	}
+	if _, err := cal.Add(at, time.Hour); !errors.Is(err, bizcal.ErrHorizonExceeded) {
+		t.Fatalf("Add(forward) = %v, want ErrHorizonExceeded", err)
+	}
+	if _, err := cal.Add(at, -time.Hour); !errors.Is(err, bizcal.ErrHorizonExceeded) {
+		t.Fatalf("Add(backward) = %v, want ErrHorizonExceeded", err)
+	}
+}

--- a/core/bizcal/options.go
+++ b/core/bizcal/options.go
@@ -1,0 +1,211 @@
+package bizcal
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// defaultHorizon bounds NextOpen/Add/AddWorkingDays scans when the caller
+// does not set WithHorizon: 5 years of calendar time.
+const defaultHorizon = 5 * 365 * 24 * time.Hour
+
+// config accumulates the raw, caller-shaped inputs New receives from Option
+// values before validation and normalization. It is never exposed outside
+// the package.
+type config struct {
+	exceptions     map[Date]Exception
+	weekly         [7][]Window
+	rules          []Rule
+	shifts         []Interval
+	workdayCap     [7]time.Duration
+	horizon        time.Duration
+	workdaySet     [7]bool
+	usedWeekday    bool
+	usedWorkdays   bool
+	usedAlwaysOpen bool
+}
+
+// Option configures a Calendar under construction. Option errors accumulate
+// across every call and are returned joined from New.
+type Option func(*config) error
+
+// WithWeekday adds clock windows open on every occurrence of wd. It is
+// repeatable per weekday: later calls for the same weekday append rather
+// than replace. wd must be Sunday through Saturday, else ErrInvalidWeekday.
+// WithWeekday establishes the calendar's base schedule and may not be
+// combined with WithWorkdays or WithAlwaysOpen.
+func WithWeekday(wd time.Weekday, windows ...Window) Option {
+	return func(c *config) error {
+		if wd < time.Sunday || wd > time.Saturday {
+			return fmt.Errorf("%w: %d", ErrInvalidWeekday, wd)
+		}
+		c.usedWeekday = true
+		ws := make([]Window, len(windows))
+		copy(ws, windows)
+		c.weekly[wd] = append(c.weekly[wd], ws...)
+		return nil
+	}
+}
+
+// WithWorkdays marks each listed weekday open for the whole civil day with
+// scheduled capacity perDay (the HR day-granular model: no invented clock
+// windows). perDay must be positive and at most 24h, else
+// ErrInvalidCapacity; each weekday must be Sunday through Saturday, else
+// ErrInvalidWeekday. WithWorkdays establishes the calendar's base schedule
+// and may not be combined with WithWeekday or WithAlwaysOpen.
+func WithWorkdays(perDay time.Duration, weekdays ...time.Weekday) Option {
+	return func(c *config) error {
+		if perDay <= 0 || perDay > 24*time.Hour {
+			return fmt.Errorf("%w: %s", ErrInvalidCapacity, perDay)
+		}
+		for _, wd := range weekdays {
+			if wd < time.Sunday || wd > time.Saturday {
+				return fmt.Errorf("%w: %d", ErrInvalidWeekday, wd)
+			}
+		}
+		c.usedWorkdays = true
+		for _, wd := range weekdays {
+			c.workdaySet[wd] = true
+			c.workdayCap[wd] = perDay
+		}
+		return nil
+	}
+}
+
+// WithAlwaysOpen marks every day open 00:00-24:00 with 24h capacity.
+// WithAlwaysOpen establishes the calendar's base schedule and may not be
+// combined with WithWeekday or WithWorkdays.
+func WithAlwaysOpen() Option {
+	return func(c *config) error {
+		c.usedAlwaysOpen = true
+		return nil
+	}
+}
+
+// WithRule registers a holiday Rule (repeatable). r must be non-nil, else
+// ErrInvalidRule; r's own field values are validated later, inside New.
+func WithRule(r Rule) Option {
+	return func(c *config) error {
+		if r == nil {
+			return fmt.Errorf("%w: nil rule", ErrInvalidRule)
+		}
+		c.rules = append(c.rules, r)
+		return nil
+	}
+}
+
+// WithRules is the bulk convenience form of WithRule.
+func WithRules(rs ...Rule) Option {
+	return func(c *config) error {
+		var errs []error
+		for _, r := range rs {
+			if r == nil {
+				errs = append(errs, fmt.Errorf("%w: nil rule", ErrInvalidRule))
+				continue
+			}
+			c.rules = append(c.rules, r)
+		}
+		return errors.Join(errs...)
+	}
+}
+
+// WithExceptions registers per-date plan overrides. If two exceptions share
+// a date (whether from the same call or across repeated calls), the last
+// one applied wins.
+func WithExceptions(excs ...Exception) Option {
+	return func(c *config) error {
+		var errs []error
+		for _, e := range excs {
+			if e.kind == exceptionShortDay && (e.capacity < 0 || e.capacity > 24*time.Hour) {
+				errs = append(errs, fmt.Errorf("%w: %s", ErrInvalidCapacity, e.capacity))
+				continue
+			}
+			if c.exceptions == nil {
+				c.exceptions = make(map[Date]Exception, len(excs))
+			}
+			c.exceptions[e.date] = e
+		}
+		return errors.Join(errs...)
+	}
+}
+
+// WithShifts registers absolute rostered coverage intervals (repeatable).
+// Each Interval must have a non-zero Start and End, with End strictly after
+// Start, else ErrInvalidShift. Shifts add open time on top of whatever the
+// base/rules/exceptions resolve a day to; they are not a base source and
+// may be combined with any base, or used with no base at all.
+func WithShifts(ivs ...Interval) Option {
+	return func(c *config) error {
+		var errs []error
+		for _, iv := range ivs {
+			if iv.Start.IsZero() || iv.End.IsZero() || !iv.End.After(iv.Start) {
+				errs = append(errs, fmt.Errorf("%w: start=%s end=%s", ErrInvalidShift, iv.Start, iv.End))
+				continue
+			}
+			c.shifts = append(c.shifts, iv)
+		}
+		return errors.Join(errs...)
+	}
+}
+
+// WithHorizon sets the scan cap NextOpen, Add, and AddWorkingDays search
+// before giving up with ErrHorizonExceeded (default 5 years of calendar
+// time). d must be positive.
+func WithHorizon(d time.Duration) Option {
+	return func(c *config) error {
+		if d <= 0 {
+			return fmt.Errorf("%w: horizon must be positive", ErrInvalidCapacity)
+		}
+		c.horizon = d
+		return nil
+	}
+}
+
+// exceptionKind distinguishes the three Exception shapes.
+type exceptionKind int
+
+const (
+	exceptionDayOff exceptionKind = iota
+	exceptionShortDay
+	exceptionCustomDay
+)
+
+// Exception is an opaque per-date override of a Calendar's resolved day
+// plan, constructed via DayOff, ShortDay, or CustomDay and registered with
+// WithExceptions.
+type Exception struct {
+	windows  []Window
+	date     Date
+	kind     exceptionKind
+	capacity time.Duration
+}
+
+// DayOff marks d as fully closed, overriding whatever the base/rules would
+// otherwise resolve that date to.
+func DayOff(d Date) Exception {
+	return Exception{date: d, kind: exceptionDayOff}
+}
+
+// ShortDay marks d open for the whole civil day with scheduled capacity
+// overridden to capacity (the workdays-model equivalent of a reduced-hours
+// day). capacity must be non-negative and at most 24h, else New reports
+// ErrInvalidCapacity; a capacity of 0 behaves exactly like DayOff.
+func ShortDay(d Date, capacity time.Duration) Exception {
+	return Exception{date: d, kind: exceptionShortDay, capacity: capacity}
+}
+
+// CustomDay replaces d's open windows with windows (the windows-model
+// equivalent of ShortDay). Calling CustomDay with no windows is equivalent
+// to DayOff.
+func CustomDay(d Date, windows ...Window) Exception {
+	if len(windows) == 0 {
+		return Exception{date: d, kind: exceptionDayOff}
+	}
+	return Exception{date: d, kind: exceptionCustomDay, windows: mergeWindows(windows)}
+}
+
+// Shift constructs an Interval for use with WithShifts.
+func Shift(start, end time.Time) Interval {
+	return Interval{Start: start, End: end}
+}

--- a/core/bizcal/oracle_test.go
+++ b/core/bizcal/oracle_test.go
@@ -1,0 +1,198 @@
+package bizcal_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/bizcal"
+)
+
+// oracleCalendar builds the calendar the brute-force oracle test runs
+// against: Europe/Kyiv, Mon-Fri 09:00-17:00 business windows plus a Sunday
+// 00:00-06:00 window (so the DST transition, which in the EU falls in the
+// small hours of the last Sunday of March/October, lands inside an open
+// window instead of a closed one), a holiday on a normally-working Monday,
+// and a reduced-hours exception on a normally-working Wednesday.
+func oracleCalendar(t *testing.T) *bizcal.Calendar {
+	t.Helper()
+	kyiv, err := time.LoadLocation("Europe/Kyiv")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	weekdayWindows := bizcal.MustWindows("09:00-17:00")
+	cal, err := bizcal.New(kyiv,
+		bizcal.WithWeekday(time.Monday, weekdayWindows...),
+		bizcal.WithWeekday(time.Tuesday, weekdayWindows...),
+		bizcal.WithWeekday(time.Wednesday, weekdayWindows...),
+		bizcal.WithWeekday(time.Thursday, weekdayWindows...),
+		bizcal.WithWeekday(time.Friday, weekdayWindows...),
+		bizcal.WithWeekday(time.Sunday, bizcal.MustWindows("00:00-06:00")...),
+		// 2026-03-23 is a Monday: a holiday landing on a normally-working day.
+		bizcal.WithRule(bizcal.Fixed{Month: time.March, Day: 23}),
+		// 2026-03-25 is a Wednesday: reduced hours via CustomDay.
+		bizcal.WithExceptions(bizcal.CustomDay(bizcal.MustDate(2026, time.March, 25), bizcal.MustWindows("09:00-11:00")...)),
+	)
+	if err != nil {
+		t.Fatalf("New(oracleCalendar) = %v", err)
+	}
+	return cal
+}
+
+// oracleMinuteTable is a brute-force, minute-granularity ground truth for
+// IsOpen over a padded span, built by calling IsOpen directly (which is
+// trivially auditable against the fixture by hand) once per minute.
+type oracleMinuteTable struct {
+	start time.Time
+	open  []bool
+}
+
+func buildOracleMinuteTable(cal *bizcal.Calendar, start, end time.Time) oracleMinuteTable {
+	n := int(end.Sub(start) / time.Minute)
+	open := make([]bool, n)
+	t := start
+	for i := range n {
+		open[i] = cal.IsOpen(t)
+		t = t.Add(time.Minute)
+	}
+	return oracleMinuteTable{start: start, open: open}
+}
+
+func (o oracleMinuteTable) index(t time.Time) int {
+	return int(t.Sub(o.start) / time.Minute)
+}
+
+// between sums open minutes in [a,b), mirroring Calendar.Between at
+// minute granularity. a and b must be minute-aligned and within table
+// bounds.
+func (o oracleMinuteTable) between(a, b time.Time) time.Duration {
+	ia, ib := o.index(a), o.index(b)
+	neg := false
+	if ia > ib {
+		ia, ib = ib, ia
+		neg = true
+	}
+	var mins int
+	for i := ia; i < ib; i++ {
+		if o.open[i] {
+			mins++
+		}
+	}
+	d := time.Duration(mins) * time.Minute
+	if neg {
+		return -d
+	}
+	return d
+}
+
+// nextOpen scans forward from t (minute-aligned) for the first open minute,
+// mirroring Calendar.NextOpen.
+func (o oracleMinuteTable) nextOpen(t time.Time) (time.Time, bool) {
+	for i := o.index(t); i < len(o.open); i++ {
+		if o.open[i] {
+			return o.start.Add(time.Duration(i) * time.Minute), true
+		}
+	}
+	return time.Time{}, false
+}
+
+// add consumes budget (a non-negative, whole-minute duration) of open
+// minutes starting at t's NextOpen anchor, mirroring Calendar.Add for
+// d >= 0.
+func (o oracleMinuteTable) add(t time.Time, budget time.Duration) (time.Time, bool) {
+	anchor, ok := o.nextOpen(t)
+	if !ok {
+		return time.Time{}, false
+	}
+	need := int(budget / time.Minute)
+	i := o.index(anchor)
+	for consumed := 0; consumed < need; i++ {
+		if i >= len(o.open) {
+			return time.Time{}, false
+		}
+		if o.open[i] {
+			consumed++
+		}
+	}
+	return o.start.Add(time.Duration(i) * time.Minute), true
+}
+
+// TestOracle_MinuteScannerAgreesWithBetweenNextOpenAdd compares Between,
+// NextOpen, and Add against a brute-force minute-granularity oracle over a
+// 3-week window (2026-03-16 to 2026-04-06) that includes a weekend every
+// week, a holiday (2026-03-23), a reduced-hours exception (2026-03-25), and
+// the DST spring-forward transition (2026-03-29, Europe/Kyiv).
+func TestOracle_MinuteScannerAgreesWithBetweenNextOpenAdd(t *testing.T) {
+	cal := oracleCalendar(t)
+	loc := cal.Location()
+
+	windowStart := time.Date(2026, time.March, 16, 0, 0, 0, 0, loc)
+	windowEnd := time.Date(2026, time.April, 6, 0, 0, 0, 0, loc)
+	// Pad the table well past the window so NextOpen/Add scans that reach
+	// beyond it (e.g. sampled near windowEnd) still resolve against real
+	// ground truth rather than running off the end of the table.
+	tablePad := time.Date(2026, time.April, 20, 0, 0, 0, 0, loc)
+
+	oracle := buildOracleMinuteTable(cal, windowStart, tablePad)
+
+	// Deterministic must-hit samples: the holiday, the exception day, a
+	// plain weekend day, and instants straddling the DST transition.
+	mustHit := []time.Time{
+		time.Date(2026, time.March, 23, 10, 0, 0, 0, loc), // holiday (normally working)
+		time.Date(2026, time.March, 25, 10, 0, 0, 0, loc), // exception: reduced hours
+		time.Date(2026, time.March, 21, 12, 0, 0, 0, loc), // Saturday, closed
+		time.Date(2026, time.March, 29, 2, 30, 0, 0, loc), // pre-DST-jump, inside Sunday window
+		time.Date(2026, time.March, 29, 5, 0, 0, 0, loc),  // post-DST-jump, inside Sunday window
+	}
+
+	rng := rand.New(rand.NewSource(99))
+	randMinuteAligned := func() time.Time {
+		offset := time.Duration(rng.Intn(int(windowEnd.Sub(windowStart)/time.Minute))) * time.Minute
+		return windowStart.Add(offset)
+	}
+
+	const samples = 300
+	as := make([]time.Time, 0, samples+len(mustHit))
+	as = append(as, mustHit...)
+	for range samples {
+		as = append(as, randMinuteAligned())
+	}
+
+	for _, a := range as {
+		// Between, paired with a second random/must-hit point.
+		b := randMinuteAligned()
+		want := oracle.between(a, b)
+		if got := cal.Between(a, b); got != want {
+			t.Fatalf("Between(%s,%s) = %s, want %s (oracle)", a, b, got, want)
+		}
+
+		// NextOpen.
+		wantNext, ok := oracle.nextOpen(a)
+		gotNext, err := cal.NextOpen(a)
+		if !ok {
+			// Ran off the padded table; skip rather than assert on a
+			// meaningless bound.
+			continue
+		}
+		if err != nil {
+			t.Fatalf("NextOpen(%s) errored: %v, want %s (oracle)", a, err, wantNext)
+		}
+		if !gotNext.Equal(wantNext) {
+			t.Fatalf("NextOpen(%s) = %s, want %s (oracle)", a, gotNext, wantNext)
+		}
+
+		// Add, with a small whole-minute budget.
+		budget := time.Duration(rng.Intn(600)) * time.Minute // up to 10h
+		wantAdd, ok := oracle.add(a, budget)
+		gotAdd, err := cal.Add(a, budget)
+		if !ok {
+			continue
+		}
+		if err != nil {
+			t.Fatalf("Add(%s,%s) errored: %v, want %s (oracle)", a, budget, err, wantAdd)
+		}
+		if !gotAdd.Equal(wantAdd) {
+			t.Fatalf("Add(%s,%s) = %s, want %s (oracle)", a, budget, gotAdd, wantAdd)
+		}
+	}
+}

--- a/core/bizcal/property_test.go
+++ b/core/bizcal/property_test.go
@@ -1,0 +1,286 @@
+package bizcal_test
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/bizcal"
+)
+
+// propIterations is the number of seeded pseudo-random cases each property
+// test runs. The generator is seeded from a fixed constant (never time or
+// flags) so failures are deterministic and reproducible across runs.
+const propIterations = 500
+
+// randInstant returns a uniformly random instant within calendar year 2026
+// in loc. Full-nanosecond precision is fine here: the algebraic properties
+// under test hold for any pair of instants, not just minute-aligned ones.
+func randInstant(rng *rand.Rand, loc *time.Location) time.Time {
+	start := time.Date(2026, time.January, 1, 0, 0, 0, 0, loc)
+	end := time.Date(2027, time.January, 1, 0, 0, 0, 0, loc)
+	span := int64(end.Sub(start))
+	return start.Add(time.Duration(rng.Int63n(span)))
+}
+
+// randDate2026 returns a uniformly random civil date within 2026.
+func randDate2026(rng *rand.Rand) bizcal.Date {
+	start := bizcal.MustDate(2026, time.January, 1)
+	return start.AddDays(rng.Intn(365))
+}
+
+// propertyFixtures returns the three fixture calendars the brief calls out
+// for property coverage: (a) the workdays model, (b) the weekly-windows
+// model, and (c) the shifts-only model.
+func propertyFixtures(t *testing.T) []*bizcal.Calendar {
+	t.Helper()
+	return []*bizcal.Calendar{calA(t), calB(t), calC(t)}
+}
+
+// --- Between: signed symmetry and additivity -----------------------------
+
+func TestProperty_BetweenSignedSymmetry(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	cals := propertyFixtures(t)
+	for i := range propIterations {
+		cal := cals[i%len(cals)]
+		a := randInstant(rng, cal.Location())
+		b := randInstant(rng, cal.Location())
+		fwd := cal.Between(a, b)
+		rev := cal.Between(b, a)
+		if fwd != -rev {
+			t.Fatalf("iter %d: Between(a,b) != -Between(b,a): a=%s b=%s fwd=%s rev=%s", i, a, b, fwd, rev)
+		}
+	}
+}
+
+func TestProperty_BetweenAdditive(t *testing.T) {
+	rng := rand.New(rand.NewSource(43))
+	cals := propertyFixtures(t)
+	for i := range propIterations {
+		cal := cals[i%len(cals)]
+		pts := []time.Time{randInstant(rng, cal.Location()), randInstant(rng, cal.Location()), randInstant(rng, cal.Location())}
+		sort.Slice(pts, func(x, y int) bool { return pts[x].Before(pts[y]) })
+		a, b, c := pts[0], pts[1], pts[2]
+		lhs := cal.Between(a, c)
+		rhs := cal.Between(a, b) + cal.Between(b, c)
+		if lhs != rhs {
+			t.Fatalf("iter %d: Between(a,c) != Between(a,b)+Between(b,c): a=%s b=%s c=%s lhs=%s rhs=%s", i, a, b, c, lhs, rhs)
+		}
+	}
+}
+
+// --- Add: round-trips through Between; NextOpen: idempotent --------------
+
+func TestProperty_AddRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(44))
+	cals := propertyFixtures(t)
+	for i := range propIterations {
+		cal := cals[i%len(cals)]
+		start := randInstant(rng, cal.Location())
+		d := time.Duration(rng.Int63n(int64(30 * 24 * time.Hour))) // always >= 0
+
+		result, err := cal.Add(start, d)
+		if err != nil {
+			continue // horizon exhausted on a sparse fixture is not a violation
+		}
+		anchor, err := cal.NextOpen(start)
+		if err != nil {
+			t.Fatalf("iter %d: NextOpen(start) errored after Add succeeded: %v", i, err)
+		}
+		if got := cal.Between(anchor, result); got != d {
+			t.Fatalf("iter %d: Add round-trip broke: Between(NextOpen(start),result)=%s, want %s (start=%s)", i, got, d, start)
+		}
+	}
+}
+
+func TestProperty_NextOpenIdempotent(t *testing.T) {
+	rng := rand.New(rand.NewSource(45))
+	cals := []*bizcal.Calendar{calA(t), calB(t), calC(t), calD(t)}
+	for i := range propIterations {
+		cal := cals[i%len(cals)]
+		t0 := randInstant(rng, cal.Location())
+		got1, err1 := cal.NextOpen(t0)
+		if err1 != nil {
+			continue
+		}
+		got2, err2 := cal.NextOpen(got1)
+		if err2 != nil {
+			t.Fatalf("iter %d: NextOpen(NextOpen(t)) errored: %v", i, err2)
+		}
+		if !got2.Equal(got1) {
+			t.Fatalf("iter %d: NextOpen not idempotent: t=%s got1=%s got2=%s", i, t0, got1, got2)
+		}
+	}
+}
+
+// --- WorkingDays / ScheduledBetween: aggregate == per-day loop -----------
+
+func TestProperty_WorkingDaysMatchesLoop(t *testing.T) {
+	rng := rand.New(rand.NewSource(46))
+	cals := propertyFixtures(t)
+	for i := range propIterations {
+		cal := cals[i%len(cals)]
+		from, to := randDate2026(rng), randDate2026(rng)
+		if to.Before(from) {
+			from, to = to, from
+		}
+		want := 0
+		for d := from; d.Before(to); d = d.AddDays(1) {
+			if cal.IsWorkingDay(d) {
+				want++
+			}
+		}
+		if got := cal.WorkingDays(from, to); got != want {
+			t.Fatalf("iter %d: WorkingDays(%s,%s)=%d, want %d (loop count)", i, from, to, got, want)
+		}
+	}
+}
+
+func TestProperty_ScheduledBetweenMatchesSum(t *testing.T) {
+	rng := rand.New(rand.NewSource(47))
+	cals := propertyFixtures(t)
+	for i := range propIterations {
+		cal := cals[i%len(cals)]
+		from, to := randDate2026(rng), randDate2026(rng)
+		if to.Before(from) {
+			from, to = to, from
+		}
+		var want time.Duration
+		for d := from; d.Before(to); d = d.AddDays(1) {
+			want += cal.DayDuration(d)
+		}
+		if got := cal.ScheduledBetween(from, to); got != want {
+			t.Fatalf("iter %d: ScheduledBetween(%s,%s)=%s, want %s (sum of DayDuration)", i, from, to, got, want)
+		}
+	}
+}
+
+// --- Pinned tests (controller-directed, Task 4/5 review follow-ups) ------
+
+// TestPin_ShiftOverlappingBaseWindow_CapacityAdditiveIntervalsUnion pins the
+// current additive-capacity / union-intervals semantic for a shift rostered
+// on top of a base window it overlaps: DayDuration double-counts the
+// overlap (base + full shift duration) while the open intervals themselves
+// merge into a single continuous span.
+func TestPin_ShiftOverlappingBaseWindow_CapacityAdditiveIntervalsUnion(t *testing.T) {
+	// 2026-07-06 is a Monday.
+	mon := bizcal.MustDate(2026, time.July, 6)
+	shiftStart := time.Date(2026, time.July, 6, 10, 0, 0, 0, time.UTC)
+	shiftEnd := time.Date(2026, time.July, 6, 12, 0, 0, 0, time.UTC)
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWeekday(time.Monday, bizcal.MustWindows("09:00-17:00")...),
+		bizcal.WithShifts(bizcal.Shift(shiftStart, shiftEnd)),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	// Capacity double-counts: 8h base + 2h shift = 10h, even though the shift
+	// is fully contained within the base window.
+	if got := cal.DayDuration(mon); got != 10*time.Hour {
+		t.Fatalf("DayDuration(overlap) = %s, want 10h (additive double-count)", got)
+	}
+
+	// Open intervals are the union: exactly one continuous [09:00,17:00)
+	// interval, not two.
+	dayStart := time.Date(2026, time.July, 6, 0, 0, 0, 0, time.UTC)
+	dayEnd := time.Date(2026, time.July, 7, 0, 0, 0, 0, time.UTC)
+	got := collect(cal.WindowsBetween(dayStart, dayEnd))
+	if len(got) != 1 {
+		t.Fatalf("WindowsBetween(overlap day) yielded %d intervals, want 1 merged", len(got))
+	}
+	wantStart := time.Date(2026, time.July, 6, 9, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, time.July, 6, 17, 0, 0, 0, time.UTC)
+	if !got[0].Start.Equal(wantStart) || !got[0].End.Equal(wantEnd) {
+		t.Fatalf("merged interval = %v, want [%s,%s)", got[0], wantStart, wantEnd)
+	}
+}
+
+// TestPin_ShiftAcrossYearBoundary_SplitsAcrossBothYearsPlans pins that a
+// shift straddling Dec 31 -> Jan 1 contributes correctly to both years'
+// independently-built, independently-cached yearPlans.
+func TestPin_ShiftAcrossYearBoundary_SplitsAcrossBothYearsPlans(t *testing.T) {
+	start := time.Date(2026, time.December, 31, 23, 0, 0, 0, time.UTC)
+	end := time.Date(2027, time.January, 1, 2, 0, 0, 0, time.UTC)
+	cal, err := bizcal.New(time.UTC, bizcal.WithShifts(bizcal.Shift(start, end)))
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	if got := cal.DayDuration(bizcal.MustDate(2026, time.December, 31)); got != time.Hour {
+		t.Fatalf("DayDuration(2026-12-31) = %s, want 1h", got)
+	}
+	if got := cal.DayDuration(bizcal.MustDate(2027, time.January, 1)); got != 2*time.Hour {
+		t.Fatalf("DayDuration(2027-01-01) = %s, want 2h", got)
+	}
+}
+
+// TestPin_CustomDayException_ObservedViaDayDurationAndIsWorkingDay pins the
+// windows-model CustomDay override as visible through the public day-op
+// surface, not just construction.
+func TestPin_CustomDayException_ObservedViaDayDurationAndIsWorkingDay(t *testing.T) {
+	// 2026-07-06 is a Monday.
+	mon := bizcal.MustDate(2026, time.July, 6)
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWeekday(time.Monday, bizcal.MustWindows("09:00-17:00")...),
+		bizcal.WithExceptions(bizcal.CustomDay(mon, bizcal.MustWindows("10:00-11:00")...)),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	if got := cal.DayDuration(mon); got != time.Hour {
+		t.Fatalf("DayDuration(CustomDay) = %s, want 1h", got)
+	}
+	if !cal.IsWorkingDay(mon) {
+		t.Fatal("IsWorkingDay(CustomDay) = false, want true")
+	}
+}
+
+// TestPin_ZeroCapacityShortDay_IsNonWorkingDay pins that a ShortDay
+// exception with zero capacity reads as a non-working day, not merely as a
+// degenerate-but-open one.
+func TestPin_ZeroCapacityShortDay_IsNonWorkingDay(t *testing.T) {
+	// 2026-07-06 is a Monday.
+	mon := bizcal.MustDate(2026, time.July, 6)
+	cal, err := bizcal.New(time.UTC,
+		bizcal.WithWorkdays(8*time.Hour, time.Monday),
+		bizcal.WithExceptions(bizcal.ShortDay(mon, 0)),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	if got := cal.DayDuration(mon); got != 0 {
+		t.Fatalf("DayDuration(zero ShortDay) = %s, want 0", got)
+	}
+	if cal.IsWorkingDay(mon) {
+		t.Fatal("IsWorkingDay(zero ShortDay) = true, want false")
+	}
+}
+
+// TestPin_AlwaysOpenDST_CapacityIsRealCivilDaySpan pins that an always-open
+// calendar's DayDuration on a DST-transition day is the real civil-day span
+// (23h spring-forward, 25h fall-back), not a nominal 24h.
+func TestPin_AlwaysOpenDST_CapacityIsRealCivilDaySpan(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	cal, err := bizcal.New(ny, bizcal.WithAlwaysOpen())
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+	// 2026-03-08: US spring-forward (2nd Sunday of March).
+	if got := cal.DayDuration(bizcal.MustDate(2026, time.March, 8)); got != 23*time.Hour {
+		t.Fatalf("DayDuration(spring-forward) = %s, want 23h", got)
+	}
+	// 2026-11-01: US fall-back (1st Sunday of November).
+	if got := cal.DayDuration(bizcal.MustDate(2026, time.November, 1)); got != 25*time.Hour {
+		t.Fatalf("DayDuration(fall-back) = %s, want 25h", got)
+	}
+	// A non-transition day stays a nominal 24h.
+	if got := cal.DayDuration(bizcal.MustDate(2026, time.March, 9)); got != 24*time.Hour {
+		t.Fatalf("DayDuration(normal day) = %s, want 24h", got)
+	}
+}

--- a/core/bizcal/resolver.go
+++ b/core/bizcal/resolver.go
@@ -1,0 +1,216 @@
+package bizcal
+
+import "time"
+
+// dayPlan is a single civil date's resolved schedule: its open intervals (in
+// absolute time) and its scheduled capacity. For the windows and always-open
+// models capacity equals the summed interval durations; for the workdays
+// model the whole civil day is open but capacity is the fixed per-day value,
+// so the two intentionally differ. Rostered shift time adds to both.
+type dayPlan struct {
+	intervals []Interval
+	capacity  time.Duration
+}
+
+// yearPlan memoizes every civil date's dayPlan for one year, computed lazily
+// on first touch of that year and cached on the Calendar.
+type yearPlan struct {
+	days map[Date]dayPlan
+}
+
+// dayPlan resolves d's plan, building and caching d's year on first touch.
+func (c *Calendar) dayPlan(d Date) dayPlan {
+	return c.yearPlanFor(d.Year).days[d]
+}
+
+// yearPlanFor returns the memoized plan for year, building it under the write
+// lock if absent. Reads take the read lock so concurrent day ops on already
+// built years never serialize.
+func (c *Calendar) yearPlanFor(year int) *yearPlan {
+	c.mu.RLock()
+	yp := c.years[year]
+	c.mu.RUnlock()
+	if yp != nil {
+		return yp
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if yp = c.years[year]; yp != nil {
+		return yp
+	}
+	yp = c.buildYear(year)
+	c.years[year] = yp
+	return yp
+}
+
+// buildYear resolves every civil date in year through the full layering
+// pipeline (base, holiday rules, exceptions, shifts) once.
+func (c *Calendar) buildYear(year int) *yearPlan {
+	ruleDates := c.ruleDates(year)
+	buckets := c.shiftBuckets(year)
+
+	days := make(map[Date]dayPlan, 366)
+	end := Date{Year: year + 1, Month: time.January, Day: 1}
+	for d := (Date{Year: year, Month: time.January, Day: 1}); d.Before(end); d = d.AddDays(1) {
+		days[d] = c.resolvePlan(d, ruleDates, buckets)
+	}
+	return &yearPlan{days: days}
+}
+
+// ruleDates expands every registered rule for year, keeping only dates that
+// actually fall in year (rules that return out-of-year dates are ignored).
+func (c *Calendar) ruleDates(year int) map[Date]bool {
+	if len(c.rules) == 0 {
+		return nil
+	}
+	out := make(map[Date]bool)
+	for _, r := range c.rules {
+		for _, rd := range r.Dates(year) {
+			if rd.Year == year {
+				out[rd] = true
+			}
+		}
+	}
+	return out
+}
+
+// resolvePlan layers the four schedule sources for a single date: base ->
+// holiday rule (full day off) -> exception (replaces the day) -> shifts (add
+// open time and capacity on top, winning over any day-off).
+func (c *Calendar) resolvePlan(d Date, ruleDates map[Date]bool, buckets map[Date][]Interval) dayPlan {
+	p := c.basePlan(d)
+	if ruleDates[d] {
+		p = dayPlan{}
+	}
+	if exc, ok := c.exceptions[d]; ok {
+		p = c.exceptionPlan(d, exc)
+	}
+	if segs := buckets[d]; len(segs) > 0 {
+		p.intervals = mergeIntervals(append(p.intervals, segs...))
+		for _, iv := range segs {
+			p.capacity += iv.Duration()
+		}
+	}
+	return p
+}
+
+// basePlan resolves d against the calendar's base source alone.
+func (c *Calendar) basePlan(d Date) dayPlan {
+	switch {
+	case c.usedWorkdays:
+		wd := d.Weekday()
+		if !c.workdaySet[wd] {
+			return dayPlan{}
+		}
+		start, next := c.civilBounds(d)
+		return dayPlan{intervals: []Interval{{Start: start, End: next}}, capacity: c.workdayCap[wd]}
+	case c.usedAlwaysOpen:
+		start, next := c.civilBounds(d)
+		return dayPlan{intervals: []Interval{{Start: start, End: next}}, capacity: next.Sub(start)}
+	case c.usedWeekday:
+		return c.windowsPlan(d, c.weekly[d.Weekday()])
+	default:
+		return dayPlan{}
+	}
+}
+
+// exceptionPlan resolves d's exception override.
+func (c *Calendar) exceptionPlan(d Date, exc Exception) dayPlan {
+	switch exc.kind {
+	case exceptionShortDay:
+		if exc.capacity == 0 {
+			return dayPlan{}
+		}
+		start, next := c.civilBounds(d)
+		return dayPlan{intervals: []Interval{{Start: start, End: next}}, capacity: exc.capacity}
+	case exceptionCustomDay:
+		return c.windowsPlan(d, exc.windows)
+	default: // exceptionDayOff
+		return dayPlan{}
+	}
+}
+
+// windowsPlan expands wall-clock windows into absolute intervals on d,
+// summing their real (DST-adjusted) durations into the capacity.
+func (c *Calendar) windowsPlan(d Date, ws []Window) dayPlan {
+	if len(ws) == 0 {
+		return dayPlan{}
+	}
+	intervals := make([]Interval, 0, len(ws))
+	var capacity time.Duration
+	for _, w := range ws {
+		iv := c.windowInterval(d, w)
+		intervals = append(intervals, iv)
+		capacity += iv.Duration()
+	}
+	return dayPlan{intervals: intervals, capacity: capacity}
+}
+
+// windowInterval resolves window w on date d into an absolute interval in the
+// calendar's zone. A 24:00 end normalizes to the next civil midnight, and DST
+// gaps or repeats are handled by time.Date normalization.
+func (c *Calendar) windowInterval(d Date, w Window) Interval {
+	sh, sm := w.Start()
+	eh, em := w.End()
+	start := time.Date(d.Year, d.Month, d.Day, sh, sm, 0, 0, c.loc)
+	end := time.Date(d.Year, d.Month, d.Day, eh, em, 0, 0, c.loc)
+	return Interval{Start: start, End: end}
+}
+
+// civilBounds returns the absolute start (00:00) and exclusive end (next
+// civil midnight) of date d in the calendar's zone. On a DST transition day
+// the span is 23h or 25h rather than 24h.
+func (c *Calendar) civilBounds(d Date) (start, next time.Time) {
+	start = time.Date(d.Year, d.Month, d.Day, 0, 0, 0, 0, c.loc)
+	next = time.Date(d.Year, d.Month, d.Day+1, 0, 0, 0, 0, c.loc)
+	return start, next
+}
+
+// shiftBuckets clips every shift to the civil dates it covers within year and
+// buckets the resulting segments by date. Segments falling outside year are
+// dropped, so a shift straddling a year boundary contributes only its
+// in-year portion.
+func (c *Calendar) shiftBuckets(year int) map[Date][]Interval {
+	if len(c.shifts) == 0 {
+		return nil
+	}
+	yearStart := time.Date(year, time.January, 1, 0, 0, 0, 0, c.loc)
+	yearEnd := time.Date(year+1, time.January, 1, 0, 0, 0, 0, c.loc)
+
+	buckets := make(map[Date][]Interval)
+	for _, sh := range c.shifts {
+		if !sh.End.After(yearStart) || !sh.Start.Before(yearEnd) {
+			continue
+		}
+		for cur := c.DateOf(sh.Start); ; cur = cur.AddDays(1) {
+			dayStart, dayNext := c.civilBounds(cur)
+			if !dayStart.Before(sh.End) {
+				break
+			}
+			segStart := maxTime(dayStart, sh.Start)
+			segEnd := minTime(dayNext, sh.End)
+			if cur.Year == year && segEnd.After(segStart) {
+				buckets[cur] = append(buckets[cur], Interval{Start: segStart, End: segEnd})
+			}
+			if !dayNext.Before(sh.End) {
+				break
+			}
+		}
+	}
+	return buckets
+}
+
+func maxTime(a, b time.Time) time.Time {
+	if a.After(b) {
+		return a
+	}
+	return b
+}
+
+func minTime(a, b time.Time) time.Time {
+	if a.Before(b) {
+		return a
+	}
+	return b
+}

--- a/core/bizcal/resolver.go
+++ b/core/bizcal/resolver.go
@@ -89,17 +89,24 @@ func isLeapYear(year int) bool {
 	return year%4 == 0 && (year%100 != 0 || year%400 == 0)
 }
 
-// ruleDates expands every registered rule for year, keeping only dates that
-// actually fall in year (rules that return out-of-year dates are ignored).
+// ruleDates expands every registered rule for years year-1, year, and year+1,
+// keeping only the produced dates that actually fall in year. Evaluating the
+// adjacent years catches holidays whose observed date shifts across a year
+// boundary (e.g. an Observed rule moving Jan 1 back to the prior Dec 31, or a
+// Dec 31 forward to the next Jan 1) while still discarding any date a rule
+// emits outside the queried year. The map dedupes dates produced more than
+// once across the three evaluations.
 func (c *Calendar) ruleDates(year int) map[Date]bool {
 	if len(c.rules) == 0 {
 		return nil
 	}
 	out := make(map[Date]bool)
 	for _, r := range c.rules {
-		for _, rd := range r.Dates(year) {
-			if rd.Year == year {
-				out[rd] = true
+		for y := year - 1; y <= year+1; y++ {
+			for _, rd := range r.Dates(y) {
+				if rd.Year == year {
+					out[rd] = true
+				}
 			}
 		}
 	}

--- a/core/bizcal/resolver.go
+++ b/core/bizcal/resolver.go
@@ -13,14 +13,21 @@ type dayPlan struct {
 }
 
 // yearPlan memoizes every civil date's dayPlan for one year, computed lazily
-// on first touch of that year and cached on the Calendar.
+// on first touch of that year and cached on the Calendar. days is indexed by
+// day-of-year minus one (dayOfYear returns 1-366) rather than keyed by Date,
+// so a resolved lookup is a slice index instead of a map hash+probe.
 type yearPlan struct {
-	days map[Date]dayPlan
+	days []dayPlan
 }
 
 // dayPlan resolves d's plan, building and caching d's year on first touch.
 func (c *Calendar) dayPlan(d Date) dayPlan {
-	return c.yearPlanFor(d.Year).days[d]
+	yp := c.yearPlanFor(d.Year)
+	idx := dayOfYear(d) - 1
+	if idx < 0 || idx >= len(yp.days) {
+		return dayPlan{}
+	}
+	return yp.days[idx]
 }
 
 // yearPlanFor returns the memoized plan for year, building it under the write
@@ -50,12 +57,36 @@ func (c *Calendar) buildYear(year int) *yearPlan {
 	ruleDates := c.ruleDates(year)
 	buckets := c.shiftBuckets(year)
 
-	days := make(map[Date]dayPlan, 366)
-	end := Date{Year: year + 1, Month: time.January, Day: 1}
-	for d := (Date{Year: year, Month: time.January, Day: 1}); d.Before(end); d = d.AddDays(1) {
-		days[d] = c.resolvePlan(d, ruleDates, buckets)
+	n := 365
+	if isLeapYear(year) {
+		n = 366
+	}
+	days := make([]dayPlan, n)
+	d := Date{Year: year, Month: time.January, Day: 1}
+	for i := range days {
+		days[i] = c.resolvePlan(d, ruleDates, buckets)
+		d = d.AddDays(1)
 	}
 	return &yearPlan{days: days}
+}
+
+// cumulativeDaysBeforeMonth[m] is the count of days in a non-leap year
+// falling in months before m (1-indexed; index 0 is unused).
+var cumulativeDaysBeforeMonth = [...]int{0, 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334}
+
+// dayOfYear returns d's 1-based ordinal day within its year (Jan 1 is 1,
+// Dec 31 is 365 or 366) via pure arithmetic, with no time.Date call.
+func dayOfYear(d Date) int {
+	doy := cumulativeDaysBeforeMonth[d.Month] + d.Day
+	if d.Month > time.February && isLeapYear(d.Year) {
+		doy++
+	}
+	return doy
+}
+
+// isLeapYear reports whether year is a Gregorian leap year.
+func isLeapYear(year int) bool {
+	return year%4 == 0 && (year%100 != 0 || year%400 == 0)
 }
 
 // ruleDates expands every registered rule for year, keeping only dates that

--- a/core/bizcal/resolver_race_test.go
+++ b/core/bizcal/resolver_race_test.go
@@ -1,0 +1,63 @@
+package bizcal_test
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/bizcal"
+)
+
+// TestResolver_ConcurrentDayOps hammers the public day operations from many
+// goroutines against a single shared Calendar, exercising the per-year memo
+// under the race detector. Dates span three years so multiple year plans
+// are built (and re-read) concurrently.
+func TestResolver_ConcurrentDayOps(t *testing.T) {
+	kyiv, err := time.LoadLocation("Europe/Kyiv")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	cal, err := bizcal.New(kyiv,
+		bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
+		bizcal.WithRule(bizcal.Fixed{Month: time.January, Day: 1}),
+		bizcal.WithExceptions(
+			bizcal.DayOff(bizcal.MustDate(2026, time.July, 24)),
+			bizcal.ShortDay(bizcal.MustDate(2026, time.December, 31), 4*time.Hour),
+		),
+		bizcal.WithShifts(bizcal.Shift(
+			time.Date(2026, time.July, 20, 22, 0, 0, 0, time.UTC),
+			time.Date(2026, time.July, 21, 2, 0, 0, 0, time.UTC),
+		)),
+	)
+	if err != nil {
+		t.Fatalf("New() = %v", err)
+	}
+
+	const goroutines = 32
+	const iterations = 300
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := range goroutines {
+		go func(seed int64) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(seed))
+			for range iterations {
+				year := 2025 + rng.Intn(3)
+				d := bizcal.MustDate(year, time.January, 1).AddDays(rng.Intn(365))
+				cal.IsWorkingDay(d)
+				cal.DayDuration(d)
+				to := d.AddDays(rng.Intn(60))
+				cal.WorkingDays(d, to)
+				cal.ScheduledBetween(d, to)
+				if _, err := cal.AddWorkingDays(d, rng.Intn(21)-10); err != nil {
+					// horizon errors are impossible on this calendar; any
+					// error would be a real defect.
+					t.Errorf("AddWorkingDays(%s) = %v", d, err)
+					return
+				}
+			}
+		}(int64(g) + 1)
+	}
+	wg.Wait()
+}

--- a/core/bizcal/rule.go
+++ b/core/bizcal/rule.go
@@ -1,0 +1,175 @@
+package bizcal
+
+import (
+	"fmt"
+	"time"
+)
+
+// Rule produces the set of civil dates a holiday falls on in a given year.
+// A year may yield zero dates (e.g. a Feb 29 rule in a non-leap year) or,
+// in principle, more than one.
+type Rule interface {
+	Dates(year int) []Date
+}
+
+// Fixed is a holiday that falls on the same month and day every year, such
+// as New Year's Day (January 1). Fixed{February, 29} is valid and yields a
+// date only in leap years.
+type Fixed struct {
+	Month time.Month
+	Day   int
+}
+
+// Dates returns the single date f falls on in year, or nil if the
+// month/day combination does not exist in that year (e.g. Feb 29 in a
+// non-leap year).
+func (f Fixed) Dates(year int) []Date {
+	d, err := NewDate(year, f.Month, f.Day)
+	if err != nil {
+		return nil
+	}
+	return []Date{d}
+}
+
+// validate reports whether f's month/day combination can ever occur on the
+// calendar. It checks against year 2000, a leap year, so Fixed{February, 29}
+// validates successfully; Fixed{February, 30} does not.
+func (f Fixed) validate() error {
+	if _, err := NewDate(2000, f.Month, f.Day); err != nil {
+		return fmt.Errorf("%w: Fixed{Month: %s, Day: %d}", ErrInvalidRule, f.Month, f.Day)
+	}
+	return nil
+}
+
+// NthWeekday is a holiday defined by its ordinal weekday within a month,
+// such as Thanksgiving (fourth Thursday in November). N counts from the
+// start of the month when positive (N=1 is the first occurrence, N=4 the
+// fourth) and from the end when negative (N=-1 is the last occurrence).
+// N==0 is invalid.
+type NthWeekday struct {
+	Month   time.Month
+	Weekday time.Weekday
+	N       int
+}
+
+// Dates returns the single date nw falls on in year, or nil if the
+// requested ordinal occurrence does not exist that month (e.g. a fifth
+// occurrence of a weekday that only happens four times).
+func (nw NthWeekday) Dates(year int) []Date {
+	switch {
+	case nw.N > 0:
+		return nw.datesFromStart(year)
+	case nw.N < 0:
+		return nw.datesFromEnd(year)
+	default:
+		return nil
+	}
+}
+
+func (nw NthWeekday) datesFromStart(year int) []Date {
+	first := Date{Year: year, Month: nw.Month, Day: 1}
+	offset := (int(nw.Weekday) - int(first.Weekday()) + 7) % 7
+	day := 1 + offset + (nw.N-1)*7
+	d, err := NewDate(year, nw.Month, day)
+	if err != nil {
+		return nil
+	}
+	return []Date{d}
+}
+
+func (nw NthWeekday) datesFromEnd(year int) []Date {
+	lastDay := time.Date(year, nw.Month+1, 0, 0, 0, 0, 0, time.UTC).Day()
+	last := Date{Year: year, Month: nw.Month, Day: lastDay}
+	offset := (int(last.Weekday()) - int(nw.Weekday) + 7) % 7
+	day := lastDay - offset - (-nw.N-1)*7
+	d, err := NewDate(year, nw.Month, day)
+	if err != nil {
+		return nil
+	}
+	return []Date{d}
+}
+
+// validate reports whether nw's fields are within range: N must be nonzero
+// and at most 5 occurrences from either end (no month has more than five
+// occurrences of a given weekday), and Month/Weekday must be in their
+// normal ranges.
+func (nw NthWeekday) validate() error {
+	if nw.N == 0 || nw.N > 5 || nw.N < -5 {
+		return fmt.Errorf("%w: NthWeekday{N: %d}: N must be nonzero and |N|<=5", ErrInvalidRule, nw.N)
+	}
+	if nw.Month < time.January || nw.Month > time.December {
+		return fmt.Errorf("%w: NthWeekday{Month: %d}: out of range", ErrInvalidRule, nw.Month)
+	}
+	if nw.Weekday < time.Sunday || nw.Weekday > time.Saturday {
+		return fmt.Errorf("%w: NthWeekday{Weekday: %d}: out of range", ErrInvalidRule, nw.Weekday)
+	}
+	return nil
+}
+
+// RuleFunc adapts a plain function to the Rule interface, for holidays
+// whose dates cannot be expressed as Fixed or NthWeekday (e.g. computed
+// religious observances). Dates it returns for a year other than the one
+// requested are ignored by the resolver.
+type RuleFunc func(year int) []Date
+
+// Dates calls f(year) and returns the result.
+func (f RuleFunc) Dates(year int) []Date {
+	return f(year)
+}
+
+// Observed wraps r so that any date it produces falling on a Saturday is
+// shifted back to the preceding Friday, and any date falling on a Sunday is
+// shifted forward to the following Monday. Dates on other weekdays pass
+// through unchanged. This is the common observed-holiday convention for
+// weekend dates.
+func Observed(r Rule) Rule {
+	return observedRule{inner: r}
+}
+
+type observedRule struct {
+	inner Rule
+}
+
+func (o observedRule) Dates(year int) []Date {
+	dates := o.inner.Dates(year)
+	if dates == nil {
+		return nil
+	}
+	out := make([]Date, len(dates))
+	for i, d := range dates {
+		out[i] = observe(d)
+	}
+	return out
+}
+
+// observe shifts d off a weekend per the Observed convention.
+func observe(d Date) Date {
+	switch d.Weekday() {
+	case time.Saturday:
+		return d.AddDays(-1)
+	case time.Sunday:
+		return d.AddDays(1)
+	default:
+		return d
+	}
+}
+
+// validateRule reports whether r is a validly configured Rule. Fixed and
+// NthWeekday values (the two struct rule kinds tenant config can hold) are
+// checked via their validate methods; RuleFunc and Observed-wrapped rules
+// always validate ok, since a RuleFunc's correctness is a property of the
+// Go code that defines it, not of serializable data. Unknown Rule
+// implementations (custom types provided by a caller) also validate ok for
+// the same reason.
+func validateRule(r Rule) error {
+	switch v := r.(type) {
+	case Fixed:
+		return v.validate()
+	case NthWeekday:
+		return v.validate()
+	case observedRule:
+		return validateRule(v.inner)
+	default:
+		return nil
+	}
+}

--- a/core/bizcal/rule.go
+++ b/core/bizcal/rule.go
@@ -121,7 +121,8 @@ func (f RuleFunc) Dates(year int) []Date {
 // shifted back to the preceding Friday, and any date falling on a Sunday is
 // shifted forward to the following Monday. Dates on other weekdays pass
 // through unchanged. This is the common observed-holiday convention for
-// weekend dates.
+// weekend dates. Cross-year shifts are honored: a Dec 31 or Jan 1 observance
+// that lands in the adjacent year is resolved into that year's plan.
 func Observed(r Rule) Rule {
 	return observedRule{inner: r}
 }

--- a/core/bizcal/rule_internal_test.go
+++ b/core/bizcal/rule_internal_test.go
@@ -1,0 +1,45 @@
+package bizcal
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// validateRule is unexported and exercised here directly; New (Task 3) is
+// its real caller, but pinning its behavior against every rule kind now
+// avoids regressions once that wiring lands.
+func TestValidateRule(t *testing.T) {
+	cases := []struct {
+		name    string
+		rule    Rule
+		wantErr bool
+	}{
+		{"fixed ordinary", Fixed{Month: time.January, Day: 1}, false},
+		{"fixed feb 29 is valid", Fixed{Month: time.February, Day: 29}, false},
+		{"fixed feb 30 is invalid", Fixed{Month: time.February, Day: 30}, true},
+		{"fixed month out of range", Fixed{Month: time.Month(13), Day: 1}, true},
+		{"nth weekday ordinary", NthWeekday{Month: time.November, Weekday: time.Thursday, N: 4}, false},
+		{"nth weekday from end", NthWeekday{Month: time.May, Weekday: time.Monday, N: -1}, false},
+		{"nth weekday n=0 is invalid", NthWeekday{Month: time.May, Weekday: time.Monday, N: 0}, true},
+		{"nth weekday n=6 is invalid", NthWeekday{Month: time.May, Weekday: time.Monday, N: 6}, true},
+		{"nth weekday n=-6 is invalid", NthWeekday{Month: time.May, Weekday: time.Monday, N: -6}, true},
+		{"nth weekday n=5 is valid", NthWeekday{Month: time.May, Weekday: time.Monday, N: 5}, false},
+		{"nth weekday n=-5 is valid", NthWeekday{Month: time.May, Weekday: time.Monday, N: -5}, false},
+		{"rulefunc always valid", RuleFunc(func(year int) []Date { return nil }), false},
+		{"observed delegates to inner valid", Observed(Fixed{Month: time.July, Day: 4}), false},
+		{"observed delegates to inner invalid", Observed(Fixed{Month: time.February, Day: 30}), true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateRule(c.rule)
+			if c.wantErr && !errors.Is(err, ErrInvalidRule) {
+				t.Fatalf("validateRule(%+v) = %v, want ErrInvalidRule", c.rule, err)
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("validateRule(%+v) = %v, want nil", c.rule, err)
+			}
+		})
+	}
+}

--- a/core/bizcal/rule_test.go
+++ b/core/bizcal/rule_test.go
@@ -1,0 +1,98 @@
+package bizcal_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/bizcal"
+)
+
+func TestFixed_Dates_OrdinaryDate(t *testing.T) {
+	r := bizcal.Fixed{Month: time.January, Day: 1}
+	got := r.Dates(2026)
+	want := []Date{bizcal.MustDate(2026, time.January, 1)}
+	assertDates(t, got, want)
+}
+
+func TestFixed_Dates_Feb29OnlyInLeapYears(t *testing.T) {
+	r := bizcal.Fixed{Month: time.February, Day: 29}
+
+	if got := r.Dates(2026); len(got) != 0 {
+		t.Fatalf("Fixed{Feb,29}.Dates(2026) = %v, want empty", got)
+	}
+
+	got := r.Dates(2028)
+	want := []Date{bizcal.MustDate(2028, time.February, 29)}
+	assertDates(t, got, want)
+}
+
+func TestNthWeekday_Dates_FromStart(t *testing.T) {
+	r := bizcal.NthWeekday{Month: time.November, Weekday: time.Thursday, N: 4}
+	got := r.Dates(2026)
+	want := []Date{bizcal.MustDate(2026, time.November, 26)}
+	assertDates(t, got, want)
+}
+
+func TestNthWeekday_Dates_FromEnd(t *testing.T) {
+	r := bizcal.NthWeekday{Month: time.May, Weekday: time.Monday, N: -1}
+	got := r.Dates(2026)
+	want := []Date{bizcal.MustDate(2026, time.May, 25)}
+	assertDates(t, got, want)
+}
+
+func TestNthWeekday_Dates_FifthOccurrence(t *testing.T) {
+	r := bizcal.NthWeekday{Month: time.February, Weekday: time.Sunday, N: 5}
+
+	if got := r.Dates(2026); len(got) != 0 {
+		t.Fatalf("NthWeekday{Feb,Sunday,5}.Dates(2026) = %v, want empty (no 5th Sunday)", got)
+	}
+
+	// February 2032 has 5 Sundays: Feb 1, 8, 15, 22, 29 (2032 is a leap year, Feb 1 is a Sunday).
+	got := r.Dates(2032)
+	want := []Date{bizcal.MustDate(2032, time.February, 29)}
+	assertDates(t, got, want)
+}
+
+func TestObserved_SaturdayShiftsToFriday(t *testing.T) {
+	r := bizcal.Observed(bizcal.Fixed{Month: time.July, Day: 4})
+	got := r.Dates(2026)
+	want := []Date{bizcal.MustDate(2026, time.July, 3)}
+	assertDates(t, got, want)
+}
+
+func TestObserved_SundayShiftsToMonday(t *testing.T) {
+	// 2027-01-03 is a Sunday.
+	r := bizcal.Observed(bizcal.Fixed{Month: time.January, Day: 3})
+	got := r.Dates(2027)
+	want := []Date{bizcal.MustDate(2027, time.January, 4)}
+	assertDates(t, got, want)
+}
+
+func TestObserved_WeekdayUnchanged(t *testing.T) {
+	// 2026-07-21 is a Tuesday.
+	r := bizcal.Observed(bizcal.Fixed{Month: time.July, Day: 21})
+	got := r.Dates(2026)
+	want := []Date{bizcal.MustDate(2026, time.July, 21)}
+	assertDates(t, got, want)
+}
+
+func TestRuleFunc_Passthrough(t *testing.T) {
+	want := []Date{bizcal.MustDate(2026, time.March, 3), bizcal.MustDate(2026, time.March, 4)}
+	r := bizcal.RuleFunc(func(year int) []bizcal.Date {
+		return want
+	})
+	got := r.Dates(2026)
+	assertDates(t, got, want)
+}
+
+func assertDates(t *testing.T, got, want []Date) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("Dates() = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("Dates()[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+}

--- a/core/bizcal/window.go
+++ b/core/bizcal/window.go
@@ -1,0 +1,149 @@
+package bizcal
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Window is a time-of-day span expressed as minutes since midnight, with
+// 0 <= start < end <= 1440. Fields are unexported so the invariant can only
+// be established through NewWindow, ParseWindow, ParseWindows, or MustWindows.
+// The zero value has start == end == 0 and is empty/invalid for scheduling;
+// it exists only as Go's default zero value, never as a usable window.
+type Window struct {
+	start, end int
+}
+
+// NewWindow constructs a Window from minutes-since-midnight bounds. It
+// returns ErrInvalidWindow if start is negative, end exceeds 1440
+// (24:00), or start is not strictly less than end.
+func NewWindow(startMin, endMin int) (Window, error) {
+	if startMin < 0 || endMin > 1440 || startMin >= endMin {
+		return Window{}, fmt.Errorf("%w: start=%d end=%d minutes", ErrInvalidWindow, startMin, endMin)
+	}
+	return Window{start: startMin, end: endMin}, nil
+}
+
+// ParseWindow parses a "HH:MM-HH:MM" span, e.g. "09:00-17:30". A single
+// digit hour is accepted ("9:00-17:00" is valid). "24:00" is accepted only
+// as an end-of-day boundary (minute must be 00). Returns ErrInvalidWindow,
+// wrapping detail, for any malformed or out-of-range input.
+func ParseWindow(s string) (Window, error) {
+	parts := strings.Split(s, "-")
+	if len(parts) != 2 {
+		return Window{}, fmt.Errorf("%w: %q: expected HH:MM-HH:MM", ErrInvalidWindow, s)
+	}
+
+	startMin, ok := parseClock(parts[0])
+	if !ok {
+		return Window{}, fmt.Errorf("%w: %q: invalid start time", ErrInvalidWindow, s)
+	}
+	endMin, ok := parseClock(parts[1])
+	if !ok {
+		return Window{}, fmt.Errorf("%w: %q: invalid end time", ErrInvalidWindow, s)
+	}
+
+	w, err := NewWindow(startMin, endMin)
+	if err != nil {
+		return Window{}, fmt.Errorf("%w: %q", ErrInvalidWindow, s)
+	}
+	return w, nil
+}
+
+// ParseWindows parses each spec via ParseWindow, returning on the first
+// error encountered.
+func ParseWindows(specs ...string) ([]Window, error) {
+	ws := make([]Window, 0, len(specs))
+	for _, s := range specs {
+		w, err := ParseWindow(s)
+		if err != nil {
+			return nil, err
+		}
+		ws = append(ws, w)
+	}
+	return ws, nil
+}
+
+// MustWindows is like ParseWindows but panics on error. Intended for
+// literals known to be valid at compile time.
+func MustWindows(specs ...string) []Window {
+	ws, err := ParseWindows(specs...)
+	if err != nil {
+		panic(err)
+	}
+	return ws
+}
+
+// Start returns w's start time as (hour, minute).
+func (w Window) Start() (hour, min int) {
+	return w.start / 60, w.start % 60
+}
+
+// End returns w's end time as (hour, minute).
+func (w Window) End() (hour, min int) {
+	return w.end / 60, w.end % 60
+}
+
+// Duration returns the span covered by w.
+func (w Window) Duration() time.Duration {
+	return time.Duration(w.end-w.start) * time.Minute
+}
+
+// String formats w as "09:00-17:30".
+func (w Window) String() string {
+	sh, sm := w.Start()
+	eh, em := w.End()
+	return fmt.Sprintf("%02d:%02d-%02d:%02d", sh, sm, eh, em)
+}
+
+// parseClock parses a "H:MM" or "HH:MM" clock string into minutes since
+// midnight. Hour must be 0-24; minute must be 0-59; hour 24 requires
+// minute 00 (the "24:00" end-of-day boundary).
+func parseClock(s string) (int, bool) {
+	idx := strings.IndexByte(s, ':')
+	if idx != 1 && idx != 2 {
+		return 0, false
+	}
+	hourStr, minStr := s[:idx], s[idx+1:]
+	if len(minStr) != 2 || !isDigits(hourStr) || !isDigits(minStr) {
+		return 0, false
+	}
+
+	hour, err := strconv.Atoi(hourStr)
+	if err != nil || hour > 24 {
+		return 0, false
+	}
+	minute, err := strconv.Atoi(minStr)
+	if err != nil || minute > 59 {
+		return 0, false
+	}
+	if hour == 24 && minute != 0 {
+		return 0, false
+	}
+	return hour*60 + minute, true
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// Interval is a concrete, absolute time span with an exclusive end,
+// used for shifts and the result of window-to-instant expansion.
+type Interval struct {
+	Start, End time.Time
+}
+
+// Duration returns the span covered by iv.
+func (iv Interval) Duration() time.Duration {
+	return iv.End.Sub(iv.Start)
+}

--- a/core/bizcal/window_test.go
+++ b/core/bizcal/window_test.go
@@ -1,0 +1,182 @@
+package bizcal_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/bizcal"
+)
+
+func TestNewWindow_Valid(t *testing.T) {
+	w, err := bizcal.NewWindow(9*60, 17*60+30)
+	if err != nil {
+		t.Fatalf("NewWindow: unexpected error: %v", err)
+	}
+	if w.String() != "09:00-17:30" {
+		t.Fatalf("NewWindow.String() = %s, want 09:00-17:30", w.String())
+	}
+}
+
+func TestNewWindow_RejectsInverted(t *testing.T) {
+	_, err := bizcal.NewWindow(17*60, 9*60)
+	if !errors.Is(err, bizcal.ErrInvalidWindow) {
+		t.Fatalf("NewWindow(inverted): got err=%v, want ErrInvalidWindow", err)
+	}
+}
+
+func TestNewWindow_RejectsOutOfRange(t *testing.T) {
+	_, err := bizcal.NewWindow(0, 1441)
+	if !errors.Is(err, bizcal.ErrInvalidWindow) {
+		t.Fatalf("NewWindow(0,1441): got err=%v, want ErrInvalidWindow", err)
+	}
+
+	_, err = bizcal.NewWindow(-1, 60)
+	if !errors.Is(err, bizcal.ErrInvalidWindow) {
+		t.Fatalf("NewWindow(-1,60): got err=%v, want ErrInvalidWindow", err)
+	}
+}
+
+func TestNewWindow_RejectsZeroDuration(t *testing.T) {
+	_, err := bizcal.NewWindow(60, 60)
+	if !errors.Is(err, bizcal.ErrInvalidWindow) {
+		t.Fatalf("NewWindow(60,60): got err=%v, want ErrInvalidWindow", err)
+	}
+}
+
+func TestParseWindow_AcceptsStandard(t *testing.T) {
+	w, err := bizcal.ParseWindow("09:00-17:30")
+	if err != nil {
+		t.Fatalf("ParseWindow: unexpected error: %v", err)
+	}
+	if w.String() != "09:00-17:30" {
+		t.Fatalf("ParseWindow.String() = %s, want 09:00-17:30", w.String())
+	}
+}
+
+func TestParseWindow_AcceptsFullDay(t *testing.T) {
+	w, err := bizcal.ParseWindow("00:00-24:00")
+	if err != nil {
+		t.Fatalf("ParseWindow(00:00-24:00): unexpected error: %v", err)
+	}
+	if w.Duration() != 24*time.Hour {
+		t.Fatalf("ParseWindow(00:00-24:00).Duration() = %v, want 24h", w.Duration())
+	}
+}
+
+func TestParseWindow_AcceptsSingleDigitHour(t *testing.T) {
+	// Controller decision: single-digit hour is accepted (DX over strictness).
+	w, err := bizcal.ParseWindow("9:00-17:00")
+	if err != nil {
+		t.Fatalf("ParseWindow(9:00-17:00): unexpected error: %v", err)
+	}
+	if w.String() != "09:00-17:00" {
+		t.Fatalf("ParseWindow(9:00-17:00).String() = %s, want 09:00-17:00", w.String())
+	}
+}
+
+func TestParseWindow_RejectsEmpty(t *testing.T) {
+	_, err := bizcal.ParseWindow("")
+	if !errors.Is(err, bizcal.ErrInvalidWindow) {
+		t.Fatalf("ParseWindow(empty): got err=%v, want ErrInvalidWindow", err)
+	}
+}
+
+func TestParseWindow_RejectsInverted(t *testing.T) {
+	_, err := bizcal.ParseWindow("17:00-09:00")
+	if !errors.Is(err, bizcal.ErrInvalidWindow) {
+		t.Fatalf("ParseWindow(17:00-09:00): got err=%v, want ErrInvalidWindow", err)
+	}
+}
+
+func TestParseWindow_RejectsMissingEnd(t *testing.T) {
+	_, err := bizcal.ParseWindow("09:00")
+	if !errors.Is(err, bizcal.ErrInvalidWindow) {
+		t.Fatalf("ParseWindow(09:00): got err=%v, want ErrInvalidWindow", err)
+	}
+}
+
+func TestParseWindow_RejectsInvalidMinute(t *testing.T) {
+	_, err := bizcal.ParseWindow("09:60-10:00")
+	if !errors.Is(err, bizcal.ErrInvalidWindow) {
+		t.Fatalf("ParseWindow(09:60-10:00): got err=%v, want ErrInvalidWindow", err)
+	}
+}
+
+func TestParseWindow_RejectsInvalidHour(t *testing.T) {
+	_, err := bizcal.ParseWindow("09:00-25:00")
+	if !errors.Is(err, bizcal.ErrInvalidWindow) {
+		t.Fatalf("ParseWindow(09:00-25:00): got err=%v, want ErrInvalidWindow", err)
+	}
+}
+
+func TestParseWindow_RejectsGarbage(t *testing.T) {
+	for _, s := range []string{"garbage", "09:00-", "-17:00", "09:00-17:00-extra", "09-17"} {
+		_, err := bizcal.ParseWindow(s)
+		if !errors.Is(err, bizcal.ErrInvalidWindow) {
+			t.Errorf("ParseWindow(%q): got err=%v, want ErrInvalidWindow", s, err)
+		}
+	}
+}
+
+func TestParseWindows_Multiple(t *testing.T) {
+	ws, err := bizcal.ParseWindows("09:00-12:00", "13:00-17:00")
+	if err != nil {
+		t.Fatalf("ParseWindows: unexpected error: %v", err)
+	}
+	if len(ws) != 2 {
+		t.Fatalf("ParseWindows: got %d windows, want 2", len(ws))
+	}
+	if ws[0].String() != "09:00-12:00" || ws[1].String() != "13:00-17:00" {
+		t.Fatalf("ParseWindows: got %v", ws)
+	}
+}
+
+func TestParseWindows_PropagatesError(t *testing.T) {
+	_, err := bizcal.ParseWindows("09:00-12:00", "bad")
+	if !errors.Is(err, bizcal.ErrInvalidWindow) {
+		t.Fatalf("ParseWindows(bad): got err=%v, want ErrInvalidWindow", err)
+	}
+}
+
+func TestMustWindows_PanicsOnGarbage(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("MustWindows: expected panic on garbage input")
+		}
+	}()
+	bizcal.MustWindows("garbage")
+}
+
+func TestMustWindows_ReturnsValid(t *testing.T) {
+	ws := bizcal.MustWindows("09:00-12:00", "13:00-17:00")
+	if len(ws) != 2 {
+		t.Fatalf("MustWindows: got %d windows, want 2", len(ws))
+	}
+}
+
+func TestWindow_Duration(t *testing.T) {
+	w := bizcal.MustWindows("09:00-13:00")[0]
+	if w.Duration() != 4*time.Hour {
+		t.Fatalf("Duration() = %v, want 4h", w.Duration())
+	}
+}
+
+func TestWindow_StartEnd(t *testing.T) {
+	w := bizcal.MustWindows("09:00-17:30")[0]
+	sh, sm := w.Start()
+	if sh != 9 || sm != 0 {
+		t.Fatalf("Start() = %d:%d, want 9:0", sh, sm)
+	}
+	eh, em := w.End()
+	if eh != 17 || em != 30 {
+		t.Fatalf("End() = %d:%d, want 17:30", eh, em)
+	}
+}
+
+func TestWindow_ZeroValueIsEmpty(t *testing.T) {
+	var w bizcal.Window
+	if w.Duration() != 0 {
+		t.Fatalf("zero Window.Duration() = %v, want 0", w.Duration())
+	}
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -17,14 +17,6 @@ External module deps stay in the entry prose. Composition partners
 
 ## core/
 
----
-
-**core/bizcal**
-
-Business-calendar arithmetic, stdlib-only and data-free: consumer-declared working-hours schedules (per-weekday windows, timezone-aware) and holiday sets compose into a `Calendar` answering `IsOpen`, `NextOpen`, `Add` (advance by business duration), and `Between` (business time elapsed) — DST-correct. Holiday data is consumer-supplied (fixed dates + computed rules); no embedded country tables. The substrate for SLA clocks and leave-day math.
-
-Deps: none (stdlib only).
-
 ## web/
 
 ---
@@ -459,7 +451,7 @@ Deps: `ops/supervisor`.
 
 SLA policy engine over `bizcal`: named targets (first-response, resolution) attach deadlines to consumer subjects, computed in business time; pause/resume (waiting-on-customer) with correct deadline extension, warning thresholds, and breach/warning events delivered through `scheduler`-driven sweeps over a storage-agnostic Store. Fulfillment, escalation actions, and reporting stay consumer-side.
 
-Deps: `async/scheduler`; `core/bizcal` (planned).
+Deps: `async/scheduler`; `core/bizcal`.
 
 ## testkit/
 

--- a/docs/superpowers/plans/2026-07-21-bizcal.md
+++ b/docs/superpowers/plans/2026-07-21-bizcal.md
@@ -1,0 +1,219 @@
+# core/bizcal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Plan-is-direction rule:** code blocks in this plan are illustrative sketches of intent, NOT transcription targets. Implement correctly and idiomatically. Exact VALUES are binding (signatures, sentinel names, test-case values, defaults); surrounding code shape is not.
+
+**Goal:** Ship `core/bizcal` — stdlib-only, immutable, DST-correct business-calendar arithmetic (schedules + holiday rules + exceptions + shifts → `IsOpen`/`NextOpen`/`Add`/`Between`/`WindowsBetween` + day ops) per [the spec](../specs/2026-07-21-bizcal-design.md).
+
+**Architecture:** Every civil date resolves to a day plan (merged open intervals + scheduled capacity) via layered sources: base (weekly windows | workdays capacity | always-open) → holiday rules (full days off) → date exceptions (replace) → shifts (add, win over holidays). Day plans are memoized per year behind an RWMutex; instant ops walk resolved days; day ops read capacities. `Calendar` is immutable and goroutine-safe after `New`.
+
+**Tech Stack:** Go stdlib only (`time`, `iter`, `sync`, `errors`, `fmt`, `strings`, `strconv`). No forge deps. Read `docs/design.md` before starting.
+
+## Global Constraints
+
+- Package path `core/bizcal`, package name `bizcal`. Stdlib-only — zero imports outside std.
+- Black-box tests (`package bizcal_test`); white-box only to pin unexported primitives (resolver internals, parse fast paths) if genuinely needed.
+- `just fmt ./core/bizcal/...` after file changes (never single-file — betteralign quirk); `just lint` before finishing a task; `go test ./core/bizcal/ -race` must pass at every commit.
+- Options are `type Option func(*config) error`-style per forge idiom; option errors accumulate and `New` returns them joined. Public methods never return unexported types.
+- Sentinel errors: single-line, `errors.Is`-matchable, defined in `errors.go`.
+- gofmt doc-comment trap: never put quote characters like `''` or SQL/spec snippets in doc comments that gofmt reformats — keep such comments inside function bodies.
+- Go 1.26: `new(expr)` is legal; run `modernize` mentally — no `interface{}`, use `any`, `min`/`max` builtins fine. Bench note: `b.Loop()` + `b.StopTimer()` inside the loop hangs on go1.26.5 — don't mix them.
+- No manual line wrapping in prose/docs/commit bodies.
+- Commit after every green task; conventional-commit subjects `feat(bizcal): …` / `test(bizcal): …` / `docs(bizcal): …` / `perf(bizcal): …`. No Claude attribution anywhere.
+- Time zone discipline: `Date` is civil (zone-free); `Calendar` interprets dates/instants in its `loc`. All instant arithmetic on absolute time after `time.Date` normalization.
+
+---
+
+### Task 1: Date, Window, Interval types + errors
+
+**Files:**
+- Create: `core/bizcal/date.go`, `core/bizcal/window.go`, `core/bizcal/errors.go`
+- Test: `core/bizcal/date_test.go`, `core/bizcal/window_test.go`
+
+**Interfaces (binding — later tasks consume these):**
+
+```go
+type Date struct { Year int; Month time.Month; Day int }
+func NewDate(year int, month time.Month, day int) (Date, error) // ErrInvalidDate on impossible dates (checked via time.Date round-trip)
+func MustDate(year int, month time.Month, day int) Date         // panics on error
+func DateOf(t time.Time) Date                                   // reads t in t's own location
+func (d Date) AddDays(n int) Date
+func (d Date) Weekday() time.Weekday                            // pure civil computation (time.Date in UTC is fine)
+func (d Date) Before(o Date) bool
+func (d Date) After(o Date) bool
+func (d Date) Compare(o Date) int
+func (d Date) IsZero() bool
+func (d Date) String() string                                   // "2026-07-21"
+
+type Window struct{ start, end int } // minutes since midnight, 0 <= start < end <= 1440; unexported fields, invariant enforced by constructors
+func NewWindow(startMin, endMin int) (Window, error)            // ErrInvalidWindow
+func ParseWindow(s string) (Window, error)                      // "09:00-17:30"; ErrInvalidWindow wrapping detail
+func ParseWindows(specs ...string) ([]Window, error)
+func MustWindows(specs ...string) []Window                      // panics on error; for literals
+func (w Window) Start() (hour, min int)
+func (w Window) End() (hour, min int)
+func (w Window) Duration() time.Duration
+func (w Window) String() string                                 // "09:00-17:30"
+
+type Interval struct{ Start, End time.Time } // End exclusive
+func (iv Interval) Duration() time.Duration
+
+// errors.go — all sentinels for the whole package live here from the start:
+ErrInvalidDate, ErrInvalidWindow, ErrInvalidWeekday, ErrInvalidRule,
+ErrInvalidShift, ErrInvalidCapacity, ErrNilLocation, ErrNeverOpen, ErrHorizonExceeded
+```
+
+- [ ] **Step 1: Write failing black-box tests.** Cover: `NewDate` rejects 2026-02-30 and month 13 (`errors.Is(err, ErrInvalidDate)`); `MustDate` panics on bad input; `DateOf` honors the instant's own zone (2026-07-21T23:30 in Kyiv = July 21; same instant in UTC = July 21 20:30 → July 21; pick a pair that actually crosses midnight, e.g. 00:30 Kyiv = previous day UTC); `AddDays` across month/year ends and with negatives; `Weekday` for known dates (2026-07-21 is Tuesday); `Compare`/`Before`/`After` ordering; `String` zero-pads. Windows: `ParseWindow` accepts `"09:00-17:30"`, `"00:00-24:00"`; rejects empty, `"17:00-09:00"`, `"09:00"`, `"9:00-17:00"` — decide and pin: single-digit hour IS accepted (`"9:00"` valid, DX over strictness) — rejects `"09:60-10:00"`, `"09:00-25:00"`; `Duration` of `"09:00-13:00"` is 4h; `MustWindows` panics on garbage.
+- [ ] **Step 2: Run `go test ./core/bizcal/` — expect compile failure (types undefined).**
+- [ ] **Step 3: Implement** `date.go`, `window.go`, `errors.go`. Keep `Window` fields unexported so a zero-duration or inverted window cannot be constructed except as the zero value (document zero Window as empty/invalid for scheduling; constructors are the only path in).
+- [ ] **Step 4: `go test ./core/bizcal/ -race` — PASS. `just fmt ./core/bizcal/...`.**
+- [ ] **Step 5: Commit** `feat(bizcal): civil Date, Window, Interval types and error sentinels`.
+
+### Task 2: Holiday rules
+
+**Files:**
+- Create: `core/bizcal/rule.go`
+- Test: `core/bizcal/rule_test.go`
+
+**Interfaces (binding):**
+
+```go
+type Rule interface{ Dates(year int) []Date }
+
+type Fixed struct { Month time.Month; Day int }             // implements Rule; invalid combos yield no dates for years where impossible? NO — see validation note
+type NthWeekday struct { Month time.Month; Weekday time.Weekday; N int } // N>=1 from start, N<=-1 from end; N==0 invalid
+type RuleFunc func(year int) []Date                          // implements Rule
+func Observed(r Rule) Rule                                   // Sat→Fri, Sun→Mon shift of every produced date
+```
+
+Validation note: `Fixed`/`NthWeekday` are plain structs (serializable from tenant config), so they can hold invalid values. `New` (Task 3) validates every registered rule via a `validate() error` check (unexported method or a package func `validateRule(Rule) error` that type-switches) and returns `ErrInvalidRule` — rules are NOT silently lenient. `Fixed{Feb, 29}` is valid (yields a date only in leap years). `Fixed{Feb, 30}` is invalid. `NthWeekday` with `N==0` or `|N|>5` invalid. `RuleFunc` validates as always-ok; dates it returns for the queried year that fall outside that year are ignored by the resolver (defensive, pinned by test in Task 4).
+
+- [ ] **Step 1: Write failing tests.** `Fixed{January,1}.Dates(2026)` → `[2026-01-01]`; `Fixed{February,29}.Dates(2026)` → empty, `.Dates(2028)` → `[2028-02-29]`; `NthWeekday{November,Thursday,4}.Dates(2026)` → `[2026-11-26]`; `NthWeekday{May,Monday,-1}.Dates(2026)` → `[2026-05-25]`; `NthWeekday{Month:February,Weekday:Sunday,N:5}.Dates(2026)` → empty (no 5th Sunday), and a year where a 5th occurrence exists returns it; `Observed(Fixed{July,4}).Dates(2026)` → `[2026-07-03]` (2026-07-04 is Saturday); `Observed` of a Sunday holiday shifts to Monday; `Observed` leaves weekday dates alone; `RuleFunc` passthrough.
+- [ ] **Step 2: Run tests — compile failure.**
+- [ ] **Step 3: Implement `rule.go`** including the unexported validation hook `New` will call.
+- [ ] **Step 4: Tests PASS, fmt.**
+- [ ] **Step 5: Commit** `feat(bizcal): holiday rule vocabulary (Fixed, NthWeekday, RuleFunc, Observed)`.
+
+### Task 3: Options, config, Calendar construction
+
+**Files:**
+- Create: `core/bizcal/options.go`, `core/bizcal/calendar.go` (struct + `New` + validation only; ops come later)
+- Test: `core/bizcal/calendar_test.go` (construction cases)
+
+**Interfaces (binding):**
+
+```go
+type Option func(*config) error
+
+func WithWeekday(wd time.Weekday, windows ...Window) Option // repeatable; appends windows for that weekday; ErrInvalidWeekday for wd outside Sunday..Saturday
+func WithWorkdays(perDay time.Duration, weekdays ...time.Weekday) Option // ErrInvalidCapacity if perDay <= 0 or > 24h; ErrInvalidWeekday
+func WithAlwaysOpen() Option
+func WithRule(r Rule) Option            // repeatable; nil rule → ErrInvalidRule
+func WithRules(rs ...Rule) Option       // convenience bulk form
+func WithExceptions(excs ...Exception) Option
+func WithShifts(ivs ...Interval) Option // ErrInvalidShift if End <= Start or zero times
+func WithHorizon(d time.Duration) Option // scan cap for NextOpen/Add/AddWorkingDays; default 5 * 365 days; ErrInvalidCapacity if <= 0
+
+type Exception struct{ /* unexported: date, kind, windows, capacity */ }
+func DayOff(d Date) Exception
+func ShortDay(d Date, capacity time.Duration) Exception      // whole-day-open, capacity override
+func CustomDay(d Date, windows ...Window) Exception          // replacement windows; empty == DayOff
+
+func Shift(start, end time.Time) Interval
+
+type Calendar struct{ /* unexported */ }
+func New(loc *time.Location, opts ...Option) (*Calendar, error)
+func (c *Calendar) Location() *time.Location
+func (c *Calendar) DateOf(t time.Time) Date // t converted to c's zone first
+```
+
+Construction rules (binding): nil `loc` → `ErrNilLocation`. Base-source conflict: at most one of `WithWorkdays` / `WithAlwaysOpen`, and `WithWeekday` may not combine with either — a second base source is a joined config error (reuse `ErrInvalidRule`? NO — add nothing: use `fmt.Errorf` wrapping `ErrNeverOpen`? NO — this is a distinct misuse; define it as a plain non-sentinel error text joined into New's error; consumers match nothing specific). Statically-never-open (no base windows/workdays/always-open AND no shifts) → `ErrNeverOpen`. All option errors + rule validation errors are collected and returned via `errors.Join`. Exceptions on duplicate dates: last one wins (document). `ShortDay` capacity must be `>= 0 && <= 24h` (`ErrInvalidCapacity`; 0 behaves as DayOff). `New` deep-copies/normalizes everything (sort+merge windows per weekday, sort shifts, clone slices) — a `Calendar` never aliases caller slices (variadic-clone rule).
+
+- [ ] **Step 1: Write failing construction tests.** Happy paths: workdays calendar (spec example), weekly-windows calendar, always-open, shifts-only (no base) constructs OK; empty calendar (no options) → `ErrNeverOpen`; nil loc → `ErrNilLocation`; two base sources → error; bad window in `WithWeekday` never happens (Window invariant) but `WithWeekday(time.Weekday(9), …)` → `ErrInvalidWeekday`; `WithWorkdays(0, …)` and `WithWorkdays(-time.Hour, …)` and `WithWorkdays(25*time.Hour, …)` → `ErrInvalidCapacity`; `WithRule(nil)` → `ErrInvalidRule`; `WithRule(NthWeekday{N:0})` → `ErrInvalidRule` (validated at New); `WithShifts` with `End.Before(Start)` → `ErrInvalidShift`; multiple option errors all present in joined error (`errors.Is` finds each). Mutation-safety: build from a `[]Window`/`[]Interval` var, mutate the slice after `New`, calendar behavior unchanged (verifiable once ops exist — write the test now against `Location`/construction success, extend in Task 4; or defer this specific test to Task 4 and note it).
+- [ ] **Step 2: Run — compile failure.**
+- [ ] **Step 3: Implement `options.go` + `calendar.go` (config struct, New, normalization).** Normalization detail: per-weekday windows sorted by start and overlapping/adjacent windows merged; shifts sorted by Start and overlapping/adjacent shifts merged (in absolute time).
+- [ ] **Step 4: Tests PASS (-race), fmt.**
+- [ ] **Step 5: Commit** `feat(bizcal): Calendar construction, options, validation`.
+
+### Task 4: Day resolver + day ops
+
+**Files:**
+- Create: `core/bizcal/resolver.go`
+- Modify: `core/bizcal/calendar.go` (day ops)
+- Test: `core/bizcal/dayops_test.go`, race test in `core/bizcal/resolver_race_test.go` (still black-box: hammer public ops)
+
+**Interfaces (binding):**
+
+```go
+func (c *Calendar) IsWorkingDay(d Date) bool
+func (c *Calendar) WorkingDays(from, to Date) int                  // half-open [from, to); 0 when from >= to
+func (c *Calendar) AddWorkingDays(d Date, n int) (Date, error)     // n-th working day strictly after/before; n==0 → d; ErrHorizonExceeded
+func (c *Calendar) DayDuration(d Date) time.Duration               // scheduled capacity
+func (c *Calendar) ScheduledBetween(from, to Date) time.Duration   // sum of capacities over [from, to)
+```
+
+Resolver design (direction): internal `dayPlan{intervals []Interval, capacity time.Duration}` resolved per civil date in `c.loc`. Per-year memo: `map[int]*yearPlan` under `sync.RWMutex` (yearPlan = 365/366 dayPlans + that year's expanded rule dates). Resolution order per spec: base → rule days-off → exception override → shifts merged in (shift segments clipped to the civil day; shift time adds to capacity; shifts apply even on rule/exception days-off). Rule dates outside the queried year are ignored. Shifts near year boundaries: a shift's segments belong to whichever date they fall on — resolve shift overlap when building each year (shifts list is small and sorted; binary search per day or precompute per-date buckets at New). DST detail: a civil day's absolute bounds come from `time.Date(y,m,d,0,0,0,0,loc)` → next day same; windows resolve via `time.Date` with the window's hour/min (normalization handles gaps); windows-model capacity = sum of real interval durations that day (DST day ≠ 8h — spec'd); workdays-model capacity is the fixed `perDay` regardless of DST.
+
+- [ ] **Step 1: Write failing tests.** Fixture calendars: (a) workdays Mon–Fri 8h in Europe/Kyiv with `Fixed{Jan,1}` + `DayOff(MustDate(2026,7,24))` + `ShortDay(MustDate(2026,12,31), 4h)`; (b) weekly-windows Mon–Thu 09–13+14–18, Fri 09–15 in America/New_York; (c) shifts-only roster incl. one cross-midnight shift and one shift landing on a `Fixed` holiday; (d) always-open. Cases: `IsWorkingDay` true/false incl. exception day off, holiday, weekend, shift-on-holiday true; `WorkingDays(2026-07-01, 2026-08-01)` on (a) = 22 (23 weekdays in July 2026 minus July 24 exception; verify by hand and pin exact number — July 2026 has 23 weekdays); `WorkingDays` empty/inverted range → 0; `AddWorkingDays` skips weekend+holiday, negative n walks back, n==0 identity, `ErrHorizonExceeded` on a calendar whose RuleFunc closes every day (shifts-free base + rule returning all dates of every year); `DayDuration` = 8h weekday / 0 weekend / 4h Dec 31 on (a); real window span on (b) incl. a DST transition day (2026-03-08 US spring-forward: if windows 09–17 the capacity is still 8h absolute — transition is 02:00, outside the window; ALSO pin a window that straddles 02:00, e.g. add weekday windows 00:00-06:00 fixture, capacity shrinks 1h on Mar 8 and grows 1h on Nov 1); `ScheduledBetween` July 2026 on (a) = 22*8h = 176h; cross-midnight shift splits capacity across the two dates (pin both `DayDuration`s); mutation-safety test deferred from Task 3 lands here.
+- [ ] **Step 2: Run — failures.**
+- [ ] **Step 3: Implement resolver + day ops.**
+- [ ] **Step 4: Race test:** 32 goroutines × random dates across 3 years on a shared calendar, `go test -race ./core/bizcal/` PASS. fmt.
+- [ ] **Step 5: Commit** `feat(bizcal): per-year day resolver and day-level operations`.
+
+### Task 5: Instant ops
+
+**Files:**
+- Modify: `core/bizcal/calendar.go` (or new `core/bizcal/instant.go` if calendar.go crowds past ~400 LOC)
+- Test: `core/bizcal/instant_test.go`
+
+**Interfaces (binding):**
+
+```go
+func (c *Calendar) IsOpen(t time.Time) bool
+func (c *Calendar) NextOpen(t time.Time) (time.Time, error)          // earliest open instant >= t; t itself if open; ErrHorizonExceeded
+func (c *Calendar) Add(t time.Time, d time.Duration) (time.Time, error) // d<0 walks backward; Add(t,0) == NextOpen(t)
+func (c *Calendar) Between(a, b time.Time) time.Duration             // signed; business time in [a,b)
+func (c *Calendar) WindowsBetween(from, to time.Time) iter.Seq[Interval] // merged open intervals clipped to [from,to), ascending
+```
+
+Semantics detail (binding): backward `Add` symmetry — `Add(t, -d)` finds the instant `x` such that `Between(x, t') == d` where walking backward from the anchor; anchor for backward walk is the latest open instant ≤ t (mirror of NextOpen; unexported `prevOpen` internal is fine, not exported — YAGNI). `Between` with a==b → 0. `WindowsBetween` on from>=to yields nothing. Zero-value `time.Time` inputs: no special-casing — they resolve like any instant (year 1; horizon guard protects scans). Iteration strategy: walk day plans date-by-date from `c.DateOf(from)` to `c.DateOf(to)`, emitting clipped intervals; `Add`/`Between`/`NextOpen` are built on the same walk (share an internal iterator; `Between` sums, `Add` consumes budget and returns the boundary instant, landing exactly at window edges when the budget exhausts precisely).
+
+- [ ] **Step 1: Write failing tests.** On fixture (b) windows calendar NY: `IsOpen` inside/outside windows, exactly at start (open — inclusive) and exactly at end (closed — exclusive); `NextOpen` from Saturday → Monday 09:00, from mid-lunch → 14:00, from open instant → itself; `Add(Fri 14:00, 4h)` crosses the weekend → Mon 12:00 (Fri has 15:00 close on fixture (b): Fri 14:00 + 1h → close, remaining 3h → Mon 09:00+3h = 12:00); `Add` with d exactly reaching a window end lands at the NEXT window start? NO — pin: it lands at the closing boundary instant (e.g. Add(Mon 09:00, 4h) on 09–13 window = Mon 13:00, not 14:00) — deterministic and matches `Between(Mon 09:00, Mon 13:00)==4h` round-trip; backward `Add(Mon 12:00, -4h)` → Fri 14:00 (mirror of the forward case); `Between` signed symmetry on concrete pair; `Between` across a full closed weekend == 0; DST: Kyiv spring-forward 2026-03-29 (03:00 skip) with a 00:00–06:00 window — `Between(00:00, 06:00 wall)` that day == 5h; fall-back 2026-10-25 == 7h; SLA add across spring-forward stays duration-exact (Add(t, 4h) lands 4 absolute in-window hours later). Workdays model (a): `Between(Tue 09:12, Tue 16:05)` == 6h53m (whole-day-open — full wall span), `Between` spanning Sat/Sun counts only weekday wall time. Always-open (d): `Add(t, 8h) == t.Add(8h)`, `NextOpen(t)==t`. Shifts (c): `IsOpen` during cross-midnight shift both sides of midnight; shift on holiday is open; `WindowsBetween` over the roster week yields the merged shift intervals clipped to range (pin count + first/last bounds); `WindowsBetween` clips partial overlap at both edges. Horizon: everything-closed calendar → `NextOpen`/`Add` return `ErrHorizonExceeded`; custom tiny `WithHorizon(48*time.Hour)` triggers it fast.
+- [ ] **Step 2: Run — failures.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Tests PASS (-race), fmt, `just lint`.**
+- [ ] **Step 5: Commit** `feat(bizcal): instant operations (IsOpen, NextOpen, Add, Between, WindowsBetween)`.
+
+### Task 6: Property, fuzz, and oracle tests
+
+**Files:**
+- Create: `core/bizcal/property_test.go`, `core/bizcal/fuzz_test.go`
+- Test-only task; no production changes expected (fix bugs it finds).
+
+Oracle (direction): brute-force minute-scanner over a small range — `oracleBetween(cal, a, b)` sums minutes where `cal.IsOpen(minute)` (IsOpen itself is trivially auditable against the fixture by hand). Compare `Between`, `NextOpen`, `Add` against minute-granularity oracle answers on minute-aligned inputs across a 3-week window that includes a weekend, a holiday, an exception short-day, and a DST transition.
+
+- [ ] **Step 1: Property tests (deterministic, table-driven over seeded pseudo-random instants — fixed seed, run-independent per fuzz-oracle memory rule):** for ~500 seeded (a,b) pairs on fixtures (a),(b),(c): `Between(a,b) == -Between(b,a)`; `Between(a,c) == Between(a,b)+Between(b,c)` for a≤b≤c; `Add` round-trip: when `Add(t,d)` succeeds with d≥0, `Between(NextOpenOrT, result)` == d; `NextOpen` idempotent; `WorkingDays(from,to)` == loop-count of `IsWorkingDay`; `ScheduledBetween` == sum of `DayDuration`.
+- [ ] **Step 2: Go fuzz targets:** `FuzzParseWindow` (no panics, valid parses round-trip through String), `FuzzBetweenSymmetry` (random unix seconds + offsets on fixture (b): symmetry + additivity + never exceeds wall span), `FuzzAddRoundTrip`. Seed corpus with the DST instants. Run each `-fuzz` target ≥ 30s locally; commit seed corpus only if a crasher was found and fixed (regression inputs into testdata).
+- [ ] **Step 3: Oracle comparison test** per direction above.
+- [ ] **Step 4: All green (-race), fmt, lint.**
+- [ ] **Step 5: Commit** `test(bizcal): property, fuzz, and brute-force-oracle coverage`.
+
+### Task 7: doc.go, benchmarks, optimization pass, catalog update
+
+**Files:**
+- Create: `core/bizcal/doc.go`, `core/bizcal/bench_test.go`
+- Modify: `docs/packages.md` (delete `core/bizcal` entry; in the SLA entry change `core/bizcal (planned)` → `core/bizcal`)
+
+- [ ] **Step 1: `doc.go`** — package comment with two runnable-style examples in prose+code per forge convention (see a shipped core package's doc.go for shape, e.g. `core/fsm`): (1) HR workdays calendar → `ScheduledBetween`, `Between(clockIn, clockOut)`, undertime/overtime formulas, `AddWorkingDays` leave math; (2) SLA: windows calendar `Add(opened, 8h)`, shifts roster + always-open variants. Plus an `example_test.go` `ExampleNew` that actually compiles and runs (forge requires runnable example). Document: immutability/caching guidance (build per tenant, cache, rebuild on policy change), workdays-model Between semantics, DST rules, horizon.
+- [ ] **Step 2: `bench_test.go`** — benchmarks: `BenchmarkNew` (workdays + 3 rules), `BenchmarkIsOpen` (resolved year, windows model), `BenchmarkNextOpen` (weekend hop), `BenchmarkAdd_Short` (same day), `BenchmarkAdd_MultiWeek` (80h across holidays), `BenchmarkBetween_Day`, `BenchmarkBetween_Month`, `BenchmarkScheduledBetween_Year`, `BenchmarkWindowsBetween_Month` (drain the iterator). Use `b.Loop()`; NO `StopTimer` inside loops (go1.26.5 hang). Record baseline numbers to `docs/superpowers/specs/2026-07-21-bizcal-bench-baseline.txt`.
+- [ ] **Step 3: Optimization pass** — profile the worst benches; expected wins: preallocate yearPlan day slice (366), avoid `time.Date` calls per minute (day-walk not minute-walk — should already hold), zero-alloc `IsOpen`/`Between` on resolved years (check with `-benchmem`; eliminate interval-slice allocs by storing per-day intervals in one backing slice per year). Apply only measured wins; save after numbers to `…-bench-after.txt`.
+- [ ] **Step 4: Catalog update** per spec: delete the `core/bizcal` roadmap entry; update the SLA entry dep tag.
+- [ ] **Step 5: Full gate:** `go test ./core/bizcal/ -race -cover` (target ≥ 90% like recent packages), `just fmt ./core/bizcal/...`, `just lint`, `go vet ./core/bizcal/`. Run `modernize` check.
+- [ ] **Step 6: Commits** — `docs(bizcal): package documentation and runnable example`, `perf(bizcal): benchmarks and measured optimization pass`, `docs(packages): remove shipped core/bizcal from roadmap`.
+
+### Task 8: Final review + PR
+
+- [ ] **Step 1:** Whole-branch self-review (fresh-eyes read of the full package against the spec; check every spec op/semantic has a test pinning it — especially layering precedence, DST cases, horizon, signed Between, workdays-vs-windows capacity).
+- [ ] **Step 2:** Push branch, open PR to `main` with: summary, salary/SLA usage snippets, bench before/after table, coverage number. No attribution lines.
+- [ ] **Step 3:** PR flow per CLAUDE.md: wait CI → fix failures → read Claude review → fix all findings + resolve threads → repeat until clean.

--- a/docs/superpowers/specs/2026-07-21-bizcal-bench-after.txt
+++ b/docs/superpowers/specs/2026-07-21-bizcal-bench-after.txt
@@ -1,0 +1,69 @@
+core/bizcal benchmark after — yearPlan indexed by day-of-year instead of map[Date]dayPlan
+go test ./core/bizcal/ -bench=. -benchmem -run=^$ -count=3
+Apple M3 Max, go1.26.5, darwin/arm64
+
+goos: darwin
+goarch: arm64
+pkg: github.com/dmitrymomot/forge/core/bizcal
+cpu: Apple M3 Max
+BenchmarkNew-14                      	 3741564	       310.7 ns/op	     928 B/op	       8 allocs/op
+BenchmarkNew-14                      	 3921465	       305.9 ns/op	     928 B/op	       8 allocs/op
+BenchmarkNew-14                      	 3906798	       308.2 ns/op	     928 B/op	       8 allocs/op
+BenchmarkIsOpen-14                   	77121234	        15.49 ns/op	       0 B/op	       0 allocs/op
+BenchmarkIsOpen-14                   	77540878	        15.43 ns/op	       0 B/op	       0 allocs/op
+BenchmarkIsOpen-14                   	78191390	        15.43 ns/op	       0 B/op	       0 allocs/op
+BenchmarkNextOpen-14                 	19000305	        63.54 ns/op	       0 B/op	       0 allocs/op
+BenchmarkNextOpen-14                 	18755433	        63.42 ns/op	       0 B/op	       0 allocs/op
+BenchmarkNextOpen-14                 	19006538	        63.29 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAdd_Short-14                	29351006	        40.93 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAdd_Short-14                	29290141	        40.98 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAdd_Short-14                	27390146	        41.12 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAdd_MultiWeek-14            	 2747268	       436.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAdd_MultiWeek-14            	 2760651	       434.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAdd_MultiWeek-14            	 2760951	       434.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBetween_Day-14              	24781291	        48.65 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBetween_Day-14              	24608779	        48.80 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBetween_Day-14              	24479450	        48.64 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBetween_Month-14            	 1000000	      1187 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBetween_Month-14            	 1000000	      1186 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBetween_Month-14            	 1000000	      1185 ns/op	       0 B/op	       0 allocs/op
+BenchmarkScheduledBetween_Year-14    	  135572	      8597 ns/op	       0 B/op	       0 allocs/op
+BenchmarkScheduledBetween_Year-14    	  140274	      8591 ns/op	       0 B/op	       0 allocs/op
+BenchmarkScheduledBetween_Year-14    	  139992	      8565 ns/op	       0 B/op	       0 allocs/op
+BenchmarkWindowsBetween_Month-14     	 1000000	      1119 ns/op	       0 B/op	       0 allocs/op
+BenchmarkWindowsBetween_Month-14     	 1000000	      1117 ns/op	       0 B/op	       0 allocs/op
+BenchmarkWindowsBetween_Month-14     	 1000000	      1116 ns/op	       0 B/op	       0 allocs/op
+PASS
+
+Optimization applied: yearPlan.days changed from map[Date]dayPlan to a
+[]dayPlan slice indexed by day-of-year minus one; dayOfYear(d) computes the
+1-based ordinal via a cumulative-days-per-month table plus a leap-year check
+(pure arithmetic, no time.Date call). cpuprofile of BenchmarkScheduledBetween_Year
+before this change showed runtime.mapaccess1 on the map[Date]dayPlan key at
+44.79% of cumulative samples (Date's three-field struct key needs a
+memequal-based probe on every lookup); replacing it with a slice index
+removes that cost entirely.
+
+Approximate before -> after deltas (median of the three counted runs):
+  BenchmarkIsOpen               27.1 ns -> 15.4 ns   (-43%)
+  BenchmarkNextOpen             75.0 ns -> 63.4 ns   (-15%)
+  BenchmarkAdd_Short            60.5 ns -> 41.0 ns   (-32%)
+  BenchmarkAdd_MultiWeek       570.6 ns -> 435.0 ns   (-24%)
+  BenchmarkBetween_Day          54.3 ns -> 48.7 ns   (-10%)
+  BenchmarkBetween_Month       1521   ns -> 1186   ns (-22%)
+  BenchmarkScheduledBetween_Year 10618 ns -> 8591  ns (-19%)
+  BenchmarkWindowsBetween_Month 1431  ns -> 1117  ns  (-22%)
+  BenchmarkNew                 297.8 ns -> 308.2 ns  (unchanged within noise;
+    construction does not touch yearPlan, as expected)
+
+All benchmarks remain zero-alloc except BenchmarkNew (construction-only
+allocations: merged window/interval slices, exceptions map, rules slice
+copy, the Calendar struct itself), which this change does not touch.
+
+Optimization considered and NOT applied: consolidating each year's
+per-day interval slices into one shared backing array (the other
+plan-suggested win). This only affects buildYear's one-time allocation
+cost, which none of the required benchmarks measure directly (they all
+prime the year before entering the timed loop), so there was no benchmark
+evidence of a win to report; skipped per the measured-wins-only rule
+rather than added speculatively.

--- a/docs/superpowers/specs/2026-07-21-bizcal-bench-baseline.txt
+++ b/docs/superpowers/specs/2026-07-21-bizcal-bench-baseline.txt
@@ -1,0 +1,43 @@
+core/bizcal benchmark baseline — before the yearPlan index optimization
+go test ./core/bizcal/ -bench=. -benchmem -run=^$ -count=3
+Apple M3 Max, go1.26.5, darwin/arm64
+
+goos: darwin
+goarch: arm64
+pkg: github.com/dmitrymomot/forge/core/bizcal
+cpu: Apple M3 Max
+BenchmarkNew-14                      	 3877026	       294.9 ns/op	     928 B/op	       8 allocs/op
+BenchmarkNew-14                      	 4142371	       307.0 ns/op	     928 B/op	       8 allocs/op
+BenchmarkNew-14                      	 3936220	       297.8 ns/op	     928 B/op	       8 allocs/op
+BenchmarkIsOpen-14                   	44746342	        27.01 ns/op	       0 B/op	       0 allocs/op
+BenchmarkIsOpen-14                   	44209615	        27.16 ns/op	       0 B/op	       0 allocs/op
+BenchmarkIsOpen-14                   	43773120	        27.18 ns/op	       0 B/op	       0 allocs/op
+BenchmarkNextOpen-14                 	16151164	        75.05 ns/op	       0 B/op	       0 allocs/op
+BenchmarkNextOpen-14                 	16201965	        74.94 ns/op	       0 B/op	       0 allocs/op
+BenchmarkNextOpen-14                 	16338339	        73.53 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAdd_Short-14                	19772342	        60.47 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAdd_Short-14                	19921186	        60.51 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAdd_Short-14                	19771813	        60.52 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAdd_MultiWeek-14            	 2118618	       567.2 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAdd_MultiWeek-14            	 2122854	       572.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAdd_MultiWeek-14            	 2059856	       570.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBetween_Day-14              	22162846	        54.12 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBetween_Day-14              	22119169	        54.36 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBetween_Day-14              	22062980	        54.25 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBetween_Month-14            	  771926	      1521 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBetween_Month-14            	  788223	      1513 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBetween_Month-14            	  784426	      1541 ns/op	       0 B/op	       0 allocs/op
+BenchmarkScheduledBetween_Year-14    	  118620	     10618 ns/op	       0 B/op	       0 allocs/op
+BenchmarkScheduledBetween_Year-14    	  122020	      9744 ns/op	       0 B/op	       0 allocs/op
+BenchmarkScheduledBetween_Year-14    	  100484	     11452 ns/op	       0 B/op	       0 allocs/op
+BenchmarkWindowsBetween_Month-14     	  819303	      1431 ns/op	       0 B/op	       0 allocs/op
+BenchmarkWindowsBetween_Month-14     	  865243	      1384 ns/op	       0 B/op	       0 allocs/op
+BenchmarkWindowsBetween_Month-14     	  869515	      1383 ns/op	       0 B/op	       0 allocs/op
+PASS
+
+Notes: at this point yearPlan.days was map[Date]dayPlan; every resolved-year
+lookup (IsOpen, NextOpen, Add, Between, ScheduledBetween, WindowsBetween) paid
+a map hash+probe on a struct key per civil day touched. All ops already
+zero-alloc on a resolved year; BenchmarkNew's 8 allocs/928B are construction
+cost (merges, exceptions map, rules slice, Calendar struct), unaffected by
+the resolver-side optimization below.

--- a/docs/superpowers/specs/2026-07-21-bizcal-design.md
+++ b/docs/superpowers/specs/2026-07-21-bizcal-design.md
@@ -1,0 +1,112 @@
+# core/bizcal — Business-Calendar Arithmetic
+
+Date: 2026-07-21
+Status: approved-pending-review
+
+## Purpose
+
+Stdlib-only, data-free business-calendar arithmetic: consumer-declared schedules (weekly windows, workday capacities, rostered shifts, always-open) plus holiday rules and date exceptions compose into an immutable, goroutine-safe `Calendar` answering instant questions (open? next open? add business duration; business time between) and day questions (working day? count; add working days; scheduled hours) — DST-correct. The substrate for SLA clocks (support app) and time-off/payroll math (HR app).
+
+No storage, no tenancy seam: a `Calendar` is pure computation built per tenant/employee from consumer-owned rows (policy tables, shift plans). Consumers cache instances (immutable ⇒ safe) and rebuild on policy change. No embedded country/holiday tables — holiday data is always consumer-supplied.
+
+Driven by two real consumers:
+- **HR / employee portal (multi-tenant):** per-employee schedules stored as `[working weekdays] + hours-per-day` (no clock windows), date exceptions (short days, days off), expected-vs-worked hours for salary, overtime derivation, leave-day counting.
+- **Customer support (multi-tenant):** SLA deadline arithmetic over business-hours, 24/7, or rostered-shift coverage; on-call duty rotas for developers (duty-hours totals, was-on-duty checks).
+
+## Core model
+
+Every civil date in the calendar's zone resolves to a **day plan**: a set of open intervals plus a **scheduled capacity** (duration that counts as the day's expected hours). Four schedule sources feed the resolver, layered in fixed precedence:
+
+1. **Base** (choose one):
+   - `WithWeekday(wd, windows...)` — per-weekday clock windows (repeatable per weekday). Capacity = sum of window durations.
+   - `WithWorkdays(perDay, weekdays...)` — day-granular: each listed weekday is open the whole civil day with capacity `perDay` (e.g. 8h). Matches HR rows exactly; no invented start times.
+   - `WithAlwaysOpen()` — every day open 00:00–24:00, capacity 24h per day.
+   - (none) — base contributes nothing; shifts alone may define the calendar.
+2. **Holiday rules** — `WithRule(r Rule)` (repeatable). A rule yields full days off per year: those dates get empty windows and zero capacity.
+3. **Date exceptions** — `WithExceptions(...Exception)`: per-date replacement of the day plan, overriding base and rules. Constructors:
+   - `DayOff(date)` — empty plan.
+   - `ShortDay(date, d)` — whole-day-open with capacity `d` (workdays-model tenants).
+   - `CustomDay(date, windows...)` — replacement clock windows (windows-model tenants).
+4. **Shifts** — `WithShifts(...Interval)`: absolute `[start, end)` instants (helper `Shift(start, end)`), may cross midnight and span days. Shifts **add** open time on top of whatever the day resolved to (they win over holidays/exceptions: rostered coverage on a holiday is still coverage). Shift time also adds to the affected dates' capacities, split at civil midnight.
+
+Overlapping windows/shifts are merged (union). Weekly windows must lie within one day (`start < end ≤ 24:00`); recurring cross-midnight coverage is expressed as two windows or as shifts.
+
+### Rules vocabulary
+
+`Rule` is a one-method interface: `Dates(year int) []Date`. Shipped implementations:
+
+- `Fixed{Month, Day}` — e.g. Jan 1.
+- `NthWeekday{Month, Weekday, N}` — N ≥ 1 from the start (4th Thursday of November); N ≤ −1 from the end (last Monday of May). N = 0 is a construction error.
+- `RuleFunc func(year int) []Date` — escape hatch (Easter and friends).
+- `Observed(r Rule) Rule` — shifts any produced Saturday date to Friday and Sunday date to Monday (US-style observed holidays).
+
+All rule outputs are memoized per year inside the calendar (lazily, thread-safe), so cached long-lived calendars never recompute.
+
+## Types
+
+- `Date{Year int, Month time.Month, Day int}` — civil date. `NewDate(y, m, d) (Date, error)` validates; `MustDate` panics; `DateOf(t time.Time) Date` reads t in its own location; `Calendar.DateOf(t)` converts to the calendar's zone first. Methods: `AddDays`, `Weekday()` (pure civil computation, no location), `Before/After/Equal`, `String` (RFC 3339 date).
+- `Window` — time-of-day span (minutes-since-midnight start/end). `NewWindow(startMin, endMin)` low-level; `ParseWindow("09:00-17:30") (Window, error)`; `ParseWindows(specs ...string) ([]Window, error)`; `MustWindows(...)` for literals.
+- `Interval{Start, End time.Time}` — concrete absolute span, `End` exclusive. Used for shifts and yielded by `WindowsBetween`.
+- `Exception` — opaque per-date plan override (constructors above).
+- `Calendar` — immutable; `New(loc *time.Location, opts ...Option) (*Calendar, error)`. `loc` must be non-nil.
+
+## Operations
+
+Instant ops (all interpret/return instants in absolute time; results normalized to the calendar's zone):
+
+- `IsOpen(t time.Time) bool`
+- `NextOpen(t time.Time) (time.Time, error)` — earliest instant ≥ t that is open (t itself if open). `ErrHorizonExceeded` if none within the scan horizon.
+- `Add(t time.Time, d time.Duration) (time.Time, error)` — the instant after `d` of business time elapses from t. `d < 0` walks backward. `Add(t, 0)` = `NextOpen(t)`.
+- `Between(a, b time.Time) time.Duration` — business time elapsed in `[a, b)`; signed: `Between(a, b) == -Between(b, a)`.
+- `WindowsBetween(from, to time.Time) iter.Seq[Interval]` — the merged concrete open intervals overlapping `[from, to)`, clipped to it, in order. The flexibility primitive for payroll rules (night differentials, per-window rounding); `Add`/`Between` are built on the same resolver.
+
+Day ops (dates in the calendar's zone; ranges half-open `[from, to)`):
+
+- `IsWorkingDay(d Date) bool` — day has non-zero capacity or any open time.
+- `WorkingDays(from, to Date) int`
+- `AddWorkingDays(d Date, n int) (Date, error)` — n-th working day strictly after (n > 0) / before (n < 0) `d`; n = 0 returns `d` unchanged. `ErrHorizonExceeded` on exhaustion.
+- `DayDuration(d Date) time.Duration` — the day's scheduled capacity.
+- `ScheduledBetween(from, to Date) time.Duration` — sum of capacities (the salary-base "expected hours").
+
+Salary formulas (consumer-side, documented in doc.go): expected = `ScheduledBetween`; payable in-schedule = `Between(clockIn, clockOut)`; undertime = `DayDuration(day) − worked`; overtime = raw span − in-schedule span (windows model) or `worked − DayDuration(day)` (workdays model).
+
+### Workdays-model semantics
+
+Under `WithWorkdays`, a working day is open the entire civil day but its capacity is `perDay`. `Between` therefore returns wall time clipped to working days (a 10h presence on an 8h day yields 10h — intended, overtime falls out via `worked − DayDuration`). `ScheduledBetween`/`DayDuration` use capacity. SLA-style `Add` on a workdays calendar consumes whole-day wall time; tenants wanting clock-accurate SLA use windows or shifts.
+
+## DST semantics
+
+Windows are wall-clock in the calendar's zone; all arithmetic happens on concrete instants after zone resolution (`time.Date` normalization):
+
+- **Spring forward** (02:00→03:00 skip): a boundary in the gap normalizes forward; the day's real open time shrinks accordingly. `Between`/`Add` measure absolute elapsed time, so an SLA spanning the transition is never over- or under-counted.
+- **Fall back** (repeated hour): boundaries resolve to the first occurrence; the repeated hour inside an open window counts twice in absolute time (it really elapsed).
+- Workdays-model capacity is a fixed duration, unaffected by DST (an 8h expectation stays 8h); windows-model `DayDuration` reflects the real instant span (DST day may be 7h or 9h) — documented.
+
+## Errors
+
+Sentinels in `errors.go`, `errors.Is`-matchable: `ErrInvalidWindow`, `ErrInvalidDate`, `ErrInvalidWeekday`, `ErrInvalidRule`, `ErrInvalidShift` (end ≤ start), `ErrInvalidCapacity` (negative), `ErrNilLocation`, `ErrNeverOpen` (statically empty calendar: no base, no shifts), `ErrHorizonExceeded`. Options accumulate errors; `New` joins and returns them (standard forge option-error pattern).
+
+Scan horizon: `NextOpen`/`Add`/`AddWorkingDays` search at most `WithHorizon(d)` (default 5 years) of calendar time from the anchor before returning `ErrHorizonExceeded` — guards against rule-funcs that close every day.
+
+## Performance
+
+- Day resolution memoized per year (windows expanded, rules applied, exceptions overlaid) behind a `sync.RWMutex`-guarded map (or `sync.Map` if benchmarks prefer); computed lazily on first touch of a year.
+- Hot ops (`IsOpen`, `Between` within a resolved year) target zero allocations.
+- `bench_test.go`: construction, `IsOpen`, `NextOpen`, `Add` (short and multi-week), `Between` (day and month span), `ScheduledBetween` (year span), `WindowsBetween` iteration; post-bench optimization pass with before/after numbers in the PR.
+
+## Testing
+
+- Black-box (`bizcal_test`) throughout; white-box only if an internal primitive needs direct pinning.
+- DST fixtures: Europe/Kyiv and America/New_York transition days for `Add`/`Between`/`NextOpen`/`DayDuration`.
+- Property/fuzz: `Between(a,b) == -Between(b,a)`; `Between(t, Add(t,d)) == d` (when `Add` succeeds and d ≥ 0); `Add` monotonicity; `WorkingDays` consistency with `IsWorkingDay` loop; oracle: minute-granularity brute-force `Between`/`NextOpen` over small ranges vs the fast implementation.
+- Concurrency: `-race` test hammering lazy year-cache population from parallel goroutines.
+- Layering: shifts over holidays, exceptions over rules, merge of overlapping windows/shifts, cross-midnight shifts splitting capacity across dates.
+- Horizon: never-open calendar construction error; rule-func closing everything hits `ErrHorizonExceeded`.
+
+## Anatomy & scope
+
+`core/bizcal`: `doc.go` (runnable example: HR workdays calendar + salary math; SLA add), `options.go`, `errors.go`, `date.go`, `window.go`, `rule.go`, `calendar.go` (+ resolver), `bizcal_test.go` et al., `bench_test.go`. Stdlib-only. Target ~250–850 LOC of implementation.
+
+Anti-scope: pay rates/overtime classes/pay-period aggregation (future `hr/` territory), embedded country holiday tables, storage/loader seams, fractional leave-day policy (consumers derive from `Between`/`DayDuration`), recurring cross-midnight weekly windows (use two windows or shifts), work-hour accounting of actual timesheets (consumer joins their clock data with bizcal outputs).
+
+After shipping: delete the `core/bizcal` entry from `docs/packages.md` (roadmap lists only unbuilt packages) and update the SLA entry's dep tag.


### PR DESCRIPTION
## Summary

New `core/bizcal` package: stdlib-only, immutable, DST-correct business-calendar arithmetic. A `Calendar` layers a base schedule (weekly windows, per-day workdays capacity, or always-open) with holiday rules (`Fixed`, `NthWeekday`, `RuleFunc`, `Observed`), date exceptions (`DayOff`, `ShortDay`, `CustomDay`), and shift rosters (`WithShifts`), then answers instant ops (`IsOpen`, `NextOpen`, `Add`, `Between`, `WindowsBetween`) and day ops (`IsWorkingDay`, `WorkingDays`, `AddWorkingDays`, `DayDuration`, `ScheduledBetween`).

Design spec: `docs/superpowers/specs/2026-07-21-bizcal-design.md`. Plan: `docs/superpowers/plans/2026-07-21-bizcal.md`.

Key semantics:
- Every civil date resolves to a day plan (merged absolute-time open intervals + scheduled capacity), memoized per year behind an RWMutex; `Calendar` is immutable and goroutine-safe after `New` — build one per tenant/policy, cache it, rebuild on change.
- DST-correct by construction: all instant arithmetic is absolute-time; windows-model capacity is the real duration on 23h/25h days; workdays-model capacity is fixed per day; SLA `Add` stays duration-exact across transitions.
- Shifts add on top of everything (open even on holidays/days off); cross-midnight and cross-year shifts split across the civil dates they touch. Holiday rules evaluate for y±1 so `Observed` dates that shift across a year boundary (New Year observed Dec 31 / Jan 1) are honored.
- Fail-closed construction: joined option errors, `ErrNeverOpen` for statically-never-open configs, `ErrHorizonExceeded` caps all scans (default 5y, `WithHorizon`).

## Usage

Salary / HR (workdays model):

```go
cal, _ := bizcal.New(kyiv,
    bizcal.WithWorkdays(8*time.Hour, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday),
    bizcal.WithRule(bizcal.Fixed{Month: time.January, Day: 1}),
    bizcal.WithExceptions(bizcal.ShortDay(bizcal.MustDate(2026, 12, 31), 4*time.Hour)),
)
scheduled := cal.ScheduledBetween(from, to)   // monthly norm
worked := cal.Between(clockIn, clockOut)      // wall time on working days
payday, _ := cal.AddWorkingDays(submitted, 3) // leave / payroll math
```

SLA (windows model):

```go
cal, _ := bizcal.New(ny,
    bizcal.WithWeekday(time.Monday, bizcal.MustWindows("09:00-13:00", "14:00-18:00")...),
    bizcal.WithWeekday(time.Friday, bizcal.MustWindows("09:00-15:00")...),
    bizcal.WithRule(bizcal.Observed(bizcal.Fixed{Month: time.July, Day: 4})),
)
deadline, _ := cal.Add(ticketOpened, 8*time.Hour) // 8 business hours, DST-exact
```

## Testing

- 96.2% coverage, full suite race-clean; black-box throughout.
- Property tests (500 seeded iterations × 3 fixture calendars): signed `Between` symmetry + additivity, `Add` round-trip, `NextOpen` idempotence, aggregate-equals-loop identities.
- Brute-force minute-scanner oracle over a 3-week window covering a weekend, holiday, short-day exception, and the Kyiv spring-forward transition.
- Fuzz: `FuzzParseWindow` 20.8M execs, `FuzzBetweenSymmetry` 3.1M, `FuzzAddRoundTrip` 3.0M — zero crashers.
- 32-goroutine race test hammering the per-year memo.
- Regression tests proven red pre-fix for the one defect found in final review (Observed cross-year drop).

## Benchmarks (before → after optimization pass)

The measured win: `yearPlan` day lookup switched from `map[Date]dayPlan` to a day-of-year-indexed slice (profiling showed map access at ~45% cumulative CPU). Artifacts: `docs/superpowers/specs/2026-07-21-bizcal-bench-{baseline,after}.txt`.

| Benchmark | Before | After | Δ |
|---|---|---|---|
| New | 295 ns/op | 308 ns/op | ~0 (untouched path) |
| IsOpen | 27.0 ns/op | 15.4 ns/op | -43% |
| NextOpen | 74.5 ns/op | 63.4 ns/op | -15% |
| Add_Short | 60.5 ns/op | 41.0 ns/op | -32% |
| Add_MultiWeek | 570 ns/op | 435 ns/op | -24% |
| Between_Day | 54.2 ns/op | 48.7 ns/op | -10% |
| Between_Month | 1525 ns/op | 1186 ns/op | -22% |
| ScheduledBetween_Year | 10.6 µs/op | 8.6 µs/op | -19% |
| WindowsBetween_Month | 1399 ns/op | 1117 ns/op | -22% |

All ops zero-alloc on resolved years except construction.

## Catalog

`docs/packages.md`: `core/bizcal` roadmap entry removed; `ops/sla` dependency tag updated to shipped.