### PR TITLE
fix(smartlink): fail closed on missing visit facts — geo matcher no longer fails open

### DIFF
--- a/web/smartlink/bench_test.go
+++ b/web/smartlink/bench_test.go
@@ -36,7 +36,9 @@ func BenchmarkDecideLiteral(b *testing.B) {
 	visit := smartlink.Visit{Country: "de", Device: "mobile", StickyKey: "visitor-42"}
 	b.ReportAllocs()
 	for b.Loop() {
-		link.Decide(visit)
+		if _, err := link.Decide(visit); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -57,7 +59,9 @@ func BenchmarkDecideSplit(b *testing.B) {
 	visit := smartlink.Visit{StickyKey: "visitor-42"}
 	b.ReportAllocs()
 	for b.Loop() {
-		link.Decide(visit)
+		if _, err := link.Decide(visit); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -73,7 +77,9 @@ func BenchmarkDecideMacro(b *testing.B) {
 	}
 	b.ReportAllocs()
 	for b.Loop() {
-		link.Decide(visit)
+		if _, err := link.Decide(visit); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -87,7 +93,9 @@ func BenchmarkDecideMerge(b *testing.B) {
 	visit := smartlink.Visit{Params: map[string]string{"sub1": "x", "sub2": "y"}}
 	b.ReportAllocs()
 	for b.Loop() {
-		link.Decide(visit)
+		if _, err := link.Decide(visit); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -99,14 +107,16 @@ func BenchmarkDecideBare(b *testing.B) {
 	visit := smartlink.Visit{StickyKey: "visitor-42"}
 	b.ReportAllocs()
 	for b.Loop() {
-		link.Decide(visit)
+		if _, err := link.Decide(visit); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
 // noopDecorator wraps d without altering the decision — isolates Chain/call
 // overhead from any decorator's own work.
 func noopDecorator(d smartlink.Decider) smartlink.Decider {
-	return smartlink.DecideFunc(func(v smartlink.Visit) smartlink.Decision {
+	return smartlink.DecideFunc(func(v smartlink.Visit) (smartlink.Decision, error) {
 		return d.Decide(v)
 	})
 }
@@ -120,7 +130,9 @@ func BenchmarkChain3(b *testing.B) {
 	visit := smartlink.Visit{StickyKey: "visitor-42"}
 	b.ReportAllocs()
 	for b.Loop() {
-		chained.Decide(visit)
+		if _, err := chained.Decide(visit); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -215,7 +227,9 @@ func BenchmarkResolveDecideTarget(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Compile() error = %v", err)
 		}
-		compiled.Decide(visit)
+		if _, err := compiled.Decide(visit); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/web/smartlink/cache_test.go
+++ b/web/smartlink/cache_test.go
@@ -150,7 +150,7 @@ func TestCacheInvalidateDuringLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
-	if got := compiled.Decide(smartlink.Visit{}).URL; got != newURL {
+	if got := mustDecide(t, compiled, smartlink.Visit{}).URL; got != newURL {
 		t.Fatalf("post-invalidate Decide().URL = %q, want %q", got, newURL)
 	}
 
@@ -161,7 +161,7 @@ func TestCacheInvalidateDuringLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("final Get() error = %v", err)
 	}
-	if got := final.Decide(smartlink.Visit{}).URL; got != newURL {
+	if got := mustDecide(t, final, smartlink.Visit{}).URL; got != newURL {
 		t.Fatalf("final Decide().URL = %q, want %q (stale store overwrote fresh entry)", got, newURL)
 	}
 	if n := calls.Load(); n != 2 {
@@ -290,9 +290,12 @@ func TestCacheResolver(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolver() error = %v", err)
 	}
-	got := d.Decide(smartlink.Visit{}).Rule
-	if got != "R" {
-		t.Fatalf("Decide().Rule = %q, want %q", got, "R")
+	dec, err := d.Decide(smartlink.Visit{})
+	if err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
+	if dec.Rule != "R" {
+		t.Fatalf("Decide().Rule = %q, want %q", dec.Rule, "R")
 	}
 }
 

--- a/web/smartlink/compile.go
+++ b/web/smartlink/compile.go
@@ -29,6 +29,7 @@ type compiledRule struct {
 // split is a target list with cumulative weights for deterministic
 // sticky-key bucketing.
 type split struct {
+	missErr error // precomputed ErrMissingFact for an empty StickyKey; nil for a single target
 	targets []compiledTarget
 	cum     []int // cumulative weights, len == len(targets); nil for a single target
 	seed    uint64
@@ -136,6 +137,7 @@ func compileSplit(targets []Target, salt, ruleName string) (split, error) {
 		}
 	}
 	if len(targets) > 1 {
+		s.missErr = fmt.Errorf("%w: %s: weighted split needs Visit.StickyKey", ErrMissingFact, where)
 		s.seed = hashString(fnvOffset, "s\x00"+salt+"\x00"+ruleName)
 		s.cum = make([]int, len(targets))
 		var total int64

--- a/web/smartlink/decide.go
+++ b/web/smartlink/decide.go
@@ -21,9 +21,19 @@ type Decision struct {
 
 // Decide evaluates the visit against the link's rules in order — first rule
 // whose matchers all match wins, falling back to the default target — picks a
-// split target by sticky-key bucket, and renders the final URL. It never
-// fails: every failure mode is a Compile error.
-func (l *Compiled) Decide(v Visit) Decision {
+// split target by sticky-key bucket, and renders the final URL.
+//
+// Decide fails closed on missing facts: when the outcome would depend on a
+// visit field the visit doesn't carry — a Geo rule with no Country (geoip
+// miss), a Device or Locale rule with the fact empty, a Percent gate or
+// weighted split with no StickyKey — it returns [ErrMissingFact] instead of
+// silently falling through to the default target. The gate is exact, not
+// eager: a missing fact never errors when the decision is provably
+// independent of it — the rule consulting it is already definitively false
+// on another matcher, or an earlier rule matched outright. A spec whose
+// consulted facts are all present — in particular the degenerate
+// single-default-target link — never fails.
+func (l *Compiled) Decide(v Visit) (Decision, error) {
 	var now time.Time
 	if l.needsNow {
 		now = v.At
@@ -33,40 +43,66 @@ func (l *Compiled) Decide(v Visit) Decision {
 	}
 	for i := range l.rules {
 		r := &l.rules[i]
-		if matchAll(r.when, &v, now) {
-			t := r.targets.pick(v.StickyKey)
-			return Decision{Rule: r.name, Target: t.raw, URL: l.finalURL(t, &v)}
+		ok, err := matchAll(r.when, &v, now)
+		if err != nil {
+			return Decision{}, err
 		}
+		if !ok {
+			continue
+		}
+		t, err := r.targets.pick(v.StickyKey)
+		if err != nil {
+			return Decision{}, err
+		}
+		return Decision{Rule: r.name, Target: t.raw, URL: l.finalURL(t, &v)}, nil
 	}
-	t := l.def.pick(v.StickyKey)
-	return Decision{Target: t.raw, URL: l.finalURL(t, &v)}
+	t, err := l.def.pick(v.StickyKey)
+	if err != nil {
+		return Decision{}, err
+	}
+	return Decision{Target: t.raw, URL: l.finalURL(t, &v)}, nil
 }
 
 // matchAll reports whether every matcher in the conjunction matches; an empty
-// conjunction always matches.
-func matchAll(when []matcher, v *Visit, now time.Time) bool {
+// conjunction always matches. Evaluation is three-valued: a matcher whose
+// visit fact is missing is unknowable, so the whole conjunction is scanned —
+// any definitively-false matcher settles the rule as non-matching regardless
+// of order, and only when the rule would otherwise match does the first
+// missing fact's precomputed error surface.
+func matchAll(when []matcher, v *Visit, now time.Time) (bool, error) {
+	var miss error
 	for i := range when {
-		if !when[i].match(v, now) {
-			return false
+		switch when[i].eval(v, now) {
+		case evalFalse:
+			return false, nil
+		case evalMissing:
+			if miss == nil {
+				miss = when[i].missErr
+			}
+		case evalTrue:
 		}
 	}
-	return true
+	return miss == nil, miss
 }
 
 // pick buckets the sticky key into the split's cumulative weights. A single
-// target returns directly; an empty key deterministically takes the first
-// target.
-func (s *split) pick(stickyKey string) *compiledTarget {
-	if s.cum == nil || stickyKey == "" {
-		return &s.targets[0]
+// target returns directly; a weighted split with an empty key fails closed
+// with the split's precomputed [ErrMissingFact] — a visit with no bucketing
+// identity must not silently collapse onto the first target.
+func (s *split) pick(stickyKey string) (*compiledTarget, error) {
+	if s.cum == nil {
+		return &s.targets[0], nil
+	}
+	if stickyKey == "" {
+		return nil, s.missErr
 	}
 	n := int(hashString(s.seed, stickyKey) % uint64(s.cum[len(s.cum)-1]))
 	for i, c := range s.cum {
 		if n < c {
-			return &s.targets[i]
+			return &s.targets[i], nil
 		}
 	}
-	return &s.targets[len(s.targets)-1] // unreachable: n < cum[last]
+	return &s.targets[len(s.targets)-1], nil // unreachable: n < cum[last]
 }
 
 // finalURL renders the target's macros and merges visit params per the link

--- a/web/smartlink/decide_test.go
+++ b/web/smartlink/decide_test.go
@@ -1,6 +1,7 @@
 package smartlink_test
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -26,6 +27,147 @@ func rule(name, url string, when ...smartlink.Matcher) smartlink.Rule {
 	return smartlink.Rule{Name: name, When: when, Targets: []smartlink.Target{{URL: url}}}
 }
 
+func mustDecide(t *testing.T, l *smartlink.Compiled, v smartlink.Visit) smartlink.Decision {
+	t.Helper()
+	d, err := l.Decide(v)
+	if err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
+	return d
+}
+
+// wantMissingFact asserts Decide fails closed with ErrMissingFact and returns
+// no decision.
+func wantMissingFact(t *testing.T, l *smartlink.Compiled, v smartlink.Visit) {
+	t.Helper()
+	d, err := l.Decide(v)
+	if !errors.Is(err, smartlink.ErrMissingFact) {
+		t.Fatalf("Decide() = (%+v, %v), want ErrMissingFact", d, err)
+	}
+	if d.URL != "" || d.Rule != "" {
+		t.Fatalf("Decide() returned a decision %+v alongside the error", d)
+	}
+}
+
+// TestDecideMissingFactFailsClosed asserts a visit lacking a fact the spec's
+// rules consult is refused instead of silently falling through to the default
+// target — the restricted-jurisdictions-on-geoip-miss failure class.
+func TestDecideMissingFactFailsClosed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		when smartlink.Matcher
+	}{
+		{"geo", smartlink.Geo{Countries: []string{"CU", "IR", "KP"}}},
+		{"device", smartlink.Device{Devices: []string{"mobile"}}},
+		{"locale", smartlink.Locale{Locales: []string{"en"}}},
+		{"percent", smartlink.Percent{Share: 30}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			link := mustCompile(t, smartlink.Spec{
+				Rules:   []smartlink.Rule{rule("gate", "https://compliance.example.com", tc.when)},
+				Default: defTargets(),
+			})
+			wantMissingFact(t, link, smartlink.Visit{})
+		})
+	}
+}
+
+// TestDecideMissingFactIrrelevantWhenEarlierRuleMatches asserts the gate is
+// lazy: a missing fact only errors when the decision depends on it, not
+// because a later rule happens to consult it.
+func TestDecideMissingFactIrrelevantWhenEarlierRuleMatches(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Rules: []smartlink.Rule{
+			rule("bot", "https://sinkhole.example.com", smartlink.ParamEquals{Key: "bot", Values: []string{"1"}}),
+			rule("geo", "https://geo.example.com", smartlink.Geo{Countries: []string{"DE"}}),
+		},
+		Default: defTargets(),
+	})
+	d := mustDecide(t, link, smartlink.Visit{Params: map[string]string{"bot": "1"}})
+	if d.Rule != "bot" {
+		t.Fatalf("Rule = %q, want bot", d.Rule)
+	}
+	// Without the earlier match the missing country is load-bearing again.
+	wantMissingFact(t, link, smartlink.Visit{})
+}
+
+// TestDecideMissingFactIrrelevantWhenRuleDefinitelyFalse asserts a conjunction
+// with a definitively-false matcher skips the rule without erroring on a
+// missing sibling fact — the outcome is provably identical either way — and
+// that matcher order within the conjunction doesn't change that.
+func TestDecideMissingFactIrrelevantWhenRuleDefinitelyFalse(t *testing.T) {
+	t.Parallel()
+	geo := smartlink.Geo{Countries: []string{"DE"}}
+	device := smartlink.Device{Devices: []string{"mobile"}}
+	for name, when := range map[string][]smartlink.Matcher{
+		"geo-first":    {geo, device},
+		"device-first": {device, geo},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			link := mustCompile(t, smartlink.Spec{
+				Rules:   []smartlink.Rule{{Name: "de-mobile", When: when, Targets: []smartlink.Target{{URL: "https://hit.com"}}}},
+				Default: defTargets(),
+			})
+			// Device is definitively not mobile: the rule cannot match no matter
+			// the country, so the missing country must not error.
+			d := mustDecide(t, link, smartlink.Visit{Device: "desktop"})
+			if d.Rule != "" {
+				t.Fatalf("Rule = %q, want default", d.Rule)
+			}
+			// Device matches, country missing: the rule's outcome now hinges on
+			// the missing fact.
+			wantMissingFact(t, link, smartlink.Visit{Device: "mobile"})
+		})
+	}
+}
+
+// TestDecideEmptyStickySplitErrors asserts a weighted split refuses an empty
+// StickyKey instead of silently collapsing onto the first target.
+func TestDecideEmptyStickySplitErrors(t *testing.T) {
+	t.Parallel()
+	splitTargets := []smartlink.Target{
+		{URL: "https://a.com", Weight: 70},
+		{URL: "https://b.com", Weight: 30},
+	}
+
+	def := mustCompile(t, smartlink.Spec{Default: splitTargets})
+	wantMissingFact(t, def, smartlink.Visit{})
+	if d := mustDecide(t, def, smartlink.Visit{StickyKey: "visitor-1"}); d.URL == "" {
+		t.Fatalf("keyed visit got no decision")
+	}
+
+	ruled := mustCompile(t, smartlink.Spec{
+		Rules: []smartlink.Rule{{
+			Name:    "de",
+			When:    []smartlink.Matcher{smartlink.Geo{Countries: []string{"DE"}}},
+			Targets: splitTargets,
+		}},
+		Default: defTargets(),
+	})
+	wantMissingFact(t, ruled, smartlink.Visit{Country: "DE"})
+	// The split is only consulted when its rule matches: a US visit takes the
+	// single default target and needs no sticky key.
+	if d := mustDecide(t, ruled, smartlink.Visit{Country: "US"}); d.Rule != "" {
+		t.Fatalf("Rule = %q, want default", d.Rule)
+	}
+}
+
+// TestDecideNoFactsNeededNeverErrors asserts the degenerate short link — one
+// default target, no rules — still decides every visit, including the empty
+// one.
+func TestDecideNoFactsNeededNeverErrors(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{Default: defTargets()})
+	if d := mustDecide(t, link, smartlink.Visit{}); d.URL != "https://example.com/" {
+		t.Fatalf("URL = %q, want default", d.URL)
+	}
+}
+
 func TestDecideFirstMatchWins(t *testing.T) {
 	t.Parallel()
 	link := mustCompile(t, smartlink.Spec{
@@ -35,7 +177,7 @@ func TestDecideFirstMatchWins(t *testing.T) {
 		},
 		Default: defTargets(),
 	})
-	d := link.Decide(smartlink.Visit{Country: "DE"})
+	d := mustDecide(t, link, smartlink.Visit{Country: "DE"})
 	if d.Rule != "first" || d.URL != "https://first.com" {
 		t.Fatalf("got (%q, %q), want first rule", d.Rule, d.URL)
 	}
@@ -47,7 +189,7 @@ func TestDecideDefaultFallback(t *testing.T) {
 		Rules:   []smartlink.Rule{rule("de", "https://de.com", smartlink.Geo{Countries: []string{"DE"}})},
 		Default: defTargets(),
 	})
-	d := link.Decide(smartlink.Visit{Country: "US"})
+	d := mustDecide(t, link, smartlink.Visit{Country: "US"})
 	if d.Rule != "" || d.URL != "https://example.com/" {
 		t.Fatalf("got (%q, %q), want default", d.Rule, d.URL)
 	}
@@ -62,7 +204,7 @@ func TestDecideUnconditionalRule(t *testing.T) {
 		Rules:   []smartlink.Rule{rule("maintenance", "https://sorry.com")},
 		Default: defTargets(),
 	})
-	if d := link.Decide(smartlink.Visit{}); d.Rule != "maintenance" {
+	if d := mustDecide(t, link, smartlink.Visit{}); d.Rule != "maintenance" {
 		t.Fatalf("Rule = %q, want maintenance", d.Rule)
 	}
 }
@@ -76,10 +218,10 @@ func TestDecideConjunction(t *testing.T) {
 		)},
 		Default: defTargets(),
 	})
-	if d := link.Decide(smartlink.Visit{Country: "DE", Device: "mobile"}); d.Rule != "de-mobile" {
+	if d := mustDecide(t, link, smartlink.Visit{Country: "DE", Device: "mobile"}); d.Rule != "de-mobile" {
 		t.Fatalf("both matchers true: Rule = %q, want de-mobile", d.Rule)
 	}
-	if d := link.Decide(smartlink.Visit{Country: "DE", Device: "desktop"}); d.Rule != "" {
+	if d := mustDecide(t, link, smartlink.Visit{Country: "DE", Device: "desktop"}); d.Rule != "" {
 		t.Fatalf("one matcher false: Rule = %q, want default", d.Rule)
 	}
 }
@@ -91,13 +233,12 @@ func TestGeoCaseInsensitive(t *testing.T) {
 		Default: defTargets(),
 	})
 	for _, country := range []string{"DE", "de", "De"} {
-		if d := link.Decide(smartlink.Visit{Country: country}); d.Rule != "geo" {
+		if d := mustDecide(t, link, smartlink.Visit{Country: country}); d.Rule != "geo" {
 			t.Fatalf("country %q: Rule = %q, want geo", country, d.Rule)
 		}
 	}
-	if d := link.Decide(smartlink.Visit{}); d.Rule != "" {
-		t.Fatalf("empty country matched geo rule")
-	}
+	// An empty country is a missing fact, not a non-match.
+	wantMissingFact(t, link, smartlink.Visit{})
 }
 
 func TestLocaleMatching(t *testing.T) {
@@ -115,17 +256,18 @@ func TestLocaleMatching(t *testing.T) {
 		{"en-US", "en", false},
 		{"en-US", "en-GB", false},
 		{"en", "de", false},
-		{"en", "", false},
 	}
 	for _, tc := range cases {
 		link := mustCompile(t, smartlink.Spec{
 			Rules:   []smartlink.Rule{rule("loc", "https://hit.com", smartlink.Locale{Locales: []string{tc.rule}})},
 			Default: defTargets(),
 		})
-		got := link.Decide(smartlink.Visit{Locale: tc.visit}).Rule == "loc"
+		got := mustDecide(t, link, smartlink.Visit{Locale: tc.visit}).Rule == "loc"
 		if got != tc.want {
 			t.Errorf("rule %q vs visit %q: matched = %v, want %v", tc.rule, tc.visit, got, tc.want)
 		}
+		// An empty locale is a missing fact, not a non-match.
+		wantMissingFact(t, link, smartlink.Visit{})
 	}
 }
 
@@ -137,13 +279,13 @@ func TestParamEqualsExact(t *testing.T) {
 		)},
 		Default: defTargets(),
 	})
-	if d := link.Decide(smartlink.Visit{Params: map[string]string{"source": "ig"}}); d.Rule != "src" {
+	if d := mustDecide(t, link, smartlink.Visit{Params: map[string]string{"source": "ig"}}); d.Rule != "src" {
 		t.Fatalf("listed value: Rule = %q, want src", d.Rule)
 	}
-	if d := link.Decide(smartlink.Visit{Params: map[string]string{"source": "FB"}}); d.Rule != "" {
+	if d := mustDecide(t, link, smartlink.Visit{Params: map[string]string{"source": "FB"}}); d.Rule != "" {
 		t.Fatalf("param match must be case-sensitive")
 	}
-	if d := link.Decide(smartlink.Visit{}); d.Rule != "" {
+	if d := mustDecide(t, link, smartlink.Visit{}); d.Rule != "" {
 		t.Fatalf("missing param matched")
 	}
 }
@@ -158,19 +300,19 @@ func TestTimeWindow(t *testing.T) {
 		Default: defTargets(),
 	}, smartlink.WithClock(mock))
 
-	if d := link.Decide(smartlink.Visit{}); d.Rule != "window" {
+	if d := mustDecide(t, link, smartlink.Visit{}); d.Rule != "window" {
 		t.Fatalf("inside window: Rule = %q, want window", d.Rule)
 	}
 	mock.Set(until) // Until is exclusive
-	if d := link.Decide(smartlink.Visit{}); d.Rule != "" {
+	if d := mustDecide(t, link, smartlink.Visit{}); d.Rule != "" {
 		t.Fatalf("at Until: Rule = %q, want default", d.Rule)
 	}
 	mock.Set(from.Add(-time.Second))
-	if d := link.Decide(smartlink.Visit{}); d.Rule != "" {
+	if d := mustDecide(t, link, smartlink.Visit{}); d.Rule != "" {
 		t.Fatalf("before From: Rule = %q, want default", d.Rule)
 	}
 	// Visit.At overrides the clock (click-log replay).
-	if d := link.Decide(smartlink.Visit{At: from.Add(time.Minute)}); d.Rule != "window" {
+	if d := mustDecide(t, link, smartlink.Visit{At: from.Add(time.Minute)}); d.Rule != "window" {
 		t.Fatalf("Visit.At inside window: Rule = %q, want window", d.Rule)
 	}
 }
@@ -185,10 +327,10 @@ func TestTimeWindowOpenEnded(t *testing.T) {
 		},
 		Default: defTargets(),
 	})
-	if d := link.Decide(smartlink.Visit{At: at.Add(-time.Hour)}); d.Rule != "until-only" {
+	if d := mustDecide(t, link, smartlink.Visit{At: at.Add(-time.Hour)}); d.Rule != "until-only" {
 		t.Fatalf("before at: Rule = %q, want until-only", d.Rule)
 	}
-	if d := link.Decide(smartlink.Visit{At: at.Add(time.Hour)}); d.Rule != "from-only" {
+	if d := mustDecide(t, link, smartlink.Visit{At: at.Add(time.Hour)}); d.Rule != "from-only" {
 		t.Fatalf("after at: Rule = %q, want from-only", d.Rule)
 	}
 }
@@ -200,21 +342,19 @@ func TestPercentDeterministicAndDistributed(t *testing.T) {
 		Default: defTargets(),
 	})
 	// Deterministic: the same sticky key always lands on the same side.
-	first := link.Decide(smartlink.Visit{StickyKey: "visitor-1"}).Rule
+	first := mustDecide(t, link, smartlink.Visit{StickyKey: "visitor-1"}).Rule
 	for range 10 {
-		if got := link.Decide(smartlink.Visit{StickyKey: "visitor-1"}).Rule; got != first {
+		if got := mustDecide(t, link, smartlink.Visit{StickyKey: "visitor-1"}).Rule; got != first {
 			t.Fatalf("same sticky key flipped: %q then %q", first, got)
 		}
 	}
-	// Empty sticky key fails closed.
-	if d := link.Decide(smartlink.Visit{}); d.Rule != "" {
-		t.Fatalf("empty sticky key matched Percent")
-	}
+	// An empty sticky key is a missing fact: refuse rather than skip the rule.
+	wantMissingFact(t, link, smartlink.Visit{})
 	// Distribution over many keys approximates the share.
 	matched := 0
 	const n = 5000
 	for i := range n {
-		if link.Decide(smartlink.Visit{StickyKey: "k" + strconv.Itoa(i)}).Rule == "pct" {
+		if mustDecide(t, link, smartlink.Visit{StickyKey: "k" + strconv.Itoa(i)}).Rule == "pct" {
 			matched++
 		}
 	}
@@ -232,21 +372,20 @@ func TestWeightedSplit(t *testing.T) {
 		},
 	})
 	// Deterministic per key.
-	first := link.Decide(smartlink.Visit{StickyKey: "visitor-1"}).URL
+	first := mustDecide(t, link, smartlink.Visit{StickyKey: "visitor-1"}).URL
 	for range 10 {
-		if got := link.Decide(smartlink.Visit{StickyKey: "visitor-1"}).URL; got != first {
+		if got := mustDecide(t, link, smartlink.Visit{StickyKey: "visitor-1"}).URL; got != first {
 			t.Fatalf("same sticky key flipped targets: %q then %q", first, got)
 		}
 	}
-	// Empty sticky key deterministically takes the first target.
-	if d := link.Decide(smartlink.Visit{}); d.URL != "https://a.com" {
-		t.Fatalf("empty sticky key got %q, want first target", d.URL)
-	}
+	// An empty sticky key is a missing fact: refuse rather than collapse the
+	// split onto its first target.
+	wantMissingFact(t, link, smartlink.Visit{})
 	// Distribution approximates the weights.
 	a := 0
 	const n = 5000
 	for i := range n {
-		if link.Decide(smartlink.Visit{StickyKey: "k" + strconv.Itoa(i)}).URL == "https://a.com" {
+		if mustDecide(t, link, smartlink.Visit{StickyKey: "k" + strconv.Itoa(i)}).URL == "https://a.com" {
 			a++
 		}
 	}
@@ -260,7 +399,7 @@ func TestMacroRendering(t *testing.T) {
 	link := mustCompile(t, smartlink.Spec{
 		Default: []smartlink.Target{{URL: "https://a.com/{country}/land?d={device}&l={locale}&s={param.sub1}"}},
 	})
-	d := link.Decide(smartlink.Visit{
+	d := mustDecide(t, link, smartlink.Visit{
 		Country: "DE",
 		Device:  "mobile",
 		Locale:  "de-DE",
@@ -271,7 +410,7 @@ func TestMacroRendering(t *testing.T) {
 		t.Fatalf("URL = %q, want %q", d.URL, want)
 	}
 	// Empty visit values render as empty substitutions.
-	if got := link.Decide(smartlink.Visit{}).URL; got != "https://a.com//land?d=&l=&s=" {
+	if got := mustDecide(t, link, smartlink.Visit{}).URL; got != "https://a.com//land?d=&l=&s=" {
 		t.Fatalf("sparse visit URL = %q", got)
 	}
 }
@@ -281,7 +420,7 @@ func TestMacroPathEscaping(t *testing.T) {
 	link := mustCompile(t, smartlink.Spec{
 		Default: []smartlink.Target{{URL: "https://a.com/{param.slug}/x"}},
 	})
-	d := link.Decide(smartlink.Visit{Params: map[string]string{"slug": "a b/c?d"}})
+	d := mustDecide(t, link, smartlink.Visit{Params: map[string]string{"slug": "a b/c?d"}})
 	if want := "https://a.com/a%20b%2Fc%3Fd/x"; d.URL != want {
 		t.Fatalf("URL = %q, want %q", d.URL, want)
 	}
@@ -293,13 +432,13 @@ func TestMacroAuthorityEscaping(t *testing.T) {
 		Default: []smartlink.Target{{URL: "https://cdn-{param.region}.example.com/lp"}},
 	})
 	// Legitimate per-region subdomains render untouched.
-	if got := link.Decide(smartlink.Visit{Params: map[string]string{"region": "eu-1"}}).URL; got != "https://cdn-eu-1.example.com/lp" {
+	if got := mustDecide(t, link, smartlink.Visit{Params: map[string]string{"region": "eu-1"}}).URL; got != "https://cdn-eu-1.example.com/lp" {
 		t.Fatalf("URL = %q", got)
 	}
 	// Hostile values cannot introduce userinfo, a port, or end the authority:
 	// the rendered URL still parses with a host under example.com.
 	for _, hostile := range []string{"evil.com@real.com", "a:9999", "evil.com/x", "e?y", "e#z"} {
-		got := link.Decide(smartlink.Visit{Params: map[string]string{"region": hostile}}).URL
+		got := mustDecide(t, link, smartlink.Visit{Params: map[string]string{"region": hostile}}).URL
 		u, err := url.Parse(got)
 		if err != nil {
 			t.Fatalf("region %q rendered unparseable URL %q: %v", hostile, got, err)
@@ -317,7 +456,7 @@ func TestMacroSchemeInjection(t *testing.T) {
 	link := mustCompile(t, smartlink.Spec{
 		Default: []smartlink.Target{{URL: "{param.p}/lp"}},
 	})
-	got := link.Decide(smartlink.Visit{Params: map[string]string{"p": "https://evil.com"}}).URL
+	got := mustDecide(t, link, smartlink.Visit{Params: map[string]string{"p": "https://evil.com"}}).URL
 	u, err := url.Parse(got)
 	if err != nil {
 		t.Fatalf("rendered unparseable URL %q: %v", got, err)
@@ -333,23 +472,23 @@ func TestParamPolicies(t *testing.T) {
 	visit := smartlink.Visit{Params: map[string]string{"keep": "new", "extra": "1", "": "skipme"}}
 
 	drop := mustCompile(t, smartlink.Spec{Default: target})
-	if got := drop.Decide(visit).URL; got != "https://a.com/lp?keep=orig" {
+	if got := mustDecide(t, drop, visit).URL; got != "https://a.com/lp?keep=orig" {
 		t.Fatalf("ParamsDrop URL = %q", got)
 	}
 
 	// Original target pairs stay first, verbatim; merged params append sorted.
 	fill := mustCompile(t, smartlink.Spec{Default: target, Params: smartlink.ParamsFill})
-	if got := fill.Decide(visit).URL; got != "https://a.com/lp?keep=orig&extra=1" {
+	if got := mustDecide(t, fill, visit).URL; got != "https://a.com/lp?keep=orig&extra=1" {
 		t.Fatalf("ParamsFill URL = %q", got)
 	}
 
 	override := mustCompile(t, smartlink.Spec{Default: target, Params: smartlink.ParamsOverride})
-	if got := override.Decide(visit).URL; got != "https://a.com/lp?keep=new&extra=1" {
+	if got := mustDecide(t, override, visit).URL; got != "https://a.com/lp?keep=new&extra=1" {
 		t.Fatalf("ParamsOverride URL = %q", got)
 	}
 
 	// No visit params: merge policies leave the URL untouched.
-	if got := fill.Decide(smartlink.Visit{}).URL; got != "https://a.com/lp?keep=orig" {
+	if got := mustDecide(t, fill, smartlink.Visit{}).URL; got != "https://a.com/lp?keep=orig" {
 		t.Fatalf("ParamsFill without params URL = %q", got)
 	}
 }
@@ -371,7 +510,7 @@ func TestPercentAndSplitDecorrelated(t *testing.T) {
 	})
 	a, b := 0, 0
 	for i := range 5000 {
-		d := link.Decide(smartlink.Visit{StickyKey: "k" + strconv.Itoa(i)})
+		d := mustDecide(t, link, smartlink.Visit{StickyKey: "k" + strconv.Itoa(i)})
 		switch d.URL {
 		case "https://a.com":
 			a++
@@ -401,7 +540,10 @@ func TestDecideConcurrent(t *testing.T) {
 	for g := range 8 {
 		wg.Go(func() {
 			for i := range 200 {
-				link.Decide(smartlink.Visit{Country: "DE", StickyKey: strconv.Itoa(g*1000 + i)})
+				if _, err := link.Decide(smartlink.Visit{Country: "DE", StickyKey: strconv.Itoa(g*1000 + i)}); err != nil {
+					t.Errorf("Decide() error = %v", err)
+					return
+				}
 			}
 		})
 	}
@@ -414,7 +556,7 @@ func TestDecisionReportsRawTarget(t *testing.T) {
 	link := mustCompile(t, smartlink.Spec{
 		Default: []smartlink.Target{{URL: tpl}},
 	})
-	d := link.Decide(smartlink.Visit{Country: "DE"})
+	d := mustDecide(t, link, smartlink.Visit{Country: "DE"})
 	if d.Target.URL != tpl {
 		t.Fatalf("Target.URL = %q, want raw template", d.Target.URL)
 	}
@@ -432,12 +574,12 @@ func TestParamMergePreservesRawPairs(t *testing.T) {
 
 	fill := mustCompile(t, smartlink.Spec{Default: target, Params: smartlink.ParamsFill})
 	visit := smartlink.Visit{Params: map[string]string{"sub": "123", "keep": "new"}}
-	if got, want := fill.Decide(visit).URL, "https://a.com/lp?promo=50%off&a=1;b=2&keep=orig&sub=123"; got != want {
+	if got, want := mustDecide(t, fill, visit).URL, "https://a.com/lp?promo=50%off&a=1;b=2&keep=orig&sub=123"; got != want {
 		t.Fatalf("ParamsFill URL = %q, want %q", got, want)
 	}
 
 	override := mustCompile(t, smartlink.Spec{Default: target, Params: smartlink.ParamsOverride})
-	if got, want := override.Decide(smartlink.Visit{Params: map[string]string{"keep": "new"}}).URL, "https://a.com/lp?promo=50%off&a=1;b=2&keep=new"; got != want {
+	if got, want := mustDecide(t, override, smartlink.Visit{Params: map[string]string{"keep": "new"}}).URL, "https://a.com/lp?promo=50%off&a=1;b=2&keep=new"; got != want {
 		t.Fatalf("ParamsOverride URL = %q, want %q", got, want)
 	}
 }
@@ -451,7 +593,7 @@ func TestParamOverrideCollapsesDuplicates(t *testing.T) {
 		Default: []smartlink.Target{{URL: "https://a.com/lp?k=1&k=2&x=9"}},
 		Params:  smartlink.ParamsOverride,
 	})
-	if got, want := link.Decide(smartlink.Visit{Params: map[string]string{"k": "new"}}).URL, "https://a.com/lp?k=new&x=9"; got != want {
+	if got, want := mustDecide(t, link, smartlink.Visit{Params: map[string]string{"k": "new"}}).URL, "https://a.com/lp?k=new&x=9"; got != want {
 		t.Fatalf("ParamsOverride URL = %q, want %q", got, want)
 	}
 }
@@ -472,7 +614,7 @@ func TestPercentConjunctionComposes(t *testing.T) {
 	const n = 20000
 	hits := 0
 	for i := range n {
-		if link.Decide(smartlink.Visit{StickyKey: fmt.Sprintf("k%d", i)}).Rule == "gate" {
+		if mustDecide(t, link, smartlink.Visit{StickyKey: fmt.Sprintf("k%d", i)}).Rule == "gate" {
 			hits++
 		}
 	}
@@ -501,11 +643,11 @@ func TestSaltDecorrelatesBucketing(t *testing.T) {
 	differ := 0
 	for i := range n {
 		key := fmt.Sprintf("k%d", i)
-		ua := a.Decide(smartlink.Visit{StickyKey: key}).URL
-		if got := a2.Decide(smartlink.Visit{StickyKey: key}).URL; got != ua {
+		ua := mustDecide(t, a, smartlink.Visit{StickyKey: key}).URL
+		if got := mustDecide(t, a2, smartlink.Visit{StickyKey: key}).URL; got != ua {
 			t.Fatalf("same salt diverged for key %q: %q vs %q", key, ua, got)
 		}
-		if b.Decide(smartlink.Visit{StickyKey: key}).URL != ua {
+		if mustDecide(t, b, smartlink.Visit{StickyKey: key}).URL != ua {
 			differ++
 		}
 	}

--- a/web/smartlink/decider.go
+++ b/web/smartlink/decider.go
@@ -4,15 +4,18 @@ import "slices"
 
 // Decider makes the per-click decision. *Compiled implements it; decorators
 // (fraud guards, metrics, A/B overrides) wrap a Decider to build another one.
+// An error refuses the click fail-closed — [Manager.Handler] answers 403 for
+// [ErrMissingFact] and 500 for anything else, never a redirect — so a
+// decorator may also reject a visit outright instead of inventing a decision.
 type Decider interface {
-	Decide(Visit) Decision
+	Decide(Visit) (Decision, error)
 }
 
 // DecideFunc adapts a plain function to a Decider.
-type DecideFunc func(Visit) Decision
+type DecideFunc func(Visit) (Decision, error)
 
 // Decide calls f.
-func (f DecideFunc) Decide(v Visit) Decision { return f(v) }
+func (f DecideFunc) Decide(v Visit) (Decision, error) { return f(v) }
 
 // Decorator wraps a Decider to produce another one, e.g. adding a fraud
 // guard, metrics, or an A/B override around Decide.

--- a/web/smartlink/decider_test.go
+++ b/web/smartlink/decider_test.go
@@ -1,6 +1,7 @@
 package smartlink_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/dmitrymomot/forge/web/smartlink"
@@ -14,8 +15,12 @@ func TestCompiledIsDecider(t *testing.T) {
 
 	link := mustCompile(t, smartlink.Spec{Default: defTargets()})
 	var d smartlink.Decider = link
-	if got := d.Decide(smartlink.Visit{}).URL; got != "https://example.com/" {
-		t.Fatalf("Decide via interface = %q, want default target", got)
+	dec, err := d.Decide(smartlink.Visit{})
+	if err != nil {
+		t.Fatalf("Decide via interface error = %v", err)
+	}
+	if dec.URL != "https://example.com/" {
+		t.Fatalf("Decide via interface = %q, want default target", dec.URL)
 	}
 }
 
@@ -23,10 +28,13 @@ func TestCompiledIsDecider(t *testing.T) {
 // delegating to the wrapped Decider, so composition order is observable.
 func tagDecorator(tag string) smartlink.Decorator {
 	return func(next smartlink.Decider) smartlink.Decider {
-		return smartlink.DecideFunc(func(v smartlink.Visit) smartlink.Decision {
-			d := next.Decide(v)
+		return smartlink.DecideFunc(func(v smartlink.Visit) (smartlink.Decision, error) {
+			d, err := next.Decide(v)
+			if err != nil {
+				return smartlink.Decision{}, err
+			}
 			d.Rule += tag
-			return d
+			return d, nil
 		})
 	}
 }
@@ -35,14 +43,16 @@ func tagDecorator(tag string) smartlink.Decorator {
 // d, and A's tag is applied last, ending up outermost in the result.
 func TestChainOrder(t *testing.T) {
 	t.Parallel()
-	base := smartlink.DecideFunc(func(smartlink.Visit) smartlink.Decision {
-		return smartlink.Decision{Rule: "base"}
+	base := smartlink.DecideFunc(func(smartlink.Visit) (smartlink.Decision, error) {
+		return smartlink.Decision{Rule: "base"}, nil
 	})
 	chained := smartlink.Chain(tagDecorator("A"), tagDecorator("B"), tagDecorator("C"))(base)
-	got := chained.Decide(smartlink.Visit{}).Rule
-	want := "baseCBA"
-	if got != want {
-		t.Fatalf("Chain(A, B, C)(base).Decide().Rule = %q, want %q", got, want)
+	got, err := chained.Decide(smartlink.Visit{})
+	if err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
+	if want := "baseCBA"; got.Rule != want {
+		t.Fatalf("Chain(A, B, C)(base).Decide().Rule = %q, want %q", got.Rule, want)
 	}
 }
 
@@ -50,12 +60,29 @@ func TestChainOrder(t *testing.T) {
 // Decider's decisions unchanged.
 func TestChainEmpty(t *testing.T) {
 	t.Parallel()
-	base := smartlink.DecideFunc(func(smartlink.Visit) smartlink.Decision {
-		return smartlink.Decision{Rule: "base", URL: "https://example.com/"}
+	base := smartlink.DecideFunc(func(smartlink.Visit) (smartlink.Decision, error) {
+		return smartlink.Decision{Rule: "base", URL: "https://example.com/"}, nil
 	})
-	got := smartlink.Chain()(base).Decide(smartlink.Visit{})
+	got, err := smartlink.Chain()(base).Decide(smartlink.Visit{})
+	if err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
 	want := smartlink.Decision{Rule: "base", URL: "https://example.com/"}
 	if got != want {
 		t.Fatalf("Chain()(base).Decide() = %+v, want %+v", got, want)
+	}
+}
+
+// TestChainPropagatesError asserts a wrapped Decider's refusal surfaces
+// through the decorator chain instead of being swallowed into a decision.
+func TestChainPropagatesError(t *testing.T) {
+	t.Parallel()
+	link := mustCompile(t, smartlink.Spec{
+		Rules:   []smartlink.Rule{rule("geo", "https://hit.com", smartlink.Geo{Countries: []string{"DE"}})},
+		Default: defTargets(),
+	})
+	chained := smartlink.Chain(tagDecorator("A"))(link)
+	if _, err := chained.Decide(smartlink.Visit{}); !errors.Is(err, smartlink.ErrMissingFact) {
+		t.Fatalf("Decide() error = %v, want ErrMissingFact through the chain", err)
 	}
 }

--- a/web/smartlink/doc.go
+++ b/web/smartlink/doc.go
@@ -19,7 +19,10 @@
 //	if err != nil {
 //		// handle error
 //	}
-//	d := link.Decide(smartlink.Visit{Country: "de", StickyKey: "visitor-42"})
+//	d, err := link.Decide(smartlink.Visit{Country: "de", StickyKey: "visitor-42"})
+//	if err != nil {
+//		// smartlink.ErrMissingFact: the visit lacks a fact the rules consult
+//	}
 //	// d.Rule == "de-mobile", d.URL == "https://a.example.com/lp"
 //
 // # Engine
@@ -28,13 +31,28 @@
 // of typed matchers ([Geo], [Device], [Locale], [ParamEquals],
 // [TimeWindow], [Percent]) evaluated over a caller-built [Visit], first
 // match wins, with a mandatory default target — and returns an immutable
-// [Compiled]; [Compiled.Decide] is the infallible per-click hot path. Rule
+// [Compiled]; [Compiled.Decide] is the per-click hot path. Rule
 // values are consumer data hydrated into the typed vocabulary — there is no
 // DSL, and rule storage/admin, target health checks, and bot filtering stay
 // consumer-side. The engine never imports net/http: the caller builds the
 // Visit from its own request facts (web/clientip + web/geoip for country,
 // web/useragent for device) and emits the returned [Decision] as the click
 // event.
+//
+// Decide fails closed on missing facts. A visit field the decision would
+// hinge on but doesn't carry — Country empty on a geoip miss while a Geo
+// rule is live, Device/Locale empty under an unparsed user agent, StickyKey
+// empty against a [Percent] gate or weighted split — returns
+// [ErrMissingFact] instead of silently falling through to the default
+// target or collapsing a split onto its first entry. A
+// restricted-jurisdictions rule therefore cannot stop firing just because
+// the country became unknowable. The gate is exact: a missing fact whose
+// rule is already definitively false on another matcher, or that only rules
+// after the winning one consult, does not error, and a spec that consults
+// no facts (the degenerate single-default-target short link) never fails.
+// [ParamEquals] deliberately treats an absent param as a non-match, not a
+// missing fact — params are click data, and their absence is a fact of the
+// click.
 //
 // Weighted splits and [Percent] shares bucket deterministically by FNV-1a
 // hash of [Spec.Salt], the rule name, and Visit.StickyKey — never RNG — so a

--- a/web/smartlink/errors.go
+++ b/web/smartlink/errors.go
@@ -2,9 +2,16 @@ package smartlink
 
 import "errors"
 
-// Compile-time validation errors. Match with errors.Is; Compile wraps each with
-// the offending rule, target, or matcher context. Decide never returns an error.
+// Engine errors. Match with errors.Is; Compile wraps each with the offending
+// rule, target, or matcher context. Decide fails only with [ErrMissingFact] —
+// every other failure mode is a Compile error.
 var (
+	// ErrMissingFact is returned by Decide when the outcome would depend on a
+	// visit fact the visit doesn't carry — a Geo/Device/Locale rule with the
+	// matching Visit field empty (geoip miss, unparsed user agent), or a
+	// Percent gate / weighted split with an empty StickyKey. Fail-closed: the
+	// click is refused instead of silently routed to the default target.
+	ErrMissingFact = errors.New("smartlink: missing visit fact")
 	// ErrNoDefault is returned when a Spec has no default target.
 	ErrNoDefault = errors.New("smartlink: no default target")
 	// ErrInvalidRule is returned for a rule with an empty or duplicate name, or no targets.

--- a/web/smartlink/example_test.go
+++ b/web/smartlink/example_test.go
@@ -30,12 +30,15 @@ func Example() {
 		panic(err)
 	}
 
-	d := link.Decide(smartlink.Visit{
+	d, err := link.Decide(smartlink.Visit{
 		Country:   "de",
 		Device:    "mobile",
 		StickyKey: "visitor-42",
 		Params:    map[string]string{"click_id": "abc123"},
 	})
+	if err != nil {
+		panic(err)
+	}
 	fmt.Println(d.Rule)
 	fmt.Println(d.URL)
 	// Output:

--- a/web/smartlink/handler.go
+++ b/web/smartlink/handler.go
@@ -29,6 +29,15 @@ import (
 // rule evaluation or offer update, so nothing here is safe for a client or
 // intermediary to cache.
 //
+// A visit the Decider refuses is never redirected: [ErrMissingFact] — the
+// link's rules consult a fact the visit doesn't carry, e.g. a Geo rule on a
+// geoip miss or a weighted split with no sticky key — answers 403 (logged at
+// warn), and any other Decider error answers 500. Fail-closed by design:
+// neither the default target nor [WithFallbackURL] is a safe destination for
+// a click the rules couldn't evaluate. A consumer that wants a friendlier
+// outcome (a compliance interstitial, a consent page) wraps the Decider with
+// a [Decorator] that catches [ErrMissingFact] and returns its own Decision.
+//
 // The Handler redirects for every HTTP method, including HEAD, and
 // [WithOnHit] fires for all of them alike — it does not special-case
 // method. A consumer that needs method awareness (e.g. to skip counting
@@ -74,7 +83,22 @@ func (m *Manager) Handler() http.Handler {
 			return
 		}
 
-		dec := d.Decide(v)
+		dec, err := d.Decide(v)
+		if err != nil {
+			// Fail closed: a click the engine refuses to route — a Geo rule
+			// with no country fact, a split with no sticky key — must never
+			// fall back to a redirect (the fallback URL is a destination, not
+			// a safe harbor). 403 for the per-visit data gap, 500 for
+			// anything else (a decorator failure is a consumer bug/outage).
+			if errors.Is(err, ErrMissingFact) {
+				m.cfg.logger.WarnContext(ctx, "smartlink: visit refused", "code", code, "error", err)
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+				return
+			}
+			m.cfg.logger.ErrorContext(ctx, "smartlink: decide error", "code", code, "error", err)
+			internalServerError(w)
+			return
+		}
 		http.Redirect(w, r, dec.URL, m.cfg.redirectStatus)
 		if m.cfg.onHit != nil {
 			// Cancellation-detached: a client that disconnects right after

--- a/web/smartlink/handler_test.go
+++ b/web/smartlink/handler_test.go
@@ -148,9 +148,9 @@ func TestHandlerVisitFuncEnriches(t *testing.T) {
 		}
 	})
 
-	t.Run("without VisitFunc falls to default", func(t *testing.T) {
+	t.Run("without VisitFunc fails closed", func(t *testing.T) {
 		t.Parallel()
-		m := newTestManager(t, smartlink.WithResolver(geoResolver()))
+		m := newTestManager(t, smartlink.WithResolver(geoResolver()), smartlink.WithFallbackURL("https://fallback.example.com/"))
 		l, err := m.Create(context.Background(), smartlink.CreateParams{Ref: "geo-1"})
 		if err != nil {
 			t.Fatalf("Create() error = %v, want nil", err)
@@ -162,8 +162,14 @@ func TestHandlerVisitFuncEnriches(t *testing.T) {
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, req)
 
-		if got, want := rec.Header().Get("Location"), "https://default.example.com/"; got != want {
-			t.Fatalf("Location = %q, want %q (default target)", got, want)
+		// The geo rule consults a country fact no VisitFunc supplied: the
+		// click must be refused, never redirected to the default target or
+		// the fallback URL.
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d (missing fact must fail closed)", rec.Code, http.StatusForbidden)
+		}
+		if got := rec.Header().Get("Location"); got != "" {
+			t.Fatalf("Location = %q, want no redirect on a refused visit", got)
 		}
 	})
 }
@@ -357,13 +363,21 @@ func TestHandlerDecoratorsWrapBothKinds(t *testing.T) {
 	t.Parallel()
 	const guardURL = "https://guard.example.com/"
 	divert := func(next smartlink.Decider) smartlink.Decider {
-		return smartlink.DecideFunc(func(v smartlink.Visit) smartlink.Decision {
-			d := next.Decide(v)
+		return smartlink.DecideFunc(func(v smartlink.Visit) (smartlink.Decision, error) {
+			d, err := next.Decide(v)
+			if err != nil {
+				return smartlink.Decision{}, err
+			}
 			d.URL = guardURL
-			return d
+			return d, nil
 		})
 	}
-	m := newTestManager(t, smartlink.WithResolver(geoResolver()), smartlink.WithDecorators(divert))
+	// A default-only resolver: the visits here carry no facts, and this test
+	// is about decorator coverage, not rule evaluation.
+	resolver := func(context.Context, smartlink.Link) (smartlink.Decider, error) {
+		return smartlink.Compile(smartlink.Spec{Default: []smartlink.Target{{URL: "https://offer.example.com/"}}})
+	}
+	m := newTestManager(t, smartlink.WithResolver(resolver), smartlink.WithDecorators(divert))
 	ctx := context.Background()
 
 	target, err := m.Create(ctx, smartlink.CreateParams{Target: "https://dest.example.com/"})

--- a/web/smartlink/matcher.go
+++ b/web/smartlink/matcher.go
@@ -38,41 +38,80 @@ const (
 // and the Visit never escapes (measured: 2 allocs → 0 on the literal decide;
 // see bench_test.go).
 type matcher struct {
-	from   time.Time
-	until  time.Time
-	key    string   // matchParam: the visit param key
-	values []string // matchGeo/matchDevice/matchLocale/matchParam: normalized any-of values
-	seed   uint64   // matchPercent: precomputed FNV state over the rule-name salt
-	share  uint64   // matchPercent: 1..99
-	kind   matcherKind
+	from    time.Time
+	until   time.Time
+	missErr error    // matchGeo/matchDevice/matchLocale/matchPercent: precomputed ErrMissingFact for an absent visit fact
+	key     string   // matchParam: the visit param key
+	values  []string // matchGeo/matchDevice/matchLocale/matchParam: normalized any-of values
+	seed    uint64   // matchPercent: precomputed FNV state over the rule-name salt
+	share   uint64   // matchPercent: 1..99
+	kind    matcherKind
 }
 
-// match reports whether the visit satisfies this condition. now is only
+// evalResult is a matcher's three-valued outcome: definitively false,
+// definitively true, or unknowable because the visit lacks the fact the
+// condition consults.
+type evalResult uint8
+
+const (
+	evalFalse evalResult = iota
+	evalTrue
+	evalMissing
+)
+
+// toEval converts a definite match outcome.
+func toEval(matched bool) evalResult {
+	if matched {
+		return evalTrue
+	}
+	return evalFalse
+}
+
+// eval reports whether the visit satisfies this condition, or evalMissing when
+// the visit lacks the consulted fact (m.missErr carries the caller-facing
+// error). ParamEquals is the deliberate exception: params are click data, so
+// an absent key is a definite fact about the click — a non-match — unlike an
+// unresolvable country, device, locale, or bucketing identity. now is only
 // meaningful for matchTime (resolved once per Decide when a link has any
 // TimeWindow).
-func (m *matcher) match(v *Visit, now time.Time) bool {
+func (m *matcher) eval(v *Visit, now time.Time) evalResult {
 	switch m.kind {
 	case matchGeo:
-		return containsFold(m.values, v.Country)
+		if v.Country == "" {
+			return evalMissing
+		}
+		return toEval(containsFold(m.values, v.Country))
 	case matchDevice:
-		return containsFold(m.values, v.Device)
+		if v.Device == "" {
+			return evalMissing
+		}
+		return toEval(containsFold(m.values, v.Device))
 	case matchLocale:
-		return localeMatches(m.values, v.Locale)
+		if v.Locale == "" {
+			return evalMissing
+		}
+		return toEval(localeMatches(m.values, v.Locale))
 	case matchParam:
 		pv, ok := v.Params[m.key]
-		return ok && slices.Contains(m.values, pv)
+		return toEval(ok && slices.Contains(m.values, pv))
 	case matchTime:
 		if !m.from.IsZero() && now.Before(m.from) {
-			return false
+			return evalFalse
 		}
-		return m.until.IsZero() || now.Before(m.until)
+		return toEval(m.until.IsZero() || now.Before(m.until))
 	case matchPercent:
 		if v.StickyKey == "" {
-			return false
+			return evalMissing
 		}
-		return hashString(m.seed, v.StickyKey)%100 < m.share
+		return toEval(hashString(m.seed, v.StickyKey)%100 < m.share)
 	}
-	return false // unreachable: compile only emits the kinds above
+	return evalFalse // unreachable: compile only emits the kinds above
+}
+
+// missingFactErr builds a matcher's precomputed ErrMissingFact so the Decide
+// hot path returns it without allocating.
+func missingFactErr(ruleName, kind, field string) error {
+	return fmt.Errorf("%w: rule %q: %s needs Visit.%s", ErrMissingFact, ruleName, kind, field)
 }
 
 // Geo matches when the visit country equals any listed ISO 3166-1 alpha-2
@@ -92,7 +131,7 @@ func (m Geo) compile(_, ruleName string, _ int) (matcher, error) {
 		}
 		countries[i] = strings.ToUpper(c)
 	}
-	return matcher{kind: matchGeo, values: countries}, nil
+	return matcher{kind: matchGeo, values: countries, missErr: missingFactErr(ruleName, "Geo", "Country")}, nil
 }
 
 // Device matches when the visit device class equals any listed value
@@ -106,7 +145,7 @@ func (m Device) compile(_, ruleName string, _ int) (matcher, error) {
 	if err != nil {
 		return matcher{}, err
 	}
-	return matcher{kind: matchDevice, values: devices}, nil
+	return matcher{kind: matchDevice, values: devices, missErr: missingFactErr(ruleName, "Device", "Device")}, nil
 }
 
 // Locale matches the visit locale against any listed BCP-47-style tag,
@@ -122,7 +161,7 @@ func (m Locale) compile(_, ruleName string, _ int) (matcher, error) {
 	if err != nil {
 		return matcher{}, err
 	}
-	return matcher{kind: matchLocale, values: locales}, nil
+	return matcher{kind: matchLocale, values: locales, missErr: missingFactErr(ruleName, "Locale", "Locale")}, nil
 }
 
 // localeMatches implements Locale semantics against pre-lowercased rule values.
@@ -182,7 +221,9 @@ func (m TimeWindow) compile(_, ruleName string, _ int) (matcher, error) {
 // rule compose as independent draws instead of collapsing into the wider one.
 // Reordering a rule's matchers therefore reassigns its Percent buckets.
 // Share must be 1..99 (0 is a dead rule, 100 is no gate — both compile
-// errors). An empty StickyKey never matches (fails closed past this rule).
+// errors). An empty StickyKey is a missing fact: a visit with no bucketing
+// identity cannot be drawn, so a decision that would hinge on this gate fails
+// closed with [ErrMissingFact] instead of silently skipping the rule.
 type Percent struct {
 	Share int
 }
@@ -192,7 +233,7 @@ func (m Percent) compile(salt, ruleName string, idx int) (matcher, error) {
 		return matcher{}, fmt.Errorf("%w: rule %q: Percent share %d outside 1..99", ErrInvalidMatcher, ruleName, m.Share)
 	}
 	seed := hashString(fnvOffset, "p\x00"+salt+"\x00"+ruleName+"\x00"+strconv.Itoa(idx))
-	return matcher{kind: matchPercent, seed: seed, share: uint64(m.Share)}, nil
+	return matcher{kind: matchPercent, seed: seed, share: uint64(m.Share), missErr: missingFactErr(ruleName, "Percent", "StickyKey")}, nil
 }
 
 // isAlpha reports whether s is ASCII letters only.

--- a/web/smartlink/visit.go
+++ b/web/smartlink/visit.go
@@ -22,9 +22,10 @@ type Visit struct {
 	// Locale is a BCP-47-style tag ("en" or "en-US"), any case.
 	Locale string
 	// StickyKey is the bucketing identity (click ID, visitor ID) that keeps
-	// Percent matchers and weighted splits deterministic per visitor. With an
-	// empty key, Percent never matches and splits pick their first target.
-	// Consumers typically set it to their fingerprint digest, so weighted-split
-	// stickiness and fraud identity agree by construction.
+	// Percent matchers and weighted splits deterministic per visitor. An empty
+	// key is a missing fact: a decision that would hinge on a Percent gate or
+	// weighted split fails closed with ErrMissingFact instead of guessing a
+	// bucket. Consumers typically set it to their fingerprint digest, so
+	// weighted-split stickiness and fraud identity agree by construction.
 	StickyKey string
 }


### PR DESCRIPTION
## What

`web/smartlink`'s decision engine failed open on missing visit facts:

- `matchGeo` was `containsFold(m.values, v.Country)` — an empty `Country` matches nothing, so a "restricted jurisdictions → compliance page" rule silently stopped firing on every geoip miss (private/loopback IP, IPv6 gap, absent CDN header, mmdb reload window, database gap) and `Decide` fell through to the default target. `Decide` "never fails" by contract, so there was no error path to catch it. For a licensed operator this routes sanctioned traffic to the main LP with zero signal.
- An empty `StickyKey` deterministically took `targets[0]`, so weighted splits silently collapsed onto one target instead of erroring; `Percent` gates silently skipped the rule.

## How

The gate now sits in front of rule evaluation, fail-closed on missing facts:

- **`Decide(Visit) (Decision, error)`** with a single decide-time sentinel **`ErrMissingFact`**; `Decider`/`DecideFunc` follow, so decorators can also refuse a click.
- **Three-valued, lazy-exact evaluation**: a matcher whose consulted fact is empty (`Geo`→`Country`, `Device`→`Device`, `Locale`→`Locale`, `Percent`→`StickyKey`) evaluates as *missing*, not *false*. A rule that is definitively false on another matcher is skipped normally regardless of matcher order, and an earlier matching rule wins normally — the error surfaces only when the decision provably hinges on the missing fact. A spec that consults no facts (the degenerate single-default-target short link) still never fails.
- **Splits**: an empty `StickyKey` against a multi-target split (rule or default) returns `ErrMissingFact` instead of collapsing onto the first target.
- **`ParamEquals` deliberately keeps absent-param = definite non-match**: params are click data; their absence is a fact of the click, unlike an unresolvable country/device/locale/identity.
- **`Manager.Handler`**: `ErrMissingFact` → 403 (warn log), any other Decider error → 500 — never the default target and never `WithFallbackURL`, since neither is a safe destination for a click the rules couldn't evaluate. A consumer wanting a compliance interstitial wraps the Decider with a `Decorator` that catches `ErrMissingFact`.
- The missing-fact errors are **precomputed at compile** per matcher/split, so the hot path returns them without allocating.

## Breaking change

`Decider`/`DecideFunc`/`Compiled.Decide` signatures changed; all in-repo consumers (handler, cache resolver, examples, tests) are migrated. Handler behavior change: a Ref link whose rules consult a fact the Visit doesn't carry now answers 403 instead of redirecting to the default target.

## Benchmarks

`benchstat` old→new (Apple M-series, `-count=8`), hot path stays 0 B/op, 0 allocs/op:

| bench | old | new | Δ |
|---|---|---|---|
| DecideLiteral | 23.27n ± 1% | 24.38n ± 1% | +4.75% |
| DecideSplit | 16.18n ± 1% | 16.75n ± 0% | +3.52% |
| DecideBare | 10.14n ± 1% | 8.85n ± 0% | −12.73% |
| Chain3 | 41.34n ± 0% | 39.12n ± 0% | −5.37% |

Net ~−2.7% geomean; the ±1ns deltas are the extra empty-fact branches vs. the removed empty-key branch in `pick`.

## Tests

TDD, new tests watched failing first: per-kind missing-fact refusal; laziness proofs (earlier rule matched, definitively-false sibling, order independence); empty-sticky refusal at rule and default split level; error propagation through `Chain`; handler 403 with no `Location` when a geo-rule link gets no country fact (previously asserted the fail-open default redirect). Old tests pinning the fail-open behaviors inverted. `just lint`, nilaway, modernize, and the full repo suite pass.
