### PR TITLE
feat(auth/invite): single-use tenant invitations with token rotation

### DIFF
--- a/auth/invite/bench_test.go
+++ b/auth/invite/bench_test.go
@@ -1,0 +1,73 @@
+package invite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/invite"
+)
+
+func BenchmarkCreate(b *testing.B) {
+	mgr := invite.New(invite.NewMemoryStore())
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, _, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com", Tenant: "t1", Role: "editor"}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPeek(b *testing.B) {
+	// The token-verification path minus the consuming write.
+	mgr := invite.New(invite.NewMemoryStore())
+	ctx := context.Background()
+	_, plaintext, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com", Tenant: "t1"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Peek(ctx, plaintext); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPeekMalformedReject(b *testing.B) {
+	// The DoS-relevant path: checksum rejection without store access.
+	// Target: zero allocations.
+	mgr := invite.New(invite.NewMemoryStore())
+	ctx := context.Background()
+	_, plaintext, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	bad := plaintext[:len(plaintext)-1] + "!"
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := mgr.Peek(ctx, bad); err == nil {
+			b.Fatal("expected rejection")
+		}
+	}
+}
+
+func BenchmarkListPending(b *testing.B) {
+	mgr := invite.New(invite.NewMemoryStore())
+	ctx := context.Background()
+	for range 100 {
+		if _, _, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com", Tenant: "t1"}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		out, err := mgr.List(ctx, invite.Filter{Tenant: "t1", Pending: true})
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(out) != 100 {
+			b.Fatalf("got %d", len(out))
+		}
+	}
+}

--- a/auth/invite/doc.go
+++ b/auth/invite/doc.go
@@ -1,0 +1,39 @@
+// Package invite issues and redeems token invitations into a tenant:
+// email-addressed, single-use, expiring invites carrying an opaque role
+// payload the package never interprets. Tokens follow the apikey
+// discipline — inv_-prefixed secrets with a CRC32 checksum that rejects
+// malformed input before any store access, SHA-256 hashes at rest, and
+// the plaintext returned exactly once at creation (and on resend, which
+// rotates the token). Accepting is constant-time and atomically
+// single-use: exactly one Accept wins, replays report ErrAlreadyAccepted.
+//
+// The package stops at the verified claim: Accept returns the {tenant,
+// email, role} the token proves, and membership creation, seat limits,
+// and the email send itself (comms/email) stay consumer-side.
+//
+//	store := invite.NewMemoryStore() // pgstore.New(pool) in production
+//	mgr := invite.New(store, invite.WithTTL(72*time.Hour))
+//
+//	inv, plaintext, err := mgr.Create(ctx, invite.CreateParams{
+//		Email: "new.hire@example.com", Tenant: "org_7", Role: "editor",
+//	})
+//	// Email a link carrying plaintext — only its SHA-256 is stored.
+//
+//	claim, err := mgr.Accept(ctx, plaintext)
+//	// claim == {Tenant: "org_7", Email: "new.hire@example.com", Role: "editor", ...}
+//	// Now create the membership in your own tables.
+//
+// Peek verifies without consuming — serve it on GET so email scanners
+// that prefetch links cannot burn the invite, and to render the "join
+// org" page before the user commits.
+//
+// Multi-tenant applications confine management operations with WithScope;
+// Accept and Peek need no hook because the invitee typically has no
+// tenant context yet — the invite record itself carries the tenant:
+//
+//	mgr := invite.New(store, invite.WithScope(func(ctx context.Context) (string, error) {
+//		return tenantFromCtx(ctx), nil // fail-closed: empty or error aborts
+//	}))
+//
+// Domain auto-join and shareable multi-use links are out of scope.
+package invite

--- a/auth/invite/errors.go
+++ b/auth/invite/errors.go
@@ -1,0 +1,42 @@
+package invite
+
+import "errors"
+
+var (
+	// ErrNotFound is returned by a Store when no record matches, and by
+	// management operations for other tenants' invites under WithScope (so
+	// cross-tenant existence cannot be probed).
+	ErrNotFound = errors.New("invite: record not found")
+
+	// ErrDuplicate is returned by Store.Create and Store.Rotate when a
+	// record with the same ID or Hash already exists.
+	ErrDuplicate = errors.New("invite: duplicate record")
+
+	// ErrMalformedToken rejects tokens failing prefix/length/checksum
+	// validation — decided before any store access.
+	ErrMalformedToken = errors.New("invite: malformed token")
+
+	// ErrInviteNotFound rejects well-formed tokens with no matching record.
+	ErrInviteNotFound = errors.New("invite: invite not found")
+
+	// ErrRevoked rejects operations on revoked invites.
+	ErrRevoked = errors.New("invite: invite revoked")
+
+	// ErrAlreadyAccepted rejects operations on already-accepted invites —
+	// including a second Accept, which is how single-use is surfaced.
+	ErrAlreadyAccepted = errors.New("invite: invite already accepted")
+
+	// ErrExpired rejects operations on expired invites.
+	ErrExpired = errors.New("invite: invite expired")
+
+	// ErrEmailRequired rejects CreateParams with an empty Email.
+	ErrEmailRequired = errors.New("invite: email required")
+
+	// ErrTenantMismatch rejects management calls whose explicit tenant
+	// conflicts with the WithScope-derived tenant.
+	ErrTenantMismatch = errors.New("invite: tenant mismatch")
+
+	// ErrScope fails management operations closed when the WithScope hook
+	// errors or yields an empty tenant.
+	ErrScope = errors.New("invite: tenant scope unavailable")
+)

--- a/auth/invite/fuzz_test.go
+++ b/auth/invite/fuzz_test.go
@@ -1,0 +1,38 @@
+package invite_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dmitrymomot/forge/auth/invite"
+)
+
+// FuzzPeek asserts the core property: no input other than the real
+// plaintext ever verifies, and no input panics the parser. Peek (not
+// Accept) keeps the invite unconsumed across iterations.
+func FuzzPeek(f *testing.F) {
+	mgr := invite.New(invite.NewMemoryStore())
+	_, plaintext, err := mgr.Create(context.Background(), invite.CreateParams{Email: "a@b.com", Tenant: "t1"})
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	f.Add(plaintext)
+	f.Add("")
+	f.Add("inv_")
+	f.Add("inv_" + strings.Repeat("a", 49))
+	f.Add(plaintext[:len(plaintext)-1] + "!")
+
+	f.Fuzz(func(t *testing.T, token string) {
+		claim, err := mgr.Peek(context.Background(), token)
+		if err == nil {
+			if token != plaintext {
+				t.Fatalf("accepted forged token %q", token)
+			}
+			if claim.Email != "a@b.com" || claim.Tenant != "t1" {
+				t.Fatalf("wrong claim %+v", claim)
+			}
+		}
+	})
+}

--- a/auth/invite/invite.go
+++ b/auth/invite/invite.go
@@ -1,0 +1,54 @@
+package invite
+
+import (
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Invite is the stored invitation record. It never contains the plaintext
+// token: Hash is the hex SHA-256 of the full plaintext, returned exactly
+// once by Create and Resend.
+type Invite struct {
+	CreatedAt  time.Time
+	ExpiresAt  time.Time // always set — invites expire
+	AcceptedAt time.Time // zero = not accepted
+	RevokedAt  time.Time // zero = not revoked
+	Hash       string    // hex SHA-256 of the full plaintext token
+	Email      string    // invitee address the token was issued for
+	Tenant     string    // tenant being joined; empty in single-tenant apps
+	Role       string    // opaque consumer payload — never interpreted here
+	ID         id.UUID   // UUIDv7 record id — time-ordered, never secret-derived
+}
+
+// Pending reports whether the invite is still acceptable at now: not
+// accepted, not revoked, not expired.
+func (i Invite) Pending(now time.Time) bool {
+	return i.AcceptedAt.IsZero() && i.RevokedAt.IsZero() && i.ExpiresAt.After(now)
+}
+
+// CreateParams describes an invite to mint. Email is required; Role is an
+// opaque payload (a role name, a JSON blob — the package never reads it).
+type CreateParams struct {
+	Email  string // required
+	Tenant string // optional; constrained by the WithScope hook when set
+	Role   string // opaque; carried verbatim into the accept Claim
+}
+
+// Filter narrows List results. Zero fields match everything; Pending
+// restricts to invites still acceptable at query time.
+type Filter struct {
+	Email   string
+	Tenant  string
+	Pending bool
+}
+
+// Claim is the verified result of accepting an invite: the tenant being
+// joined, the email the token was addressed to, and the opaque role
+// payload. Membership creation from a Claim is the consumer's job.
+type Claim struct {
+	Tenant string
+	Email  string
+	Role   string
+	ID     id.UUID // accepted invite's record id, for audit trails
+}

--- a/auth/invite/manager.go
+++ b/auth/invite/manager.go
@@ -1,0 +1,214 @@
+package invite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/crypto/consttime"
+)
+
+// Manager issues, manages, and accepts tenant invitations over a Store.
+// Safe for concurrent use.
+type Manager struct {
+	store Store
+	cfg   config
+}
+
+// New builds a Manager. It panics on a nil store or a non-positive TTL —
+// wiring bugs caught at startup, like apikey.New's nil-store panic.
+func New(store Store, opts ...Option) *Manager {
+	if store == nil {
+		panic("invite: nil store")
+	}
+	cfg := config{ttl: 7 * 24 * time.Hour}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.ttl <= 0 {
+		panic(fmt.Sprintf("invite: non-positive TTL %s", cfg.ttl))
+	}
+	return &Manager{store: store, cfg: cfg}
+}
+
+// Create mints an invite for p, returning the stored record and the
+// plaintext token. The plaintext is shown exactly once — only its hash is
+// persisted; sending it (comms/email) is the consumer's job.
+func (m *Manager) Create(ctx context.Context, p CreateParams) (Invite, string, error) {
+	if p.Email == "" {
+		return Invite{}, "", ErrEmailRequired
+	}
+	tenant, err := m.scoped(ctx, p.Tenant)
+	if err != nil {
+		return Invite{}, "", err
+	}
+	plaintext := newToken()
+	now := time.Now().UTC()
+	inv := Invite{
+		ID:        id.NewUUID(),
+		Hash:      hashToken(plaintext),
+		Email:     p.Email,
+		Tenant:    tenant,
+		Role:      p.Role,
+		CreatedAt: now,
+		ExpiresAt: now.Add(m.cfg.ttl),
+	}
+	if err := m.store.Create(ctx, inv); err != nil {
+		return Invite{}, "", fmt.Errorf("invite: create: %w", err)
+	}
+	return inv, plaintext, nil
+}
+
+// scoped resolves the tenant a management operation is confined to. With
+// no WithScope hook it passes the requested tenant through. Fail-closed:
+// hook errors and empty scoped tenants abort the operation with ErrScope;
+// an explicit requested tenant must be empty or equal to the scoped one.
+func (m *Manager) scoped(ctx context.Context, requested string) (string, error) {
+	if m.cfg.scope == nil {
+		return requested, nil
+	}
+	t, err := m.cfg.scope(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrScope, err)
+	}
+	if t == "" {
+		return "", ErrScope
+	}
+	if requested != "" && requested != t {
+		return "", ErrTenantMismatch
+	}
+	return t, nil
+}
+
+// Get returns one invite record. With WithScope configured, other tenants'
+// invites read as ErrNotFound so existence cannot be probed across tenants.
+func (m *Manager) Get(ctx context.Context, inviteID id.UUID) (Invite, error) {
+	tenant, err := m.scoped(ctx, "")
+	if err != nil {
+		return Invite{}, err
+	}
+	inv, err := m.store.Get(ctx, inviteID)
+	if err != nil {
+		return Invite{}, err
+	}
+	if m.cfg.scope != nil && inv.Tenant != tenant {
+		return Invite{}, ErrNotFound
+	}
+	return inv, nil
+}
+
+// List returns invites matching f, newest first. With WithScope configured
+// the filter is confined to the scoped tenant.
+func (m *Manager) List(ctx context.Context, f Filter) ([]Invite, error) {
+	tenant, err := m.scoped(ctx, f.Tenant)
+	if err != nil {
+		return nil, err
+	}
+	f.Tenant = tenant
+	return m.store.List(ctx, f)
+}
+
+// Revoke withdraws a pending invite so its token can never be accepted.
+// Revoking an already-revoked invite is a no-op; an accepted one reports
+// ErrAlreadyAccepted — revocation does not undo membership.
+func (m *Manager) Revoke(ctx context.Context, inviteID id.UUID) error {
+	if _, err := m.Get(ctx, inviteID); err != nil {
+		return err
+	}
+	return m.store.Revoke(ctx, inviteID, time.Now().UTC())
+}
+
+// Resend rotates the invite's token for another delivery attempt: a fresh
+// plaintext, a fresh expiry window, and the old token dead — resending a
+// leaked or expired invite never revives the previous token. Accepted and
+// revoked invites report ErrAlreadyAccepted / ErrRevoked. The send itself
+// stays consumer-side.
+func (m *Manager) Resend(ctx context.Context, inviteID id.UUID) (Invite, string, error) {
+	inv, err := m.Get(ctx, inviteID)
+	if err != nil {
+		return Invite{}, "", err
+	}
+	switch {
+	case !inv.AcceptedAt.IsZero():
+		return Invite{}, "", ErrAlreadyAccepted
+	case !inv.RevokedAt.IsZero():
+		return Invite{}, "", ErrRevoked
+	}
+	plaintext := newToken()
+	hash := hashToken(plaintext)
+	expiresAt := time.Now().UTC().Add(m.cfg.ttl)
+	if err := m.store.Rotate(ctx, inviteID, hash, expiresAt); err != nil {
+		return Invite{}, "", fmt.Errorf("invite: resend: %w", err)
+	}
+	inv.Hash = hash
+	inv.ExpiresAt = expiresAt
+	return inv, plaintext, nil
+}
+
+// Accept redeems a plaintext token exactly once and returns the verified
+// claim. Malformed tokens are rejected before any store access; the
+// store's atomic accept is the single-use guard, so under a race exactly
+// one caller wins and the rest see ErrAlreadyAccepted. Accept is
+// deliberately unscoped — the invitee typically has no tenant context yet;
+// the returned Claim carries the tenant to join.
+func (m *Manager) Accept(ctx context.Context, token string) (Claim, error) {
+	inv, err := m.verify(ctx, token)
+	if err != nil {
+		return Claim{}, err
+	}
+	if err := m.store.Accept(ctx, inv.ID, time.Now().UTC()); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			// The record vanished between lookup and accept.
+			return Claim{}, ErrInviteNotFound
+		}
+		return Claim{}, fmt.Errorf("invite: accept: %w", err)
+	}
+	return claim(inv), nil
+}
+
+// Peek verifies a token without consuming it — serve it on GET so email
+// scanners that prefetch links cannot burn the invite, and to render the
+// "join <tenant>" page before the user commits. The consuming Accept is
+// authoritative.
+func (m *Manager) Peek(ctx context.Context, token string) (Claim, error) {
+	inv, err := m.verify(ctx, token)
+	if err != nil {
+		return Claim{}, err
+	}
+	return claim(inv), nil
+}
+
+// verify resolves a plaintext token to its still-pending invite record.
+func (m *Manager) verify(ctx context.Context, token string) (Invite, error) {
+	if !validToken(token) {
+		return Invite{}, ErrMalformedToken
+	}
+	h := hashToken(token)
+	inv, err := m.store.GetByHash(ctx, h)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return Invite{}, ErrInviteNotFound
+		}
+		return Invite{}, fmt.Errorf("invite: verify: %w", err)
+	}
+	// Defense-in-depth: a buggy store returning the wrong record (or a
+	// corrupt email-less row) must not mint a claim.
+	if !consttime.StringEqual(inv.Hash, h) || inv.Email == "" {
+		return Invite{}, ErrInviteNotFound
+	}
+	switch {
+	case !inv.RevokedAt.IsZero():
+		return Invite{}, ErrRevoked
+	case !inv.AcceptedAt.IsZero():
+		return Invite{}, ErrAlreadyAccepted
+	case !inv.ExpiresAt.After(time.Now().UTC()):
+		return Invite{}, ErrExpired
+	}
+	return inv, nil
+}
+
+func claim(inv Invite) Claim {
+	return Claim{Tenant: inv.Tenant, Email: inv.Email, Role: inv.Role, ID: inv.ID}
+}

--- a/auth/invite/manager_test.go
+++ b/auth/invite/manager_test.go
@@ -1,0 +1,311 @@
+package invite_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/invite"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+func newManager(t *testing.T, opts ...invite.Option) *invite.Manager {
+	t.Helper()
+	return invite.New(invite.NewMemoryStore(), opts...)
+}
+
+func TestNew_Panics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { invite.New(nil) })
+	assert.Panics(t, func() { invite.New(invite.NewMemoryStore(), invite.WithTTL(0)) })
+	assert.Panics(t, func() { invite.New(invite.NewMemoryStore(), invite.WithTTL(-time.Hour)) })
+}
+
+func TestCreate(t *testing.T) {
+	t.Parallel()
+	mgr := newManager(t, invite.WithTTL(time.Hour))
+	ctx := context.Background()
+
+	before := time.Now().UTC()
+	inv, plaintext, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com", Tenant: "t1", Role: "editor"})
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(plaintext, "inv_"))
+	assert.NotContains(t, plaintext, inv.Hash, "plaintext must not embed the hash")
+	assert.Equal(t, "a@b.com", inv.Email)
+	assert.Equal(t, "t1", inv.Tenant)
+	assert.Equal(t, "editor", inv.Role)
+	assert.False(t, inv.ID.IsZero())
+	assert.True(t, inv.Pending(time.Now().UTC()))
+	assert.WithinRange(t, inv.ExpiresAt, before.Add(time.Hour), time.Now().UTC().Add(time.Hour))
+
+	// Only the hash is persisted — the stored record matches the returned one.
+	got, err := mgr.Get(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, inv.Hash, got.Hash)
+	assert.NotEqual(t, plaintext, got.Hash)
+}
+
+func TestCreate_EmailRequired(t *testing.T) {
+	t.Parallel()
+	mgr := newManager(t)
+	_, _, err := mgr.Create(context.Background(), invite.CreateParams{})
+	assert.ErrorIs(t, err, invite.ErrEmailRequired)
+}
+
+func TestAccept(t *testing.T) {
+	t.Parallel()
+	mgr := newManager(t)
+	ctx := context.Background()
+	inv, plaintext, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com", Tenant: "t1", Role: "admin"})
+	require.NoError(t, err)
+
+	claim, err := mgr.Accept(ctx, plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, invite.Claim{Tenant: "t1", Email: "a@b.com", Role: "admin", ID: inv.ID}, claim)
+
+	got, err := mgr.Get(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.False(t, got.AcceptedAt.IsZero())
+	assert.False(t, got.Pending(time.Now().UTC()))
+
+	// Single-use: the replay reports ErrAlreadyAccepted.
+	_, err = mgr.Accept(ctx, plaintext)
+	assert.ErrorIs(t, err, invite.ErrAlreadyAccepted)
+}
+
+func TestAccept_Rejections(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("malformed", func(t *testing.T) {
+		t.Parallel()
+		mgr := newManager(t)
+		for _, tok := range []string{"", "inv_", "garbage", strings.Repeat("a", 53), "inv_" + strings.Repeat("a", 49)} {
+			_, err := mgr.Accept(ctx, tok)
+			assert.ErrorIs(t, err, invite.ErrMalformedToken, "token %q", tok)
+		}
+	})
+
+	t.Run("wellformed unknown", func(t *testing.T) {
+		t.Parallel()
+		mgr := newManager(t)
+		_, other, err := newManager(t).Create(ctx, invite.CreateParams{Email: "a@b.com"})
+		require.NoError(t, err)
+		_, err = mgr.Accept(ctx, other) // valid structure, no record in this store
+		assert.ErrorIs(t, err, invite.ErrInviteNotFound)
+	})
+
+	t.Run("revoked", func(t *testing.T) {
+		t.Parallel()
+		mgr := newManager(t)
+		inv, plaintext, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com"})
+		require.NoError(t, err)
+		require.NoError(t, mgr.Revoke(ctx, inv.ID))
+		_, err = mgr.Accept(ctx, plaintext)
+		assert.ErrorIs(t, err, invite.ErrRevoked)
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		t.Parallel()
+		mgr := newManager(t, invite.WithTTL(time.Nanosecond))
+		_, plaintext, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com"})
+		require.NoError(t, err)
+		_, err = mgr.Accept(ctx, plaintext)
+		assert.ErrorIs(t, err, invite.ErrExpired)
+	})
+}
+
+func TestAccept_ConcurrentSingleUse(t *testing.T) {
+	t.Parallel()
+	mgr := newManager(t)
+	ctx := context.Background()
+	_, plaintext, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com"})
+	require.NoError(t, err)
+
+	const n = 32
+	var wg sync.WaitGroup
+	wins := make(chan invite.Claim, n)
+	var start sync.WaitGroup
+	start.Add(1)
+	for range n {
+		wg.Go(func() {
+			start.Wait()
+			if claim, err := mgr.Accept(ctx, plaintext); err == nil {
+				wins <- claim
+			} else {
+				assert.ErrorIs(t, err, invite.ErrAlreadyAccepted)
+			}
+		})
+	}
+	start.Done()
+	wg.Wait()
+	close(wins)
+	assert.Len(t, wins, 1, "exactly one concurrent accept must win")
+}
+
+func TestPeek_DoesNotConsume(t *testing.T) {
+	t.Parallel()
+	mgr := newManager(t)
+	ctx := context.Background()
+	inv, plaintext, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com", Tenant: "t1", Role: "viewer"})
+	require.NoError(t, err)
+
+	for range 3 { // scanner prefetches must not burn the invite
+		claim, err := mgr.Peek(ctx, plaintext)
+		require.NoError(t, err)
+		assert.Equal(t, invite.Claim{Tenant: "t1", Email: "a@b.com", Role: "viewer", ID: inv.ID}, claim)
+	}
+
+	_, err = mgr.Accept(ctx, plaintext)
+	require.NoError(t, err)
+	_, err = mgr.Peek(ctx, plaintext)
+	assert.ErrorIs(t, err, invite.ErrAlreadyAccepted)
+}
+
+func TestRevoke(t *testing.T) {
+	t.Parallel()
+	mgr := newManager(t)
+	ctx := context.Background()
+
+	t.Run("pending then idempotent", func(t *testing.T) {
+		t.Parallel()
+		inv, _, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com"})
+		require.NoError(t, err)
+		require.NoError(t, mgr.Revoke(ctx, inv.ID))
+		got, err := mgr.Get(ctx, inv.ID)
+		require.NoError(t, err)
+		first := got.RevokedAt
+		require.False(t, first.IsZero())
+
+		require.NoError(t, mgr.Revoke(ctx, inv.ID)) // no-op
+		got, err = mgr.Get(ctx, inv.ID)
+		require.NoError(t, err)
+		assert.Equal(t, first, got.RevokedAt, "second revoke must keep the original timestamp")
+	})
+
+	t.Run("accepted", func(t *testing.T) {
+		t.Parallel()
+		inv, plaintext, err := mgr.Create(ctx, invite.CreateParams{Email: "b@b.com"})
+		require.NoError(t, err)
+		_, err = mgr.Accept(ctx, plaintext)
+		require.NoError(t, err)
+		assert.ErrorIs(t, mgr.Revoke(ctx, inv.ID), invite.ErrAlreadyAccepted)
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+		t.Parallel()
+		assert.ErrorIs(t, mgr.Revoke(ctx, id.NewUUID()), invite.ErrNotFound)
+	})
+}
+
+func TestResend(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("rotates token and expiry", func(t *testing.T) {
+		t.Parallel()
+		mgr := newManager(t)
+		inv, oldToken, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com", Tenant: "t1", Role: "editor"})
+		require.NoError(t, err)
+
+		fresh, newToken, err := mgr.Resend(ctx, inv.ID)
+		require.NoError(t, err)
+		assert.NotEqual(t, oldToken, newToken)
+		assert.Equal(t, inv.ID, fresh.ID)
+		assert.NotEqual(t, inv.Hash, fresh.Hash)
+		assert.False(t, fresh.ExpiresAt.Before(inv.ExpiresAt))
+
+		// The old token is dead; the new one carries the same claim.
+		_, err = mgr.Accept(ctx, oldToken)
+		assert.ErrorIs(t, err, invite.ErrInviteNotFound)
+		claim, err := mgr.Accept(ctx, newToken)
+		require.NoError(t, err)
+		assert.Equal(t, invite.Claim{Tenant: "t1", Email: "a@b.com", Role: "editor", ID: inv.ID}, claim)
+	})
+
+	t.Run("revives expired invite", func(t *testing.T) {
+		t.Parallel()
+		mgr := newManager(t, invite.WithTTL(time.Nanosecond))
+		inv, stale, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com"})
+		require.NoError(t, err)
+		_, err = mgr.Accept(ctx, stale)
+		require.ErrorIs(t, err, invite.ErrExpired)
+
+		// A fresh TTL applies from resend time; nanosecond TTL keeps it
+		// expired, which is fine — what matters is the rotation succeeded.
+		fresh, rotated, err := mgr.Resend(ctx, inv.ID)
+		require.NoError(t, err)
+		assert.NotEqual(t, stale, rotated)
+		assert.True(t, fresh.ExpiresAt.After(inv.ExpiresAt))
+	})
+
+	t.Run("accepted", func(t *testing.T) {
+		t.Parallel()
+		mgr := newManager(t)
+		inv, plaintext, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com"})
+		require.NoError(t, err)
+		_, err = mgr.Accept(ctx, plaintext)
+		require.NoError(t, err)
+		_, _, err = mgr.Resend(ctx, inv.ID)
+		assert.ErrorIs(t, err, invite.ErrAlreadyAccepted)
+	})
+
+	t.Run("revoked", func(t *testing.T) {
+		t.Parallel()
+		mgr := newManager(t)
+		inv, _, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com"})
+		require.NoError(t, err)
+		require.NoError(t, mgr.Revoke(ctx, inv.ID))
+		_, _, err = mgr.Resend(ctx, inv.ID)
+		assert.ErrorIs(t, err, invite.ErrRevoked)
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+		t.Parallel()
+		mgr := newManager(t)
+		_, _, err := mgr.Resend(ctx, id.NewUUID())
+		assert.ErrorIs(t, err, invite.ErrNotFound)
+	})
+}
+
+func TestList(t *testing.T) {
+	t.Parallel()
+	mgr := newManager(t)
+	ctx := context.Background()
+
+	a, _, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com", Tenant: "t1"})
+	require.NoError(t, err)
+	b, bTok, err := mgr.Create(ctx, invite.CreateParams{Email: "b@b.com", Tenant: "t1"})
+	require.NoError(t, err)
+	c, _, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com", Tenant: "t2"})
+	require.NoError(t, err)
+
+	all, err := mgr.List(ctx, invite.Filter{})
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	// Ordering is untested here: same-millisecond UUIDv7 ids have random
+	// tails (store_test pins ordering with handcrafted ids).
+	t1, err := mgr.List(ctx, invite.Filter{Tenant: "t1"})
+	require.NoError(t, err)
+	require.Len(t, t1, 2)
+	assert.ElementsMatch(t, []id.UUID{a.ID, b.ID}, []id.UUID{t1[0].ID, t1[1].ID})
+
+	byEmail, err := mgr.List(ctx, invite.Filter{Email: "a@b.com"})
+	require.NoError(t, err)
+	assert.Len(t, byEmail, 2)
+
+	// Accepting b removes it from the pending view only.
+	_, err = mgr.Accept(ctx, bTok)
+	require.NoError(t, err)
+	pending, err := mgr.List(ctx, invite.Filter{Pending: true})
+	require.NoError(t, err)
+	require.Len(t, pending, 2)
+	assert.ElementsMatch(t, []id.UUID{a.ID, c.ID}, []id.UUID{pending[0].ID, pending[1].ID})
+}

--- a/auth/invite/memory.go
+++ b/auth/invite/memory.go
@@ -1,0 +1,142 @@
+package invite
+
+import (
+	"bytes"
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+type memoryStore struct {
+	byID   map[id.UUID]Invite
+	byHash map[string]id.UUID
+	mu     sync.RWMutex
+}
+
+// NewMemoryStore returns an in-memory Store for tests and development.
+func NewMemoryStore() Store {
+	return &memoryStore{
+		byID:   make(map[id.UUID]Invite),
+		byHash: make(map[string]id.UUID),
+	}
+}
+
+func (s *memoryStore) Create(_ context.Context, inv Invite) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.byID[inv.ID]; ok {
+		return ErrDuplicate
+	}
+	if _, ok := s.byHash[inv.Hash]; ok {
+		return ErrDuplicate
+	}
+	s.byID[inv.ID] = inv
+	s.byHash[inv.Hash] = inv.ID
+	return nil
+}
+
+func (s *memoryStore) Get(_ context.Context, inviteID id.UUID) (Invite, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	inv, ok := s.byID[inviteID]
+	if !ok {
+		return Invite{}, ErrNotFound
+	}
+	return inv, nil
+}
+
+func (s *memoryStore) GetByHash(_ context.Context, hash string) (Invite, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	inviteID, ok := s.byHash[hash]
+	if !ok {
+		return Invite{}, ErrNotFound
+	}
+	return s.byID[inviteID], nil
+}
+
+func (s *memoryStore) List(_ context.Context, f Filter) ([]Invite, error) {
+	now := time.Now().UTC()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Invite, 0, len(s.byID))
+	for _, inv := range s.byID {
+		if f.Email != "" && inv.Email != f.Email {
+			continue
+		}
+		if f.Tenant != "" && inv.Tenant != f.Tenant {
+			continue
+		}
+		if f.Pending && !inv.Pending(now) {
+			continue
+		}
+		out = append(out, inv)
+	}
+	// UUIDv7 ids are time-ordered, so byte-descending is newest first.
+	slices.SortFunc(out, func(a, b Invite) int {
+		return bytes.Compare(b.ID[:], a.ID[:])
+	})
+	return out, nil
+}
+
+func (s *memoryStore) Accept(_ context.Context, inviteID id.UUID, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	inv, ok := s.byID[inviteID]
+	switch {
+	case !ok:
+		return ErrNotFound
+	case !inv.AcceptedAt.IsZero():
+		return ErrAlreadyAccepted
+	case !inv.RevokedAt.IsZero():
+		return ErrRevoked
+	case !inv.ExpiresAt.After(at):
+		return ErrExpired
+	}
+	inv.AcceptedAt = at
+	s.byID[inviteID] = inv
+	return nil
+}
+
+func (s *memoryStore) Revoke(_ context.Context, inviteID id.UUID, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	inv, ok := s.byID[inviteID]
+	switch {
+	case !ok:
+		return ErrNotFound
+	case !inv.AcceptedAt.IsZero():
+		return ErrAlreadyAccepted
+	case !inv.RevokedAt.IsZero():
+		return nil // idempotent — keep the original RevokedAt
+	}
+	inv.RevokedAt = at
+	s.byID[inviteID] = inv
+	return nil
+}
+
+func (s *memoryStore) Rotate(_ context.Context, inviteID id.UUID, hash string, expiresAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	inv, ok := s.byID[inviteID]
+	switch {
+	case !ok:
+		return ErrNotFound
+	case !inv.AcceptedAt.IsZero():
+		return ErrAlreadyAccepted
+	case !inv.RevokedAt.IsZero():
+		return ErrRevoked
+	}
+	if other, ok := s.byHash[hash]; ok && other != inviteID {
+		return ErrDuplicate
+	}
+	delete(s.byHash, inv.Hash)
+	inv.Hash = hash
+	inv.ExpiresAt = expiresAt
+	s.byID[inviteID] = inv
+	s.byHash[hash] = inviteID
+	return nil
+}

--- a/auth/invite/options.go
+++ b/auth/invite/options.go
@@ -1,0 +1,31 @@
+package invite
+
+import (
+	"context"
+	"time"
+)
+
+type config struct {
+	scope func(context.Context) (string, error)
+	ttl   time.Duration
+}
+
+// Option configures New.
+type Option func(*config)
+
+// WithTTL sets how long a freshly minted (or resent) invite stays
+// acceptable (default 7 days). New panics on a non-positive TTL.
+func WithTTL(d time.Duration) Option {
+	return func(c *config) { c.ttl = d }
+}
+
+// WithScope derives the tenant from context for every management
+// operation: Create stamps it, List is confined to it, and
+// Get/Revoke/Resend report ErrNotFound for other tenants' invites.
+// Fail-closed: a hook error or empty tenant fails the operation with
+// ErrScope. Accept and Peek are unaffected — the invitee typically has no
+// tenant context yet, and the invite record itself carries the tenant. A
+// nil fn leaves the manager unscoped.
+func WithScope(fn func(context.Context) (string, error)) Option {
+	return func(c *config) { c.scope = fn }
+}

--- a/auth/invite/pgstore/doc.go
+++ b/auth/invite/pgstore/doc.go
@@ -1,0 +1,12 @@
+// Package pgstore is the Postgres invite.Store driver over pgx. The DDL
+// (forge_invites) ships as an embedded goose migration in Migrations;
+// apply it via data/migration under its own version table before first
+// use:
+//
+//	_ = migration.New(pgstore.Migrations, migration.WithTable("forge_invite_schema")).Up(ctx, db)
+//
+// GetByHash — the accept path — is a single point lookup on the unique
+// hash index. Accept, Revoke, and Rotate are conditional single-row
+// UPDATEs, so single-use holds under concurrent accepts without
+// transactions. Zero time.Time fields map to SQL NULL and back.
+package pgstore

--- a/auth/invite/pgstore/migrations/00001_create_invites.sql
+++ b/auth/invite/pgstore/migrations/00001_create_invites.sql
@@ -13,5 +13,13 @@ CREATE TABLE forge_invites (
 
 CREATE INDEX forge_invites_list_idx ON forge_invites (tenant, email, id DESC);
 
+-- Serves a pending-only List (no tenant/email filter): the predicate matches
+-- the query's accepted/revoked conditions exactly, and the expires_at range
+-- scan returns just the acceptable rows. Expired-but-pending rows are never
+-- deleted, so without this a cross-tenant pending listing degrades into a
+-- sequential scan as dead invites accumulate.
+CREATE INDEX forge_invites_pending_idx ON forge_invites (expires_at)
+    WHERE accepted_at IS NULL AND revoked_at IS NULL;
+
 -- +goose Down
 DROP TABLE forge_invites;

--- a/auth/invite/pgstore/migrations/00001_create_invites.sql
+++ b/auth/invite/pgstore/migrations/00001_create_invites.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+CREATE TABLE forge_invites (
+    id          uuid PRIMARY KEY,
+    hash        text NOT NULL UNIQUE,
+    email       text NOT NULL,
+    tenant      text NOT NULL DEFAULT '',
+    role        text NOT NULL DEFAULT '',
+    created_at  timestamptz NOT NULL,
+    expires_at  timestamptz NOT NULL,
+    accepted_at timestamptz,
+    revoked_at  timestamptz
+);
+
+CREATE INDEX forge_invites_list_idx ON forge_invites (tenant, email, id DESC);
+
+-- +goose Down
+DROP TABLE forge_invites;

--- a/auth/invite/pgstore/pgstore.go
+++ b/auth/invite/pgstore/pgstore.go
@@ -1,0 +1,241 @@
+package pgstore
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"io/fs"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/dmitrymomot/forge/auth/invite"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Migrations holds the goose migration creating forge_invites, rooted so
+// its .sql files sit at fsys root (data/migration.New globs fsys's root,
+// not subdirectories). Apply via data/migration under its own version
+// table ("forge_invite_schema").
+var Migrations fs.FS
+
+func init() {
+	sub, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		panic(err) // unreachable: migrations/*.sql is embedded at compile time
+	}
+	Migrations = sub
+}
+
+// Store is the Postgres implementation of invite.Store. The pool's
+// lifecycle is the caller's.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+var _ invite.Store = (*Store)(nil)
+
+// New builds a Postgres invite Store. Apply Migrations first.
+func New(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const cols = `id, hash, email, tenant, role, created_at, expires_at, accepted_at, revoked_at`
+
+const createSQL = `
+INSERT INTO forge_invites (` + cols + `)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+
+// Create inserts inv. A colliding id or hash yields invite.ErrDuplicate.
+func (s *Store) Create(ctx context.Context, inv invite.Invite) error {
+	_, err := s.pool.Exec(ctx, createSQL,
+		inv.ID, inv.Hash, inv.Email, inv.Tenant, inv.Role,
+		inv.CreatedAt, inv.ExpiresAt, nullTime(inv.AcceptedAt), nullTime(inv.RevokedAt))
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
+		return invite.ErrDuplicate
+	}
+	return err
+}
+
+// Get returns the record for inviteID, or invite.ErrNotFound.
+func (s *Store) Get(ctx context.Context, inviteID id.UUID) (invite.Invite, error) {
+	return scanInvite(s.pool.QueryRow(ctx, `SELECT `+cols+` FROM forge_invites WHERE id = $1`, inviteID))
+}
+
+// GetByHash returns the record whose hash matches, or invite.ErrNotFound.
+// This is the accept path: one point lookup on the unique index.
+func (s *Store) GetByHash(ctx context.Context, hash string) (invite.Invite, error) {
+	return scanInvite(s.pool.QueryRow(ctx, `SELECT `+cols+` FROM forge_invites WHERE hash = $1`, hash))
+}
+
+// List returns records matching f, newest first (UUIDv7 ids are
+// time-ordered, so id DESC is creation order).
+func (s *Store) List(ctx context.Context, f invite.Filter) ([]invite.Invite, error) {
+	// The WHERE clause carries only the filters actually set, rather than
+	// the static `($n = '' OR col = $n)` idiom: once a prepared statement
+	// switches to a generic plan (pgx prepares every query, and Postgres
+	// goes generic after five executions) those ORs cannot be pruned and
+	// the planner stops using forge_invites_list_idx. The filter
+	// combinations bound the statement cache at 8 shapes.
+	var (
+		conds []string
+		args  []any
+	)
+	arg := func(v any) string {
+		args = append(args, v)
+		return "$" + strconv.Itoa(len(args))
+	}
+	if f.Tenant != "" {
+		conds = append(conds, "tenant = "+arg(f.Tenant))
+	}
+	if f.Email != "" {
+		conds = append(conds, "email = "+arg(f.Email))
+	}
+	if f.Pending {
+		conds = append(conds, "accepted_at IS NULL AND revoked_at IS NULL AND expires_at > "+arg(time.Now().UTC()))
+	}
+	sql := `SELECT ` + cols + ` FROM forge_invites`
+	if len(conds) > 0 {
+		sql += " WHERE " + strings.Join(conds, " AND ")
+	}
+	sql += " ORDER BY id DESC"
+	rows, err := s.pool.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	// Non-nil empty (not nil) on zero rows, matching the memory store so
+	// callers see identical List results whichever Store backs the Manager.
+	out := []invite.Invite{}
+	for rows.Next() {
+		inv, err := scanInvite(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, inv)
+	}
+	return out, rows.Err()
+}
+
+// Accept marks the invite accepted at `at` if it is still pending. The
+// conditional UPDATE is the single-use guard: exactly one concurrent
+// accept matches the row, the rest classify their refusal.
+func (s *Store) Accept(ctx context.Context, inviteID id.UUID, at time.Time) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE forge_invites SET accepted_at = $2
+		 WHERE id = $1 AND accepted_at IS NULL AND revoked_at IS NULL AND expires_at > $2`,
+		inviteID, at)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 1 {
+		return nil
+	}
+	inv, err := s.Get(ctx, inviteID)
+	if err != nil {
+		return err // includes invite.ErrNotFound
+	}
+	switch {
+	case !inv.AcceptedAt.IsZero():
+		return invite.ErrAlreadyAccepted
+	case !inv.RevokedAt.IsZero():
+		return invite.ErrRevoked
+	default:
+		return invite.ErrExpired
+	}
+}
+
+// Revoke marks the invite revoked at `at` unless it was accepted.
+// Already-revoked is a no-op success keeping the original revoked_at.
+func (s *Store) Revoke(ctx context.Context, inviteID id.UUID, at time.Time) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE forge_invites SET revoked_at = $2
+		 WHERE id = $1 AND accepted_at IS NULL AND revoked_at IS NULL`,
+		inviteID, at)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 1 {
+		return nil
+	}
+	inv, err := s.Get(ctx, inviteID)
+	if err != nil {
+		return err
+	}
+	if !inv.AcceptedAt.IsZero() {
+		return invite.ErrAlreadyAccepted
+	}
+	return nil // already revoked — idempotent
+}
+
+// Rotate swaps the token hash and expiry if the invite is neither
+// accepted nor revoked (expired invites rotate — that is Resend).
+func (s *Store) Rotate(ctx context.Context, inviteID id.UUID, hash string, expiresAt time.Time) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE forge_invites SET hash = $2, expires_at = $3
+		 WHERE id = $1 AND accepted_at IS NULL AND revoked_at IS NULL`,
+		inviteID, hash, expiresAt)
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation on hash
+		return invite.ErrDuplicate
+	}
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 1 {
+		return nil
+	}
+	inv, err := s.Get(ctx, inviteID)
+	if err != nil {
+		return err
+	}
+	switch {
+	case !inv.AcceptedAt.IsZero():
+		return invite.ErrAlreadyAccepted
+	default:
+		return invite.ErrRevoked
+	}
+}
+
+// row is satisfied by both pgx.Row and pgx.Rows.
+type row interface{ Scan(dest ...any) error }
+
+func scanInvite(r row) (invite.Invite, error) {
+	var inv invite.Invite
+	var acc, rv *time.Time
+	err := r.Scan(&inv.ID, &inv.Hash, &inv.Email, &inv.Tenant, &inv.Role,
+		&inv.CreatedAt, &inv.ExpiresAt, &acc, &rv)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return invite.Invite{}, invite.ErrNotFound
+	}
+	if err != nil {
+		return invite.Invite{}, err
+	}
+	inv.AcceptedAt = deref(acc)
+	inv.RevokedAt = deref(rv)
+	return inv, nil
+}
+
+// deref maps SQL NULL back to the zero time.
+func deref(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
+// nullTime maps the zero time to SQL NULL.
+func nullTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}

--- a/auth/invite/pgstore/pgstore_test.go
+++ b/auth/invite/pgstore/pgstore_test.go
@@ -1,0 +1,275 @@
+//go:build integration
+
+package pgstore_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/invite"
+	"github.com/dmitrymomot/forge/auth/invite/pgstore"
+	"github.com/dmitrymomot/forge/core/id"
+	"github.com/dmitrymomot/forge/data/migration"
+	"github.com/dmitrymomot/forge/data/postgres"
+	"github.com/dmitrymomot/forge/testkit/pgtest"
+)
+
+var _ invite.Store = (*pgstore.Store)(nil)
+
+func newStore(t *testing.T) *pgstore.Store {
+	t.Helper()
+	cfg := postgres.DefaultConfig()
+	cfg.URL = pgtest.DSN(t)
+	pool, err := postgres.Open(context.Background(), postgres.WithConfig(cfg))
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, migration.New(pgstore.Migrations, migration.WithTable("forge_invite_schema")).Up(context.Background(), db))
+	return pgstore.New(pool)
+}
+
+// mkInvite builds a record whose hash/email/tenant are unique per call:
+// the table persists across test runs, so deterministic values would
+// collide on the unique hash index or inflate List counts on re-runs.
+func mkInvite(t *testing.T) invite.Invite {
+	t.Helper()
+	uid := id.NewUUID()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	return invite.Invite{
+		ID:        uid,
+		Hash:      "hash-" + uid.String(),
+		Email:     "user-" + uid.String() + "@example.com",
+		Tenant:    "tenant-" + uid.String(),
+		Role:      "editor",
+		CreatedAt: now,
+		ExpiresAt: now.Add(time.Hour),
+	}
+}
+
+func TestPg_CreateGetRoundTrip(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	inv := mkInvite(t)
+
+	require.NoError(t, s.Create(ctx, inv))
+
+	got, err := s.Get(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, inv.Hash, got.Hash)
+	assert.Equal(t, inv.Email, got.Email)
+	assert.Equal(t, inv.Tenant, got.Tenant)
+	assert.Equal(t, inv.Role, got.Role)
+	assert.True(t, inv.CreatedAt.Equal(got.CreatedAt))
+	assert.True(t, inv.ExpiresAt.Equal(got.ExpiresAt))
+	assert.True(t, got.AcceptedAt.IsZero())
+	assert.True(t, got.RevokedAt.IsZero())
+
+	byHash, err := s.GetByHash(ctx, inv.Hash)
+	require.NoError(t, err)
+	assert.Equal(t, inv.ID, byHash.ID)
+}
+
+func TestPg_Duplicate(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	inv := mkInvite(t)
+	require.NoError(t, s.Create(ctx, inv))
+
+	sameID := mkInvite(t)
+	sameID.ID = inv.ID
+	assert.ErrorIs(t, s.Create(ctx, sameID), invite.ErrDuplicate)
+
+	sameHash := mkInvite(t)
+	sameHash.Hash = inv.Hash
+	assert.ErrorIs(t, s.Create(ctx, sameHash), invite.ErrDuplicate)
+}
+
+func TestPg_NotFound(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	missing := id.NewUUID()
+
+	_, err := s.Get(ctx, missing)
+	assert.ErrorIs(t, err, invite.ErrNotFound)
+	_, err = s.GetByHash(ctx, "missing-"+missing.String())
+	assert.ErrorIs(t, err, invite.ErrNotFound)
+	assert.ErrorIs(t, s.Accept(ctx, missing, now), invite.ErrNotFound)
+	assert.ErrorIs(t, s.Revoke(ctx, missing, now), invite.ErrNotFound)
+	assert.ErrorIs(t, s.Rotate(ctx, missing, "h-"+missing.String(), now), invite.ErrNotFound)
+}
+
+func TestPg_AcceptClassification(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	inv := mkInvite(t)
+	require.NoError(t, s.Create(ctx, inv))
+	require.NoError(t, s.Accept(ctx, inv.ID, now))
+	got, err := s.Get(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.True(t, now.Equal(got.AcceptedAt))
+	assert.ErrorIs(t, s.Accept(ctx, inv.ID, now), invite.ErrAlreadyAccepted)
+
+	revoked := mkInvite(t)
+	require.NoError(t, s.Create(ctx, revoked))
+	require.NoError(t, s.Revoke(ctx, revoked.ID, now))
+	assert.ErrorIs(t, s.Accept(ctx, revoked.ID, now), invite.ErrRevoked)
+
+	expired := mkInvite(t)
+	require.NoError(t, s.Create(ctx, expired))
+	assert.ErrorIs(t, s.Accept(ctx, expired.ID, expired.ExpiresAt), invite.ErrExpired)
+}
+
+func TestPg_AcceptConcurrentSingleUse(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	inv := mkInvite(t)
+	require.NoError(t, s.Create(ctx, inv))
+
+	const n = 16
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var winners int
+	for range n {
+		wg.Go(func() {
+			err := s.Accept(ctx, inv.ID, time.Now().UTC())
+			if err == nil {
+				mu.Lock()
+				winners++
+				mu.Unlock()
+				return
+			}
+			assert.ErrorIs(t, err, invite.ErrAlreadyAccepted)
+		})
+	}
+	wg.Wait()
+	assert.Equal(t, 1, winners, "exactly one concurrent accept must win")
+}
+
+func TestPg_RevokeClassification(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	inv := mkInvite(t)
+	require.NoError(t, s.Create(ctx, inv))
+	require.NoError(t, s.Revoke(ctx, inv.ID, now))
+	require.NoError(t, s.Revoke(ctx, inv.ID, now.Add(time.Minute))) // idempotent
+	got, err := s.Get(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.True(t, now.Equal(got.RevokedAt), "second revoke keeps original timestamp")
+
+	accepted := mkInvite(t)
+	require.NoError(t, s.Create(ctx, accepted))
+	require.NoError(t, s.Accept(ctx, accepted.ID, now))
+	assert.ErrorIs(t, s.Revoke(ctx, accepted.ID, now), invite.ErrAlreadyAccepted)
+}
+
+func TestPg_Rotate(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	inv := mkInvite(t)
+	require.NoError(t, s.Create(ctx, inv))
+	fresh := "rotated-" + inv.ID.String()
+	later := now.Add(2 * time.Hour)
+	require.NoError(t, s.Rotate(ctx, inv.ID, fresh, later))
+
+	got, err := s.Get(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, fresh, got.Hash)
+	assert.True(t, later.Equal(got.ExpiresAt))
+	_, err = s.GetByHash(ctx, inv.Hash)
+	assert.ErrorIs(t, err, invite.ErrNotFound)
+
+	// Rotating to another record's hash trips the unique index.
+	other := mkInvite(t)
+	require.NoError(t, s.Create(ctx, other))
+	assert.ErrorIs(t, s.Rotate(ctx, inv.ID, other.Hash, later), invite.ErrDuplicate)
+
+	// Accepted and revoked invites refuse rotation.
+	require.NoError(t, s.Accept(ctx, other.ID, now))
+	assert.ErrorIs(t, s.Rotate(ctx, other.ID, "x-"+other.ID.String(), later), invite.ErrAlreadyAccepted)
+	revoked := mkInvite(t)
+	require.NoError(t, s.Create(ctx, revoked))
+	require.NoError(t, s.Revoke(ctx, revoked.ID, now))
+	assert.ErrorIs(t, s.Rotate(ctx, revoked.ID, "y-"+revoked.ID.String(), later), invite.ErrRevoked)
+}
+
+func TestPg_List(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// One shared tenant/email pair unique to this run.
+	base := mkInvite(t)
+	tenant, email := base.Tenant, base.Email
+
+	a := base
+	b := mkInvite(t)
+	b.Tenant, b.Email = tenant, email
+	expired := mkInvite(t)
+	expired.Tenant = tenant
+	expired.ExpiresAt = now.Add(-time.Minute)
+	otherTenant := mkInvite(t)
+	for _, inv := range []invite.Invite{a, b, expired, otherTenant} {
+		require.NoError(t, s.Create(ctx, inv))
+	}
+	require.NoError(t, s.Accept(ctx, b.ID, now))
+
+	// Ordering is unasserted: same-millisecond UUIDv7 ids have random tails.
+	all, err := s.List(ctx, invite.Filter{Tenant: tenant})
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+	assert.ElementsMatch(t, []id.UUID{a.ID, b.ID, expired.ID}, []id.UUID{all[0].ID, all[1].ID, all[2].ID})
+
+	byEmail, err := s.List(ctx, invite.Filter{Tenant: tenant, Email: email})
+	require.NoError(t, err)
+	assert.Len(t, byEmail, 2)
+
+	// Pending excludes the accepted and the expired record.
+	pending, err := s.List(ctx, invite.Filter{Tenant: tenant, Pending: true})
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, a.ID, pending[0].ID)
+
+	// Empty result is non-nil, matching the memory store.
+	empty, err := s.List(ctx, invite.Filter{Tenant: "absent-" + base.ID.String()})
+	require.NoError(t, err)
+	assert.NotNil(t, empty)
+	assert.Empty(t, empty)
+}
+
+func TestPg_ManagerEndToEnd(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	mgr := invite.New(s)
+
+	uid := id.NewUUID()
+	email := "e2e-" + uid.String() + "@example.com"
+	inv, plaintext, err := mgr.Create(ctx, invite.CreateParams{Email: email, Tenant: "t-" + uid.String(), Role: "admin"})
+	require.NoError(t, err)
+
+	// Resend rotates: old token dead, new one accepts once.
+	_, rotated, err := mgr.Resend(ctx, inv.ID)
+	require.NoError(t, err)
+	_, err = mgr.Accept(ctx, plaintext)
+	assert.ErrorIs(t, err, invite.ErrInviteNotFound)
+
+	claim, err := mgr.Accept(ctx, rotated)
+	require.NoError(t, err)
+	assert.Equal(t, email, claim.Email)
+	assert.Equal(t, "admin", claim.Role)
+	_, err = mgr.Accept(ctx, rotated)
+	assert.ErrorIs(t, err, invite.ErrAlreadyAccepted)
+}

--- a/auth/invite/pgstore/pgstore_test.go
+++ b/auth/invite/pgstore/pgstore_test.go
@@ -243,6 +243,18 @@ func TestPg_List(t *testing.T) {
 	require.Len(t, pending, 1)
 	assert.Equal(t, a.ID, pending[0].ID)
 
+	// Unscoped pending-only listing (the forge_invites_pending_idx shape):
+	// contains-style asserts because the table is shared across tests/runs.
+	allPending, err := s.List(ctx, invite.Filter{Pending: true})
+	require.NoError(t, err)
+	ids := make(map[id.UUID]bool, len(allPending))
+	for _, inv := range allPending {
+		ids[inv.ID] = true
+	}
+	assert.True(t, ids[a.ID], "pending invite missing from unscoped listing")
+	assert.False(t, ids[b.ID], "accepted invite leaked into pending listing")
+	assert.False(t, ids[expired.ID], "expired invite leaked into pending listing")
+
 	// Empty result is non-nil, matching the memory store.
 	empty, err := s.List(ctx, invite.Filter{Tenant: "absent-" + base.ID.String()})
 	require.NoError(t, err)

--- a/auth/invite/scope_test.go
+++ b/auth/invite/scope_test.go
@@ -1,0 +1,127 @@
+package invite_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/invite"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+type tenantCtxKey struct{}
+
+func scopeHook(ctx context.Context) (string, error) {
+	t, _ := ctx.Value(tenantCtxKey{}).(string)
+	return t, nil
+}
+
+func tenantCtx(tenant string) context.Context {
+	return context.WithValue(context.Background(), tenantCtxKey{}, tenant)
+}
+
+func TestScope_CreateStampsTenant(t *testing.T) {
+	t.Parallel()
+	mgr := invite.New(invite.NewMemoryStore(), invite.WithScope(scopeHook))
+
+	inv, _, err := mgr.Create(tenantCtx("t1"), invite.CreateParams{Email: "a@b.com"})
+	require.NoError(t, err)
+	assert.Equal(t, "t1", inv.Tenant)
+
+	// Matching explicit tenant is fine; conflicting one is not.
+	_, _, err = mgr.Create(tenantCtx("t1"), invite.CreateParams{Email: "a@b.com", Tenant: "t1"})
+	assert.NoError(t, err)
+	_, _, err = mgr.Create(tenantCtx("t1"), invite.CreateParams{Email: "a@b.com", Tenant: "t2"})
+	assert.ErrorIs(t, err, invite.ErrTenantMismatch)
+}
+
+// TestScope_FailClosed sweeps every scoped operation: with the hook
+// yielding no tenant (empty) or an error, each must refuse with ErrScope
+// rather than fall back to unscoped behavior.
+func TestScope_FailClosed(t *testing.T) {
+	t.Parallel()
+	hookErr := errors.New("no session")
+	for name, hook := range map[string]func(context.Context) (string, error){
+		"empty tenant": scopeHook, // background ctx carries no tenant
+		"hook error":   func(context.Context) (string, error) { return "", hookErr },
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			mgr := invite.New(invite.NewMemoryStore(), invite.WithScope(hook))
+			ctx := context.Background()
+
+			_, _, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com"})
+			assert.ErrorIs(t, err, invite.ErrScope)
+			_, err = mgr.Get(ctx, id.NewUUID())
+			assert.ErrorIs(t, err, invite.ErrScope)
+			_, err = mgr.List(ctx, invite.Filter{})
+			assert.ErrorIs(t, err, invite.ErrScope)
+			err = mgr.Revoke(ctx, id.NewUUID())
+			assert.ErrorIs(t, err, invite.ErrScope)
+			_, _, err = mgr.Resend(ctx, id.NewUUID())
+			assert.ErrorIs(t, err, invite.ErrScope)
+		})
+	}
+}
+
+func TestScope_CrossTenantReadsAsNotFound(t *testing.T) {
+	t.Parallel()
+	store := invite.NewMemoryStore()
+	mgr := invite.New(store, invite.WithScope(scopeHook))
+
+	inv, _, err := mgr.Create(tenantCtx("t1"), invite.CreateParams{Email: "a@b.com"})
+	require.NoError(t, err)
+
+	// Same record, other tenant's context: invisible for every management op.
+	_, err = mgr.Get(tenantCtx("t2"), inv.ID)
+	assert.ErrorIs(t, err, invite.ErrNotFound)
+	assert.ErrorIs(t, mgr.Revoke(tenantCtx("t2"), inv.ID), invite.ErrNotFound)
+	_, _, err = mgr.Resend(tenantCtx("t2"), inv.ID)
+	assert.ErrorIs(t, err, invite.ErrNotFound)
+
+	got, err := mgr.Get(tenantCtx("t1"), inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, inv.ID, got.ID)
+}
+
+func TestScope_ListConfined(t *testing.T) {
+	t.Parallel()
+	store := invite.NewMemoryStore()
+	mgr := invite.New(store, invite.WithScope(scopeHook))
+
+	_, _, err := mgr.Create(tenantCtx("t1"), invite.CreateParams{Email: "a@b.com"})
+	require.NoError(t, err)
+	_, _, err = mgr.Create(tenantCtx("t2"), invite.CreateParams{Email: "b@b.com"})
+	require.NoError(t, err)
+
+	got, err := mgr.List(tenantCtx("t1"), invite.Filter{})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "t1", got[0].Tenant)
+
+	// An explicit conflicting filter tenant cannot widen the scope.
+	_, err = mgr.List(tenantCtx("t1"), invite.Filter{Tenant: "t2"})
+	assert.ErrorIs(t, err, invite.ErrTenantMismatch)
+}
+
+func TestScope_AcceptAndPeekUnscoped(t *testing.T) {
+	t.Parallel()
+	store := invite.NewMemoryStore()
+	mgr := invite.New(store, invite.WithScope(scopeHook))
+
+	inv, plaintext, err := mgr.Create(tenantCtx("t1"), invite.CreateParams{Email: "a@b.com", Role: "editor"})
+	require.NoError(t, err)
+
+	// The invitee has no tenant context — background ctx must still work.
+	ctx := context.Background()
+	peeked, err := mgr.Peek(ctx, plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, "t1", peeked.Tenant)
+
+	claim, err := mgr.Accept(ctx, plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, invite.Claim{Tenant: "t1", Email: "a@b.com", Role: "editor", ID: inv.ID}, claim)
+}

--- a/auth/invite/store.go
+++ b/auth/invite/store.go
@@ -1,0 +1,40 @@
+package invite
+
+import (
+	"context"
+	"time"
+
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// Store persists Invite records. Implementations must be safe for
+// concurrent use. Create fails with ErrDuplicate when a record with the
+// same ID or Hash exists; lookups return ErrNotFound for unknown ids.
+// Accept, Revoke, and Rotate are the single-use guards: each mutates only
+// records still in the required state, atomically, and classifies the
+// refusal otherwise — callers pre-check for better errors, but the store
+// decision is authoritative under races.
+type Store interface {
+	Create(ctx context.Context, inv Invite) error
+	Get(ctx context.Context, inviteID id.UUID) (Invite, error)
+	// GetByHash is the accept path: one point lookup by the hex SHA-256 of
+	// the presented plaintext token.
+	GetByHash(ctx context.Context, hash string) (Invite, error)
+	// List returns records matching f, newest first (UUIDv7 id order; ties
+	// within one millisecond are unordered).
+	List(ctx context.Context, f Filter) ([]Invite, error)
+	// Accept atomically marks the invite accepted at `at` if it is still
+	// pending (not accepted, not revoked, and expiring after at). It fails
+	// with ErrNotFound, ErrAlreadyAccepted, ErrRevoked, or ErrExpired.
+	Accept(ctx context.Context, inviteID id.UUID, at time.Time) error
+	// Revoke atomically marks the invite revoked at `at` unless it was
+	// accepted. Revoking an already-revoked invite is a no-op success that
+	// keeps the original RevokedAt. It fails with ErrNotFound or
+	// ErrAlreadyAccepted.
+	Revoke(ctx context.Context, inviteID id.UUID, at time.Time) error
+	// Rotate atomically swaps the token hash and expiry if the invite is
+	// neither accepted nor revoked (an expired invite may be rotated —
+	// that is what Resend is for). It fails with ErrNotFound,
+	// ErrAlreadyAccepted, ErrRevoked, or ErrDuplicate (hash collision).
+	Rotate(ctx context.Context, inviteID id.UUID, hash string, expiresAt time.Time) error
+}

--- a/auth/invite/store_test.go
+++ b/auth/invite/store_test.go
@@ -1,0 +1,189 @@
+package invite_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/invite"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// mkInvite builds a record with a handcrafted ID so ordering tests are
+// deterministic (UUIDv7 ids from the same millisecond have random tails).
+func mkInvite(b byte, hash, email, tenant string) invite.Invite {
+	now := time.Now().UTC()
+	return invite.Invite{
+		ID:        id.UUID{15: b}, // last byte varies → byte-ascending = ascending b
+		Hash:      hash,
+		Email:     email,
+		Tenant:    tenant,
+		Role:      "member",
+		CreatedAt: now,
+		ExpiresAt: now.Add(time.Hour),
+	}
+}
+
+func TestMemoryStore_CreateGet(t *testing.T) {
+	t.Parallel()
+	s := invite.NewMemoryStore()
+	ctx := context.Background()
+	inv := mkInvite(1, "h1", "a@b.com", "t1")
+
+	require.NoError(t, s.Create(ctx, inv))
+
+	got, err := s.Get(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, inv, got)
+
+	byHash, err := s.GetByHash(ctx, "h1")
+	require.NoError(t, err)
+	assert.Equal(t, inv.ID, byHash.ID)
+}
+
+func TestMemoryStore_Duplicate(t *testing.T) {
+	t.Parallel()
+	s := invite.NewMemoryStore()
+	ctx := context.Background()
+	require.NoError(t, s.Create(ctx, mkInvite(1, "h1", "a@b.com", "t1")))
+
+	assert.ErrorIs(t, s.Create(ctx, mkInvite(1, "h2", "a@b.com", "t1")), invite.ErrDuplicate)
+	assert.ErrorIs(t, s.Create(ctx, mkInvite(2, "h1", "a@b.com", "t1")), invite.ErrDuplicate)
+}
+
+func TestMemoryStore_NotFound(t *testing.T) {
+	t.Parallel()
+	s := invite.NewMemoryStore()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	missing := id.UUID{15: 9}
+
+	_, err := s.Get(ctx, missing)
+	assert.ErrorIs(t, err, invite.ErrNotFound)
+	_, err = s.GetByHash(ctx, "missing")
+	assert.ErrorIs(t, err, invite.ErrNotFound)
+	assert.ErrorIs(t, s.Accept(ctx, missing, now), invite.ErrNotFound)
+	assert.ErrorIs(t, s.Revoke(ctx, missing, now), invite.ErrNotFound)
+	assert.ErrorIs(t, s.Rotate(ctx, missing, "h2", now), invite.ErrNotFound)
+}
+
+func TestMemoryStore_AcceptClassification(t *testing.T) {
+	t.Parallel()
+	s := invite.NewMemoryStore()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	pending := mkInvite(1, "h1", "a@b.com", "t1")
+	require.NoError(t, s.Create(ctx, pending))
+	require.NoError(t, s.Accept(ctx, pending.ID, now))
+	assert.ErrorIs(t, s.Accept(ctx, pending.ID, now), invite.ErrAlreadyAccepted)
+
+	revoked := mkInvite(2, "h2", "a@b.com", "t1")
+	require.NoError(t, s.Create(ctx, revoked))
+	require.NoError(t, s.Revoke(ctx, revoked.ID, now))
+	assert.ErrorIs(t, s.Accept(ctx, revoked.ID, now), invite.ErrRevoked)
+
+	expired := mkInvite(3, "h3", "a@b.com", "t1")
+	require.NoError(t, s.Create(ctx, expired))
+	assert.ErrorIs(t, s.Accept(ctx, expired.ID, expired.ExpiresAt), invite.ErrExpired)
+	// Boundary: at is strictly before ExpiresAt → acceptable.
+	require.NoError(t, s.Accept(ctx, expired.ID, expired.ExpiresAt.Add(-time.Nanosecond)))
+}
+
+func TestMemoryStore_RevokeClassification(t *testing.T) {
+	t.Parallel()
+	s := invite.NewMemoryStore()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	inv := mkInvite(1, "h1", "a@b.com", "t1")
+	require.NoError(t, s.Create(ctx, inv))
+	require.NoError(t, s.Revoke(ctx, inv.ID, now))
+	require.NoError(t, s.Revoke(ctx, inv.ID, now.Add(time.Minute))) // idempotent
+	got, err := s.Get(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, now, got.RevokedAt, "second revoke keeps original timestamp")
+
+	accepted := mkInvite(2, "h2", "a@b.com", "t1")
+	require.NoError(t, s.Create(ctx, accepted))
+	require.NoError(t, s.Accept(ctx, accepted.ID, now))
+	assert.ErrorIs(t, s.Revoke(ctx, accepted.ID, now), invite.ErrAlreadyAccepted)
+}
+
+func TestMemoryStore_Rotate(t *testing.T) {
+	t.Parallel()
+	s := invite.NewMemoryStore()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	inv := mkInvite(1, "h1", "a@b.com", "t1")
+	require.NoError(t, s.Create(ctx, inv))
+	later := now.Add(2 * time.Hour)
+	require.NoError(t, s.Rotate(ctx, inv.ID, "h1b", later))
+
+	got, err := s.Get(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "h1b", got.Hash)
+	assert.Equal(t, later, got.ExpiresAt)
+
+	// The old hash no longer resolves; the new one does.
+	_, err = s.GetByHash(ctx, "h1")
+	assert.ErrorIs(t, err, invite.ErrNotFound)
+	byHash, err := s.GetByHash(ctx, "h1b")
+	require.NoError(t, err)
+	assert.Equal(t, inv.ID, byHash.ID)
+
+	// Rotating to another record's hash is a duplicate.
+	other := mkInvite(2, "h2", "b@b.com", "t1")
+	require.NoError(t, s.Create(ctx, other))
+	assert.ErrorIs(t, s.Rotate(ctx, inv.ID, "h2", later), invite.ErrDuplicate)
+
+	// Accepted and revoked invites refuse rotation.
+	require.NoError(t, s.Accept(ctx, other.ID, now))
+	assert.ErrorIs(t, s.Rotate(ctx, other.ID, "h2b", later), invite.ErrAlreadyAccepted)
+	revoked := mkInvite(3, "h3", "c@b.com", "t1")
+	require.NoError(t, s.Create(ctx, revoked))
+	require.NoError(t, s.Revoke(ctx, revoked.ID, now))
+	assert.ErrorIs(t, s.Rotate(ctx, revoked.ID, "h3b", later), invite.ErrRevoked)
+}
+
+func TestMemoryStore_List(t *testing.T) {
+	t.Parallel()
+	s := invite.NewMemoryStore()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	a := mkInvite(1, "h1", "a@b.com", "t1")
+	b := mkInvite(2, "h2", "b@b.com", "t1")
+	c := mkInvite(3, "h3", "a@b.com", "t2")
+	expired := mkInvite(4, "h4", "d@b.com", "t1")
+	expired.ExpiresAt = now.Add(-time.Minute)
+	for _, inv := range []invite.Invite{a, b, c, expired} {
+		require.NoError(t, s.Create(ctx, inv))
+	}
+	require.NoError(t, s.Accept(ctx, b.ID, now))
+
+	all, err := s.List(ctx, invite.Filter{})
+	require.NoError(t, err)
+	require.Len(t, all, 4)
+	// Newest first by id bytes: 4, 3, 2, 1.
+	assert.Equal(t, []id.UUID{expired.ID, c.ID, b.ID, a.ID},
+		[]id.UUID{all[0].ID, all[1].ID, all[2].ID, all[3].ID})
+
+	t1, err := s.List(ctx, invite.Filter{Tenant: "t1"})
+	require.NoError(t, err)
+	assert.Len(t, t1, 3)
+
+	byEmail, err := s.List(ctx, invite.Filter{Email: "a@b.com"})
+	require.NoError(t, err)
+	assert.Len(t, byEmail, 2)
+
+	// Pending excludes the accepted and the expired record.
+	pending, err := s.List(ctx, invite.Filter{Pending: true})
+	require.NoError(t, err)
+	require.Len(t, pending, 2)
+	assert.ElementsMatch(t, []id.UUID{a.ID, c.ID}, []id.UUID{pending[0].ID, pending[1].ID})
+}

--- a/auth/invite/storeerr_test.go
+++ b/auth/invite/storeerr_test.go
@@ -1,0 +1,73 @@
+package invite_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/auth/invite"
+	"github.com/dmitrymomot/forge/core/id"
+)
+
+// errStoreBoom is a sentinel returned by boomStore to prove the manager
+// wraps unexpected store errors with %w instead of swallowing them.
+var errStoreBoom = errors.New("boom")
+
+// boomStore implements invite.Store, failing every call with errStoreBoom.
+type boomStore struct{}
+
+func (boomStore) Create(context.Context, invite.Invite) error { return errStoreBoom }
+
+func (boomStore) Get(context.Context, id.UUID) (invite.Invite, error) {
+	return invite.Invite{}, errStoreBoom
+}
+
+func (boomStore) GetByHash(context.Context, string) (invite.Invite, error) {
+	return invite.Invite{}, errStoreBoom
+}
+
+func (boomStore) List(context.Context, invite.Filter) ([]invite.Invite, error) {
+	return nil, errStoreBoom
+}
+
+func (boomStore) Accept(context.Context, id.UUID, time.Time) error         { return errStoreBoom }
+func (boomStore) Revoke(context.Context, id.UUID, time.Time) error         { return errStoreBoom }
+func (boomStore) Rotate(context.Context, id.UUID, string, time.Time) error { return errStoreBoom }
+
+func TestStoreErrorsWrapped(t *testing.T) {
+	t.Parallel()
+	mgr := invite.New(boomStore{})
+	ctx := context.Background()
+
+	_, _, err := mgr.Create(ctx, invite.CreateParams{Email: "a@b.com"})
+	assert.ErrorIs(t, err, errStoreBoom)
+
+	// A well-formed token reaches GetByHash; the failure must surface.
+	real := invite.New(invite.NewMemoryStore())
+	_, plaintext, err := real.Create(ctx, invite.CreateParams{Email: "a@b.com"})
+	require.NoError(t, err)
+	_, err = mgr.Accept(ctx, plaintext)
+	assert.ErrorIs(t, err, errStoreBoom)
+	_, err = mgr.Peek(ctx, plaintext)
+	assert.ErrorIs(t, err, errStoreBoom)
+}
+
+// panicStore proves malformed tokens are rejected before any store access.
+type panicStore struct{ invite.Store }
+
+func (panicStore) GetByHash(context.Context, string) (invite.Invite, error) {
+	panic("store touched for malformed token")
+}
+
+func TestMalformedTokenSkipsStore(t *testing.T) {
+	t.Parallel()
+	mgr := invite.New(panicStore{})
+	_, err := mgr.Accept(context.Background(), "inv_garbage")
+	assert.ErrorIs(t, err, invite.ErrMalformedToken)
+	_, err = mgr.Peek(context.Background(), "inv_garbage")
+	assert.ErrorIs(t, err, invite.ErrMalformedToken)
+}

--- a/auth/invite/token.go
+++ b/auth/invite/token.go
@@ -1,0 +1,93 @@
+package invite
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash/crc32"
+	"strings"
+
+	"github.com/dmitrymomot/forge/core/random"
+)
+
+// Invite tokens follow the apikey discipline: <prefix>_<payload><checksum>
+// with a fixed "inv" prefix, a 43-char base62 payload (~256 bits of
+// entropy), and a CRC32 checksum so garbage is rejected allocation-free
+// before any store access.
+const (
+	tokenPrefix = "inv"
+	payloadLen  = 43 // base62 chars ≈ 256 bits of entropy
+	checksumLen = 6  // fixed-width base62 CRC32 (62^6 > 2^32)
+	tokenLen    = len(tokenPrefix) + 1 + payloadLen + checksumLen
+)
+
+// base62 is the checksum alphabet. The payload draws from the same 62
+// characters via random.String's default Alphanumeric set.
+const base62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// newToken mints a plaintext invite token: inv_<payload><checksum>.
+func newToken() string {
+	payload := random.String(payloadLen)
+	var b strings.Builder
+	b.Grow(tokenLen)
+	b.WriteString(tokenPrefix)
+	b.WriteByte('_')
+	b.WriteString(payload)
+	b.WriteString(encodeChecksum(crc32String(payload)))
+	return b.String()
+}
+
+// crc32String computes the IEEE CRC32 of s without allocating. The
+// []byte(s) conversion crc32.ChecksumIEEE requires escapes to the heap
+// through the hardware-accelerated path, so validToken — the DoS-relevant
+// reject surface — computes the checksum over the string bytes directly
+// via the standard table-driven update. The result is identical to
+// crc32.ChecksumIEEE (same IEEE polynomial).
+func crc32String(s string) uint32 {
+	crc := ^uint32(0)
+	for i := range len(s) {
+		crc = crc32.IEEETable[byte(crc)^s[i]] ^ (crc >> 8)
+	}
+	return ^crc
+}
+
+// encodeChecksum renders v as fixed-width base62, most significant first.
+func encodeChecksum(v uint32) string {
+	var buf [checksumLen]byte
+	for i := checksumLen - 1; i >= 0; i-- {
+		buf[i] = base62[v%62]
+		v /= 62
+	}
+	return string(buf[:])
+}
+
+// validToken reports whether token is structurally valid: exact length,
+// "inv_" prefix, and payload CRC32 matching the checksum suffix. The
+// checksum is computed over the string bytes directly (crc32String) and
+// compared in place (no encodeChecksum string) to keep this reject path
+// allocation-free — it shields the store from token-stuffing garbage.
+func validToken(token string) bool {
+	if len(token) != tokenLen {
+		return false
+	}
+	if token[:len(tokenPrefix)] != tokenPrefix || token[len(tokenPrefix)] != '_' {
+		return false
+	}
+	payload := token[len(tokenPrefix)+1 : tokenLen-checksumLen]
+	sum := crc32String(payload)
+	suffix := token[tokenLen-checksumLen:]
+	for i := checksumLen - 1; i >= 0; i-- {
+		if suffix[i] != base62[sum%62] {
+			return false
+		}
+		sum /= 62
+	}
+	return true
+}
+
+// hashToken returns the hex SHA-256 of the full plaintext token — the
+// stored lookup hash. Unsalted is safe: the payload carries ~256 bits of
+// entropy, so preimage search is infeasible.
+func hashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -304,14 +304,6 @@ consumer-side.
 
 Deps: `web/httpclient`.
 
----
-
-**auth/invite**
-
-Token invitations into a tenant: email-addressed, single-use, expiring invites carrying an opaque role payload the package never interprets. Tokens hashed at rest (`apikey`/`magiclink` discipline), constant-time accept, revoke and resend (resend rotates the token), pending-invite listing. Accept returns the verified `{tenant, email, role}` claim — membership creation, seat limits, and the send itself (`comms/email`) stay consumer-side. Domain auto-join and shareable multi-use links are out of scope.
-
-Deps: `data/postgres`.
-
 ## comms/
 
 ---


### PR DESCRIPTION
## Summary

Implements the `auth/invite` catalog entry: email-addressed, single-use, expiring token invitations into a tenant, carrying an opaque role payload the package never interprets. The catalog entry is removed from `docs/packages.md` per the shipped-package rule.

- **Token discipline (apikey mold):** `inv_`-prefixed secrets — 43-char base62 payload (~256 bits) + CRC32 checksum. Malformed input is rejected allocation-free before any store access; only the hex SHA-256 is persisted; the plaintext is returned exactly once (at Create, and at Resend which rotates it).
- **Constant-time, atomically single-use Accept:** hash lookup + `consttime.StringEqual` defense-in-depth, then a conditional store update (`WHERE accepted_at IS NULL AND revoked_at IS NULL AND expires_at > $2`) so exactly one concurrent Accept wins and replays report `ErrAlreadyAccepted`. Accept returns the verified `Claim{Tenant, Email, Role, ID}` — membership creation, seat limits, and the email send stay consumer-side.
- **Peek** verifies without consuming, so email scanners that prefetch links cannot burn an invite and the "join org" page renders before the user commits.
- **Revoke** is idempotent (keeps the original timestamp); revoking an accepted invite reports `ErrAlreadyAccepted`. **Resend** rotates hash + expiry — the old token is dead the moment resend succeeds, and an expired (but not accepted/revoked) invite can be revived.
- **Tenancy:** fail-closed `WithScope` seam confines Create/Get/List/Revoke/Resend (hook error or empty tenant → `ErrScope`; cross-tenant reads → `ErrNotFound`); Accept/Peek are deliberately unscoped because the invitee has no tenant context yet — the record carries the tenant. Single-tenant use pays zero ceremony.
- **Stores:** in-memory for tests/dev + `pgstore` pgx driver with embedded goose migration (`forge_invites`, unique hash index, dynamic WHERE in List — no `($n='' OR …)` idiom). The single-use/rotate guards are conditional single-row UPDATEs classified on zero rows affected, so no transactions are needed.

## Benchmarks (M3 Max, memory store)

```
BenchmarkCreate-14                	  862774	  1367 ns/op	  806 B/op	  9 allocs/op
BenchmarkPeek-14                  	 1000000	  1138 ns/op	 1376 B/op	 18 allocs/op
BenchmarkPeekMalformedReject-14   	17445250	 68.36 ns/op	    0 B/op	  0 allocs/op
BenchmarkListPending-14           	   80653	 14940 ns/op	18432 B/op	  1 allocs/op
```

Post-benchmark pass: the DoS-relevant reject path is 0 allocs (same crc32String trick as apikey). Peek/Accept's 18 allocs are entirely `consttime.StringEqual`'s deliberate double-HMAC pattern (verified via alloc profile) — identical to apikey's verify path and not worth bypassing for a human-rare operation, so no perf-motivated changes were made.

## Testing

- Unit + `-race`: manager lifecycle, rejection classes, concurrent single-use (exactly one winner of 32), scope fail-closed sweep across all five management ops, store contract (CAS classification, rotate reindexing, idempotent revoke), store-error wrapping, malformed-token-never-touches-store.
- `FuzzPeek` (15s clean): no forged token verifies, no input panics.
- Integration (`-tags=integration`, testcontainers Postgres): full store contract against real Postgres incl. concurrent accept and an end-to-end manager flow — all green locally.
