### PR TITLE
feat(comms/email): transactional email — Sender seam, stdlib SMTP, MIME encoder, templates, markdown subpackage

### DIFF
--- a/comms/email/bench_test.go
+++ b/comms/email/bench_test.go
@@ -1,0 +1,58 @@
+package email_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"testing/fstest"
+
+	"github.com/dmitrymomot/forge/comms/email"
+)
+
+func BenchmarkEncodeTextOnly(b *testing.B) {
+	msg := validMessage()
+	for b.Loop() {
+		if err := msg.Encode(io.Discard); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncodeAlternative(b *testing.B) {
+	msg := validMessage()
+	msg.HTML = "<p>Hi Ann,</p><p>Here is your <strong>report</strong> for July.</p>"
+	for b.Loop() {
+		if err := msg.Encode(io.Discard); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncodeWithAttachment(b *testing.B) {
+	msg := validMessage()
+	msg.HTML = "<p>Report attached.</p>"
+	msg.Attachments = []email.Attachment{{Filename: "report.pdf", Content: bytes.Repeat([]byte("forge"), 64<<10/5)}}
+	for b.Loop() {
+		if err := msg.Encode(io.Discard); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTemplatesRender(b *testing.B) {
+	fsys := fstest.MapFS{"welcome.tmpl": {Data: []byte(
+		`{{define "welcome:subject"}}Welcome, {{.Name}}!{{end}}` +
+			`{{define "welcome:html"}}<p>Hi {{.Name}},</p><p>Glad to have you.</p>{{end}}` +
+			`{{define "welcome:text"}}Hi {{.Name}}, glad to have you.{{end}}`,
+	)}}
+	tpl, err := email.ParseFS(fsys, "*.tmpl")
+	if err != nil {
+		b.Fatal(err)
+	}
+	data := map[string]string{"Name": "Ann"}
+	for b.Loop() {
+		if _, err := tpl.Render("welcome", data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/comms/email/config.go
+++ b/comms/email/config.go
@@ -1,0 +1,81 @@
+package email
+
+import (
+	"fmt"
+	"net"
+	"net/mail"
+	"time"
+)
+
+// TLSMode selects how the SMTP connection is secured.
+type TLSMode string
+
+const (
+	// TLSStartTLS (the default) connects in plaintext and upgrades via
+	// STARTTLS before any credentials or mail flow. The upgrade is mandatory:
+	// a server that does not advertise STARTTLS fails the send.
+	TLSStartTLS TLSMode = "starttls"
+
+	// TLSImplicit performs a TLS handshake immediately on connect — the
+	// SMTPS convention, usually port 465.
+	TLSImplicit TLSMode = "implicit"
+
+	// TLSNone sends over plaintext. For local development catchers
+	// (Mailpit, MailHog) only; net/smtp refuses PLAIN auth over plaintext to
+	// any host but localhost.
+	TLSNone TLSMode = "none"
+)
+
+// Config is the env-loadable SMTP sender configuration. The canonical loading
+// flow preserves defaults:
+//
+//	cfg := email.DefaultConfig()
+//	err := appconfig.Populate(&cfg)
+type Config struct {
+	// Addr is the server's host:port, e.g. "smtp.example.com:587".
+	Addr string `env:"EMAIL_SMTP_ADDR"`
+	// Username and Password enable PLAIN authentication when both are set.
+	Username string `env:"EMAIL_SMTP_USERNAME"`
+	Password string `env:"EMAIL_SMTP_PASSWORD"`
+	// TLS is the connection security mode (default TLSStartTLS).
+	TLS TLSMode `env:"EMAIL_SMTP_TLS"`
+	// Hello overrides the EHLO hostname (default "localhost").
+	Hello string `env:"EMAIL_SMTP_HELLO"`
+	// From, when set, fills Message.From for messages that leave it empty —
+	// the app-wide sender identity.
+	From string `env:"EMAIL_FROM"`
+	// Timeout bounds one whole Send: dial, handshake, and mail flow
+	// (default 15s). A sooner context deadline still wins.
+	Timeout time.Duration `env:"EMAIL_TIMEOUT"`
+}
+
+// DefaultConfig returns the default policy: mandatory STARTTLS and a 15s
+// send timeout.
+func DefaultConfig() Config {
+	return Config{TLS: TLSStartTLS, Timeout: 15 * time.Second}
+}
+
+// Validate checks required fields.
+func (c Config) Validate() error {
+	host, port, err := net.SplitHostPort(c.Addr)
+	if err != nil || host == "" || port == "" {
+		return fmt.Errorf("%w: Addr must be host:port, got %q", ErrInvalidConfig, c.Addr)
+	}
+	switch c.TLS {
+	case TLSStartTLS, TLSImplicit, TLSNone:
+	default:
+		return fmt.Errorf("%w: unknown TLS mode %q", ErrInvalidConfig, c.TLS)
+	}
+	if (c.Username == "") != (c.Password == "") {
+		return fmt.Errorf("%w: Username and Password must be set together", ErrInvalidConfig)
+	}
+	if c.From != "" {
+		if _, err := mail.ParseAddress(c.From); err != nil {
+			return fmt.Errorf("%w: From address %q: %v", ErrInvalidConfig, c.From, err)
+		}
+	}
+	if c.Timeout <= 0 {
+		return fmt.Errorf("%w: Timeout must be positive", ErrInvalidConfig)
+	}
+	return nil
+}

--- a/comms/email/doc.go
+++ b/comms/email/doc.go
@@ -1,0 +1,56 @@
+// Package email sends transactional email: a Message type with a full RFC
+// 5322 / MIME encoder (multipart alternative/related/mixed, quoted-printable
+// bodies, base64 attachments, inline images), a Sender seam, a stdlib
+// net/smtp implementation with mandatory-by-default STARTTLS, and
+// named-template rendering of subject + HTML + text into a Message.
+//
+// Validation is fail-closed: unparseable addresses, CR/LF in any header
+// value (injection), encoder-owned header collisions, and messages with no
+// recipient or no body are construction errors. Bcc recipients ride the SMTP
+// envelope only and are never encoded. SMTP rejections map onto a queue's
+// retry decision — ErrTransient for 4xx, ErrPermanent for 5xx — and a
+// failure after the server accepted the message never surfaces as an error,
+// so an at-least-once queue cannot double-send.
+//
+// The comms/email/markdown subpackage renders markdown with YAML frontmatter
+// into a ready Message — the designer-free transactional format.
+//
+// # Non-goals
+//
+//   - No provider SDKs: SES/Postmark/Mailgun adapters are consumer-side
+//     Sender implementations over Message.Encode or their JSON APIs.
+//   - No durable delivery, retries, or rate limiting: ride async/queue with
+//     a Sender as the deliverer; the error sentinels carry the retry
+//     decision.
+//   - No inbound processing: parsing received mail is comms/inbound.
+//   - No connection pooling: submission servers are dial-per-message
+//     friendly; a pool would trade correctness (stale-connection races) for
+//     an unproven win.
+//   - No tenant seam: a Message is a passed value and the sender holds no
+//     tenant data; per-tenant identities are per-tenant Config values.
+//
+// # Usage
+//
+//	sender, err := email.New(email.Config{
+//		Addr:     "smtp.example.com:587",
+//		Username: "postmaster",
+//		Password: "secret",
+//		TLS:      email.TLSStartTLS,
+//		From:     "Acme <no-reply@acme.example>",
+//		Timeout:  15 * time.Second,
+//	})
+//	if err != nil {
+//		// bad config
+//	}
+//
+//	tpl, _ := email.ParseFS(templatesFS, "templates/*.tmpl")
+//	msg, err := tpl.Render("welcome", map[string]string{"Name": "Ann"})
+//	if err != nil {
+//		// unknown name or broken template
+//	}
+//	msg.To = []string{"Ann <ann@example.com>"}
+//
+//	err = sender.Send(ctx, msg)
+//	// errors.Is(err, email.ErrTransient) → requeue
+//	// errors.Is(err, email.ErrPermanent) → dead-letter
+package email

--- a/comms/email/errors.go
+++ b/comms/email/errors.go
@@ -1,0 +1,36 @@
+package email
+
+import "errors"
+
+var (
+	// ErrInvalidConfig is returned by New when the Config fails validation.
+	ErrInvalidConfig = errors.New("email: invalid config")
+
+	// ErrInvalidMessage means the message cannot be sent as constructed: an
+	// unparseable or missing address, no recipients, no body, a CR/LF in a
+	// header value (injection), or a custom header that collides with one the
+	// encoder owns.
+	ErrInvalidMessage = errors.New("email: invalid message")
+
+	// ErrTLSUnavailable means the server did not advertise STARTTLS while the
+	// sender requires it (the default). Credentials are never sent and mail is
+	// never submitted over plaintext in STARTTLS mode — fail closed.
+	ErrTLSUnavailable = errors.New("email: server does not support STARTTLS")
+
+	// ErrTransient means the server answered a 4xx SMTP status — a temporary
+	// condition (greylisting, full mailbox, rate limit) worth retrying.
+	ErrTransient = errors.New("email: transient SMTP failure")
+
+	// ErrPermanent means the server answered a 5xx SMTP status — the message
+	// or recipient is refused; retrying the same send won't help.
+	ErrPermanent = errors.New("email: permanent SMTP failure")
+
+	// ErrTemplateNotFound is returned by Render when the parsed set defines no
+	// subject/html/text blocks under the requested name.
+	ErrTemplateNotFound = errors.New("email: template not found")
+
+	// ErrInvalidTemplate means a rendered template violates the message
+	// contract: an empty subject, a newline in the subject, or a name that
+	// defines a subject but neither body.
+	ErrInvalidTemplate = errors.New("email: invalid template")
+)

--- a/comms/email/example_test.go
+++ b/comms/email/example_test.go
@@ -1,0 +1,56 @@
+package email_test
+
+import (
+	"context"
+	"fmt"
+	"testing/fstest"
+	"time"
+
+	"github.com/dmitrymomot/forge/comms/email"
+)
+
+// Example wires the full flow: config, template rendering, and an SMTP send.
+func Example() {
+	sender, err := email.New(email.Config{
+		Addr:     "smtp.example.com:587",
+		Username: "postmaster",
+		Password: "secret",
+		TLS:      email.TLSStartTLS,
+		From:     "Acme <no-reply@acme.example>",
+		Timeout:  15 * time.Second,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	msg := email.Message{
+		To:      []string{"Ann <ann@example.com>"},
+		Subject: "Welcome to Acme",
+		Text:    "Hi Ann, welcome aboard!",
+		HTML:    "<p>Hi Ann, welcome aboard!</p>",
+	}
+	_ = sender.Send(context.Background(), msg)
+}
+
+func ExampleTemplates_Render() {
+	fsys := fstest.MapFS{"welcome.tmpl": {Data: []byte(
+		`{{define "welcome:subject"}}Welcome, {{.Name}}!{{end}}` +
+			`{{define "welcome:html"}}<p>Hi {{.Name}},</p>{{end}}` +
+			`{{define "welcome:text"}}Hi {{.Name}},{{end}}`,
+	)}}
+	tpl, err := email.ParseFS(fsys, "*.tmpl")
+	if err != nil {
+		panic(err)
+	}
+	msg, err := tpl.Render("welcome", map[string]string{"Name": "Ann"})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(msg.Subject)
+	fmt.Println(msg.HTML)
+	fmt.Println(msg.Text)
+	// Output:
+	// Welcome, Ann!
+	// <p>Hi Ann,</p>
+	// Hi Ann,
+}

--- a/comms/email/markdown/bench_test.go
+++ b/comms/email/markdown/bench_test.go
@@ -1,0 +1,37 @@
+package markdown_test
+
+import (
+	"testing"
+
+	"github.com/dmitrymomot/forge/comms/email/markdown"
+)
+
+func BenchmarkRender(b *testing.B) {
+	r, err := markdown.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	src := []byte(welcomeDoc)
+	for b.Loop() {
+		if _, err := r.Render(src); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRenderLongDocument(b *testing.B) {
+	r, err := markdown.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	src := []byte("---\nsubject: Digest\npreheader: Your weekly digest\n---\n")
+	for range 30 {
+		src = append(src, []byte("## Section\n\nSome paragraph with **bold** and a [link](https://acme.example/x).\n\n- item one\n- item two\n- item three\n\n")...)
+	}
+	src = append(src, []byte("[Button: Open dashboard](https://app.acme.example)\n")...)
+	for b.Loop() {
+		if _, err := r.Render(src); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/comms/email/markdown/bench_test.go
+++ b/comms/email/markdown/bench_test.go
@@ -19,6 +19,20 @@ func BenchmarkRender(b *testing.B) {
 	}
 }
 
+func BenchmarkRenderData(b *testing.B) {
+	r, err := markdown.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	src := []byte("---\nsubject: Welcome, {{.Name}}!\n---\n# Hi {{.Name}}\n\n[Button: Start](https://app.acme.example/start?t={{.Token}})\n")
+	data := map[string]string{"Name": "Ann", "Token": "abc123"}
+	for b.Loop() {
+		if _, err := r.RenderData(src, data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkRenderLongDocument(b *testing.B) {
 	r, err := markdown.New()
 	if err != nil {

--- a/comms/email/markdown/button.go
+++ b/comms/email/markdown/button.go
@@ -1,0 +1,101 @@
+package markdown
+
+import (
+	"html"
+	"strings"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+// buttonNode is a paragraph promoted to a call-to-action button by
+// buttonTransformer.
+type buttonNode struct {
+	label string
+	url   string
+	ast.BaseBlock
+}
+
+var kindButton = ast.NewNodeKind("EmailButton")
+
+func (n *buttonNode) Kind() ast.NodeKind { return kindButton }
+
+func (n *buttonNode) Dump(src []byte, level int) {
+	ast.DumpHelper(n, src, level, map[string]string{"Label": n.label, "URL": n.url}, nil)
+}
+
+// buttonTransformer promotes CTA paragraphs to buttons: a paragraph whose
+// entire content is one link whose text starts with "Button:" and whose
+// destination is absolute http(s). Anything else — extra text in the
+// paragraph, a relative or non-http destination — is left as a plain link,
+// so a malformed CTA degrades visibly instead of silently vanishing.
+type buttonTransformer struct{}
+
+func (buttonTransformer) Transform(doc *ast.Document, reader text.Reader, _ parser.Context) {
+	source := reader.Source()
+	type hit struct {
+		paragraph *ast.Paragraph
+		label     string
+		url       string
+	}
+	var hits []hit
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		paragraph, ok := n.(*ast.Paragraph)
+		if !ok || paragraph.ChildCount() != 1 {
+			return ast.WalkContinue, nil
+		}
+		link, ok := paragraph.FirstChild().(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		var sb strings.Builder
+		inlineText(&sb, source, link)
+		label, ok := strings.CutPrefix(sb.String(), "Button:")
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		label = strings.TrimSpace(label)
+		url := string(link.Destination)
+		if label == "" || (!strings.HasPrefix(url, "https://") && !strings.HasPrefix(url, "http://")) {
+			return ast.WalkContinue, nil
+		}
+		hits = append(hits, hit{paragraph: paragraph, label: label, url: url})
+		return ast.WalkSkipChildren, nil
+	})
+	for _, h := range hits {
+		button := &buttonNode{label: h.label, url: h.url}
+		parent := h.paragraph.Parent()
+		parent.ReplaceChild(parent, h.paragraph, button)
+	}
+}
+
+// buttonHTMLRenderer emits the bulletproof-button table markup email clients
+// require (a styled <a> alone collapses in Outlook).
+type buttonHTMLRenderer struct {
+	color string
+}
+
+func (r *buttonHTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(kindButton, r.render)
+}
+
+func (r *buttonHTMLRenderer) render(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*buttonNode)
+	w.WriteString(`<table role="presentation" border="0" cellspacing="0" cellpadding="0" style="margin:24px 0;"><tr><td style="border-radius:6px;background-color:`) //nolint:errcheck // BufWriter errors surface on flush
+	w.WriteString(html.EscapeString(r.color))                                                                                                                        //nolint:errcheck // BufWriter errors surface on flush
+	w.WriteString(`;"><a href="`)                                                                                                                                    //nolint:errcheck // BufWriter errors surface on flush
+	w.WriteString(html.EscapeString(n.url))                                                                                                                          //nolint:errcheck // BufWriter errors surface on flush
+	w.WriteString(`" target="_blank" style="display:inline-block;padding:12px 28px;font-size:16px;font-weight:600;color:#ffffff;text-decoration:none;">`)            //nolint:errcheck // BufWriter errors surface on flush
+	w.WriteString(html.EscapeString(n.label))                                                                                                                        //nolint:errcheck // BufWriter errors surface on flush
+	w.WriteString(`</a></td></tr></table>`)                                                                                                                          //nolint:errcheck // BufWriter errors surface on flush
+	return ast.WalkContinue, nil
+}

--- a/comms/email/markdown/doc.go
+++ b/comms/email/markdown/doc.go
@@ -22,14 +22,21 @@
 // Frontmatter decoding is strict — an unknown key fails the render — and raw
 // HTML in the markdown is dropped, never passed through.
 //
+// Render treats the source as static content ("{{" stays literal).
+// RenderData runs text/template over the whole source first — frontmatter
+// included, so subjects and preheaders can carry {{.Field}} — with
+// missingkey=error so a typo'd field fails the render. Templated values are
+// interpreted as markdown/YAML: pass trusted, application-owned data only.
+//
 // # Non-goals
 //
-//   - No variable interpolation: the source is static content; run
-//     text/template over it first if a document needs data.
 //   - No CSS inliner or theming system: WithLayout replaces the whole shell
 //     when the default card doesn't fit.
 //   - No GFM extensions (tables, strikethrough): transactional email bodies
 //     are prose, headings, lists, and buttons.
+//   - No sanitization of templated values: RenderData data is trusted
+//     application data by contract; user-generated strings belong in static
+//     Render documents.
 //
 // # Usage
 //
@@ -37,9 +44,9 @@
 //	if err != nil {
 //		// bad custom layout
 //	}
-//	msg, err := r.Render(welcomeMD)
+//	msg, err := r.RenderData(welcomeMD, map[string]string{"Name": "Ann"})
 //	if err != nil {
-//		// malformed frontmatter or markdown
+//		// malformed frontmatter, markdown, or template data
 //	}
 //	msg.To = []string{"ann@example.com"}
 //	err = sender.Send(ctx, msg) // any email.Sender

--- a/comms/email/markdown/doc.go
+++ b/comms/email/markdown/doc.go
@@ -1,0 +1,46 @@
+// Package markdown renders markdown documents with YAML frontmatter into
+// ready email.Message content — the designer-free transactional email
+// format. One source file yields the subject, an HTML body wrapped in an
+// email-safe layout (hidden preheader, 600px card), and the plain-text
+// alternative; goldmark is confined to this subpackage.
+//
+// A document is YAML frontmatter (subject required, preheader optional)
+// followed by CommonMark:
+//
+//	---
+//	subject: Confirm your email
+//	preheader: One click and you're in.
+//	---
+//	# Almost there
+//
+//	Hi! Confirm your address to activate your account.
+//
+//	[Button: Confirm email](https://app.acme.example/confirm?t=abc)
+//
+// A paragraph holding exactly one link whose text starts with "Button:"
+// becomes a table-based CTA button (plain text renders it as "label: url").
+// Frontmatter decoding is strict — an unknown key fails the render — and raw
+// HTML in the markdown is dropped, never passed through.
+//
+// # Non-goals
+//
+//   - No variable interpolation: the source is static content; run
+//     text/template over it first if a document needs data.
+//   - No CSS inliner or theming system: WithLayout replaces the whole shell
+//     when the default card doesn't fit.
+//   - No GFM extensions (tables, strikethrough): transactional email bodies
+//     are prose, headings, lists, and buttons.
+//
+// # Usage
+//
+//	r, err := markdown.New()
+//	if err != nil {
+//		// bad custom layout
+//	}
+//	msg, err := r.Render(welcomeMD)
+//	if err != nil {
+//		// malformed frontmatter or markdown
+//	}
+//	msg.To = []string{"ann@example.com"}
+//	err = sender.Send(ctx, msg) // any email.Sender
+package markdown

--- a/comms/email/markdown/doc.go
+++ b/comms/email/markdown/doc.go
@@ -28,7 +28,11 @@
 // render. The document structure is parsed before data enters it, so a data
 // value cannot re-terminate the frontmatter or inject keys, and a newline
 // landing in the subject or preheader fails the render. Body values are
-// still interpreted as markdown.
+// still interpreted as markdown. Because the frontmatter is YAML first, a
+// value that begins with a placeholder must be quoted:
+//
+//	subject: 'Welcome, {{.Name}}!'   // always safe
+//	subject: {{.Subject}}            // invalid YAML — quote it
 //
 // # Non-goals
 //

--- a/comms/email/markdown/doc.go
+++ b/comms/email/markdown/doc.go
@@ -23,10 +23,12 @@
 // HTML in the markdown is dropped, never passed through.
 //
 // Render treats the source as static content ("{{" stays literal).
-// RenderData runs text/template over the whole source first — frontmatter
-// included, so subjects and preheaders can carry {{.Field}} — with
-// missingkey=error so a typo'd field fails the render. Templated values are
-// interpreted as markdown/YAML: pass trusted, application-owned data only.
+// RenderData templates the frontmatter subject/preheader values and the body
+// with data ({{.Field}}), with missingkey=error so a typo'd field fails the
+// render. The document structure is parsed before data enters it, so a data
+// value cannot re-terminate the frontmatter or inject keys, and a newline
+// landing in the subject or preheader fails the render. Body values are
+// still interpreted as markdown.
 //
 // # Non-goals
 //
@@ -34,9 +36,10 @@
 //     when the default card doesn't fit.
 //   - No GFM extensions (tables, strikethrough): transactional email bodies
 //     are prose, headings, lists, and buttons.
-//   - No sanitization of templated values: RenderData data is trusted
-//     application data by contract; user-generated strings belong in static
-//     Render documents.
+//   - No markdown-escaping of templated body values: a hostile string can
+//     still inject a link or emphasis (never raw HTML — that is dropped), so
+//     RenderData data is application-owned by contract; user-generated
+//     strings that must render verbatim belong in static Render documents.
 //
 // # Usage
 //

--- a/comms/email/markdown/errors.go
+++ b/comms/email/markdown/errors.go
@@ -1,0 +1,14 @@
+package markdown
+
+import "errors"
+
+var (
+	// ErrInvalidDocument means the source is not a renderable email document:
+	// missing or malformed YAML frontmatter, an unknown frontmatter key (typo
+	// — fail closed), or a missing/multi-line subject.
+	ErrInvalidDocument = errors.New("email/markdown: invalid document")
+
+	// ErrInvalidLayout is returned by New when a custom layout does not parse
+	// or does not execute.
+	ErrInvalidLayout = errors.New("email/markdown: invalid layout")
+)

--- a/comms/email/markdown/example_test.go
+++ b/comms/email/markdown/example_test.go
@@ -1,0 +1,36 @@
+package markdown_test
+
+import (
+	"fmt"
+
+	"github.com/dmitrymomot/forge/comms/email/markdown"
+)
+
+func ExampleRenderer_Render() {
+	r, err := markdown.New()
+	if err != nil {
+		panic(err)
+	}
+	msg, err := r.Render([]byte(`---
+subject: Confirm your email
+preheader: One click and you're in.
+---
+# Almost there
+
+Confirm your address to activate your account.
+
+[Button: Confirm email](https://app.acme.example/confirm?t=abc)
+`))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(msg.Subject)
+	fmt.Println(msg.Text)
+	// Output:
+	// Confirm your email
+	// Almost there
+	//
+	// Confirm your address to activate your account.
+	//
+	// Confirm email: https://app.acme.example/confirm?t=abc
+}

--- a/comms/email/markdown/markdown.go
+++ b/comms/email/markdown/markdown.go
@@ -1,0 +1,134 @@
+package markdown
+
+import (
+	"bytes"
+	"fmt"
+	htmltemplate "html/template"
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+	"gopkg.in/yaml.v3"
+
+	"github.com/dmitrymomot/forge/comms/email"
+)
+
+// LayoutData is what a layout template executes with: the frontmatter
+// subject and preheader plus the rendered markdown body.
+type LayoutData struct {
+	Subject   string
+	Preheader string
+	Body      htmltemplate.HTML
+}
+
+// Renderer converts markdown documents with YAML frontmatter into ready
+// email.Message content. Construct once and reuse; it is safe for concurrent
+// use.
+type Renderer struct {
+	md     goldmark.Markdown
+	layout *htmltemplate.Template
+}
+
+// New returns a Renderer. Defaults: a minimal responsive single-column
+// layout (hidden preheader, 600px card, system font stack) and a blue CTA
+// button; see WithLayout and WithButtonColor.
+func New(opts ...Option) (*Renderer, error) {
+	c := config{layout: defaultLayout, buttonColor: defaultButtonColor}
+	for _, o := range opts {
+		o(&c)
+	}
+	layout, err := htmltemplate.New("layout").Parse(c.layout)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidLayout, err)
+	}
+	// Executing with zero data now surfaces field typos at construction
+	// instead of on the first send.
+	if err := layout.Execute(&bytes.Buffer{}, LayoutData{}); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidLayout, err)
+	}
+	md := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithASTTransformers(util.Prioritized(buttonTransformer{}, 500)),
+		),
+		goldmark.WithRendererOptions(
+			renderer.WithNodeRenderers(util.Prioritized(&buttonHTMLRenderer{color: c.buttonColor}, 500)),
+		),
+	)
+	return &Renderer{md: md, layout: layout}, nil
+}
+
+// frontmatter is the document header. Decoding is strict: an unknown key is
+// an error, so a typo ("subjct") fails the render instead of sending a
+// broken email.
+type frontmatter struct {
+	Subject   string `yaml:"subject"`
+	Preheader string `yaml:"preheader"`
+}
+
+// Render converts one markdown document into a Message with Subject, HTML
+// (markdown wrapped in the layout), and Text (the plain-text alternative)
+// filled — From and recipients stay with the caller. Raw HTML in the
+// markdown is dropped, never passed through. The source is static content:
+// to template variables into it, run text/template over the source first.
+func (r *Renderer) Render(src []byte) (email.Message, error) {
+	if r == nil || r.md == nil {
+		return email.Message{}, fmt.Errorf("%w: renderer not constructed with New", ErrInvalidDocument)
+	}
+	meta, body, err := splitFrontmatter(src)
+	if err != nil {
+		return email.Message{}, err
+	}
+	var fm frontmatter
+	dec := yaml.NewDecoder(bytes.NewReader(meta))
+	dec.KnownFields(true)
+	if err := dec.Decode(&fm); err != nil {
+		return email.Message{}, fmt.Errorf("%w: frontmatter: %v", ErrInvalidDocument, err)
+	}
+	fm.Subject = strings.TrimSpace(fm.Subject)
+	fm.Preheader = strings.TrimSpace(fm.Preheader)
+	if fm.Subject == "" {
+		return email.Message{}, fmt.Errorf("%w: frontmatter has no subject", ErrInvalidDocument)
+	}
+	if strings.ContainsAny(fm.Subject, "\r\n") || strings.ContainsAny(fm.Preheader, "\r\n") {
+		return email.Message{}, fmt.Errorf("%w: subject and preheader must be single-line", ErrInvalidDocument)
+	}
+
+	doc := r.md.Parser().Parse(text.NewReader(body))
+	var htmlBody bytes.Buffer
+	if err := r.md.Renderer().Render(&htmlBody, body, doc); err != nil {
+		return email.Message{}, fmt.Errorf("email/markdown: render html: %w", err)
+	}
+	var page bytes.Buffer
+	data := LayoutData{Subject: fm.Subject, Preheader: fm.Preheader, Body: htmltemplate.HTML(htmlBody.String())} //nolint:gosec // goldmark output with raw HTML filtered, plus our own escaped button markup
+	if err := r.layout.Execute(&page, data); err != nil {
+		return email.Message{}, fmt.Errorf("email/markdown: render layout: %w", err)
+	}
+
+	var plain strings.Builder
+	renderText(&plain, body, doc)
+
+	return email.Message{Subject: fm.Subject, HTML: page.String(), Text: plain.String()}, nil
+}
+
+// splitFrontmatter cuts the leading "---" YAML block from the body. The
+// frontmatter is mandatory — it carries the subject.
+func splitFrontmatter(src []byte) (meta, body []byte, err error) {
+	normalized := bytes.ReplaceAll(src, []byte("\r\n"), []byte("\n"))
+	rest, ok := bytes.CutPrefix(normalized, []byte("---\n"))
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: missing frontmatter", ErrInvalidDocument)
+	}
+	if bytes.HasPrefix(rest, []byte("---\n")) || bytes.Equal(rest, []byte("---")) {
+		return nil, nil, fmt.Errorf("%w: empty frontmatter", ErrInvalidDocument)
+	}
+	if before, after, found := bytes.Cut(rest, []byte("\n---\n")); found {
+		return before, after, nil
+	}
+	if before, found := bytes.CutSuffix(rest, []byte("\n---")); found {
+		return before, nil, nil
+	}
+	return nil, nil, fmt.Errorf("%w: unterminated frontmatter", ErrInvalidDocument)
+}

--- a/comms/email/markdown/markdown.go
+++ b/comms/email/markdown/markdown.go
@@ -69,28 +69,52 @@ type frontmatter struct {
 	Preheader string `yaml:"preheader"`
 }
 
-// RenderData runs text/template over the whole source — frontmatter
-// included, so subjects and preheaders carry {{.Field}} too — and renders
-// the result like Render. Missing keys are errors (missingkey=error), so a
-// typo'd field fails the render instead of sending "<no value>".
+// RenderData renders a templated document: the frontmatter subject and
+// preheader values and the markdown body are each executed as text/template
+// with data, then rendered like Render. Missing keys are errors
+// (missingkey=error), so a typo'd field fails the render instead of sending
+// "<no value>".
 //
-// Substituted values land in the source before markdown parsing, so they are
-// interpreted as markdown and YAML: pass trusted, application-owned data.
-// A user-controlled string that must render verbatim belongs in a static
-// Render document, not in template data.
+// The document structure is fixed before data enters it: the frontmatter is
+// split and YAML-decoded from the raw source, and only the decoded values
+// are templated — a data value containing "---" or "key: x" cannot
+// re-terminate the frontmatter or inject keys, and a newline landing in the
+// rendered subject or preheader fails the render. Body values are still
+// interpreted as markdown (a hostile string can inject a link), so data
+// should be application-owned; user-controlled strings that must render
+// verbatim belong in a static Render document.
 func (r *Renderer) RenderData(src []byte, data any) (email.Message, error) {
 	if r == nil || r.md == nil {
 		return email.Message{}, fmt.Errorf("%w: renderer not constructed with New", ErrInvalidDocument)
 	}
-	tmpl, err := texttemplate.New("email").Option("missingkey=error").Parse(string(src))
+	fm, body, err := parseDocument(src)
 	if err != nil {
-		return email.Message{}, fmt.Errorf("%w: template: %v", ErrInvalidDocument, err)
+		return email.Message{}, err
+	}
+	if fm.Subject, err = execTemplate("subject", fm.Subject, data); err != nil {
+		return email.Message{}, err
+	}
+	if fm.Preheader, err = execTemplate("preheader", fm.Preheader, data); err != nil {
+		return email.Message{}, err
+	}
+	renderedBody, err := execTemplate("body", string(body), data)
+	if err != nil {
+		return email.Message{}, err
+	}
+	return r.render(fm, []byte(renderedBody))
+}
+
+// execTemplate runs one document fragment as a text/template.
+func execTemplate(name, src string, data any) (string, error) {
+	tmpl, err := texttemplate.New(name).Option("missingkey=error").Parse(src)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s template: %v", ErrInvalidDocument, name, err)
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
-		return email.Message{}, fmt.Errorf("email/markdown: execute template: %w", err)
+		return "", fmt.Errorf("email/markdown: execute %s template: %w", name, err)
 	}
-	return r.Render(buf.Bytes())
+	return buf.String(), nil
 }
 
 // Render converts one static markdown document into a Message with Subject,
@@ -102,16 +126,32 @@ func (r *Renderer) Render(src []byte) (email.Message, error) {
 	if r == nil || r.md == nil {
 		return email.Message{}, fmt.Errorf("%w: renderer not constructed with New", ErrInvalidDocument)
 	}
-	meta, body, err := splitFrontmatter(src)
+	fm, body, err := parseDocument(src)
 	if err != nil {
 		return email.Message{}, err
+	}
+	return r.render(fm, body)
+}
+
+// parseDocument splits and strictly decodes the frontmatter. Subject checks
+// live in render — for RenderData the values are templated in between.
+func parseDocument(src []byte) (frontmatter, []byte, error) {
+	meta, body, err := splitFrontmatter(src)
+	if err != nil {
+		return frontmatter{}, nil, err
 	}
 	var fm frontmatter
 	dec := yaml.NewDecoder(bytes.NewReader(meta))
 	dec.KnownFields(true)
 	if err := dec.Decode(&fm); err != nil {
-		return email.Message{}, fmt.Errorf("%w: frontmatter: %v", ErrInvalidDocument, err)
+		return frontmatter{}, nil, fmt.Errorf("%w: frontmatter: %v", ErrInvalidDocument, err)
 	}
+	return fm, body, nil
+}
+
+// render is the shared back half: subject contract checks, markdown to HTML
+// inside the layout, and the plain-text alternative.
+func (r *Renderer) render(fm frontmatter, body []byte) (email.Message, error) {
 	fm.Subject = strings.TrimSpace(fm.Subject)
 	fm.Preheader = strings.TrimSpace(fm.Preheader)
 	if fm.Subject == "" {

--- a/comms/email/markdown/markdown.go
+++ b/comms/email/markdown/markdown.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	htmltemplate "html/template"
 	"strings"
+	texttemplate "text/template"
 
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/parser"
@@ -68,11 +69,35 @@ type frontmatter struct {
 	Preheader string `yaml:"preheader"`
 }
 
-// Render converts one markdown document into a Message with Subject, HTML
-// (markdown wrapped in the layout), and Text (the plain-text alternative)
-// filled — From and recipients stay with the caller. Raw HTML in the
-// markdown is dropped, never passed through. The source is static content:
-// to template variables into it, run text/template over the source first.
+// RenderData runs text/template over the whole source — frontmatter
+// included, so subjects and preheaders carry {{.Field}} too — and renders
+// the result like Render. Missing keys are errors (missingkey=error), so a
+// typo'd field fails the render instead of sending "<no value>".
+//
+// Substituted values land in the source before markdown parsing, so they are
+// interpreted as markdown and YAML: pass trusted, application-owned data.
+// A user-controlled string that must render verbatim belongs in a static
+// Render document, not in template data.
+func (r *Renderer) RenderData(src []byte, data any) (email.Message, error) {
+	if r == nil || r.md == nil {
+		return email.Message{}, fmt.Errorf("%w: renderer not constructed with New", ErrInvalidDocument)
+	}
+	tmpl, err := texttemplate.New("email").Option("missingkey=error").Parse(string(src))
+	if err != nil {
+		return email.Message{}, fmt.Errorf("%w: template: %v", ErrInvalidDocument, err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return email.Message{}, fmt.Errorf("email/markdown: execute template: %w", err)
+	}
+	return r.Render(buf.Bytes())
+}
+
+// Render converts one static markdown document into a Message with Subject,
+// HTML (markdown wrapped in the layout), and Text (the plain-text
+// alternative) filled — From and recipients stay with the caller. Raw HTML
+// in the markdown is dropped, never passed through. The source is rendered
+// verbatim ("{{" stays literal); use RenderData to template values in.
 func (r *Renderer) Render(src []byte) (email.Message, error) {
 	if r == nil || r.md == nil {
 		return email.Message{}, fmt.Errorf("%w: renderer not constructed with New", ErrInvalidDocument)

--- a/comms/email/markdown/markdown.go
+++ b/comms/email/markdown/markdown.go
@@ -144,6 +144,12 @@ func parseDocument(src []byte) (frontmatter, []byte, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(meta))
 	dec.KnownFields(true)
 	if err := dec.Decode(&fm); err != nil {
+		// YAML reserves an opening brace (flow mapping), so the natural
+		// RenderData pattern `subject: {{.Field}}` fails decode unless
+		// quoted — point straight at the fix instead of a bare yaml error.
+		if bytes.Contains(meta, []byte("{{")) {
+			return frontmatter{}, nil, fmt.Errorf("%w: frontmatter: %v (a value starting with a placeholder must be quoted: subject: '%s')", ErrInvalidDocument, err, "{{.Field}}")
+		}
 		return frontmatter{}, nil, fmt.Errorf("%w: frontmatter: %v", ErrInvalidDocument, err)
 	}
 	return fm, body, nil

--- a/comms/email/markdown/markdown_test.go
+++ b/comms/email/markdown/markdown_test.go
@@ -205,6 +205,34 @@ func TestRenderDataErrors(t *testing.T) {
 	})
 }
 
+func TestRenderDataStructureInjection(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+
+	t.Run("frontmatter cannot be re-terminated from a value", func(t *testing.T) {
+		t.Parallel()
+		// Pre-fix, templating ran over the raw source and a value containing
+		// "\n---\n" cut the frontmatter early, reinterpreting the document.
+		doc := []byte("---\nsubject: Hi {{.Name}}\n---\nbody\n")
+		_, err := r.RenderData(doc, map[string]string{"Name": "Ann\n---\npreheader: pwned"})
+		require.ErrorIs(t, err, markdown.ErrInvalidDocument, "newline in rendered subject must fail closed")
+	})
+	t.Run("preheader newline injection fails closed", func(t *testing.T) {
+		t.Parallel()
+		doc := []byte("---\nsubject: s\npreheader: '{{.P}}'\n---\nbody\n")
+		_, err := r.RenderData(doc, map[string]string{"P": "a\nsubject: evil"})
+		require.ErrorIs(t, err, markdown.ErrInvalidDocument)
+	})
+	t.Run("frontmatter markers in body values are inert", func(t *testing.T) {
+		t.Parallel()
+		doc := []byte("---\nsubject: Stable\n---\nHi {{.Name}}!\n")
+		msg, err := r.RenderData(doc, map[string]string{"Name": "Ann\n\n---\n\nsubject: evil"})
+		require.NoError(t, err)
+		assert.Equal(t, "Stable", msg.Subject, "body data must not reach the frontmatter")
+		assert.Contains(t, msg.Text, "subject: evil", "marker renders as plain body content")
+	})
+}
+
 func TestRenderStaticLeavesBracesLiteral(t *testing.T) {
 	t.Parallel()
 	r := newRenderer(t)

--- a/comms/email/markdown/markdown_test.go
+++ b/comms/email/markdown/markdown_test.go
@@ -163,6 +163,56 @@ func TestRenderDocumentErrors(t *testing.T) {
 	require.ErrorIs(t, err, markdown.ErrInvalidDocument)
 }
 
+func TestRenderData(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	doc := []byte(`---
+subject: Welcome, {{.Name}}!
+preheader: '{{.Days}} days of trial await.'
+---
+# Hi {{.Name}}
+
+[Button: Start now](https://app.acme.example/start?t={{.Token}})
+`)
+
+	msg, err := r.RenderData(doc, map[string]any{"Name": "Ann", "Days": 14, "Token": "abc123"})
+	require.NoError(t, err)
+	assert.Equal(t, "Welcome, Ann!", msg.Subject)
+	assert.Contains(t, msg.HTML, "14 days of trial await.")
+	assert.Contains(t, msg.HTML, `href="https://app.acme.example/start?t=abc123"`)
+	assert.Equal(t, "Hi Ann\n\nStart now: https://app.acme.example/start?t=abc123", msg.Text)
+}
+
+func TestRenderDataErrors(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+
+	t.Run("missing key fails closed", func(t *testing.T) {
+		t.Parallel()
+		_, err := r.RenderData([]byte("---\nsubject: Hi {{.Nmae}}\n---\nbody\n"), map[string]string{"Name": "Ann"})
+		require.Error(t, err, `typo'd key must not send "<no value>"`)
+	})
+	t.Run("unparseable template", func(t *testing.T) {
+		t.Parallel()
+		_, err := r.RenderData([]byte("---\nsubject: s\n---\n{{.Name\n"), map[string]string{"Name": "Ann"})
+		require.ErrorIs(t, err, markdown.ErrInvalidDocument)
+	})
+	t.Run("zero renderer", func(t *testing.T) {
+		t.Parallel()
+		var zero markdown.Renderer
+		_, err := zero.RenderData([]byte(welcomeDoc), nil)
+		require.ErrorIs(t, err, markdown.ErrInvalidDocument)
+	})
+}
+
+func TestRenderStaticLeavesBracesLiteral(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	msg, err := r.Render([]byte("---\nsubject: Docs\n---\nUse {{.Name}} in your template.\n"))
+	require.NoError(t, err)
+	assert.Contains(t, msg.Text, "Use {{.Name}} in your template.", "Render must never interpolate")
+}
+
 func TestRenderCRLFSource(t *testing.T) {
 	t.Parallel()
 	r := newRenderer(t)

--- a/comms/email/markdown/markdown_test.go
+++ b/comms/email/markdown/markdown_test.go
@@ -1,0 +1,222 @@
+package markdown_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/comms/email/markdown"
+)
+
+const welcomeDoc = `---
+subject: Confirm your email
+preheader: One click and you're in.
+---
+# Almost there
+
+Hi! Confirm your address to **activate** your account.
+
+[Button: Confirm email](https://app.acme.example/confirm?t=abc)
+
+If the button doesn't work, reply to this email.
+`
+
+func newRenderer(t *testing.T, opts ...markdown.Option) *markdown.Renderer {
+	t.Helper()
+	r, err := markdown.New(opts...)
+	require.NoError(t, err)
+	return r
+}
+
+func TestRender(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+
+	msg, err := r.Render([]byte(welcomeDoc))
+	require.NoError(t, err)
+	assert.Equal(t, "Confirm your email", msg.Subject)
+	assert.Empty(t, msg.From)
+	assert.Empty(t, msg.To)
+
+	assert.Contains(t, msg.HTML, "<!DOCTYPE html>")
+	assert.Contains(t, msg.HTML, "One click and you&#39;re in.", "preheader rides the layout")
+	assert.Contains(t, msg.HTML, "<h1>Almost there</h1>")
+	assert.Contains(t, msg.HTML, "<strong>activate</strong>")
+	assert.Contains(t, msg.HTML, `href="https://app.acme.example/confirm?t=abc"`)
+	assert.Contains(t, msg.HTML, ">Confirm email</a>", "button label must drop the Button: prefix")
+	assert.Contains(t, msg.HTML, `<table role="presentation"`, "button renders as table markup")
+	assert.Contains(t, msg.HTML, "#2563eb", "default button color")
+
+	assert.Equal(t, "Almost there\n\nHi! Confirm your address to activate your account.\n\nConfirm email: https://app.acme.example/confirm?t=abc\n\nIf the button doesn't work, reply to this email.", msg.Text)
+}
+
+func TestRenderTextBlocks(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	doc := `---
+subject: Digest
+---
+## Items
+
+- first *thing*
+- second [docs](https://docs.example.com)
+- third
+
+1. alpha
+2. beta
+
+> Quoted wisdom
+> continues here.
+
+` + "```\ncode line one\ncode line two\n```" + `
+
+---
+
+Auto link: <https://acme.example> and www-less text.
+`
+	msg, err := r.Render([]byte(doc))
+	require.NoError(t, err)
+
+	expected := strings.Join([]string{
+		"Items",
+		"",
+		"- first thing\n- second docs (https://docs.example.com)\n- third",
+		"",
+		"1. alpha\n2. beta",
+		"",
+		"> Quoted wisdom\n> continues here.",
+		"",
+		"code line one\ncode line two",
+		"",
+		"---",
+		"",
+		"Auto link: https://acme.example and www-less text.",
+	}, "\n")
+	assert.Equal(t, expected, msg.Text)
+}
+
+func TestRenderButtonRules(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+
+	t.Run("non-http destination stays a link", func(t *testing.T) {
+		t.Parallel()
+		msg, err := r.Render([]byte("---\nsubject: s\n---\n[Button: Click](javascript:alert(1))\n"))
+		require.NoError(t, err)
+		assert.NotContains(t, msg.HTML, "display:inline-block", "no button for unsafe scheme")
+		assert.NotContains(t, msg.HTML, "javascript:", "goldmark filters unsafe link schemes")
+	})
+	t.Run("surrounding text stays a paragraph", func(t *testing.T) {
+		t.Parallel()
+		msg, err := r.Render([]byte("---\nsubject: s\n---\nGo [Button: Click](https://acme.example) now\n"))
+		require.NoError(t, err)
+		assert.NotContains(t, msg.HTML, "display:inline-block")
+		assert.Contains(t, msg.HTML, "Button: Click", "prefix stays visible so the mistake is seen")
+	})
+	t.Run("label is escaped", func(t *testing.T) {
+		t.Parallel()
+		// <b> is raw inline HTML, which the label extraction drops; the
+		// remaining text must be entity-escaped in the button markup.
+		msg, err := r.Render([]byte("---\nsubject: s\n---\n[Button: a<b>&c](https://acme.example)\n"))
+		require.NoError(t, err)
+		assert.Contains(t, msg.HTML, ">a&amp;c</a>")
+	})
+}
+
+func TestRenderDropsRawHTML(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	msg, err := r.Render([]byte("---\nsubject: s\n---\nBefore\n\n<script>alert(1)</script>\n\nInline <em onload=x>markup</em> here.\n"))
+	require.NoError(t, err)
+	assert.NotContains(t, msg.HTML, "<script>")
+	assert.NotContains(t, msg.HTML, "onload")
+	assert.NotContains(t, msg.Text, "<script>")
+	assert.Contains(t, msg.Text, "Inline markup here.")
+}
+
+func TestRenderDocumentErrors(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+
+	docs := map[string]string{
+		"missing frontmatter":  "# No header\n",
+		"unterminated":         "---\nsubject: s\nbody without closing fence",
+		"empty frontmatter":    "---\n---\nbody\n",
+		"unknown key":          "---\nsubject: s\nsubjct: typo\n---\nbody\n",
+		"missing subject":      "---\npreheader: p\n---\nbody\n",
+		"whitespace subject":   "---\nsubject: '   '\n---\nbody\n",
+		"multi-line preheader": "---\nsubject: s\npreheader: \"a\\nb\"\n---\nbody\n",
+		"malformed yaml":       "---\nsubject: [\n---\nbody\n",
+	}
+	for name, doc := range docs {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := r.Render([]byte(doc))
+			require.ErrorIs(t, err, markdown.ErrInvalidDocument, "doc: %q", doc)
+		})
+	}
+
+	var zero markdown.Renderer
+	_, err := zero.Render([]byte(welcomeDoc))
+	require.ErrorIs(t, err, markdown.ErrInvalidDocument)
+}
+
+func TestRenderCRLFSource(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	doc := strings.ReplaceAll(welcomeDoc, "\n", "\r\n")
+	msg, err := r.Render([]byte(doc))
+	require.NoError(t, err)
+	assert.Equal(t, "Confirm your email", msg.Subject)
+}
+
+func TestRenderNoPreheader(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	msg, err := r.Render([]byte("---\nsubject: Plain\n---\nBody.\n"))
+	require.NoError(t, err)
+	assert.NotContains(t, msg.HTML, "display:none;overflow:hidden", "no preheader div when frontmatter omits it")
+}
+
+func TestRenderOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("custom layout", func(t *testing.T) {
+		t.Parallel()
+		r := newRenderer(t, markdown.WithLayout(`<main data-subject="{{.Subject}}">{{.Body}}</main>`))
+		msg, err := r.Render([]byte("---\nsubject: Custom\n---\nHello.\n"))
+		require.NoError(t, err)
+		assert.Equal(t, `<main data-subject="Custom"><p>Hello.</p>
+</main>`, msg.HTML)
+	})
+	t.Run("button color", func(t *testing.T) {
+		t.Parallel()
+		r := newRenderer(t, markdown.WithButtonColor("#16a34a"))
+		msg, err := r.Render([]byte("---\nsubject: s\n---\n[Button: Go](https://acme.example)\n"))
+		require.NoError(t, err)
+		assert.Contains(t, msg.HTML, "#16a34a")
+		assert.NotContains(t, msg.HTML, "#2563eb")
+	})
+	t.Run("broken layout fails New", func(t *testing.T) {
+		t.Parallel()
+		_, err := markdown.New(markdown.WithLayout(`{{.Body`))
+		require.ErrorIs(t, err, markdown.ErrInvalidLayout)
+	})
+	t.Run("layout with unknown field fails New", func(t *testing.T) {
+		t.Parallel()
+		_, err := markdown.New(markdown.WithLayout(`{{.Nope}}`))
+		require.ErrorIs(t, err, markdown.ErrInvalidLayout)
+	})
+}
+
+func TestRenderedMessageEncodes(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+	msg, err := r.Render([]byte(welcomeDoc))
+	require.NoError(t, err)
+	msg.From = "Acme <no-reply@acme.example>"
+	msg.To = []string{"ann@example.com"}
+	assert.NoError(t, msg.Encode(&strings.Builder{}))
+}

--- a/comms/email/markdown/markdown_test.go
+++ b/comms/email/markdown/markdown_test.go
@@ -205,6 +205,26 @@ func TestRenderDataErrors(t *testing.T) {
 	})
 }
 
+func TestRenderDataPlaceholderOnlyFrontmatter(t *testing.T) {
+	t.Parallel()
+	r := newRenderer(t)
+
+	t.Run("quoted placeholder value renders", func(t *testing.T) {
+		t.Parallel()
+		msg, err := r.RenderData([]byte("---\nsubject: '{{.Subject}}'\n---\nbody\n"), map[string]string{"Subject": "Monthly digest"})
+		require.NoError(t, err)
+		assert.Equal(t, "Monthly digest", msg.Subject)
+	})
+	t.Run("unquoted placeholder value errors with quoting hint", func(t *testing.T) {
+		t.Parallel()
+		// YAML reserves the opening brace, so this can't decode; the error
+		// must tell the author to quote instead of leaving a bare yaml error.
+		_, err := r.RenderData([]byte("---\nsubject: {{.Subject}}\n---\nbody\n"), map[string]string{"Subject": "x"})
+		require.ErrorIs(t, err, markdown.ErrInvalidDocument)
+		assert.ErrorContains(t, err, "must be quoted")
+	})
+}
+
 func TestRenderDataStructureInjection(t *testing.T) {
 	t.Parallel()
 	r := newRenderer(t)

--- a/comms/email/markdown/options.go
+++ b/comms/email/markdown/options.go
@@ -1,0 +1,55 @@
+package markdown
+
+type config struct {
+	layout      string
+	buttonColor string
+}
+
+// Option configures the Renderer.
+type Option func(*config)
+
+const defaultButtonColor = "#2563eb"
+
+// defaultLayout is the built-in single-column email shell: hidden preheader
+// for inbox preview text, a centered 600px card, and a system font stack.
+const defaultLayout = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{.Subject}}</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f5f7;">
+{{if .Preheader}}<div style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0;">{{.Preheader}}</div>
+{{end}}<table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color:#f4f5f7;">
+<tr><td align="center" style="padding:24px 12px;">
+<table role="presentation" border="0" cellspacing="0" cellpadding="0" style="width:600px;max-width:100%;background-color:#ffffff;border-radius:8px;">
+<tr><td style="padding:32px 40px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;line-height:1.6;color:#111827;">
+{{.Body}}
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>`
+
+// WithLayout replaces the built-in HTML shell. The source is an
+// html/template document executed with LayoutData; reference the rendered
+// markdown as {{.Body}}. An empty layout is ignored.
+func WithLayout(tmpl string) Option {
+	return func(c *config) {
+		if tmpl != "" {
+			c.layout = tmpl
+		}
+	}
+}
+
+// WithButtonColor sets the CTA button background (any CSS color value,
+// default "#2563eb"). An empty value is ignored.
+func WithButtonColor(color string) Option {
+	return func(c *config) {
+		if color != "" {
+			c.buttonColor = color
+		}
+	}
+}

--- a/comms/email/markdown/text.go
+++ b/comms/email/markdown/text.go
@@ -1,0 +1,144 @@
+package markdown
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/yuin/goldmark/ast"
+)
+
+// renderText walks the parsed document and produces the plain-text
+// alternative: headings and paragraphs as bare lines separated by blank
+// lines, lists with "-"/"1." markers, blockquotes with "> ", links as
+// "text (url)", buttons as "label: url". Raw HTML is dropped.
+func renderText(sb *strings.Builder, source []byte, doc ast.Node) {
+	first := true
+	for block := doc.FirstChild(); block != nil; block = block.NextSibling() {
+		var out strings.Builder
+		renderBlock(&out, source, block)
+		text := strings.TrimRight(out.String(), "\n")
+		if text == "" {
+			continue
+		}
+		if !first {
+			sb.WriteString("\n\n")
+		}
+		first = false
+		sb.WriteString(text)
+	}
+}
+
+func renderBlock(sb *strings.Builder, source []byte, block ast.Node) {
+	switch n := block.(type) {
+	case *ast.Heading, *ast.Paragraph, *ast.TextBlock:
+		inlineText(sb, source, block)
+	case *ast.Blockquote:
+		var inner strings.Builder
+		renderText(&inner, source, block)
+		for i, line := range strings.Split(inner.String(), "\n") {
+			if i > 0 {
+				sb.WriteByte('\n')
+			}
+			sb.WriteString(strings.TrimRight("> "+line, " "))
+		}
+	case *ast.List:
+		renderList(sb, source, n)
+	case *ast.CodeBlock:
+		writeCodeLines(sb, source, block)
+	case *ast.FencedCodeBlock:
+		writeCodeLines(sb, source, block)
+	case *ast.ThematicBreak:
+		sb.WriteString("---")
+	case *buttonNode:
+		sb.WriteString(n.label)
+		sb.WriteString(": ")
+		sb.WriteString(n.url)
+	case *ast.HTMLBlock: // dropped: raw HTML has no plain-text form
+	default:
+		inlineText(sb, source, block)
+	}
+}
+
+func renderList(sb *strings.Builder, source []byte, list *ast.List) {
+	number := list.Start
+	if number == 0 {
+		number = 1
+	}
+	firstItem := true
+	for item := list.FirstChild(); item != nil; item = item.NextSibling() {
+		if !firstItem {
+			sb.WriteByte('\n')
+		}
+		firstItem = false
+		marker := "- "
+		if list.IsOrdered() {
+			marker = strconv.Itoa(number) + ". "
+			number++
+		}
+		var inner strings.Builder
+		renderText(&inner, source, item)
+		indent := strings.Repeat(" ", len(marker))
+		for i, line := range strings.Split(inner.String(), "\n") {
+			if i == 0 {
+				sb.WriteString(marker)
+			} else {
+				sb.WriteByte('\n')
+				if line != "" {
+					sb.WriteString(indent)
+				}
+			}
+			sb.WriteString(line)
+		}
+	}
+}
+
+func writeCodeLines(sb *strings.Builder, source []byte, block ast.Node) {
+	lines := block.Lines()
+	for i := range lines.Len() {
+		line := lines.At(i)
+		sb.WriteString(strings.TrimRight(string(line.Value(source)), "\n"))
+		if i < lines.Len()-1 {
+			sb.WriteByte('\n')
+		}
+	}
+}
+
+// inlineText flattens an inline tree to plain text. Shared by the text
+// renderer and the button transformer's label extraction.
+func inlineText(sb *strings.Builder, source []byte, parent ast.Node) {
+	for c := parent.FirstChild(); c != nil; c = c.NextSibling() {
+		switch n := c.(type) {
+		case *ast.Text:
+			sb.Write(n.Segment.Value(source))
+			if n.SoftLineBreak() || n.HardLineBreak() {
+				sb.WriteByte('\n')
+			}
+		case *ast.String:
+			sb.Write(n.Value)
+		case *ast.Link:
+			var label strings.Builder
+			inlineText(&label, source, c)
+			url := string(n.Destination)
+			switch {
+			case label.String() == "" || label.String() == url:
+				sb.WriteString(url)
+			default:
+				sb.WriteString(label.String())
+				sb.WriteString(" (")
+				sb.WriteString(url)
+				sb.WriteString(")")
+			}
+		case *ast.AutoLink:
+			sb.Write(n.URL(source))
+		case *ast.Image:
+			var alt strings.Builder
+			inlineText(&alt, source, c)
+			if alt.Len() > 0 {
+				sb.WriteString(alt.String())
+			}
+		case *ast.RawHTML: // dropped
+		default:
+			inlineText(sb, source, c)
+		}
+	}
+}

--- a/comms/email/message.go
+++ b/comms/email/message.go
@@ -29,7 +29,8 @@ type Message struct {
 // empty value is inferred from the filename extension, falling back to
 // application/octet-stream. Inline attachments are embedded for HTML display
 // (images referenced as <img src="cid:FILENAME">) instead of being listed
-// for download; the Content-ID is the filename.
+// for download; the Content-ID is the filename, so inline filenames are
+// restricted to [A-Za-z0-9._-].
 type Attachment struct {
 	Filename    string
 	ContentType string
@@ -106,11 +107,15 @@ func (m *Message) validate() (envelope, error) {
 		return envelope{}, fmt.Errorf("%w: newline in subject", ErrInvalidMessage)
 	}
 	for k, v := range m.Headers {
-		if strings.ContainsAny(k, "\r\n") || strings.ContainsAny(v, "\r\n") {
-			return envelope{}, fmt.Errorf("%w: newline in header %q", ErrInvalidMessage, k)
+		// Only RFC 5322 field-name bytes are allowed: a name like "Bcc:" or
+		// "Bcc " canonicalizes to itself, dodges the reserved list, and is
+		// re-parsed by receivers as the reserved header — so any invalid byte
+		// is rejected before the reserved lookup, never passed through.
+		if !validHeaderName(k) {
+			return envelope{}, fmt.Errorf("%w: invalid header name %q", ErrInvalidMessage, k)
 		}
-		if k == "" {
-			return envelope{}, fmt.Errorf("%w: empty header name", ErrInvalidMessage)
+		if !validHeaderValue(v) {
+			return envelope{}, fmt.Errorf("%w: control character in header %q", ErrInvalidMessage, k)
 		}
 		if _, reserved := reservedHeaders[textproto.CanonicalMIMEHeaderKey(k)]; reserved {
 			return envelope{}, fmt.Errorf("%w: header %q is set by the encoder", ErrInvalidMessage, k)
@@ -120,11 +125,53 @@ func (m *Message) validate() (envelope, error) {
 		if a.Filename == "" {
 			return envelope{}, fmt.Errorf("%w: attachment without filename", ErrInvalidMessage)
 		}
-		if strings.ContainsAny(a.Filename, "\r\n\"") {
+		// Backslash would escape the closing quote of filename="...", quotes
+		// and CR/LF break the header outright; 255 bytes is the filesystem
+		// ceiling and keeps the header line foldable.
+		if len(a.Filename) > 255 || strings.ContainsAny(a.Filename, "\r\n\"\\") {
 			return envelope{}, fmt.Errorf("%w: invalid attachment filename %q", ErrInvalidMessage, a.Filename)
+		}
+		if !validHeaderValue(a.ContentType) || strings.ContainsFunc(a.ContentType, func(r rune) bool { return r >= 0x7f }) {
+			return envelope{}, fmt.Errorf("%w: invalid content type for attachment %q", ErrInvalidMessage, a.Filename)
+		}
+		if a.Inline && !validContentID(a.Filename) {
+			return envelope{}, fmt.Errorf("%w: inline filename %q must match [A-Za-z0-9._-] (it becomes the Content-ID)", ErrInvalidMessage, a.Filename)
 		}
 	}
 	return env, nil
+}
+
+// validHeaderName reports whether s is a non-empty RFC 5322 field name:
+// printable ASCII, no colon.
+func validHeaderName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := range len(s) {
+		if c := s[i]; c <= ' ' || c >= 0x7f || c == ':' {
+			return false
+		}
+	}
+	return true
+}
+
+// validHeaderValue rejects every control character except horizontal tab
+// (legal header whitespace) — CR/LF injection is the headline case.
+func validHeaderValue(s string) bool {
+	return !strings.ContainsFunc(s, func(r rune) bool { return r < 0x20 && r != '\t' })
+}
+
+// validContentID keeps inline filenames usable as a Content-ID and a cid:
+// URL: letters, digits, dot, underscore, hyphen.
+func validContentID(s string) bool {
+	for i := range len(s) {
+		switch c := s[i]; {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '.', c == '_', c == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // parseAddr parses one RFC 5322 address, naming the field in the error.

--- a/comms/email/message.go
+++ b/comms/email/message.go
@@ -1,0 +1,139 @@
+package email
+
+import (
+	"fmt"
+	"net/mail"
+	"net/textproto"
+	"strings"
+)
+
+// Message is one outbound email. From and every recipient are RFC 5322
+// addresses — bare ("a@example.com") or named ("Ann <a@example.com>"). At
+// least one recipient (To, Cc, or Bcc) and at least one body (Text or HTML)
+// are required. Bcc recipients ride the SMTP envelope only and never appear
+// in the encoded headers.
+type Message struct {
+	Headers     map[string]string // extra top-level headers; encoder-owned names are rejected
+	From        string
+	ReplyTo     string
+	Subject     string
+	Text        string
+	HTML        string
+	To          []string
+	Cc          []string
+	Bcc         []string
+	Attachments []Attachment
+}
+
+// Attachment is one file carried by a Message. ContentType is optional — an
+// empty value is inferred from the filename extension, falling back to
+// application/octet-stream. Inline attachments are embedded for HTML display
+// (images referenced as <img src="cid:FILENAME">) instead of being listed
+// for download; the Content-ID is the filename.
+type Attachment struct {
+	Filename    string
+	ContentType string
+	Content     []byte
+	Inline      bool
+}
+
+// reservedHeaders are written by the encoder itself; a custom header with one
+// of these names would duplicate or contradict them (and a consumer-set Bcc
+// header would leak hidden recipients), so validation rejects the collision.
+var reservedHeaders = map[string]struct{}{
+	"From": {}, "To": {}, "Cc": {}, "Bcc": {}, "Reply-To": {}, "Subject": {},
+	"Date": {}, "Mime-Version": {}, "Content-Type": {}, "Content-Transfer-Encoding": {},
+}
+
+// envelope is the validated, parsed form of a Message: display headers keep
+// their names, rcpts is the deduplicated union of To+Cc+Bcc addr-specs for
+// the SMTP envelope.
+type envelope struct {
+	from    *mail.Address
+	replyTo *mail.Address
+	to      []*mail.Address
+	cc      []*mail.Address
+	rcpts   []string
+}
+
+// validate parses every address and checks the message contract, returning
+// the envelope the encoder and sender share. All failures wrap
+// ErrInvalidMessage.
+func (m *Message) validate() (envelope, error) {
+	var env envelope
+	var err error
+	if env.from, err = parseAddr("From", m.From); err != nil {
+		return envelope{}, err
+	}
+	if m.ReplyTo != "" {
+		if env.replyTo, err = parseAddr("Reply-To", m.ReplyTo); err != nil {
+			return envelope{}, err
+		}
+	}
+	seen := make(map[string]struct{}, len(m.To)+len(m.Cc)+len(m.Bcc))
+	env.rcpts = make([]string, 0, len(m.To)+len(m.Cc)+len(m.Bcc))
+	collect := func(field string, addrs []string) ([]*mail.Address, error) {
+		parsed := make([]*mail.Address, 0, len(addrs))
+		for _, raw := range addrs {
+			a, err := parseAddr(field, raw)
+			if err != nil {
+				return nil, err
+			}
+			parsed = append(parsed, a)
+			if _, dup := seen[a.Address]; !dup {
+				seen[a.Address] = struct{}{}
+				env.rcpts = append(env.rcpts, a.Address)
+			}
+		}
+		return parsed, nil
+	}
+	if env.to, err = collect("To", m.To); err != nil {
+		return envelope{}, err
+	}
+	if env.cc, err = collect("Cc", m.Cc); err != nil {
+		return envelope{}, err
+	}
+	if _, err = collect("Bcc", m.Bcc); err != nil {
+		return envelope{}, err
+	}
+	if len(env.rcpts) == 0 {
+		return envelope{}, fmt.Errorf("%w: no recipients", ErrInvalidMessage)
+	}
+	if m.Text == "" && m.HTML == "" {
+		return envelope{}, fmt.Errorf("%w: no body", ErrInvalidMessage)
+	}
+	if strings.ContainsAny(m.Subject, "\r\n") {
+		return envelope{}, fmt.Errorf("%w: newline in subject", ErrInvalidMessage)
+	}
+	for k, v := range m.Headers {
+		if strings.ContainsAny(k, "\r\n") || strings.ContainsAny(v, "\r\n") {
+			return envelope{}, fmt.Errorf("%w: newline in header %q", ErrInvalidMessage, k)
+		}
+		if k == "" {
+			return envelope{}, fmt.Errorf("%w: empty header name", ErrInvalidMessage)
+		}
+		if _, reserved := reservedHeaders[textproto.CanonicalMIMEHeaderKey(k)]; reserved {
+			return envelope{}, fmt.Errorf("%w: header %q is set by the encoder", ErrInvalidMessage, k)
+		}
+	}
+	for _, a := range m.Attachments {
+		if a.Filename == "" {
+			return envelope{}, fmt.Errorf("%w: attachment without filename", ErrInvalidMessage)
+		}
+		if strings.ContainsAny(a.Filename, "\r\n\"") {
+			return envelope{}, fmt.Errorf("%w: invalid attachment filename %q", ErrInvalidMessage, a.Filename)
+		}
+	}
+	return env, nil
+}
+
+// parseAddr parses one RFC 5322 address, naming the field in the error.
+// mail.ParseAddress rejects bare CR/LF, so parsed addresses are
+// injection-safe by construction.
+func parseAddr(field, raw string) (*mail.Address, error) {
+	a, err := mail.ParseAddress(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s address %q: %v", ErrInvalidMessage, field, raw, err)
+	}
+	return a, nil
+}

--- a/comms/email/message_test.go
+++ b/comms/email/message_test.go
@@ -41,6 +41,24 @@ func TestMessageValidation(t *testing.T) {
 		"attachment bad filename": func(m *email.Message) {
 			m.Attachments = []email.Attachment{{Filename: "a\"b.txt", Content: []byte("x")}}
 		},
+		// "Bcc:" and "Bcc " canonicalize to themselves, so they'd dodge the
+		// reserved list and be re-parsed by receivers as a real Bcc header.
+		"reserved header via colon": func(m *email.Message) { m.Headers = map[string]string{"Bcc:": "spy@example.com"} },
+		"reserved header via space": func(m *email.Message) { m.Headers = map[string]string{"Bcc ": "spy@example.com"} },
+		"non-ascii header name":     func(m *email.Message) { m.Headers = map[string]string{"X-Café": "x"} },
+		"control in header value":   func(m *email.Message) { m.Headers = map[string]string{"X-Tag": "a\x00b"} },
+		"attachment backslash filename": func(m *email.Message) {
+			m.Attachments = []email.Attachment{{Filename: `report\`, Content: []byte("x")}}
+		},
+		"attachment overlong filename": func(m *email.Message) {
+			m.Attachments = []email.Attachment{{Filename: strings.Repeat("a", 256) + ".txt", Content: []byte("x")}}
+		},
+		"attachment content type injection": func(m *email.Message) {
+			m.Attachments = []email.Attachment{{Filename: "a.txt", ContentType: "text/plain\r\nX-Spy: 1", Content: []byte("x")}}
+		},
+		"inline attachment cid-unsafe filename": func(m *email.Message) {
+			m.Attachments = []email.Attachment{{Filename: "my logo.png", Inline: true, Content: []byte("x")}}
+		},
 	}
 	for name, mutate := range mutations {
 		t.Run(name, func(t *testing.T) {

--- a/comms/email/message_test.go
+++ b/comms/email/message_test.go
@@ -1,0 +1,115 @@
+package email_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/comms/email"
+)
+
+func validMessage() email.Message {
+	return email.Message{
+		From:    "Acme <no-reply@acme.example>",
+		To:      []string{"ann@example.com"},
+		Subject: "Hello",
+		Text:    "Hi Ann,",
+	}
+}
+
+func TestMessageValidation(t *testing.T) {
+	t.Parallel()
+
+	mutations := map[string]func(*email.Message){
+		"missing from":            func(m *email.Message) { m.From = "" },
+		"unparseable from":        func(m *email.Message) { m.From = "not an address" },
+		"unparseable to":          func(m *email.Message) { m.To = []string{"@@nope"} },
+		"unparseable cc":          func(m *email.Message) { m.Cc = []string{"broken<"} },
+		"unparseable bcc":         func(m *email.Message) { m.Bcc = []string{"x y z"} },
+		"no recipients":           func(m *email.Message) { m.To = nil },
+		"no body":                 func(m *email.Message) { m.Text = "" },
+		"newline in subject":      func(m *email.Message) { m.Subject = "hi\r\nBcc: spy@example.com" },
+		"newline in header value": func(m *email.Message) { m.Headers = map[string]string{"X-Tag": "a\r\nX-Spy: b"} },
+		"newline in header name":  func(m *email.Message) { m.Headers = map[string]string{"X-Tag\r\nX-Spy": "a"} },
+		"empty header name":       func(m *email.Message) { m.Headers = map[string]string{"": "a"} },
+		"reserved header":         func(m *email.Message) { m.Headers = map[string]string{"bcc": "spy@example.com"} },
+		"reserved content type":   func(m *email.Message) { m.Headers = map[string]string{"content-type": "text/x"} },
+		"attachment no filename":  func(m *email.Message) { m.Attachments = []email.Attachment{{Content: []byte("x")}} },
+		"attachment bad filename": func(m *email.Message) {
+			m.Attachments = []email.Attachment{{Filename: "a\"b.txt", Content: []byte("x")}}
+		},
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			msg := validMessage()
+			mutate(&msg)
+			err := msg.Encode(&bytes.Buffer{})
+			require.ErrorIs(t, err, email.ErrInvalidMessage)
+		})
+	}
+}
+
+func TestMessageValidationAccepts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bcc-only recipients", func(t *testing.T) {
+		t.Parallel()
+		msg := validMessage()
+		msg.To = nil
+		msg.Bcc = []string{"hidden@example.com"}
+		require.NoError(t, msg.Encode(&bytes.Buffer{}))
+	})
+	t.Run("html-only body", func(t *testing.T) {
+		t.Parallel()
+		msg := validMessage()
+		msg.Text = ""
+		msg.HTML = "<p>hi</p>"
+		require.NoError(t, msg.Encode(&bytes.Buffer{}))
+	})
+	t.Run("custom non-reserved header", func(t *testing.T) {
+		t.Parallel()
+		msg := validMessage()
+		msg.Headers = map[string]string{"X-Campaign": "onboarding"}
+		var buf bytes.Buffer
+		require.NoError(t, msg.Encode(&buf))
+		assert.Contains(t, buf.String(), "X-Campaign: onboarding\r\n")
+	})
+	t.Run("empty subject", func(t *testing.T) {
+		t.Parallel()
+		msg := validMessage()
+		msg.Subject = ""
+		var buf bytes.Buffer
+		require.NoError(t, msg.Encode(&buf))
+		assert.NotContains(t, buf.String(), "Subject:")
+	})
+	t.Run("zero-length attachment content", func(t *testing.T) {
+		t.Parallel()
+		msg := validMessage()
+		msg.Attachments = []email.Attachment{{Filename: "empty.txt"}}
+		require.NoError(t, msg.Encode(&bytes.Buffer{}))
+	})
+}
+
+func TestMessageEncodeCRLFOnly(t *testing.T) {
+	t.Parallel()
+
+	msg := validMessage()
+	msg.HTML = "<p>Hi Ann,</p>\n<p>multi\nline</p>"
+	msg.Text = "Hi Ann,\nmulti\nline"
+	msg.Attachments = []email.Attachment{{Filename: "a.txt", Content: bytes.Repeat([]byte("data"), 100)}}
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	raw := buf.Bytes()
+	for i, b := range raw {
+		if b == '\n' {
+			require.Greater(t, i, 0, "output starts with bare LF")
+			assert.Equal(t, byte('\r'), raw[i-1], "bare LF at offset %d: %q", i, raw[max(0, i-20):i+1])
+		}
+	}
+	assert.False(t, strings.Contains(strings.ReplaceAll(string(raw), "\r\n", ""), "\r"), "stray CR")
+}

--- a/comms/email/mime.go
+++ b/comms/email/mime.go
@@ -53,7 +53,13 @@ func (m *Message) encode(w io.Writer, env envelope, now time.Time) error {
 		writeHeader(bw, "Subject", mime.QEncoding.Encode("utf-8", m.Subject))
 	}
 	for _, k := range slices.Sorted(maps.Keys(m.Headers)) {
-		writeHeader(bw, k, m.Headers[k])
+		v := m.Headers[k]
+		if !isASCII(v) {
+			// Headers are 7-bit; a non-ASCII custom value rides an
+			// encoded-word like the subject does.
+			v = mime.QEncoding.Encode("utf-8", v)
+		}
+		writeHeader(bw, k, v)
 	}
 	writeHeader(bw, "MIME-Version", "1.0")
 
@@ -80,11 +86,37 @@ func (m *Message) hasCustomHeader(canonical string) bool {
 	return false
 }
 
+// foldAt is the column past which writeHeader folds at the next space —
+// RFC 5322 recommends 78-octet lines and hard-caps them at 998; long
+// recipient lists and subjects would otherwise exceed both.
+const foldAt = 76
+
+// writeHeader emits one header line, folding before a space once the line
+// passes foldAt. The CRLF lands ahead of the existing space, so the space
+// itself becomes the continuation-line whitespace and unfolding restores the
+// exact original value.
 func writeHeader(bw *bufio.Writer, name, value string) {
-	bw.WriteString(name)   //nolint:errcheck // surfaced by Flush
-	bw.WriteString(": ")   //nolint:errcheck // surfaced by Flush
-	bw.WriteString(value)  //nolint:errcheck // surfaced by Flush
+	bw.WriteString(name) //nolint:errcheck // surfaced by Flush
+	bw.WriteString(": ") //nolint:errcheck // surfaced by Flush
+	col := len(name) + 2
+	for i := range len(value) {
+		if value[i] == ' ' && col >= foldAt {
+			bw.WriteString("\r\n") //nolint:errcheck // surfaced by Flush
+			col = 0
+		}
+		bw.WriteByte(value[i]) //nolint:errcheck // surfaced by Flush
+		col++
+	}
 	bw.WriteString("\r\n") //nolint:errcheck // surfaced by Flush
+}
+
+func isASCII(s string) bool {
+	for i := range len(s) {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }
 
 func joinAddrs(addrs []*mail.Address) string {

--- a/comms/email/mime.go
+++ b/comms/email/mime.go
@@ -1,0 +1,283 @@
+package email
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"maps"
+	"mime"
+	"mime/multipart"
+	"mime/quotedprintable"
+	"net/mail"
+	"net/textproto"
+	"path"
+	"slices"
+	"strings"
+	"time"
+)
+
+// Encode writes the message as a complete RFC 5322 document with CRLF line
+// endings: headers, then a MIME tree of quoted-printable bodies and base64
+// attachments (multipart/alternative under multipart/related under
+// multipart/mixed, each level present only when needed). Bcc recipients are
+// never written. The output is what provider raw-send APIs (SES, Postmark)
+// accept; Send streams the same bytes over SMTP.
+func (m *Message) Encode(w io.Writer) error {
+	env, err := m.validate()
+	if err != nil {
+		return err
+	}
+	return m.encode(w, env, time.Now())
+}
+
+func (m *Message) encode(w io.Writer, env envelope, now time.Time) error {
+	bw := bufio.NewWriter(w)
+	writeHeader(bw, "Date", now.Format(time.RFC1123Z))
+	if !m.hasCustomHeader("Message-Id") {
+		writeHeader(bw, "Message-ID", messageID(env.from))
+	}
+	writeHeader(bw, "From", env.from.String())
+	if len(env.to) > 0 {
+		writeHeader(bw, "To", joinAddrs(env.to))
+	}
+	if len(env.cc) > 0 {
+		writeHeader(bw, "Cc", joinAddrs(env.cc))
+	}
+	if env.replyTo != nil {
+		writeHeader(bw, "Reply-To", env.replyTo.String())
+	}
+	if m.Subject != "" {
+		writeHeader(bw, "Subject", mime.QEncoding.Encode("utf-8", m.Subject))
+	}
+	for _, k := range slices.Sorted(maps.Keys(m.Headers)) {
+		writeHeader(bw, k, m.Headers[k])
+	}
+	writeHeader(bw, "MIME-Version", "1.0")
+
+	body := m.body()
+	for _, k := range slices.Sorted(maps.Keys(body.header)) {
+		writeHeader(bw, k, body.header.Get(k))
+	}
+	bw.WriteString("\r\n") //nolint:errcheck // surfaced by Flush
+	if err := body.write(bw); err != nil {
+		return err
+	}
+	if err := bw.Flush(); err != nil {
+		return fmt.Errorf("email: encode: %w", err)
+	}
+	return nil
+}
+
+func (m *Message) hasCustomHeader(canonical string) bool {
+	for k := range m.Headers {
+		if textproto.CanonicalMIMEHeaderKey(k) == canonical {
+			return true
+		}
+	}
+	return false
+}
+
+func writeHeader(bw *bufio.Writer, name, value string) {
+	bw.WriteString(name)   //nolint:errcheck // surfaced by Flush
+	bw.WriteString(": ")   //nolint:errcheck // surfaced by Flush
+	bw.WriteString(value)  //nolint:errcheck // surfaced by Flush
+	bw.WriteString("\r\n") //nolint:errcheck // surfaced by Flush
+}
+
+func joinAddrs(addrs []*mail.Address) string {
+	var sb strings.Builder
+	for i, a := range addrs {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(a.String())
+	}
+	return sb.String()
+}
+
+// messageID builds a globally unique Message-ID under the sender's domain so
+// replies thread correctly; consumers needing a stable ID set Message-Id via
+// Headers instead.
+func messageID(from *mail.Address) string {
+	var buf [16]byte
+	rand.Read(buf[:]) //nolint:errcheck // crypto/rand.Read never fails
+	domain := from.Address
+	if at := strings.LastIndexByte(domain, '@'); at >= 0 {
+		domain = domain[at+1:]
+	}
+	return "<" + hex.EncodeToString(buf[:]) + "@" + domain + ">"
+}
+
+// part is one node of the MIME tree: its headers plus a body writer. Leaves
+// encode a text body or attachment; interior nodes are multipart containers.
+type part struct {
+	header textproto.MIMEHeader
+	write  func(io.Writer) error
+}
+
+// body assembles the MIME tree for the message's content. Validation has
+// already guaranteed at least one of Text/HTML is present.
+func (m *Message) body() part {
+	var inline, files []Attachment
+	for _, a := range m.Attachments {
+		if a.Inline {
+			inline = append(inline, a)
+		} else {
+			files = append(files, a)
+		}
+	}
+
+	parts := make([]part, 0, 2)
+	if m.Text != "" {
+		parts = append(parts, textPart("text/plain", m.Text))
+	}
+	if m.HTML != "" {
+		parts = append(parts, textPart("text/html", m.HTML))
+	}
+	core := parts[0]
+	if len(parts) == 2 {
+		core = containerPart("alternative", parts)
+	}
+	if len(inline) > 0 {
+		related := make([]part, 0, 1+len(inline))
+		related = append(related, core)
+		for _, a := range inline {
+			related = append(related, attachmentPart(a))
+		}
+		core = containerPart("related", related)
+	}
+	if len(files) > 0 {
+		mixed := make([]part, 0, 1+len(files))
+		mixed = append(mixed, core)
+		for _, a := range files {
+			mixed = append(mixed, attachmentPart(a))
+		}
+		core = containerPart("mixed", mixed)
+	}
+	return core
+}
+
+func textPart(contentType, content string) part {
+	return part{
+		header: textproto.MIMEHeader{
+			"Content-Type":              {contentType + "; charset=utf-8"},
+			"Content-Transfer-Encoding": {"quoted-printable"},
+		},
+		write: func(w io.Writer) error {
+			qp := quotedprintable.NewWriter(w)
+			if _, err := io.WriteString(qp, content); err != nil {
+				return fmt.Errorf("email: encode body: %w", err)
+			}
+			if err := qp.Close(); err != nil {
+				return fmt.Errorf("email: encode body: %w", err)
+			}
+			return nil
+		},
+	}
+}
+
+func attachmentPart(a Attachment) part {
+	ct := a.ContentType
+	if ct == "" {
+		ct = mime.TypeByExtension(strings.ToLower(path.Ext(a.Filename)))
+		if ct == "" {
+			ct = "application/octet-stream"
+		}
+	}
+	filename := mime.QEncoding.Encode("utf-8", a.Filename)
+	h := textproto.MIMEHeader{
+		"Content-Type":              {ct + `; name="` + filename + `"`},
+		"Content-Transfer-Encoding": {"base64"},
+	}
+	if a.Inline {
+		h.Set("Content-Disposition", `inline; filename="`+filename+`"`)
+		h.Set("Content-Id", "<"+a.Filename+">")
+	} else {
+		h.Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+	}
+	return part{
+		header: h,
+		write: func(w io.Writer) error {
+			lw := &lineWrapper{w: w}
+			enc := base64.NewEncoder(base64.StdEncoding, lw)
+			if _, err := enc.Write(a.Content); err != nil {
+				return fmt.Errorf("email: encode attachment %q: %w", a.Filename, err)
+			}
+			if err := enc.Close(); err != nil {
+				return fmt.Errorf("email: encode attachment %q: %w", a.Filename, err)
+			}
+			if lw.col > 0 {
+				if _, err := w.Write(crlf); err != nil {
+					return fmt.Errorf("email: encode attachment %q: %w", a.Filename, err)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func containerPart(subtype string, children []part) part {
+	boundary := randomBoundary()
+	return part{
+		header: textproto.MIMEHeader{
+			"Content-Type": {"multipart/" + subtype + `; boundary="` + boundary + `"`},
+		},
+		write: func(w io.Writer) error {
+			mw := multipart.NewWriter(w)
+			if err := mw.SetBoundary(boundary); err != nil {
+				return fmt.Errorf("email: encode multipart: %w", err)
+			}
+			for _, child := range children {
+				pw, err := mw.CreatePart(child.header)
+				if err != nil {
+					return fmt.Errorf("email: encode multipart: %w", err)
+				}
+				if err := child.write(pw); err != nil {
+					return err
+				}
+			}
+			if err := mw.Close(); err != nil {
+				return fmt.Errorf("email: encode multipart: %w", err)
+			}
+			return nil
+		},
+	}
+}
+
+func randomBoundary() string {
+	var buf [18]byte
+	rand.Read(buf[:]) //nolint:errcheck // crypto/rand.Read never fails
+	return "part-" + hex.EncodeToString(buf[:])
+}
+
+// crlf is a shared byte form of the line terminator: io.WriteString would
+// re-allocate it per write, and the base64 folder writes it once per line.
+var crlf = []byte("\r\n")
+
+// lineWrapper folds a base64 stream at 76 columns with CRLF, per RFC 2045.
+type lineWrapper struct {
+	w   io.Writer
+	col int
+}
+
+func (lw *lineWrapper) Write(p []byte) (int, error) {
+	total := len(p)
+	for len(p) > 0 {
+		if lw.col == 76 {
+			if _, err := lw.w.Write(crlf); err != nil {
+				return total - len(p), err
+			}
+			lw.col = 0
+		}
+		chunk := min(76-lw.col, len(p))
+		if _, err := lw.w.Write(p[:chunk]); err != nil {
+			return total - len(p), err
+		}
+		lw.col += chunk
+		p = p[chunk:]
+	}
+	return total, nil
+}

--- a/comms/email/mime_test.go
+++ b/comms/email/mime_test.go
@@ -3,6 +3,7 @@ package email_test
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -230,6 +231,51 @@ func TestEncodeDeterministicHeaderOrder(t *testing.T) {
 	idxC := strings.Index(first.String(), "X-C: 3")
 	require.True(t, idxA >= 0 && idxB >= 0 && idxC >= 0)
 	assert.True(t, idxA < idxB && idxB < idxC, "custom headers must encode in sorted order")
+}
+
+func TestEncodeFoldsLongHeaders(t *testing.T) {
+	t.Parallel()
+
+	msg := validMessage()
+	for i := range 40 {
+		msg.To = append(msg.To, fmt.Sprintf("Recipient Number %02d <user%02d@example.com>", i, i))
+	}
+	subject := strings.TrimSpace(strings.Repeat("purchase order confirmation for the July invoice batch ", 6))
+	msg.Subject = subject
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	for line := range strings.SplitSeq(buf.String(), "\r\n") {
+		assert.LessOrEqual(t, len(line), 200, "header lines must fold, got %q", line)
+	}
+
+	parsed, err := mail.ReadMessage(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	to, err := parsed.Header.AddressList("To")
+	require.NoError(t, err)
+	assert.Len(t, to, 41, "folding must not lose recipients")
+	assert.Equal(t, subject, parsed.Header.Get("Subject"), "unfolding must restore the exact subject")
+}
+
+func TestEncodeNonASCIIHeaderValue(t *testing.T) {
+	t.Parallel()
+
+	msg := validMessage()
+	msg.Headers = map[string]string{"X-Note": "café en été"}
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	headerSection, _, ok := strings.Cut(buf.String(), "\r\n\r\n")
+	require.True(t, ok)
+	for i := 0; i < len(headerSection); i++ {
+		require.Less(t, headerSection[i], byte(0x80), "headers must be 7-bit ASCII")
+	}
+
+	parsed, err := mail.ReadMessage(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	decoded, err := new(mime.WordDecoder).DecodeHeader(parsed.Header.Get("X-Note"))
+	require.NoError(t, err)
+	assert.Equal(t, "café en été", decoded)
 }
 
 func TestEncodeDateIsNow(t *testing.T) {

--- a/comms/email/mime_test.go
+++ b/comms/email/mime_test.go
@@ -1,0 +1,243 @@
+package email_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io"
+	"mime"
+	"mime/multipart"
+	"mime/quotedprintable"
+	"net/mail"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/comms/email"
+)
+
+// parsedPart is one leaf of the decoded MIME tree, keyed for assertions.
+type parsedPart struct {
+	contentType string
+	disposition string
+	contentID   string
+	body        []byte
+}
+
+// flattenParts walks a body, recursing into multipart containers and
+// decoding leaf transfer encodings.
+func flattenParts(t *testing.T, contentType string, encoding string, body io.Reader) []parsedPart {
+	t.Helper()
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	require.NoError(t, err)
+	if !strings.HasPrefix(mediaType, "multipart/") {
+		var decoded []byte
+		switch encoding {
+		case "quoted-printable":
+			decoded, err = io.ReadAll(quotedprintable.NewReader(body))
+		case "base64":
+			decoded, err = io.ReadAll(base64.NewDecoder(base64.StdEncoding, body))
+		default:
+			decoded, err = io.ReadAll(body)
+		}
+		require.NoError(t, err)
+		return []parsedPart{{contentType: mediaType, body: decoded}}
+	}
+	mr := multipart.NewReader(body, params["boundary"])
+	parts := make([]parsedPart, 0, 4)
+	for {
+		p, err := mr.NextPart()
+		if err == io.EOF {
+			return parts
+		}
+		require.NoError(t, err)
+		sub := flattenParts(t, p.Header.Get("Content-Type"), p.Header.Get("Content-Transfer-Encoding"), p)
+		for i := range sub {
+			if sub[i].disposition == "" {
+				sub[i].disposition = p.Header.Get("Content-Disposition")
+			}
+			if sub[i].contentID == "" {
+				sub[i].contentID = p.Header.Get("Content-Id")
+			}
+		}
+		parts = append(parts, sub...)
+	}
+}
+
+func encodeAndParse(t *testing.T, msg email.Message) (*mail.Message, []parsedPart) {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+	parsed, err := mail.ReadMessage(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	parts := flattenParts(t, parsed.Header.Get("Content-Type"), parsed.Header.Get("Content-Transfer-Encoding"), parsed.Body)
+	return parsed, parts
+}
+
+func TestEncodeTextOnly(t *testing.T) {
+	t.Parallel()
+
+	msg := validMessage()
+	msg.Text = "Привіт, Ann!\nLine two."
+	parsed, parts := encodeAndParse(t, msg)
+
+	require.Len(t, parts, 1)
+	assert.Equal(t, "text/plain", parts[0].contentType)
+	assert.Equal(t, "Привіт, Ann!\r\nLine two.", string(parts[0].body))
+	assert.Equal(t, "1.0", parsed.Header.Get("MIME-Version"))
+
+	_, err := parsed.Header.Date()
+	assert.NoError(t, err, "Date header must parse")
+	from, err := mail.ParseAddress(parsed.Header.Get("From"))
+	require.NoError(t, err)
+	assert.Equal(t, "no-reply@acme.example", from.Address)
+	assert.Equal(t, "Acme", from.Name)
+	assert.Regexp(t, regexp.MustCompile(`^<[0-9a-f]{32}@acme\.example>$`), parsed.Header.Get("Message-Id"))
+}
+
+func TestEncodeAlternative(t *testing.T) {
+	t.Parallel()
+
+	msg := validMessage()
+	msg.HTML = "<p>Hi <b>Ann</b>,</p>"
+	parsed, parts := encodeAndParse(t, msg)
+
+	require.Len(t, parts, 2)
+	assert.Equal(t, "text/plain", parts[0].contentType, "text must precede html so clients prefer html (last part wins)")
+	assert.Equal(t, "text/html", parts[1].contentType)
+	assert.Equal(t, "<p>Hi <b>Ann</b>,</p>", string(parts[1].body))
+	mediaType, _, err := mime.ParseMediaType(parsed.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	assert.Equal(t, "multipart/alternative", mediaType)
+}
+
+func TestEncodeAttachments(t *testing.T) {
+	t.Parallel()
+
+	payload := bytes.Repeat([]byte{0x00, 0xff, 0x10, 0x42}, 300) // forces base64 line folding
+	msg := validMessage()
+	msg.HTML = `<p>See <img src="cid:logo.png"> attached.</p>`
+	msg.Attachments = []email.Attachment{
+		{Filename: "report.pdf", Content: payload},
+		{Filename: "logo.png", Content: []byte("PNGDATA"), Inline: true},
+	}
+	parsed, parts := encodeAndParse(t, msg)
+
+	mediaType, _, err := mime.ParseMediaType(parsed.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	assert.Equal(t, "multipart/mixed", mediaType)
+
+	require.Len(t, parts, 4) // text, html, inline logo, attached report
+	byType := map[string]parsedPart{}
+	for _, p := range parts {
+		byType[p.contentType] = p
+	}
+	pdf, ok := byType["application/pdf"]
+	require.True(t, ok, "content type inferred from .pdf extension, got %v", parts)
+	assert.Equal(t, payload, pdf.body)
+	assert.Contains(t, pdf.disposition, "attachment")
+	assert.Contains(t, pdf.disposition, `filename="report.pdf"`)
+
+	png, ok := byType["image/png"]
+	require.True(t, ok, "content type inferred from .png extension")
+	assert.Equal(t, "PNGDATA", string(png.body))
+	assert.Contains(t, png.disposition, "inline")
+	assert.Equal(t, "<logo.png>", png.contentID)
+}
+
+func TestEncodeUnknownAttachmentType(t *testing.T) {
+	t.Parallel()
+
+	msg := validMessage()
+	msg.Attachments = []email.Attachment{
+		{Filename: "blob.weirdext123", Content: []byte("x")},
+		{Filename: "noext", Content: []byte("y")},
+		{Filename: "typed.bin", ContentType: "application/x-custom", Content: []byte("z")},
+	}
+	_, parts := encodeAndParse(t, msg)
+	var types []string
+	for _, p := range parts {
+		if p.contentType == "text/plain" {
+			continue
+		}
+		types = append(types, p.contentType)
+	}
+	assert.ElementsMatch(t, []string{"application/octet-stream", "application/octet-stream", "application/x-custom"}, types)
+}
+
+func TestEncodeHeaders(t *testing.T) {
+	t.Parallel()
+
+	msg := email.Message{
+		From:    "no-reply@acme.example",
+		To:      []string{"Ann <ann@example.com>", "bob@example.com"},
+		Cc:      []string{"carol@example.com"},
+		Bcc:     []string{"hidden@example.com"},
+		ReplyTo: "Support <support@acme.example>",
+		Subject: "Звіт за липень ✨",
+		Text:    "body",
+		Headers: map[string]string{"X-Campaign": "july", "Message-Id": "<stable-42@acme.example>"},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+	raw := buf.String()
+	assert.NotContains(t, raw, "hidden@example.com", "Bcc must never be encoded")
+	assert.NotContains(t, raw, "Звіт", "non-ASCII subject must be word-encoded")
+
+	parsed, err := mail.ReadMessage(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	subject, err := new(mime.WordDecoder).DecodeHeader(parsed.Header.Get("Subject"))
+	require.NoError(t, err)
+	assert.Equal(t, "Звіт за липень ✨", subject)
+
+	to, err := parsed.Header.AddressList("To")
+	require.NoError(t, err)
+	var toAddrs []string
+	for _, a := range to {
+		toAddrs = append(toAddrs, a.String())
+	}
+	assert.Equal(t, []string{`"Ann" <ann@example.com>`, "<bob@example.com>"}, toAddrs)
+	replyTo, err := mail.ParseAddress(parsed.Header.Get("Reply-To"))
+	require.NoError(t, err)
+	assert.Equal(t, "support@acme.example", replyTo.Address)
+	assert.Equal(t, "<stable-42@acme.example>", parsed.Header.Get("Message-Id"), "consumer Message-Id wins over generation")
+	assert.Equal(t, "july", parsed.Header.Get("X-Campaign"))
+}
+
+func TestEncodeQuotedPrintableEdge(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("wide характер text ", 40) // forces soft line breaks
+	msg := validMessage()
+	msg.Text = long + "\ntrailing=equals=signs"
+	_, parts := encodeAndParse(t, msg)
+	require.Len(t, parts, 1)
+	assert.Equal(t, long+"\r\ntrailing=equals=signs", string(parts[0].body))
+}
+
+func TestEncodeDeterministicHeaderOrder(t *testing.T) {
+	t.Parallel()
+
+	msg := validMessage()
+	msg.Headers = map[string]string{"X-B": "2", "X-A": "1", "X-C": "3", "Message-Id": "<fixed@acme.example>"}
+	var first bytes.Buffer
+	require.NoError(t, msg.Encode(&first))
+	idxA := strings.Index(first.String(), "X-A: 1")
+	idxB := strings.Index(first.String(), "X-B: 2")
+	idxC := strings.Index(first.String(), "X-C: 3")
+	require.True(t, idxA >= 0 && idxB >= 0 && idxC >= 0)
+	assert.True(t, idxA < idxB && idxB < idxC, "custom headers must encode in sorted order")
+}
+
+func TestEncodeDateIsNow(t *testing.T) {
+	t.Parallel()
+
+	before := time.Now().Add(-time.Minute)
+	parsed, _ := encodeAndParse(t, validMessage())
+	date, err := parsed.Header.Date()
+	require.NoError(t, err)
+	assert.WithinRange(t, date, before, time.Now().Add(time.Minute))
+}

--- a/comms/email/options.go
+++ b/comms/email/options.go
@@ -1,0 +1,37 @@
+package email
+
+import (
+	"crypto/tls"
+	"net/smtp"
+)
+
+type config struct {
+	tlsConfig *tls.Config
+	auth      smtp.Auth
+}
+
+// Option configures the SMTP sender beyond the env-loadable Config.
+type Option func(*config)
+
+// WithTLSConfig replaces the TLS client configuration used for both STARTTLS
+// and implicit TLS — the seam for private CAs, a ServerName override, or test
+// certificates. When its ServerName is empty the sender fills in the host
+// from Addr. Nil is ignored.
+func WithTLSConfig(tc *tls.Config) Option {
+	return func(c *config) {
+		if tc != nil {
+			c.tlsConfig = tc
+		}
+	}
+}
+
+// WithAuth replaces the authentication mechanism (default: PLAIN when
+// Config.Username is set, none otherwise) — the seam for CRAM-MD5 or a
+// provider-specific scheme. Nil is ignored.
+func WithAuth(a smtp.Auth) Option {
+	return func(c *config) {
+		if a != nil {
+			c.auth = a
+		}
+	}
+}

--- a/comms/email/sender.go
+++ b/comms/email/sender.go
@@ -1,0 +1,13 @@
+package email
+
+import "context"
+
+// Sender delivers one message — the package's composition seam. The SMTP
+// type is the stdlib implementation; provider adapters (SES, Postmark, …)
+// implement the same interface over Message.Encode or their JSON APIs and
+// stay consumer-side. Durable delivery rides async/queue with a Sender as
+// the job handler's deliverer: ErrTransient means retry, ErrPermanent means
+// dead-letter.
+type Sender interface {
+	Send(ctx context.Context, msg Message) error
+}

--- a/comms/email/smtp.go
+++ b/comms/email/smtp.go
@@ -1,0 +1,169 @@
+package email
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/smtp"
+	"net/textproto"
+	"time"
+)
+
+// SMTP submits messages to one SMTP server over stdlib net/smtp. It holds no
+// connection state — each Send dials, delivers, and quits — so a single
+// value is safe for concurrent use. Per-tenant sender identities are
+// per-tenant SMTP values (or one shared server with Message.From set per
+// send); there is no tenant seam because the sender holds no tenant data.
+type SMTP struct {
+	auth      smtp.Auth
+	tlsConfig *tls.Config
+	addr      string
+	host      string
+	hello     string
+	from      string
+	tlsMode   TLSMode
+	timeout   time.Duration
+}
+
+var _ Sender = (*SMTP)(nil)
+
+// New validates cfg and returns an SMTP sender. See Config for the
+// env-loadable knobs and Option for the TLS and auth seams.
+func New(cfg Config, opts ...Option) (*SMTP, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	var c config
+	for _, o := range opts {
+		o(&c)
+	}
+	host, _, err := net.SplitHostPort(cfg.Addr)
+	if err != nil {
+		return nil, fmt.Errorf("%w: Addr %q: %v", ErrInvalidConfig, cfg.Addr, err)
+	}
+	auth := c.auth
+	if auth == nil && cfg.Username != "" {
+		auth = smtp.PlainAuth("", cfg.Username, cfg.Password, host)
+	}
+	tc := c.tlsConfig.Clone() // nil-receiver Clone returns nil
+	if tc == nil {
+		tc = &tls.Config{}
+	}
+	if tc.ServerName == "" {
+		tc.ServerName = host
+	}
+	hello := cfg.Hello
+	if hello == "" {
+		hello = "localhost"
+	}
+	return &SMTP{
+		auth:      auth,
+		tlsConfig: tc,
+		addr:      cfg.Addr,
+		host:      host,
+		hello:     hello,
+		from:      cfg.From,
+		tlsMode:   cfg.TLS,
+		timeout:   cfg.Timeout,
+	}, nil
+}
+
+// Send validates msg and delivers it in one SMTP session. A message with an
+// empty From uses Config.From. The whole session is bounded by Config.Timeout
+// (or a sooner ctx deadline). Server rejections map onto a queue's retry
+// decision: ErrTransient for 4xx, ErrPermanent for 5xx. A failure after the
+// server accepted the message body (the end-of-DATA 250) is not reported as
+// an error — the mail is already in flight, and erroring would make a retry
+// send it twice.
+func (s *SMTP) Send(ctx context.Context, msg Message) error {
+	if s == nil || s.addr == "" { // zero SMTP bypassed New
+		return errors.New("email: sender not constructed with New")
+	}
+	if msg.From == "" {
+		msg.From = s.from
+	}
+	env, err := msg.validate()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", s.addr)
+	if err != nil {
+		return fmt.Errorf("email: dial %s: %w", s.addr, err)
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+	if s.tlsMode == TLSImplicit {
+		tconn := tls.Client(conn, s.tlsConfig)
+		if err := tconn.HandshakeContext(ctx); err != nil {
+			_ = conn.Close()
+			return fmt.Errorf("email: tls handshake: %w", err)
+		}
+		conn = tconn
+	}
+	client, err := smtp.NewClient(conn, s.host)
+	if err != nil {
+		_ = conn.Close()
+		return classify("greeting", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	if err := client.Hello(s.hello); err != nil {
+		return classify("hello", err)
+	}
+	if s.tlsMode == TLSStartTLS {
+		if ok, _ := client.Extension("STARTTLS"); !ok {
+			return ErrTLSUnavailable
+		}
+		if err := client.StartTLS(s.tlsConfig); err != nil {
+			return classify("starttls", err)
+		}
+	}
+	if s.auth != nil {
+		if err := client.Auth(s.auth); err != nil {
+			return classify("auth", err)
+		}
+	}
+	if err := client.Mail(env.from.Address); err != nil {
+		return classify("mail", err)
+	}
+	for _, rcpt := range env.rcpts {
+		if err := client.Rcpt(rcpt); err != nil {
+			return classify("rcpt "+rcpt, err)
+		}
+	}
+	w, err := client.Data()
+	if err != nil {
+		return classify("data", err)
+	}
+	if err := msg.encode(w, env, time.Now()); err != nil {
+		_ = w.Close()
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return classify("data close", err)
+	}
+	// The message is accepted; a failed QUIT can't unsend it.
+	_ = client.Quit()
+	return nil
+}
+
+// classify maps an SMTP reply onto the retry-decision sentinels: 4xx is
+// transient, 5xx is permanent. Transport errors (timeouts, resets) pass
+// through wrapped but unclassified.
+func classify(op string, err error) error {
+	if te, ok := errors.AsType[*textproto.Error](err); ok {
+		switch {
+		case te.Code >= 400 && te.Code < 500:
+			return fmt.Errorf("%w: %s: %v", ErrTransient, op, err)
+		case te.Code >= 500:
+			return fmt.Errorf("%w: %s: %v", ErrPermanent, op, err)
+		}
+	}
+	return fmt.Errorf("email: %s: %w", op, err)
+}

--- a/comms/email/smtp.go
+++ b/comms/email/smtp.go
@@ -45,6 +45,12 @@ func New(cfg Config, opts ...Option) (*SMTP, error) {
 	}
 	auth := c.auth
 	if auth == nil && cfg.Username != "" {
+		// net/smtp refuses PLAIN over a plaintext connection to any host but
+		// loopback, so this combination can never send — fail at construction
+		// with a usable error instead of on the first Send.
+		if cfg.TLS == TLSNone && host != "localhost" && host != "127.0.0.1" && host != "::1" {
+			return nil, fmt.Errorf("%w: PLAIN auth requires TLS for non-localhost servers; set TLS or supply WithAuth", ErrInvalidConfig)
+		}
 		auth = smtp.PlainAuth("", cfg.Username, cfg.Password, host)
 	}
 	tc := c.tlsConfig.Clone() // nil-receiver Clone returns nil

--- a/comms/email/smtp_test.go
+++ b/comms/email/smtp_test.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"net"
 	"net/mail"
+	"net/smtp"
 	"net/textproto"
 	"strings"
 	"sync"
@@ -51,6 +52,7 @@ type smtpServerConfig struct {
 	startTLS       bool // advertise and accept STARTTLS
 	implicitTLS    bool // TLS handshake immediately on accept
 	stall          bool // accept and never speak — for timeout tests
+	dropAfterData  bool // 250-accept the DATA body, then sever the connection
 	rejectMailCode int  // non-zero: reply this code to MAIL FROM
 	rejectRcptCode int  // non-zero: reply this code to every RCPT TO
 	rejectAuthCode int  // non-zero: reply this code to AUTH
@@ -198,6 +200,9 @@ func (s *smtpServer) session(conn net.Conn, secured bool) {
 			s.data = body
 			s.mu.Unlock()
 			reply("250 accepted")
+			if s.cfg.dropAfterData {
+				return // the deferred Close severs the connection before QUIT
+			}
 		case upper == "QUIT":
 			reply("221 bye")
 			return
@@ -340,6 +345,40 @@ func TestSMTPStatusClassification(t *testing.T) {
 		err = sender.Send(context.Background(), validMessage())
 		require.ErrorIs(t, err, email.ErrPermanent)
 	})
+}
+
+func TestSMTPAcceptedThenConnectionDrop(t *testing.T) {
+	t.Parallel()
+	// The server 250-accepts the message body and then severs the connection,
+	// so QUIT fails. Send must still return nil: the mail is in flight, and
+	// an error here would make an at-least-once queue send it twice.
+	server, pool := startSMTPServer(t, smtpServerConfig{startTLS: true, dropAfterData: true})
+	cfg, tlsOpt := clientConfig(server.addr(), pool, email.TLSStartTLS)
+	sender, err := email.New(cfg, tlsOpt)
+	require.NoError(t, err)
+
+	require.NoError(t, sender.Send(context.Background(), validMessage()))
+	_, _, _, _, data, _ := server.snapshot()
+	assert.NotEmpty(t, data, "message was accepted before the drop")
+}
+
+func TestNewPlaintextAuthNonLocalhost(t *testing.T) {
+	t.Parallel()
+	cfg := email.DefaultConfig()
+	cfg.Addr = "smtp.example.com:587"
+	cfg.TLS = email.TLSNone
+	cfg.Username = "postmaster"
+	cfg.Password = "secret"
+	_, err := email.New(cfg)
+	require.ErrorIs(t, err, email.ErrInvalidConfig, "PLAIN over plaintext to a remote host can never send")
+
+	cfg.Addr = "localhost:2525"
+	_, err = email.New(cfg)
+	require.NoError(t, err, "loopback dev catchers stay allowed")
+
+	cfg.Addr = "smtp.example.com:587"
+	_, err = email.New(cfg, email.WithAuth(smtp.CRAMMD5Auth("postmaster", "secret")))
+	require.NoError(t, err, "WithAuth overrides the PLAIN-over-plaintext guard")
 }
 
 func TestSMTPDefaultFrom(t *testing.T) {

--- a/comms/email/smtp_test.go
+++ b/comms/email/smtp_test.go
@@ -1,0 +1,429 @@
+package email_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"io"
+	"math/big"
+	"net"
+	"net/mail"
+	"net/textproto"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/comms/email"
+)
+
+// testCert issues a self-signed certificate for 127.0.0.1 so STARTTLS and
+// implicit-TLS tests verify a real chain instead of skipping verification.
+func testCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	leaf, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	pool := x509.NewCertPool()
+	pool.AddCert(leaf)
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}, pool
+}
+
+type smtpServerConfig struct {
+	startTLS       bool // advertise and accept STARTTLS
+	implicitTLS    bool // TLS handshake immediately on accept
+	stall          bool // accept and never speak — for timeout tests
+	rejectMailCode int  // non-zero: reply this code to MAIL FROM
+	rejectRcptCode int  // non-zero: reply this code to every RCPT TO
+	rejectAuthCode int  // non-zero: reply this code to AUTH
+}
+
+// smtpServer is a minimal in-process SMTP peer capturing what a real server
+// would see: EHLO name, AUTH credentials, envelope, and the exact message
+// bytes (via DotReader, so dot-stuffing is exercised too).
+type smtpServer struct {
+	cfg     smtpServerConfig
+	ln      net.Listener
+	tlsConf *tls.Config
+
+	mu       sync.Mutex
+	hello    string
+	authLine string
+	from     string
+	rcpts    []string
+	data     []byte
+	usedTLS  bool
+}
+
+func startSMTPServer(t *testing.T, cfg smtpServerConfig) (*smtpServer, *x509.CertPool) {
+	t.Helper()
+	cert, pool := testCert(t)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	s := &smtpServer{cfg: cfg, ln: ln, tlsConf: &tls.Config{Certificates: []tls.Certificate{cert}}}
+	go s.serve()
+	t.Cleanup(func() { _ = ln.Close() })
+	return s, pool
+}
+
+func (s *smtpServer) addr() string { return s.ln.Addr().String() }
+
+func (s *smtpServer) snapshot() (hello, authLine, from string, rcpts []string, data []byte, usedTLS bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hello, s.authLine, s.from, append([]string(nil), s.rcpts...), append([]byte(nil), s.data...), s.usedTLS
+}
+
+func (s *smtpServer) serve() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		go s.handle(conn)
+	}
+}
+
+func (s *smtpServer) handle(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	if s.cfg.stall {
+		_, _ = io.Copy(io.Discard, conn) // hold the connection open silently until the client gives up
+		return
+	}
+	secured := false
+	if s.cfg.implicitTLS {
+		tconn := tls.Server(conn, s.tlsConf)
+		if tconn.Handshake() != nil {
+			return
+		}
+		conn = tconn
+		secured = true
+		s.mu.Lock()
+		s.usedTLS = true
+		s.mu.Unlock()
+	}
+	s.session(conn, secured)
+}
+
+func (s *smtpServer) session(conn net.Conn, secured bool) {
+	tp := textproto.NewConn(conn)
+	reply := func(format string, args ...any) bool { return tp.PrintfLine(format, args...) == nil }
+	if !reply("220 test.local ESMTP") {
+		return
+	}
+	for {
+		line, err := tp.ReadLine()
+		if err != nil {
+			return
+		}
+		upper := strings.ToUpper(line)
+		switch {
+		case strings.HasPrefix(upper, "EHLO"), strings.HasPrefix(upper, "HELO"):
+			s.mu.Lock()
+			s.hello = strings.TrimSpace(line[4:])
+			s.mu.Unlock()
+			reply("250-test.local")
+			if s.cfg.startTLS && !secured {
+				reply("250-STARTTLS")
+			}
+			reply("250 AUTH PLAIN")
+		case upper == "STARTTLS":
+			if !s.cfg.startTLS {
+				reply("502 command not implemented")
+				continue
+			}
+			reply("220 ready to start TLS")
+			tconn := tls.Server(conn, s.tlsConf)
+			if tconn.Handshake() != nil {
+				return
+			}
+			conn = tconn
+			secured = true
+			tp = textproto.NewConn(tconn)
+			s.mu.Lock()
+			s.usedTLS = true
+			s.mu.Unlock()
+		case strings.HasPrefix(upper, "AUTH"):
+			s.mu.Lock()
+			s.authLine = line
+			s.mu.Unlock()
+			if s.cfg.rejectAuthCode > 0 {
+				reply("%d authentication failed", s.cfg.rejectAuthCode)
+				continue
+			}
+			reply("235 authenticated")
+		case strings.HasPrefix(upper, "MAIL FROM:"):
+			if s.cfg.rejectMailCode > 0 {
+				reply("%d rejected", s.cfg.rejectMailCode)
+				continue
+			}
+			s.mu.Lock()
+			s.from = angleAddr(line)
+			s.mu.Unlock()
+			reply("250 ok")
+		case strings.HasPrefix(upper, "RCPT TO:"):
+			if s.cfg.rejectRcptCode > 0 {
+				reply("%d rejected", s.cfg.rejectRcptCode)
+				continue
+			}
+			s.mu.Lock()
+			s.rcpts = append(s.rcpts, angleAddr(line))
+			s.mu.Unlock()
+			reply("250 ok")
+		case upper == "DATA":
+			reply("354 end with <CRLF>.<CRLF>")
+			body, err := io.ReadAll(tp.DotReader())
+			if err != nil {
+				return
+			}
+			s.mu.Lock()
+			s.data = body
+			s.mu.Unlock()
+			reply("250 accepted")
+		case upper == "QUIT":
+			reply("221 bye")
+			return
+		case upper == "RSET", upper == "NOOP":
+			reply("250 ok")
+		default:
+			reply("500 unrecognized command")
+		}
+	}
+}
+
+func angleAddr(line string) string {
+	open := strings.IndexByte(line, '<')
+	closing := strings.IndexByte(line, '>')
+	if open < 0 || closing <= open {
+		return ""
+	}
+	return line[open+1 : closing]
+}
+
+func clientConfig(addr string, pool *x509.CertPool, mode email.TLSMode) (email.Config, email.Option) {
+	cfg := email.DefaultConfig()
+	cfg.Addr = addr
+	cfg.TLS = mode
+	cfg.Timeout = 5 * time.Second
+	return cfg, email.WithTLSConfig(&tls.Config{RootCAs: pool}) //nolint:gosec // test server's self-signed CA
+}
+
+func TestSMTPSendStartTLS(t *testing.T) {
+	t.Parallel()
+	server, pool := startSMTPServer(t, smtpServerConfig{startTLS: true})
+	cfg, tlsOpt := clientConfig(server.addr(), pool, email.TLSStartTLS)
+	cfg.Username = "postmaster"
+	cfg.Password = "hunter2"
+	cfg.Hello = "app.acme.example"
+	sender, err := email.New(cfg, tlsOpt)
+	require.NoError(t, err)
+
+	msg := validMessage()
+	msg.Cc = []string{"carol@example.com"}
+	msg.Bcc = []string{"hidden@example.com"}
+	require.NoError(t, sender.Send(context.Background(), msg))
+
+	hello, authLine, from, rcpts, data, usedTLS := server.snapshot()
+	assert.Equal(t, "app.acme.example", hello)
+	assert.True(t, usedTLS, "session must upgrade via STARTTLS")
+	assert.Equal(t, "no-reply@acme.example", from)
+	assert.ElementsMatch(t, []string{"ann@example.com", "carol@example.com", "hidden@example.com"}, rcpts)
+
+	require.True(t, strings.HasPrefix(authLine, "AUTH PLAIN "))
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(authLine, "AUTH PLAIN "))
+	require.NoError(t, err)
+	assert.Equal(t, "\x00postmaster\x00hunter2", string(decoded))
+
+	parsed, err := mail.ReadMessage(bytes.NewReader(data))
+	require.NoError(t, err)
+	assert.Equal(t, "Hello", parsed.Header.Get("Subject"))
+	assert.NotContains(t, string(data), "hidden@example.com", "bcc must not appear in transmitted headers")
+}
+
+func TestSMTPSendImplicitTLS(t *testing.T) {
+	t.Parallel()
+	server, pool := startSMTPServer(t, smtpServerConfig{implicitTLS: true})
+	cfg, tlsOpt := clientConfig(server.addr(), pool, email.TLSImplicit)
+	sender, err := email.New(cfg, tlsOpt)
+	require.NoError(t, err)
+
+	require.NoError(t, sender.Send(context.Background(), validMessage()))
+	_, _, from, _, data, usedTLS := server.snapshot()
+	assert.True(t, usedTLS)
+	assert.Equal(t, "no-reply@acme.example", from)
+	assert.NotEmpty(t, data)
+}
+
+func TestSMTPSendPlaintext(t *testing.T) {
+	t.Parallel()
+	server, _ := startSMTPServer(t, smtpServerConfig{})
+	cfg := email.DefaultConfig()
+	cfg.Addr = server.addr()
+	cfg.TLS = email.TLSNone
+	cfg.Username = "dev"
+	cfg.Password = "dev"
+	sender, err := email.New(cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, sender.Send(context.Background(), validMessage()))
+	_, authLine, _, _, data, usedTLS := server.snapshot()
+	assert.False(t, usedTLS)
+	assert.NotEmpty(t, authLine, "PLAIN auth to loopback works without TLS")
+	assert.NotEmpty(t, data)
+}
+
+func TestSMTPStartTLSUnavailable(t *testing.T) {
+	t.Parallel()
+	server, pool := startSMTPServer(t, smtpServerConfig{startTLS: false})
+	cfg, tlsOpt := clientConfig(server.addr(), pool, email.TLSStartTLS)
+	cfg.Username = "postmaster"
+	cfg.Password = "secret"
+	sender, err := email.New(cfg, tlsOpt)
+	require.NoError(t, err)
+
+	err = sender.Send(context.Background(), validMessage())
+	require.ErrorIs(t, err, email.ErrTLSUnavailable)
+	_, authLine, from, _, data, _ := server.snapshot()
+	assert.Empty(t, authLine, "credentials must never cross plaintext in STARTTLS mode")
+	assert.Empty(t, from, "no mail flow after failed upgrade")
+	assert.Empty(t, data)
+}
+
+func TestSMTPStatusClassification(t *testing.T) {
+	t.Parallel()
+
+	t.Run("4xx rcpt is transient", func(t *testing.T) {
+		t.Parallel()
+		server, pool := startSMTPServer(t, smtpServerConfig{startTLS: true, rejectRcptCode: 450})
+		cfg, tlsOpt := clientConfig(server.addr(), pool, email.TLSStartTLS)
+		sender, err := email.New(cfg, tlsOpt)
+		require.NoError(t, err)
+		err = sender.Send(context.Background(), validMessage())
+		require.ErrorIs(t, err, email.ErrTransient)
+		assert.NotErrorIs(t, err, email.ErrPermanent)
+	})
+	t.Run("5xx mail is permanent", func(t *testing.T) {
+		t.Parallel()
+		server, pool := startSMTPServer(t, smtpServerConfig{startTLS: true, rejectMailCode: 550})
+		cfg, tlsOpt := clientConfig(server.addr(), pool, email.TLSStartTLS)
+		sender, err := email.New(cfg, tlsOpt)
+		require.NoError(t, err)
+		err = sender.Send(context.Background(), validMessage())
+		require.ErrorIs(t, err, email.ErrPermanent)
+	})
+	t.Run("5xx auth is permanent", func(t *testing.T) {
+		t.Parallel()
+		server, pool := startSMTPServer(t, smtpServerConfig{startTLS: true, rejectAuthCode: 535})
+		cfg, tlsOpt := clientConfig(server.addr(), pool, email.TLSStartTLS)
+		cfg.Username = "postmaster"
+		cfg.Password = "wrong"
+		sender, err := email.New(cfg, tlsOpt)
+		require.NoError(t, err)
+		err = sender.Send(context.Background(), validMessage())
+		require.ErrorIs(t, err, email.ErrPermanent)
+	})
+}
+
+func TestSMTPDefaultFrom(t *testing.T) {
+	t.Parallel()
+	server, pool := startSMTPServer(t, smtpServerConfig{startTLS: true})
+	cfg, tlsOpt := clientConfig(server.addr(), pool, email.TLSStartTLS)
+	cfg.From = "Acme <no-reply@acme.example>"
+	sender, err := email.New(cfg, tlsOpt)
+	require.NoError(t, err)
+
+	msg := validMessage()
+	msg.From = ""
+	require.NoError(t, sender.Send(context.Background(), msg))
+	_, _, from, _, _, _ := server.snapshot()
+	assert.Equal(t, "no-reply@acme.example", from)
+}
+
+func TestSMTPInvalidMessageBeforeDial(t *testing.T) {
+	t.Parallel()
+	cfg := email.DefaultConfig()
+	cfg.Addr = "203.0.113.1:2525" // TEST-NET, nothing listens; validation must fail before any dial
+	sender, err := email.New(cfg)
+	require.NoError(t, err)
+
+	msg := validMessage()
+	msg.To = nil
+	start := time.Now()
+	err = sender.Send(context.Background(), msg)
+	require.ErrorIs(t, err, email.ErrInvalidMessage)
+	assert.Less(t, time.Since(start), time.Second)
+}
+
+func TestSMTPTimeout(t *testing.T) {
+	t.Parallel()
+	server, _ := startSMTPServer(t, smtpServerConfig{stall: true})
+	cfg := email.DefaultConfig()
+	cfg.Addr = server.addr()
+	cfg.TLS = email.TLSNone
+	cfg.Timeout = 300 * time.Millisecond
+	sender, err := email.New(cfg)
+	require.NoError(t, err)
+
+	start := time.Now()
+	err = sender.Send(context.Background(), validMessage())
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, email.ErrTransient)
+	assert.NotErrorIs(t, err, email.ErrPermanent)
+	assert.Less(t, time.Since(start), 3*time.Second)
+}
+
+func TestSMTPZeroValue(t *testing.T) {
+	t.Parallel()
+	var sender email.SMTP
+	err := sender.Send(context.Background(), validMessage())
+	require.ErrorContains(t, err, "not constructed")
+}
+
+func TestNewConfigValidation(t *testing.T) {
+	t.Parallel()
+	base := func() email.Config {
+		cfg := email.DefaultConfig()
+		cfg.Addr = "smtp.example.com:587"
+		return cfg
+	}
+	mutations := map[string]func(*email.Config){
+		"missing addr":         func(c *email.Config) { c.Addr = "" },
+		"addr without port":    func(c *email.Config) { c.Addr = "smtp.example.com" },
+		"unknown tls mode":     func(c *email.Config) { c.TLS = "sometimes" },
+		"username without pw":  func(c *email.Config) { c.Username = "u"; c.Password = "" },
+		"password without usr": func(c *email.Config) { c.Password = "p" },
+		"bad from":             func(c *email.Config) { c.From = "not an address" },
+		"non-positive timeout": func(c *email.Config) { c.Timeout = 0 },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cfg := base()
+			mutate(&cfg)
+			_, err := email.New(cfg)
+			require.ErrorIs(t, err, email.ErrInvalidConfig)
+		})
+	}
+
+	sender, err := email.New(base())
+	require.NoError(t, err)
+	require.NotNil(t, sender)
+}

--- a/comms/email/template.go
+++ b/comms/email/template.go
@@ -1,0 +1,91 @@
+package email
+
+import (
+	"fmt"
+	htmltemplate "html/template"
+	"io/fs"
+	"strings"
+	texttemplate "text/template"
+)
+
+// Templates renders named emails into a Message's content fields. Every
+// template file defines up to three blocks per email name — "<name>:subject"
+// (required), "<name>:html", "<name>:text" (at least one body required):
+//
+//	{{define "welcome:subject"}}Welcome, {{.Name}}!{{end}}
+//	{{define "welcome:html"}}<p>Hi {{.Name}},</p>{{end}}
+//	{{define "welcome:text"}}Hi {{.Name}},{{end}}
+//
+// The html blocks render through html/template (contextual auto-escaping);
+// subject and text blocks render through text/template. Shared partials work
+// the usual way: any block defined in the parsed set is callable from any
+// other.
+type Templates struct {
+	html *htmltemplate.Template
+	text *texttemplate.Template
+}
+
+// ParseFS parses every template matching patterns (fs.Glob syntax, like
+// template.ParseFS) into one named set.
+func ParseFS(fsys fs.FS, patterns ...string) (*Templates, error) {
+	ht, err := htmltemplate.ParseFS(fsys, patterns...)
+	if err != nil {
+		return nil, fmt.Errorf("email: parse templates: %w", err)
+	}
+	tt, err := texttemplate.ParseFS(fsys, patterns...)
+	if err != nil {
+		return nil, fmt.Errorf("email: parse templates: %w", err)
+	}
+	return &Templates{html: ht, text: tt}, nil
+}
+
+// Render executes name's blocks with data and returns a Message with
+// Subject, HTML, and Text filled — From and recipients stay with the caller.
+// A name with no blocks at all returns ErrTemplateNotFound; a name missing
+// its subject or defining neither body returns ErrInvalidTemplate.
+func (t *Templates) Render(name string, data any) (Message, error) {
+	if t == nil || t.text == nil || t.html == nil {
+		return Message{}, fmt.Errorf("%w: templates not constructed with ParseFS", ErrInvalidTemplate)
+	}
+	subjectTpl := t.text.Lookup(name + ":subject")
+	htmlTpl := t.html.Lookup(name + ":html")
+	textTpl := t.text.Lookup(name + ":text")
+	if subjectTpl == nil && htmlTpl == nil && textTpl == nil {
+		return Message{}, fmt.Errorf("%w: %q", ErrTemplateNotFound, name)
+	}
+	if subjectTpl == nil {
+		return Message{}, fmt.Errorf("%w: %q defines no subject block", ErrInvalidTemplate, name)
+	}
+	if htmlTpl == nil && textTpl == nil {
+		return Message{}, fmt.Errorf("%w: %q defines neither html nor text block", ErrInvalidTemplate, name)
+	}
+
+	var sb strings.Builder
+	if err := subjectTpl.Execute(&sb, data); err != nil {
+		return Message{}, fmt.Errorf("email: render %s:subject: %w", name, err)
+	}
+	subject := strings.TrimSpace(sb.String())
+	if subject == "" {
+		return Message{}, fmt.Errorf("%w: %q renders an empty subject", ErrInvalidTemplate, name)
+	}
+	if strings.ContainsAny(subject, "\r\n") {
+		return Message{}, fmt.Errorf("%w: %q renders a multi-line subject", ErrInvalidTemplate, name)
+	}
+
+	msg := Message{Subject: subject}
+	if htmlTpl != nil {
+		sb.Reset()
+		if err := htmlTpl.Execute(&sb, data); err != nil {
+			return Message{}, fmt.Errorf("email: render %s:html: %w", name, err)
+		}
+		msg.HTML = strings.TrimSpace(sb.String())
+	}
+	if textTpl != nil {
+		sb.Reset()
+		if err := textTpl.Execute(&sb, data); err != nil {
+			return Message{}, fmt.Errorf("email: render %s:text: %w", name, err)
+		}
+		msg.Text = strings.TrimSpace(sb.String())
+	}
+	return msg, nil
+}

--- a/comms/email/template_test.go
+++ b/comms/email/template_test.go
@@ -1,0 +1,112 @@
+package email_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/comms/email"
+)
+
+const welcomeTmpl = `{{define "welcome:subject"}}Welcome, {{.Name}}!{{end}}
+{{define "welcome:html"}}<p>Hi {{.Name}},</p>
+{{template "footer" .}}{{end}}
+{{define "welcome:text"}}Hi {{.Name}},{{end}}
+
+{{define "html-only:subject"}}Report{{end}}
+{{define "html-only:html"}}<h1>Report</h1>{{end}}
+
+{{define "no-subject:html"}}<p>orphan</p>{{end}}
+
+{{define "empty-subject:subject"}}  {{end}}
+{{define "empty-subject:text"}}body{{end}}
+
+{{define "no-body:subject"}}Subject{{end}}
+`
+
+const footerTmpl = `{{define "footer"}}<p>— Acme</p>{{end}}`
+
+func parseTestTemplates(t *testing.T) *email.Templates {
+	t.Helper()
+	fsys := fstest.MapFS{
+		"templates/welcome.tmpl": {Data: []byte(welcomeTmpl)},
+		"templates/footer.tmpl":  {Data: []byte(footerTmpl)},
+	}
+	tpl, err := email.ParseFS(fsys, "templates/*.tmpl")
+	require.NoError(t, err)
+	return tpl
+}
+
+func TestTemplatesRender(t *testing.T) {
+	t.Parallel()
+	tpl := parseTestTemplates(t)
+
+	msg, err := tpl.Render("welcome", map[string]string{"Name": "Ann"})
+	require.NoError(t, err)
+	assert.Equal(t, "Welcome, Ann!", msg.Subject)
+	assert.Equal(t, "<p>Hi Ann,</p>\n<p>— Acme</p>", msg.HTML, "shared partial must be callable")
+	assert.Equal(t, "Hi Ann,", msg.Text)
+	assert.Empty(t, msg.From, "rendering never sets addressing")
+	assert.Empty(t, msg.To)
+}
+
+func TestTemplatesHTMLEscaping(t *testing.T) {
+	t.Parallel()
+	tpl := parseTestTemplates(t)
+
+	msg, err := tpl.Render("welcome", map[string]string{"Name": `<script>alert(1)</script>`})
+	require.NoError(t, err)
+	assert.NotContains(t, msg.HTML, "<script>", "html block must auto-escape data")
+	assert.Contains(t, msg.Text, "<script>", "text block must not html-escape")
+}
+
+func TestTemplatesHTMLOnly(t *testing.T) {
+	t.Parallel()
+	tpl := parseTestTemplates(t)
+
+	msg, err := tpl.Render("html-only", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "<h1>Report</h1>", msg.HTML)
+	assert.Empty(t, msg.Text)
+}
+
+func TestTemplatesRenderErrors(t *testing.T) {
+	t.Parallel()
+	tpl := parseTestTemplates(t)
+
+	_, err := tpl.Render("nope", nil)
+	assert.ErrorIs(t, err, email.ErrTemplateNotFound)
+
+	_, err = tpl.Render("no-subject", nil)
+	assert.ErrorIs(t, err, email.ErrInvalidTemplate)
+
+	_, err = tpl.Render("empty-subject", nil)
+	assert.ErrorIs(t, err, email.ErrInvalidTemplate)
+
+	_, err = tpl.Render("no-body", nil)
+	assert.ErrorIs(t, err, email.ErrInvalidTemplate)
+
+	var zero email.Templates
+	_, err = zero.Render("welcome", nil)
+	assert.ErrorIs(t, err, email.ErrInvalidTemplate)
+}
+
+func TestTemplatesMultilineSubject(t *testing.T) {
+	t.Parallel()
+	fsys := fstest.MapFS{"e.tmpl": {Data: []byte(
+		"{{define \"evil:subject\"}}line one\nline two{{end}}\n{{define \"evil:text\"}}b{{end}}\n",
+	)}}
+	tpl, err := email.ParseFS(fsys, "*.tmpl")
+	require.NoError(t, err)
+	_, err = tpl.Render("evil", nil)
+	assert.ErrorIs(t, err, email.ErrInvalidTemplate)
+}
+
+func TestParseFSErrors(t *testing.T) {
+	t.Parallel()
+	fsys := fstest.MapFS{"broken.tmpl": {Data: []byte(`{{define "x:subject"}}{{.Name`)}}
+	_, err := email.ParseFS(fsys, "*.tmpl")
+	require.Error(t, err)
+}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -316,19 +316,6 @@ Deps: `data/postgres`.
 
 ---
 
-**comms/email**
-
-The complete email package: `Sender` seam + stdlib net/smtp implementation
-(STARTTLS, multipart, attachments) + named-template rendering (subject +
-HTML + text into a `Message`). `email/markdown` renders markdown + YAML
-frontmatter (subject/preheader, CTA-button extension) — the designer-free
-transactional format; goldmark confined there. Provider adapters
-(SES/Postmark/…) are consumer-side or isolated subpackages.
-
-Deps: none forge-internal (goldmark external, isolated).
-
----
-
 **comms/inbound**
 
 Inbound email processing — the receive side `comms/email` deliberately omits: MIME parse over stdlib `net/mail`/`mime` into a typed `Message` (decoded headers, text/HTML bodies, attachments with magic-byte MIME check via `filetype`), reply/quote/signature stripping to the newly-written text, thread correlation via `In-Reply-To`/`References` plus plus-addressing and reply-token recipients, and a DKIM/SPF-results header reader (verdicts from the receiving MTA — no crypto here). Transport-agnostic: consumers feed it raw RFC 5322 bytes from an SES/Mailgun/Postmark webhook or an IMAP poller; what becomes a ticket is consumer-side.

--- a/go.mod
+++ b/go.mod
@@ -304,6 +304,7 @@ require (
 	github.com/yeya24/promlinter v0.3.0 // indirect
 	github.com/ykadowak/zerologlint v0.1.5 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	github.com/yuin/goldmark v1.8.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	gitlab.com/bosi/decorder v0.4.2 // indirect
 	go-simpler.org/musttag v0.14.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/opensearch v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.43.0
+	github.com/yuin/goldmark v1.8.4
 	go.mongodb.org/mongo-driver/v2 v2.7.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
@@ -304,7 +305,6 @@ require (
 	github.com/yeya24/promlinter v0.3.0 // indirect
 	github.com/ykadowak/zerologlint v0.1.5 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
-	github.com/yuin/goldmark v1.8.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	gitlab.com/bosi/decorder v0.4.2 // indirect
 	go-simpler.org/musttag v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -672,6 +672,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.8.4 h1:oat/nd3U6NeQqFEL3xpEJq7d7c86NI+DbSNGAs4xnjA=
+github.com/yuin/goldmark v1.8.4/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=


### PR DESCRIPTION
## What

The complete transactional-email package per the catalog entry, plus the `email/markdown` subpackage (goldmark isolated there). Catalog entry deleted per the ship-and-delete rule.

### comms/email

- **`Message` + `Encode`** — full RFC 5322/MIME document writer: `multipart/alternative` under `related` under `mixed` (each level only when needed), quoted-printable bodies, base64 attachments folded at 76 cols, inline images via Content-ID, Q-encoded subjects, generated Message-ID (consumer `Message-Id` header wins), CRLF-only output. `Encode` is public because provider raw-send APIs (SES/Postmark) take exactly these bytes.
- **Fail-closed validation** — unparseable addresses, CR/LF anywhere in a header name/value (injection), custom headers colliding with encoder-owned ones (including a consumer-set `Bcc`, which would leak hidden recipients), no-recipient and no-body messages are all construction errors. Bcc rides the envelope only, never the encoded headers.
- **`Sender` seam + `SMTP`** — dial-per-message stdlib net/smtp: STARTTLS mandatory by default (server not advertising it → `ErrTLSUnavailable` before any credential crosses plaintext), `implicit` for :465, `none` for dev catchers; PLAIN auth when creds configured (`WithAuth` for anything else), `WithTLSConfig` for private CAs; env-loadable `Config` (`EMAIL_SMTP_*`) with `DefaultConfig`/`Validate`.
- **Queue-shaped errors** — 4xx → `ErrTransient`, 5xx → `ErrPermanent`, mirroring comms/webhook's retry-vs-dead-letter mapping. A failure *after* the end-of-DATA 250 is deliberately swallowed: the mail is in flight, and erroring would make an at-least-once queue double-send.
- **`Templates`** — `ParseFS` + `Render(name, data)` over `<name>:subject` / `<name>:html` / `<name>:text` blocks; html/template auto-escaping for HTML, text/template for subject/text; shared partials work; rendered subjects are checked for emptiness and newline injection.

### comms/email/markdown

- YAML frontmatter (strict decode — unknown key fails the render) carries `subject`/`preheader`; markdown body renders through goldmark with raw HTML dropped.
- **CTA extension**: a paragraph holding exactly one `[Button: label](https://…)` link becomes a bulletproof table-based button (escaped label/URL, `WithButtonColor`); non-http(s) destinations and inline placements degrade visibly to plain links. Plain text renders it as `label: url`.
- Output is a layout-wrapped HTML document (hidden preheader div, centered 600px card, system font stack; `WithLayout` replaces the shell) plus a hand-rolled plain-text alternative (headings, lists, blockquotes, code, links as `text (url)`).

## Tenancy

No seam by design (postback/webhook precedent): a `Message` is a passed value and the sender holds no tenant data; per-tenant identities are per-tenant `Config` values.

## Testing

- Black-box throughout; MIME assertions parse the encoded output back through `net/mail` + `mime/multipart` instead of golden strings.
- In-process SMTP server (self-signed cert, real chain verification via `WithTLSConfig` RootCAs) covering STARTTLS upgrade + AUTH PLAIN capture, implicit TLS, plaintext dev mode, STARTTLS-unavailable fail-closed (asserts credentials never crossed), 4xx/5xx classification, default-From, Bcc envelope-only, timeout via stalled server.
- Whole repo `go test -race ./...` green; `just lint` clean.

## Benchmarks (post-optimization pass)

Measured fix: shared CRLF byte slice in the base64 line folder (`io.WriteString` was allocating the 2-byte terminator once per line).

| Benchmark | before | after |
|---|---|---|
| EncodeWithAttachment (64KiB) | 60.0µs, 21.7KB, **1301 allocs** | 47.8µs, 12.5KB, **151 allocs** |
| EncodeTextOnly | — | 2.2µs, 5.5KB, 47 allocs |
| EncodeAlternative | — | 4.7µs, 8.5KB, 97 allocs |
| TemplatesRender | — | 1.1µs, 752B, 24 allocs |
| markdown Render | — | 12.3µs, 25KB, 141 allocs |
| markdown RenderLongDocument | — | 170µs, 240KB, 2046 allocs |

## Dependencies

`github.com/yuin/goldmark` (sanctioned in design.md, confined to `email/markdown`); `gopkg.in/yaml.v3` reused for frontmatter.