### PR TITLE
feat(realtime/sse): Server-Sent Events endpoint over fanout + low-level writer

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -208,20 +208,6 @@ Deps: `async/queue`; drivers: `data/sqlite`, `data/nats` (planned),
 
 ---
 
-**realtime/sse**
-
-The complete Server-Sent Events package, stdlib-only: typed event
-constructors (string/JSON/comment/retry), correct framing + headers,
-per-event flush, keep-alive, ctx cancellation — plus the mountable
-endpoint over `fanout`: per-request subscribe, heartbeat, disconnect
-handling, Last-Event-ID resume via the replay ring. The low-level writer
-stays exported as the brick under `web/htmx`'s SendComponent bridge and
-`llm.SSE`. Requires httpserver WriteTimeout=0 (documented).
-
-Deps: `realtime/fanout`.
-
----
-
 **realtime/websocket**
 
 The complete WebSocket package: accept/read/write/ping-pong/close over
@@ -383,7 +369,7 @@ truncation; exported usage type (prices are consumer-supplied — never
 library data). Drivers `llm/openai`, `llm/anthropic` are stdlib JSON+SSE
 adapters over httpclient — never the official SDKs.
 
-Deps: `web/httpclient`; `realtime/sse` (planned).
+Deps: `web/httpclient`; `realtime/sse`.
 
 ---
 

--- a/realtime/sse/bench_test.go
+++ b/realtime/sse/bench_test.go
@@ -1,0 +1,123 @@
+package sse_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dmitrymomot/forge/realtime/fanout"
+	"github.com/dmitrymomot/forge/realtime/sse"
+)
+
+// discard is a flushable ResponseWriter that throws the stream away.
+type discard struct {
+	header http.Header
+	notify chan struct{}
+}
+
+func (d *discard) Header() http.Header { return d.header }
+func (d *discard) Write(p []byte) (int, error) {
+	if d.notify != nil {
+		d.notify <- struct{}{}
+	}
+	return len(p), nil
+}
+func (d *discard) WriteHeader(int) {}
+func (d *discard) Flush()          {}
+
+// SetWriteDeadline models a real server connection (which supports write
+// deadlines); without it the benchmarks measure ResponseController's
+// wrapped not-supported error instead of the production path.
+func (d *discard) SetWriteDeadline(time.Time) error { return nil }
+
+func newBenchWriter(b *testing.B) *sse.Writer {
+	b.Helper()
+	w, err := sse.NewWriter(&discard{header: make(http.Header)})
+	if err != nil {
+		b.Fatal(err)
+	}
+	return w
+}
+
+func BenchmarkSendText(b *testing.B) {
+	w := newBenchWriter(b)
+	e := sse.Event{ID: "123456", Name: "update", Data: []byte(`{"unread":3,"total":128}`)}
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := w.Send(e); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSendMultiline(b *testing.B) {
+	w := newBenchWriter(b)
+	e := sse.Event{Name: "chunk", Data: []byte("line one\nline two\nline three\nline four")}
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := w.Send(e); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSendComment(b *testing.B) {
+	w := newBenchWriter(b)
+	e := sse.Comment("")
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := w.Send(e); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkHandlerDelivery measures the full publish → hub dispatch → encode
+// → frame → write round trip through a connected handler.
+func BenchmarkHandlerDelivery(b *testing.B) {
+	hub, err := fanout.New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer hub.Close()
+	h, err := sse.NewHandler(hub, func(*http.Request) ([]string, error) {
+		return []string{"bench"}, nil
+	}, sse.WithKeepAlive(0))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	w := &discard{header: make(http.Header), notify: make(chan struct{}, 1)}
+	req := httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/events", nil)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.ServeHTTP(w, req)
+	}()
+
+	ctx := b.Context()
+	payload := []byte(`{"unread":3,"total":128}`)
+	// Wait for the subscription: the first delivered publish proves it.
+	for {
+		if err := hub.Publish(ctx, "bench", payload); err != nil {
+			b.Fatal(err)
+		}
+		select {
+		case <-w.notify:
+		case <-time.After(10 * time.Millisecond):
+			continue
+		}
+		break
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := hub.Publish(ctx, "bench", payload); err != nil {
+			b.Fatal(err)
+		}
+		<-w.notify
+	}
+	hub.Close()
+	<-done
+}

--- a/realtime/sse/doc.go
+++ b/realtime/sse/doc.go
@@ -1,0 +1,65 @@
+// Package sse serves Server-Sent Events: the mountable live-updates endpoint
+// over a fanout hub, and the low-level event writer it is built on. Delivery
+// is the realtime contract — ephemeral, at-most-once, to currently-connected
+// clients; durable messaging is async/eventbus.
+//
+// # Endpoint over fanout
+//
+// NewHandler turns a hub into an endpoint: each GET request subscribes to the
+// topics your TopicsFunc resolves for it, streams every published message as
+// an SSE event (topic as the event name, hub message ID as the "id:" resume
+// cursor), sends heartbeat comments while idle, and tears the subscription
+// down when the client disconnects.
+//
+//	hub, _ := fanout.New(fanout.WithReplay(256))
+//	defer hub.Close()
+//
+//	handler, _ := sse.NewHandler(hub, func(r *http.Request) ([]string, error) {
+//		return []string{"notifications." + userID(r)}, nil
+//	})
+//	mux.Handle("GET /events", handler)
+//
+//	// elsewhere:
+//	_ = hub.Publish(ctx, "notifications.42", []byte(`{"unread":3}`))
+//
+// With replay enabled on the hub, a reconnecting EventSource automatically
+// resumes: the browser sends Last-Event-ID and the handler replays the missed
+// messages from the ring before going live. Hub message IDs are per-instance
+// — after a restart or behind a round-robin balancer a stale cursor degrades
+// to a live-only stream, never an error. Multi-tenant apps configure
+// fanout.WithScope on the hub; the handler passes the request context
+// through, so topics stay tenant-isolated with zero ceremony here, and a
+// missing scope fails the request closed with 403.
+//
+// The default event name is the topic: EventSource dispatches those only to
+// addEventListener(topic) listeners (htmx's sse extension keys sse-swap the
+// same way). For plain onmessage clients, install a WithEncoder that clears
+// Event.Name.
+//
+// # Low-level writer
+//
+// Writer is the brick under the handler and under bridges like web/htmx and
+// llm: it sets the stream headers, then frames and flushes one event per
+// Send.
+//
+//	w, err := sse.NewWriter(rw) // rw is the http.ResponseWriter
+//	if err != nil { ... }       // ErrStreamingUnsupported: respond 500
+//	_ = w.Send(sse.Text("update", "building"))
+//	ev, _ := sse.JSON("update", payload)
+//	_ = w.Send(ev)
+//
+// # Deployment
+//
+// An SSE response never finishes, so the server's write timeout must not
+// apply to it. NewWriter clears the write deadline through
+// http.ResponseController, which works on net/http servers as long as every
+// wrapping middleware implements Unwrap (all forge middleware does). If a
+// deadline-oblivious wrapper sits in the chain, run the server with
+// httpserver WriteTimeout=0 instead. In place of the cleared deadline, every
+// Send arms a per-write one (WithSendTimeout, default 30s), so a client that
+// stays connected but stops reading fails the stream instead of pinning the
+// connection forever. Heartbeats (WithKeepAlive, default 15s) keep proxies
+// from cutting idle streams — and give a silent topic regular Sends, which is
+// what makes the send timeout catch stalled clients even with no traffic —
+// and the X-Accel-Buffering header disables nginx response buffering.
+package sse

--- a/realtime/sse/doc.go
+++ b/realtime/sse/doc.go
@@ -48,6 +48,17 @@
 //	ev, _ := sse.JSON("update", payload)
 //	_ = w.Send(ev)
 //
+// HTML-over-SSE (htmx sse-swap) rides the Component seam — templ components
+// satisfy it implicitly, sse imports nothing:
+//
+//	ev, err := sse.Templ(ctx, "orders.42", views.OrderRow(order))
+//	if err != nil { ... }
+//	_ = w.Send(ev)
+//
+// Multi-line HTML frames as multiple "data:" lines and reassembles
+// byte-identical in the browser (CR/CRLF normalize to LF), so the swapped
+// markup is exactly what the component rendered.
+//
 // # Deployment
 //
 // An SSE response never finishes, so the server's write timeout must not

--- a/realtime/sse/errors.go
+++ b/realtime/sse/errors.go
@@ -1,0 +1,14 @@
+package sse
+
+import "errors"
+
+var (
+	// ErrInvalidEvent is returned by Writer.Send for an event that cannot be
+	// framed: an ID or event name containing a line break, an ID containing
+	// NUL, or a negative Retry.
+	ErrInvalidEvent = errors.New("sse: invalid event")
+	// ErrStreamingUnsupported is returned by NewWriter when the
+	// http.ResponseWriter cannot flush, so events would sit in a buffer
+	// instead of reaching the client.
+	ErrStreamingUnsupported = errors.New("sse: streaming unsupported")
+)

--- a/realtime/sse/event.go
+++ b/realtime/sse/event.go
@@ -74,7 +74,13 @@ func Templ(ctx context.Context, name string, c Component) (Event, error) {
 	if err := c.Render(ctx, &buf); err != nil {
 		return Event{}, fmt.Errorf("sse: render component: %w", err)
 	}
-	return Event{Name: name, Data: buf.Bytes()}, nil
+	data := buf.Bytes()
+	if data == nil {
+		// A component that rendered nothing still dispatches an empty event
+		// (matching Text(name, "")); nil Data would drop the frame entirely.
+		data = []byte{}
+	}
+	return Event{Name: name, Data: data}, nil
 }
 
 // Comment builds a comment-only frame (": text"). Clients ignore comments;

--- a/realtime/sse/event.go
+++ b/realtime/sse/event.go
@@ -1,8 +1,11 @@
 package sse
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -50,6 +53,28 @@ func JSON(name string, v any) (Event, error) {
 		return Event{}, fmt.Errorf("sse: marshal event data: %w", err)
 	}
 	return Event{Name: name, Data: data}, nil
+}
+
+// Component is the structural seam for templ components — anything with
+// templ's Render method satisfies it implicitly, so sse never imports templ
+// and html/template users can adapt with a small func type.
+type Component interface {
+	Render(ctx context.Context, w io.Writer) error
+}
+
+// Templ builds a named event carrying the rendered HTML of c. Multi-line
+// output is framed as multiple "data:" lines and reassembles byte-identical
+// client-side (CR/CRLF normalize to LF), so htmx's sse extension swaps it in
+// unchanged. An empty name means the client's default "message" event.
+func Templ(ctx context.Context, name string, c Component) (Event, error) {
+	if c == nil {
+		return Event{}, fmt.Errorf("sse: nil component")
+	}
+	var buf bytes.Buffer
+	if err := c.Render(ctx, &buf); err != nil {
+		return Event{}, fmt.Errorf("sse: render component: %w", err)
+	}
+	return Event{Name: name, Data: buf.Bytes()}, nil
 }
 
 // Comment builds a comment-only frame (": text"). Clients ignore comments;

--- a/realtime/sse/event.go
+++ b/realtime/sse/event.go
@@ -1,0 +1,125 @@
+package sse
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Event is one Server-Sent Events frame. The zero value frames to a blank
+// line, which every client ignores; set fields directly or use the Text,
+// JSON, Comment, and Retry constructors. Multi-line Data is framed as
+// multiple "data:" lines and reassembles into the same string client-side.
+type Event struct {
+	// ID sets the "id:" field: the client's Last-Event-ID resume cursor. It
+	// must not contain line breaks or NUL.
+	ID string
+	// Name sets the "event:" field. Empty means the client's default
+	// "message" event; EventSource dispatches any other name only to
+	// addEventListener(name) listeners, not onmessage. It must not contain
+	// line breaks.
+	Name string
+
+	comment string
+	// Data is the event payload, framed as one "data:" line per line of
+	// input. A nil Data frames no "data:" line at all, which makes the
+	// client ignore the frame (an ID-only frame still advances the resume
+	// cursor); an empty non-nil Data dispatches an empty string.
+	Data []byte
+	// Retry sets the "retry:" field: the client's reconnection delay,
+	// rounded up to a whole millisecond. Zero omits the field; negative is
+	// invalid.
+	Retry time.Duration
+
+	hasComment bool
+}
+
+// Text builds a named event carrying a plain-text payload. An empty name
+// means the client's default "message" event.
+func Text(name, data string) Event {
+	return Event{Name: name, Data: []byte(data)}
+}
+
+// JSON builds a named event carrying the JSON encoding of v. An empty name
+// means the client's default "message" event.
+func JSON(name string, v any) (Event, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return Event{}, fmt.Errorf("sse: marshal event data: %w", err)
+	}
+	return Event{Name: name, Data: data}, nil
+}
+
+// Comment builds a comment-only frame (": text"). Clients ignore comments;
+// they exist to keep idle connections alive through proxies. Multi-line text
+// frames as one comment line per line of input.
+func Comment(text string) Event {
+	return Event{comment: text, hasComment: true}
+}
+
+// Retry builds a frame carrying only a reconnection-delay advice for the
+// client, rounded up to a whole millisecond.
+func Retry(d time.Duration) Event {
+	return Event{Retry: d}
+}
+
+// appendTo validates e and appends its wire frame to b.
+func (e Event) appendTo(b []byte) ([]byte, error) {
+	if strings.ContainsAny(e.Name, "\r\n") {
+		return nil, fmt.Errorf("%w: event name contains a line break", ErrInvalidEvent)
+	}
+	if strings.ContainsAny(e.ID, "\r\n\x00") {
+		return nil, fmt.Errorf("%w: id contains a line break or NUL", ErrInvalidEvent)
+	}
+	if e.Retry < 0 {
+		return nil, fmt.Errorf("%w: negative retry %s", ErrInvalidEvent, e.Retry)
+	}
+	if e.hasComment {
+		b = appendLines(b, ": ", []byte(e.comment))
+	}
+	if e.ID != "" {
+		b = append(b, "id: "...)
+		b = append(b, e.ID...)
+		b = append(b, '\n')
+	}
+	if e.Name != "" {
+		b = append(b, "event: "...)
+		b = append(b, e.Name...)
+		b = append(b, '\n')
+	}
+	if e.Retry > 0 {
+		b = append(b, "retry: "...)
+		ms := int64((e.Retry + time.Millisecond - 1) / time.Millisecond)
+		b = strconv.AppendInt(b, ms, 10)
+		b = append(b, '\n')
+	}
+	if e.Data != nil {
+		b = appendLines(b, "data: ", e.Data)
+	}
+	return append(b, '\n'), nil
+}
+
+// appendLines appends value as one prefixed field line per line of input,
+// treating \n, \r, and \r\n all as line breaks (raw line breaks are illegal
+// inside a field line).
+func appendLines(b []byte, prefix string, value []byte) []byte {
+	b = append(b, prefix...)
+	for i := 0; i < len(value); i++ {
+		switch c := value[i]; c {
+		case '\n':
+			b = append(b, '\n')
+			b = append(b, prefix...)
+		case '\r':
+			if i+1 < len(value) && value[i+1] == '\n' {
+				i++
+			}
+			b = append(b, '\n')
+			b = append(b, prefix...)
+		default:
+			b = append(b, c)
+		}
+	}
+	return append(b, '\n')
+}

--- a/realtime/sse/event_test.go
+++ b/realtime/sse/event_test.go
@@ -1,0 +1,95 @@
+package sse_test
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/realtime/sse"
+)
+
+// frame renders one event through a Writer and returns its wire bytes.
+func frame(t *testing.T, e sse.Event) (string, error) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	w, err := sse.NewWriter(rec)
+	require.NoError(t, err)
+	before := rec.Body.Len()
+	if err := w.Send(e); err != nil {
+		return "", err
+	}
+	return rec.Body.String()[before:], nil
+}
+
+func TestEventFraming(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		event sse.Event
+		want  string
+	}{
+		"text":            {sse.Text("update", "hi"), "event: update\ndata: hi\n\n"},
+		"unnamed text":    {sse.Text("", "hi"), "data: hi\n\n"},
+		"multiline LF":    {sse.Text("", "a\nb"), "data: a\ndata: b\n\n"},
+		"multiline CRLF":  {sse.Text("", "a\r\nb"), "data: a\ndata: b\n\n"},
+		"multiline CR":    {sse.Text("", "a\rb"), "data: a\ndata: b\n\n"},
+		"trailing LF":     {sse.Text("", "a\n"), "data: a\ndata: \n\n"},
+		"empty data":      {sse.Text("", ""), "data: \n\n"},
+		"nil data":        {sse.Event{ID: "7"}, "id: 7\n\n"},
+		"zero event":      {sse.Event{}, "\n"},
+		"comment":         {sse.Comment("ping"), ": ping\n\n"},
+		"empty comment":   {sse.Comment(""), ": \n\n"},
+		"comment lines":   {sse.Comment("a\nb"), ": a\n: b\n\n"},
+		"retry":           {sse.Retry(3 * time.Second), "retry: 3000\n\n"},
+		"retry rounds up": {sse.Retry(1500 * time.Microsecond), "retry: 2\n\n"},
+		"retry sub-ms":    {sse.Retry(time.Microsecond), "retry: 1\n\n"},
+		"all fields": {
+			sse.Event{ID: "9", Name: "tick", Data: []byte("x"), Retry: time.Second},
+			"id: 9\nevent: tick\nretry: 1000\ndata: x\n\n",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := frame(t, tc.event)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestEventValidation(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]sse.Event{
+		"name newline": {Name: "a\nb"},
+		"name CR":      {Name: "a\rb"},
+		"id newline":   {ID: "1\n2"},
+		"id NUL":       {ID: "1\x002"},
+		"neg retry":    {Retry: -time.Second},
+	}
+	for name, e := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := frame(t, e)
+			require.ErrorIs(t, err, sse.ErrInvalidEvent)
+			assert.Empty(t, got, "nothing must be written on validation failure")
+		})
+	}
+}
+
+func TestJSON(t *testing.T) {
+	t.Parallel()
+
+	e, err := sse.JSON("update", map[string]int{"unread": 3})
+	require.NoError(t, err)
+	got, err := frame(t, e)
+	require.NoError(t, err)
+	assert.Equal(t, "event: update\ndata: {\"unread\":3}\n\n", got)
+
+	_, err = sse.JSON("update", make(chan int))
+	require.Error(t, err)
+}

--- a/realtime/sse/event_test.go
+++ b/realtime/sse/event_test.go
@@ -115,6 +115,21 @@ func TestTempl(t *testing.T) {
 	assert.Equal(t, html, strings.Join(lines, "\n"))
 }
 
+func TestTemplEmptyRender(t *testing.T) {
+	t.Parallel()
+
+	// A component that writes nothing (an empty-state branch) must still
+	// dispatch an empty event — "clear this row" — not vanish for lack of a
+	// data line, matching Text(name, "").
+	e, err := sse.Templ(t.Context(), "orders.42", componentFunc(func(context.Context, io.Writer) error {
+		return nil
+	}))
+	require.NoError(t, err)
+	got, err := frame(t, e)
+	require.NoError(t, err)
+	assert.Equal(t, "event: orders.42\ndata: \n\n", got)
+}
+
 func TestTemplErrors(t *testing.T) {
 	t.Parallel()
 

--- a/realtime/sse/event_test.go
+++ b/realtime/sse/event_test.go
@@ -1,7 +1,11 @@
 package sse_test
 
 import (
+	"context"
+	"errors"
+	"io"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -79,6 +83,48 @@ func TestEventValidation(t *testing.T) {
 			assert.Empty(t, got, "nothing must be written on validation failure")
 		})
 	}
+}
+
+// componentFunc adapts a render func to sse.Component, the same way an
+// html/template consumer would.
+type componentFunc func(ctx context.Context, w io.Writer) error
+
+func (f componentFunc) Render(ctx context.Context, w io.Writer) error { return f(ctx, w) }
+
+func TestTempl(t *testing.T) {
+	t.Parallel()
+
+	html := "<tr>\n  <td>paid</td>\n</tr>"
+	e, err := sse.Templ(t.Context(), "orders.42", componentFunc(func(_ context.Context, w io.Writer) error {
+		_, err := io.WriteString(w, html)
+		return err
+	}))
+	require.NoError(t, err)
+	got, err := frame(t, e)
+	require.NoError(t, err)
+	assert.Equal(t, "event: orders.42\ndata: <tr>\ndata:   <td>paid</td>\ndata: </tr>\n\n", got)
+
+	// What a spec-compliant EventSource reassembles (data lines joined with
+	// \n) must be the exact HTML htmx swaps in.
+	var lines []string
+	for line := range strings.Lines(got) {
+		if rest, ok := strings.CutPrefix(line, "data: "); ok {
+			lines = append(lines, strings.TrimSuffix(rest, "\n"))
+		}
+	}
+	assert.Equal(t, html, strings.Join(lines, "\n"))
+}
+
+func TestTemplErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := sse.Templ(t.Context(), "x", nil)
+	require.Error(t, err)
+
+	_, err = sse.Templ(t.Context(), "x", componentFunc(func(context.Context, io.Writer) error {
+		return errors.New("render failed")
+	}))
+	require.Error(t, err)
 }
 
 func TestJSON(t *testing.T) {

--- a/realtime/sse/example_test.go
+++ b/realtime/sse/example_test.go
@@ -1,0 +1,84 @@
+package sse_test
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/dmitrymomot/forge/realtime/fanout"
+	"github.com/dmitrymomot/forge/realtime/sse"
+)
+
+func Example() {
+	ctx := context.Background()
+
+	hub, err := fanout.New(fanout.WithReplay(256))
+	if err != nil {
+		panic(err)
+	}
+	defer hub.Close()
+
+	handler, err := sse.NewHandler(hub, func(r *http.Request) ([]string, error) {
+		return []string{"notifications.42"}, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// The browser side of this is: new EventSource("/events") plus
+	// addEventListener("notifications.42", ...).
+	resp, err := http.Get(srv.URL)
+	if err != nil || resp == nil {
+		panic(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if err := hub.Publish(ctx, "notifications.42", []byte(`{"unread":3}`)); err != nil {
+		panic(err)
+	}
+
+	br := bufio.NewReader(resp.Body)
+	for range 3 { // id line, event line, data line
+		line, err := br.ReadString('\n')
+		if err != nil {
+			panic(err)
+		}
+		fmt.Print(line)
+	}
+
+	// Output:
+	// id: 1
+	// event: notifications.42
+	// data: {"unread":3}
+}
+
+func ExampleNewWriter() {
+	rec := httptest.NewRecorder() // any flushable http.ResponseWriter
+
+	w, err := sse.NewWriter(rec)
+	if err != nil {
+		panic(err) // ErrStreamingUnsupported: respond 500 instead
+	}
+	if err := w.Send(sse.Text("progress", "building")); err != nil {
+		panic(err)
+	}
+	ev, err := sse.JSON("progress", map[string]int{"done": 80})
+	if err != nil {
+		panic(err)
+	}
+	if err := w.Send(ev); err != nil {
+		panic(err)
+	}
+
+	fmt.Print(rec.Body.String())
+	// Output:
+	// event: progress
+	// data: building
+	//
+	// event: progress
+	// data: {"done":80}
+}

--- a/realtime/sse/handler.go
+++ b/realtime/sse/handler.go
@@ -1,0 +1,148 @@
+package sse
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/dmitrymomot/forge/realtime/fanout"
+)
+
+// TopicsFunc resolves the fanout topics one request subscribes to — from the
+// URL, the session, the tenant, wherever the consumer keeps them. An error
+// fails the request with 400 before anything is subscribed or written.
+type TopicsFunc func(r *http.Request) ([]string, error)
+
+// handler is the mountable SSE endpoint over a fanout hub.
+type handler struct {
+	hub        *fanout.Hub
+	topics     TopicsFunc
+	encode     func(fanout.Message) (Event, error)
+	log        *slog.Logger
+	subOpts    []fanout.SubscribeOption
+	writerOpts []WriterOption
+	keepAlive  time.Duration
+	retry      time.Duration
+}
+
+// NewHandler builds the SSE endpoint over hub: GET only, one fanout
+// subscription per request via topics, heartbeat comments while idle,
+// teardown on client disconnect, and Last-Event-ID resume through the hub's
+// replay ring. It returns the accumulated option errors, if any.
+func NewHandler(hub *fanout.Hub, topics TopicsFunc, opts ...HandlerOption) (http.Handler, error) {
+	if hub == nil {
+		return nil, errors.New("sse: nil hub")
+	}
+	if topics == nil {
+		return nil, errors.New("sse: nil topics func")
+	}
+	c := newHandlerConfig()
+	for _, opt := range opts {
+		opt(c)
+	}
+	if len(c.errs) > 0 {
+		return nil, errors.Join(c.errs...)
+	}
+	return &handler{
+		hub:        hub,
+		topics:     topics,
+		encode:     c.encode,
+		log:        c.log,
+		subOpts:    c.subOpts,
+		writerOpts: c.writerOpts,
+		keepAlive:  c.keepAlive,
+		retry:      c.retry,
+	}, nil
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	topics, err := h.topics(r)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	sub, err := h.subscribe(r, topics)
+	if err != nil {
+		status := http.StatusBadRequest
+		switch {
+		case errors.Is(err, fanout.ErrScopeMissing):
+			// Fail closed: a configured tenancy hook that cannot produce a
+			// scope means this request must not observe any topic.
+			status = http.StatusForbidden
+		case errors.Is(err, fanout.ErrClosed):
+			status = http.StatusServiceUnavailable
+		}
+		http.Error(w, http.StatusText(status), status)
+		return
+	}
+	defer sub.Close()
+	wr, err := NewWriter(w, h.writerOpts...)
+	if err != nil {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	if h.retry > 0 {
+		if err := wr.Send(Retry(h.retry)); err != nil {
+			return
+		}
+	}
+	var heartbeat <-chan time.Time
+	if h.keepAlive > 0 {
+		t := time.NewTicker(h.keepAlive)
+		defer t.Stop()
+		heartbeat = t.C
+	}
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-sub.C():
+			if !ok {
+				// The hub tore the subscription down (Close or a slow
+				// consumer); ending the response makes the client reconnect
+				// and resume.
+				return
+			}
+			ev, err := h.encode(msg)
+			if err != nil {
+				h.log.WarnContext(ctx, "sse: encode event failed, message skipped",
+					slog.String("topic", msg.Topic), slog.Uint64("message_id", msg.ID), slog.Any("error", err))
+				continue
+			}
+			if err := wr.Send(ev); err != nil {
+				return
+			}
+		case <-heartbeat:
+			if err := wr.Send(Comment("")); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// subscribe opens the request's fanout subscription, resuming after the
+// client's Last-Event-ID when it carries a valid cursor. A cursor the hub
+// cannot honor (replay disabled) degrades to a live-only stream instead of
+// failing the request.
+func (h *handler) subscribe(r *http.Request, topics []string) (*fanout.Subscription, error) {
+	if raw := r.Header.Get("Last-Event-ID"); raw != "" {
+		if id, err := strconv.ParseUint(raw, 10, 64); err == nil {
+			opts := make([]fanout.SubscribeOption, len(h.subOpts), len(h.subOpts)+1)
+			copy(opts, h.subOpts)
+			opts = append(opts, fanout.WithResumeAfter(id))
+			sub, err := h.hub.Subscribe(r.Context(), topics, opts...)
+			if err == nil || !errors.Is(err, fanout.ErrReplayDisabled) {
+				return sub, err
+			}
+		}
+	}
+	return h.hub.Subscribe(r.Context(), topics, h.subOpts...)
+}

--- a/realtime/sse/handler_test.go
+++ b/realtime/sse/handler_test.go
@@ -1,0 +1,373 @@
+package sse_test
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/realtime/fanout"
+	"github.com/dmitrymomot/forge/realtime/sse"
+)
+
+// event is one parsed SSE frame.
+type event struct {
+	id, name, data, comment, retry string
+}
+
+// readEvent parses one frame (lines up to a blank line) from br. Frames that
+// carry only a comment come back with just the comment set.
+func readEvent(br *bufio.Reader) (event, error) {
+	var e event
+	var dataLines []string
+	seen := false
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return e, err
+		}
+		line = strings.TrimSuffix(line, "\n")
+		if line == "" {
+			if !seen {
+				continue // leading blank line between frames
+			}
+			e.data = strings.Join(dataLines, "\n")
+			return e, nil
+		}
+		seen = true
+		switch {
+		case strings.HasPrefix(line, ": "):
+			e.comment = line[2:]
+		case strings.HasPrefix(line, "id: "):
+			e.id = line[4:]
+		case strings.HasPrefix(line, "event: "):
+			e.name = line[7:]
+		case strings.HasPrefix(line, "data: "):
+			dataLines = append(dataLines, line[6:])
+		case strings.HasPrefix(line, "retry: "):
+			e.retry = line[7:]
+		default:
+			return e, fmt.Errorf("unexpected line %q", line)
+		}
+	}
+}
+
+// connect opens a stream against srv. The response having arrived guarantees
+// the handler's fanout subscription is registered, so publishing after
+// connect returns is race-free.
+func connect(t *testing.T, srv *httptest.Server, header http.Header) *bufio.Reader {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	maps.Copy(req.Header, header)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+	return bufio.NewReader(resp.Body)
+}
+
+// newServer serves h for the test. Registering Close as a cleanup — before
+// connect registers the response-body close — matters: cleanups run LIFO, the
+// body close disconnects the client and lets the handler return, and only
+// then can Close (which waits for in-flight handlers) finish.
+func newServer(t *testing.T, h http.Handler) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newHub(t *testing.T, opts ...fanout.Option) *fanout.Hub {
+	t.Helper()
+	hub, err := fanout.New(opts...)
+	require.NoError(t, err)
+	t.Cleanup(hub.Close)
+	return hub
+}
+
+func staticTopics(topics ...string) sse.TopicsFunc {
+	return func(*http.Request) ([]string, error) { return topics, nil }
+}
+
+func TestHandlerStream(t *testing.T) {
+	t.Parallel()
+
+	hub := newHub(t)
+	h, err := sse.NewHandler(hub, staticTopics("notifications.42"))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	br := connect(t, srv, nil)
+	require.NoError(t, hub.Publish(t.Context(), "notifications.42", []byte("first")))
+	require.NoError(t, hub.Publish(t.Context(), "notifications.42", []byte("a\nb")))
+
+	got, err := readEvent(br)
+	require.NoError(t, err)
+	assert.Equal(t, event{id: "1", name: "notifications.42", data: "first"}, got)
+
+	got, err = readEvent(br)
+	require.NoError(t, err)
+	assert.Equal(t, "a\nb", got.data, "multi-line payloads must survive framing")
+}
+
+func TestHandlerMethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	h, err := sse.NewHandler(newHub(t), staticTopics("x"))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	resp, err := srv.Client().Post(srv.URL, "text/plain", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	assert.Equal(t, http.MethodGet, resp.Header.Get("Allow"))
+}
+
+func TestHandlerTopicsError(t *testing.T) {
+	t.Parallel()
+
+	h, err := sse.NewHandler(newHub(t), func(*http.Request) ([]string, error) {
+		return nil, errors.New("unknown channel")
+	})
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	resp, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestHandlerScopeMissing(t *testing.T) {
+	t.Parallel()
+
+	hub := newHub(t, fanout.WithScope(func(context.Context) (string, error) {
+		return "", nil // no tenant on this request
+	}))
+	h, err := sse.NewHandler(hub, staticTopics("x"))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	resp, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode, "missing tenant scope must fail closed")
+}
+
+func TestHandlerHubClosed(t *testing.T) {
+	t.Parallel()
+
+	hub, err := fanout.New()
+	require.NoError(t, err)
+	hub.Close()
+	h, err := sse.NewHandler(hub, staticTopics("x"))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	resp, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestHandlerResume(t *testing.T) {
+	t.Parallel()
+
+	hub := newHub(t, fanout.WithReplay(16))
+	// The subscribe options must survive alongside the resume cursor the
+	// handler appends per request.
+	h, err := sse.NewHandler(hub, staticTopics("feed"),
+		sse.WithSubscribeOptions(fanout.WithBuffer(8), fanout.WithPolicy(fanout.DropNewest)))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	for _, payload := range []string{"one", "two", "three"} {
+		require.NoError(t, hub.Publish(t.Context(), "feed", []byte(payload)))
+	}
+
+	br := connect(t, srv, http.Header{"Last-Event-Id": {"1"}})
+	got, err := readEvent(br)
+	require.NoError(t, err)
+	assert.Equal(t, event{id: "2", name: "feed", data: "two"}, got)
+	got, err = readEvent(br)
+	require.NoError(t, err)
+	assert.Equal(t, event{id: "3", name: "feed", data: "three"}, got)
+}
+
+func TestHandlerResumeWithoutReplay(t *testing.T) {
+	t.Parallel()
+
+	hub := newHub(t) // no replay ring
+	h, err := sse.NewHandler(hub, staticTopics("feed"))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	// A cursor the hub cannot honor must degrade to a live-only stream.
+	br := connect(t, srv, http.Header{"Last-Event-Id": {"99"}})
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("live")))
+	got, err := readEvent(br)
+	require.NoError(t, err)
+	assert.Equal(t, "live", got.data)
+}
+
+func TestHandlerInvalidLastEventID(t *testing.T) {
+	t.Parallel()
+
+	hub := newHub(t, fanout.WithReplay(16))
+	h, err := sse.NewHandler(hub, staticTopics("feed"))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("old")))
+	br := connect(t, srv, http.Header{"Last-Event-Id": {"not-a-cursor"}})
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("live")))
+	got, err := readEvent(br)
+	require.NoError(t, err)
+	assert.Equal(t, "live", got.data, "an unparseable cursor starts a fresh live stream, no replay")
+}
+
+func TestHandlerKeepAlive(t *testing.T) {
+	t.Parallel()
+
+	h, err := sse.NewHandler(newHub(t), staticTopics("x"), sse.WithKeepAlive(10*time.Millisecond))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	br := connect(t, srv, nil)
+	got, err := readEvent(br)
+	require.NoError(t, err)
+	assert.Equal(t, event{comment: ""}, got, "idle stream must carry heartbeat comments")
+}
+
+func TestHandlerRetryAnnounce(t *testing.T) {
+	t.Parallel()
+
+	h, err := sse.NewHandler(newHub(t), staticTopics("x"), sse.WithRetry(2*time.Second))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	br := connect(t, srv, nil)
+	got, err := readEvent(br)
+	require.NoError(t, err)
+	assert.Equal(t, "2000", got.retry)
+}
+
+func TestHandlerCustomEncoder(t *testing.T) {
+	t.Parallel()
+
+	hub := newHub(t)
+	h, err := sse.NewHandler(hub, staticTopics("feed"), sse.WithEncoder(func(m fanout.Message) (sse.Event, error) {
+		if string(m.Payload) == "bad" {
+			return sse.Event{}, errors.New("unencodable")
+		}
+		return sse.Text("", string(m.Payload)+"!"), nil
+	}))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	br := connect(t, srv, nil)
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("bad")))
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("good")))
+
+	got, err := readEvent(br)
+	require.NoError(t, err)
+	assert.Equal(t, event{data: "good!"}, got, "encoder failure must skip the message and keep the stream alive")
+}
+
+func TestHandlerClientDisconnect(t *testing.T) {
+	t.Parallel()
+
+	hub := newHub(t)
+	h, err := sse.NewHandler(hub, staticTopics("x"))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/events", nil)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.ServeHTTP(httptest.NewRecorder(), req)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not return after client disconnect")
+	}
+}
+
+func TestHandlerHubCloseEndsStream(t *testing.T) {
+	t.Parallel()
+
+	hub, err := fanout.New()
+	require.NoError(t, err)
+	h, err := sse.NewHandler(hub, staticTopics("x"))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	br := connect(t, srv, nil)
+	hub.Close()
+	_, err = readEvent(br)
+	require.Error(t, err, "hub shutdown must end the response so clients reconnect")
+}
+
+func TestHandlerStreamingUnsupported(t *testing.T) {
+	t.Parallel()
+
+	h, err := sse.NewHandler(newHub(t), staticTopics("x"))
+	require.NoError(t, err)
+
+	w := &noFlush{header: make(http.Header)}
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/events", nil))
+	assert.Equal(t, http.StatusInternalServerError, w.code)
+}
+
+func TestNewHandlerValidation(t *testing.T) {
+	t.Parallel()
+
+	hub := newHub(t)
+	_, err := sse.NewHandler(nil, staticTopics("x"))
+	require.Error(t, err)
+	_, err = sse.NewHandler(hub, nil)
+	require.Error(t, err)
+	_, err = sse.NewHandler(hub, staticTopics("x"),
+		sse.WithKeepAlive(-time.Second), sse.WithRetry(0), sse.WithEncoder(nil), sse.WithLogger(nil))
+	require.Error(t, err)
+}

--- a/realtime/sse/handler_test.go
+++ b/realtime/sse/handler_test.go
@@ -359,6 +359,27 @@ func TestHandlerStreamingUnsupported(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.code)
 }
 
+func TestHandlerWriterOptionsForwarded(t *testing.T) {
+	t.Parallel()
+
+	// An invalid writer option fails only inside the per-request NewWriter
+	// call, so the 500 proves the handler forwards WithWriterOptions to it.
+	h, err := sse.NewHandler(newHub(t), staticTopics("x"),
+		sse.WithWriterOptions(sse.WithSendTimeout(-time.Second)))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	resp, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
 func TestNewHandlerValidation(t *testing.T) {
 	t.Parallel()
 

--- a/realtime/sse/options.go
+++ b/realtime/sse/options.go
@@ -1,0 +1,141 @@
+package sse
+
+import (
+	"fmt"
+	"log/slog"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/dmitrymomot/forge/ops/logger"
+	"github.com/dmitrymomot/forge/realtime/fanout"
+)
+
+const (
+	defaultKeepAlive   = 15 * time.Second
+	defaultSendTimeout = 30 * time.Second
+)
+
+type writerConfig struct {
+	errs        []error
+	sendTimeout time.Duration
+}
+
+// WriterOption configures NewWriter.
+type WriterOption func(*writerConfig)
+
+// WithSendTimeout bounds how long one Send may block writing to a client.
+// The writer clears the server-wide write deadline, so without this bound a
+// connected client that stopped reading would pin the goroutine and the
+// connection forever; with it the blocked Send fails and ends the stream.
+// Zero disables the bound; negative is an error. Defaults to 30s.
+// Best-effort: a middleware chain that cannot set deadlines falls back to
+// the server's own write timeout.
+func WithSendTimeout(d time.Duration) WriterOption {
+	return func(c *writerConfig) {
+		if d < 0 {
+			c.errs = append(c.errs, fmt.Errorf("sse: send timeout must not be negative, got %s", d))
+			return
+		}
+		c.sendTimeout = d
+	}
+}
+
+type handlerConfig struct {
+	encode     func(fanout.Message) (Event, error)
+	log        *slog.Logger
+	subOpts    []fanout.SubscribeOption
+	writerOpts []WriterOption
+	errs       []error
+	keepAlive  time.Duration
+	retry      time.Duration
+}
+
+func newHandlerConfig() *handlerConfig {
+	return &handlerConfig{
+		encode:    defaultEncode,
+		log:       logger.NewNope(),
+		keepAlive: defaultKeepAlive,
+	}
+}
+
+// defaultEncode maps a fanout message onto the wire: the message ID becomes
+// the resume cursor and the topic becomes the event name.
+func defaultEncode(m fanout.Message) (Event, error) {
+	return Event{ID: strconv.FormatUint(m.ID, 10), Name: m.Topic, Data: m.Payload}, nil
+}
+
+// HandlerOption configures NewHandler.
+type HandlerOption func(*handlerConfig)
+
+// WithKeepAlive sets how often an idle stream sends a heartbeat comment so
+// proxies do not cut the connection. Zero disables heartbeats; negative is an
+// error. Defaults to 15s.
+func WithKeepAlive(d time.Duration) HandlerOption {
+	return func(c *handlerConfig) {
+		if d < 0 {
+			c.errs = append(c.errs, fmt.Errorf("sse: keep-alive must not be negative, got %s", d))
+			return
+		}
+		c.keepAlive = d
+	}
+}
+
+// WithRetry announces the client's reconnection delay (a "retry:" frame,
+// rounded up to a whole millisecond) at the start of every stream. Must be
+// positive; by default nothing is announced and clients keep their own
+// default.
+func WithRetry(d time.Duration) HandlerOption {
+	return func(c *handlerConfig) {
+		if d <= 0 {
+			c.errs = append(c.errs, fmt.Errorf("sse: retry must be positive, got %s", d))
+			return
+		}
+		c.retry = d
+	}
+}
+
+// WithEncoder replaces the default fanout.Message → Event mapping (message ID
+// as the "id:" resume cursor, topic as the event name, payload as data). An
+// encoder that clears Event.ID opts that message out of Last-Event-ID resume.
+// An encoder error skips the message — logged, never delivered — and the
+// stream continues.
+func WithEncoder(fn func(fanout.Message) (Event, error)) HandlerOption {
+	return func(c *handlerConfig) {
+		if fn == nil {
+			c.errs = append(c.errs, fmt.Errorf("sse: nil encoder"))
+			return
+		}
+		c.encode = fn
+	}
+}
+
+// WithSubscribeOptions forwards options to every per-request
+// hub.Subscribe call — per-stream buffer size or overflow policy, typically.
+// Do not pass fanout.WithResumeAfter here: the handler manages resume from
+// the Last-Event-ID header.
+func WithSubscribeOptions(opts ...fanout.SubscribeOption) HandlerOption {
+	return func(c *handlerConfig) {
+		c.subOpts = slices.Clone(opts)
+	}
+}
+
+// WithWriterOptions forwards options to every per-request NewWriter call —
+// the per-send timeout, typically.
+func WithWriterOptions(opts ...WriterOption) HandlerOption {
+	return func(c *handlerConfig) {
+		c.writerOpts = slices.Clone(opts)
+	}
+}
+
+// WithLogger sets the logger for encoder failures. Defaults to a no-op
+// logger.
+func WithLogger(l *slog.Logger) HandlerOption {
+	return func(c *handlerConfig) {
+		if l == nil {
+			c.errs = append(c.errs, fmt.Errorf("sse: nil logger"))
+			return
+		}
+		c.log = l
+	}
+}

--- a/realtime/sse/writer.go
+++ b/realtime/sse/writer.go
@@ -40,18 +40,24 @@ func NewWriter(w http.ResponseWriter, opts ...WriterOption) (*Writer, error) {
 	h.Set("Content-Type", "text/event-stream")
 	h.Set("Cache-Control", "no-cache")
 	h.Set("X-Accel-Buffering", "no")
+	// On any failure below, nothing has been written yet: reset the stream
+	// headers so the caller can still respond with a clean error.
+	resetHeaders := func() {
+		h.Del("Content-Type")
+		h.Del("Cache-Control")
+		h.Del("X-Accel-Buffering")
+	}
 	rc := http.NewResponseController(w)
 	// A wrapping middleware that does not implement Unwrap surfaces
 	// ErrNotSupported here even though the underlying connection has a
 	// deadline; that is the caller's cue to run the server with
 	// WriteTimeout=0 instead (see the package comment).
 	if err := rc.SetWriteDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		resetHeaders()
 		return nil, fmt.Errorf("sse: clear write deadline: %w", err)
 	}
 	if err := rc.Flush(); err != nil {
-		h.Del("Content-Type")
-		h.Del("Cache-Control")
-		h.Del("X-Accel-Buffering")
+		resetHeaders()
 		if errors.Is(err, http.ErrNotSupported) {
 			return nil, ErrStreamingUnsupported
 		}

--- a/realtime/sse/writer.go
+++ b/realtime/sse/writer.go
@@ -1,0 +1,87 @@
+package sse
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Writer streams Server-Sent Events over one HTTP response. NewWriter sets
+// the stream headers and commits the response; every Send writes one frame
+// and flushes it to the client. Safe for concurrent use.
+type Writer struct {
+	w           http.ResponseWriter
+	rc          *http.ResponseController
+	buf         []byte
+	sendTimeout time.Duration
+	mu          sync.Mutex
+}
+
+// NewWriter starts a Server-Sent Events stream on w: it sets the stream
+// headers (Content-Type: text/event-stream, no-cache, proxy-buffering off),
+// clears the server's write deadline where supported so the stream outlives
+// httpserver's WriteTimeout — each Send then arms its own deadline (see
+// WithSendTimeout) so a stalled client cannot pin the connection forever —
+// and commits the 200 response by flushing the headers. If w cannot flush —
+// required for events to reach the client as they happen — it resets the
+// headers and returns ErrStreamingUnsupported before anything is written, so
+// the caller can still respond with an error.
+func NewWriter(w http.ResponseWriter, opts ...WriterOption) (*Writer, error) {
+	c := &writerConfig{sendTimeout: defaultSendTimeout}
+	for _, opt := range opts {
+		opt(c)
+	}
+	if len(c.errs) > 0 {
+		return nil, errors.Join(c.errs...)
+	}
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("X-Accel-Buffering", "no")
+	rc := http.NewResponseController(w)
+	// A wrapping middleware that does not implement Unwrap surfaces
+	// ErrNotSupported here even though the underlying connection has a
+	// deadline; that is the caller's cue to run the server with
+	// WriteTimeout=0 instead (see the package comment).
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return nil, fmt.Errorf("sse: clear write deadline: %w", err)
+	}
+	if err := rc.Flush(); err != nil {
+		h.Del("Content-Type")
+		h.Del("Cache-Control")
+		h.Del("X-Accel-Buffering")
+		if errors.Is(err, http.ErrNotSupported) {
+			return nil, ErrStreamingUnsupported
+		}
+		return nil, fmt.Errorf("sse: flush headers: %w", err)
+	}
+	return &Writer{w: w, rc: rc, sendTimeout: c.sendTimeout}, nil
+}
+
+// Send frames e, writes it, and flushes it to the client. A validation
+// failure returns ErrInvalidEvent with nothing written; a write or flush
+// error means the client is gone (or stopped reading past WithSendTimeout)
+// and the stream is over.
+func (w *Writer) Send(e Event) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	buf, err := e.appendTo(w.buf[:0])
+	if err != nil {
+		return err
+	}
+	w.buf = buf
+	if w.sendTimeout > 0 {
+		// Best-effort: a chain that cannot set deadlines falls back to the
+		// server's own write timeout.
+		_ = w.rc.SetWriteDeadline(time.Now().Add(w.sendTimeout))
+	}
+	if _, err := w.w.Write(buf); err != nil {
+		return fmt.Errorf("sse: write event: %w", err)
+	}
+	if err := w.rc.Flush(); err != nil {
+		return fmt.Errorf("sse: flush event: %w", err)
+	}
+	return nil
+}

--- a/realtime/sse/writer_test.go
+++ b/realtime/sse/writer_test.go
@@ -69,6 +69,29 @@ func TestNewWriterStreamingUnsupported(t *testing.T) {
 	assert.Empty(t, w.header.Get("X-Accel-Buffering"))
 }
 
+// deadlineFail flushes fine but hard-fails deadline changes (not a mere
+// not-supported), forcing NewWriter's clear-deadline error path.
+type deadlineFail struct {
+	header http.Header
+}
+
+func (w *deadlineFail) Header() http.Header              { return w.header }
+func (w *deadlineFail) Write(p []byte) (int, error)      { return len(p), nil }
+func (w *deadlineFail) WriteHeader(int)                  {}
+func (w *deadlineFail) Flush()                           {}
+func (w *deadlineFail) SetWriteDeadline(time.Time) error { return errors.New("deadline broken") }
+
+func TestNewWriterDeadlineErrorResetsHeaders(t *testing.T) {
+	t.Parallel()
+
+	w := &deadlineFail{header: make(http.Header)}
+	_, err := sse.NewWriter(w)
+	require.Error(t, err)
+	assert.Empty(t, w.header.Get("Content-Type"), "stream headers must be reset on failure")
+	assert.Empty(t, w.header.Get("Cache-Control"))
+	assert.Empty(t, w.header.Get("X-Accel-Buffering"))
+}
+
 func TestSendFlushesEveryEvent(t *testing.T) {
 	t.Parallel()
 

--- a/realtime/sse/writer_test.go
+++ b/realtime/sse/writer_test.go
@@ -1,0 +1,170 @@
+package sse_test
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/forge/realtime/sse"
+)
+
+// noFlush is a ResponseWriter without http.Flusher, like a buffering wrapper
+// that does not implement Unwrap.
+type noFlush struct {
+	header http.Header
+	code   int
+}
+
+func (w *noFlush) Header() http.Header         { return w.header }
+func (w *noFlush) Write(p []byte) (int, error) { return len(p), nil }
+func (w *noFlush) WriteHeader(code int)        { w.code = code }
+
+// countingFlusher records flushes and write errors around a recorder.
+type countingFlusher struct {
+	rec      *httptest.ResponseRecorder
+	writeErr error
+	flushes  int
+}
+
+func (w *countingFlusher) Header() http.Header { return w.rec.Header() }
+func (w *countingFlusher) Write(p []byte) (int, error) {
+	if w.writeErr != nil {
+		return 0, w.writeErr
+	}
+	return w.rec.Write(p)
+}
+func (w *countingFlusher) WriteHeader(code int) { w.rec.WriteHeader(code) }
+func (w *countingFlusher) Flush()               { w.flushes++ }
+
+func TestNewWriterHeaders(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	_, err := sse.NewWriter(rec)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, rec.Flushed, "headers must be flushed so the client sees the stream open")
+	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "no-cache", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "no", rec.Header().Get("X-Accel-Buffering"))
+}
+
+func TestNewWriterStreamingUnsupported(t *testing.T) {
+	t.Parallel()
+
+	w := &noFlush{header: make(http.Header)}
+	_, err := sse.NewWriter(w)
+	require.ErrorIs(t, err, sse.ErrStreamingUnsupported)
+	assert.Empty(t, w.header.Get("Content-Type"), "stream headers must be reset on failure")
+	assert.Empty(t, w.header.Get("Cache-Control"))
+	assert.Empty(t, w.header.Get("X-Accel-Buffering"))
+}
+
+func TestSendFlushesEveryEvent(t *testing.T) {
+	t.Parallel()
+
+	cw := &countingFlusher{rec: httptest.NewRecorder()}
+	w, err := sse.NewWriter(cw)
+	require.NoError(t, err)
+	flushed := cw.flushes // header flush
+
+	require.NoError(t, w.Send(sse.Text("", "one")))
+	require.NoError(t, w.Send(sse.Text("", "two")))
+	assert.Equal(t, flushed+2, cw.flushes)
+	assert.Equal(t, "data: one\n\ndata: two\n\n", cw.rec.Body.String())
+}
+
+func TestSendWriteError(t *testing.T) {
+	t.Parallel()
+
+	cw := &countingFlusher{rec: httptest.NewRecorder()}
+	w, err := sse.NewWriter(cw)
+	require.NoError(t, err)
+
+	cw.writeErr = errors.New("client gone")
+	require.Error(t, w.Send(sse.Text("", "lost")))
+}
+
+func TestSendTimeoutUnblocksStalledClient(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		wr, err := sse.NewWriter(w, sse.WithSendTimeout(100*time.Millisecond))
+		if err != nil {
+			errCh <- err
+			return
+		}
+		e := sse.Event{Data: bytes.Repeat([]byte("x"), 1<<20)}
+		for {
+			if err := wr.Send(e); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	// Never read the body: the client stalls, kernel buffers fill, and the
+	// per-send deadline must fail the blocked write instead of pinning the
+	// handler forever.
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+	case <-time.After(15 * time.Second):
+		t.Fatal("stalled client never unblocked the writer")
+	}
+}
+
+func TestSendTimeoutValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := sse.NewWriter(httptest.NewRecorder(), sse.WithSendTimeout(-time.Second))
+	require.Error(t, err)
+}
+
+func TestWriterConcurrentSend(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	w, err := sse.NewWriter(rec)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Go(func() {
+			for range 50 {
+				_ = w.Send(sse.Event{ID: "1", Data: []byte{byte('a' + i)}})
+			}
+		})
+	}
+	wg.Wait()
+
+	// Frames must never interleave: every frame is exactly id line + data
+	// line + blank line.
+	body := rec.Body.String()
+	require.NotEmpty(t, body)
+	for line := range strings.SplitSeq(body, "\n") {
+		switch {
+		case line == "" || line == "id: 1":
+		case len(line) == 7 && strings.HasPrefix(line, "data: "):
+		default:
+			t.Fatalf("torn frame line: %q", line)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`realtime/sse` — the complete Server-Sent Events package: the mountable live-updates endpoint over `realtime/fanout`, plus the low-level `Event`/`Writer` brick it is built on (the future seam for `web/htmx`'s SendComponent bridge and `llm.SSE`).

### Low-level brick

- `Event` with typed constructors `Text` / `JSON` / `Comment` / `Retry`; spec-correct framing: multi-line data split into `data:` lines (LF/CRLF/CR all handled, trailing-newline round-trips), comments split the same way, `retry:` rounded up to whole milliseconds, `id`/`event` validated against line breaks (and NUL in `id`) with `ErrInvalidEvent` before anything is written.
- `Writer` sets the stream headers (`text/event-stream`, `no-cache`, `X-Accel-Buffering: no`), commits the 200 by flushing headers, and flushes every `Send`. A non-flushable chain returns `ErrStreamingUnsupported` with headers reset so the caller can still respond 500. Safe for concurrent use.

### Write-deadline story (the slow-loris angle)

An SSE response never finishes, so `NewWriter` clears the server write deadline via `http.ResponseController` (works through any middleware chain implementing `Unwrap` — all forge middleware does; otherwise run httpserver with `WriteTimeout=0`, documented). In place of the cleared deadline, **every `Send` arms a per-write deadline** (`WithSendTimeout`, default 30s): a client that stays connected but stops reading fails the blocked write and ends the stream instead of pinning the goroutine + subscription forever. Heartbeats give idle streams regular Sends, so stalled clients are caught even with zero traffic. Covered by a real-server test that stalls a client and asserts the write unblocks.

### Endpoint over fanout

`NewHandler(hub, topicsFunc, ...)` — GET-only endpoint; per-request subscription via the consumer's `TopicsFunc`; default encoding: hub message ID → `id:` (the Last-Event-ID currency), topic → `event:`, payload → `data:`, replaceable via `WithEncoder` (encoder errors skip the message, logged, stream lives on). Heartbeat comments (`WithKeepAlive`, default 15s, 0 disables), optional `retry:` announcement (`WithRetry`), pass-throughs `WithSubscribeOptions` / `WithWriterOptions` (stored slices cloned), optional `WithLogger` (defaults to `logger.NewNope()`).

- **Resume:** `Last-Event-ID` → `fanout.WithResumeAfter`; an unparseable cursor or a hub without replay degrades to a live-only stream, never an error (hub IDs are per-instance, so post-restart cursors must not break reconnects).
- **Error mapping:** topics error → 400, `fanout.ErrScopeMissing` → **403 fail-closed**, `fanout.ErrClosed` → 503, non-GET → 405 + `Allow`.
- **Teardown:** client disconnect via `r.Context()`; hub `Close`/slow-consumer teardown ends the response so EventSource reconnects and resumes.
- **Tenancy:** zero ceremony — the hub's `fanout.WithScope` sees the request context; single-tenant apps configure nothing.

### Benchmarks (Apple M3 Max, post-optimization pass)

```
BenchmarkSendText-14          10715217   104.6 ns/op    0 B/op   0 allocs/op
BenchmarkSendMultiline-14     11826840    99.4 ns/op    0 B/op   0 allocs/op
BenchmarkSendComment-14       26910732    44.6 ns/op    0 B/op   0 allocs/op
BenchmarkHandlerDelivery-14    1968436   614.3 ns/op    7 B/op   0 allocs/op
```

Send is zero-alloc from the start (frame assembled into a reused buffer, single write + flush); the initial numbers (79ns Send / 546ns delivery) already hit the target, so the only measured change since is the per-send deadline arm (~25ns — the safety trade documented above). `BenchmarkHandlerDelivery` is the full publish → dispatch → encode → frame → write round trip; the 7 B/op is the `strconv.FormatUint` ID string in the default encoder.

### Catalog

`realtime/sse` entry deleted from `docs/packages.md` per the ship-and-delete rule; `ai/llm`'s dep note drops "(planned)".

## Testing

- `just test ./realtime/sse/` — unit tier, race detector, all green.
- `just lint` — clean (vet, golangci-lint, nilaway, betteralign, modernize, incl. integration-tag passes).
- Black-box tests: framing table (constructors, line splits, validation), writer headers/flush-per-event/write-error/concurrency/stalled-client, handler e2e over real HTTP (stream, resume, degraded resume, invalid cursor, keep-alive, retry announce, custom encoder + encoder-error skip, 405/400/403/503, client disconnect, hub-close ends stream, streaming-unsupported 500), runnable godoc examples.
