### PR TITLE
fix(realtime): SSE resume cursor, invalid events, send-timeout, retry overflow + fanout cross-topic ordering

### DIFF
--- a/realtime/fanout/bench_test.go
+++ b/realtime/fanout/bench_test.go
@@ -44,6 +44,38 @@ func BenchmarkPublish(b *testing.B) {
 	}
 }
 
+// BenchmarkPublishMultiTopic drives concurrent publishes across several topics
+// — the workload seqMu serializes to keep cross-topic delivery ordered.
+func BenchmarkPublishMultiTopic(b *testing.B) {
+	ctx := context.Background()
+	payload := []byte(`{"text":"hi"}`)
+	topics := []string{"a", "b", "c", "d"}
+
+	hub, err := fanout.New(fanout.WithDefaultBuffer(1024))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer hub.Close()
+	for _, topic := range topics {
+		sub, err := hub.Subscribe(ctx, []string{topic})
+		if err != nil {
+			b.Fatal(err)
+		}
+		go drain(sub)
+	}
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if err := hub.Publish(ctx, topics[i%len(topics)], payload); err != nil {
+				b.Fatal(err)
+			}
+			i++
+		}
+	})
+}
+
 func BenchmarkPublishNoSubscribers(b *testing.B) {
 	ctx := context.Background()
 	hub, err := fanout.New()

--- a/realtime/fanout/fanout.go
+++ b/realtime/fanout/fanout.go
@@ -41,6 +41,9 @@ type Hub struct {
 	nextID    atomic.Uint64
 	lastSweep atomic.Int64
 	mu        sync.RWMutex
+	// seqMu orders ID allocation and delivery across topics so a subscriber on
+	// several topics never observes IDs out of order. See dispatch.
+	seqMu sync.Mutex
 	// closed is written under mu but read lock-free on the publish hot path.
 	closed atomic.Bool
 	policy OverflowPolicy
@@ -225,6 +228,12 @@ func (h *Hub) dispatch(key string, payload []byte) {
 		return
 	}
 	var stale []*Subscription
+	// seqMu serializes ID allocation, ring insertion, and delivery across every
+	// topic. IDs are a single global sequence, but topics lock independently, so
+	// without this a subscriber on two topics could see a higher ID enqueued
+	// before a lower one and regress its Last-Event-ID cursor. Held only around
+	// non-blocking sends, so it never waits on a slow consumer.
+	h.seqMu.Lock()
 	ts.mu.Lock()
 	msg := Message{Topic: ts.topic, Payload: payload, ID: h.nextID.Add(1)}
 	if ts.ring != nil {
@@ -239,6 +248,7 @@ func (h *Hub) dispatch(key string, payload []byte) {
 	}
 	empty := len(ts.subs) == 0 && ts.ring == nil
 	ts.mu.Unlock()
+	h.seqMu.Unlock()
 	for _, sub := range stale {
 		h.removeSub(sub)
 	}

--- a/realtime/fanout/fanout_test.go
+++ b/realtime/fanout/fanout_test.go
@@ -43,6 +43,46 @@ func expectClosed(t *testing.T, sub *fanout.Subscription) {
 	}
 }
 
+func TestMultiTopicDeliveryMonotonic(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	hub, err := fanout.New()
+	require.NoError(t, err)
+	defer hub.Close()
+
+	const perTopic = 500
+	// Buffer larger than the total so nothing is dropped and every published ID
+	// is observed.
+	sub, err := hub.Subscribe(ctx, []string{"a", "b"}, fanout.WithBuffer(4*perTopic))
+	require.NoError(t, err)
+	defer sub.Close()
+
+	var wg sync.WaitGroup
+	for _, topic := range []string{"a", "b"} {
+		wg.Go(func() {
+			for range perTopic {
+				if err := hub.Publish(ctx, topic, []byte("x")); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	// A subscriber multiplexing both topics must observe the global ID sequence
+	// strictly increasing; the SSE Last-Event-ID cursor depends on it. IDs are
+	// allocated globally but topics lock independently, so without ordering a
+	// higher ID could be enqueued ahead of a lower one.
+	prev := uint64(0)
+	for range 2 * perTopic {
+		id := recv(t, sub).ID
+		require.Greater(t, id, prev, "IDs must arrive strictly increasing across topics")
+		prev = id
+	}
+}
+
 func TestPublishSubscribe(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/realtime/sse/doc.go
+++ b/realtime/sse/doc.go
@@ -64,12 +64,15 @@
 // An SSE response never finishes, so the server's write timeout must not
 // apply to it. NewWriter clears the write deadline through
 // http.ResponseController, which works on net/http servers as long as every
-// wrapping middleware implements Unwrap (all forge middleware does). If a
-// deadline-oblivious wrapper sits in the chain, run the server with
-// httpserver WriteTimeout=0 instead. In place of the cleared deadline, every
-// Send arms a per-write one (WithSendTimeout, default 30s), so a client that
-// stays connected but stops reading fails the stream instead of pinning the
-// connection forever. Heartbeats (WithKeepAlive, default 15s) keep proxies
+// wrapping middleware implements Unwrap (all forge middleware does). In place
+// of the cleared deadline, every Send arms a per-write one (WithSendTimeout,
+// default 30s), so a client that stays connected but stops reading fails the
+// stream instead of pinning the connection forever. If a deadline-oblivious
+// wrapper sits in the chain, NewWriter cannot arm that per-send deadline and
+// fails closed rather than silently drop the protection; make the wrapper
+// implement Unwrap, or pass WithSendTimeout(0) and run the server with
+// httpserver WriteTimeout=0 to accept unbounded writes. Heartbeats
+// (WithKeepAlive, default 15s) keep proxies
 // from cutting idle streams — and give a silent topic regular Sends, which is
 // what makes the send timeout catch stalled clients even with no traffic —
 // and the X-Accel-Buffering header disables nginx response buffering.

--- a/realtime/sse/event.go
+++ b/realtime/sse/event.go
@@ -122,7 +122,12 @@ func (e Event) appendTo(b []byte) ([]byte, error) {
 	}
 	if e.Retry > 0 {
 		b = append(b, "retry: "...)
-		ms := int64((e.Retry + time.Millisecond - 1) / time.Millisecond)
+		// Divide before rounding up: Retry+time.Millisecond-1 would overflow
+		// int64 for durations within a millisecond of math.MaxInt64.
+		ms := int64(e.Retry / time.Millisecond)
+		if e.Retry%time.Millisecond != 0 {
+			ms++
+		}
 		b = strconv.AppendInt(b, ms, 10)
 		b = append(b, '\n')
 	}

--- a/realtime/sse/event_test.go
+++ b/realtime/sse/event_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -19,7 +20,7 @@ import (
 func frame(t *testing.T, e sse.Event) (string, error) {
 	t.Helper()
 	rec := httptest.NewRecorder()
-	w, err := sse.NewWriter(rec)
+	w, err := sse.NewWriter(rec, sse.WithSendTimeout(0)) // recorder has no deadline control
 	require.NoError(t, err)
 	before := rec.Body.Len()
 	if err := w.Send(e); err != nil {
@@ -63,6 +64,17 @@ func TestEventFraming(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestRetryNoOverflow(t *testing.T) {
+	t.Parallel()
+
+	// A duration within a millisecond of MaxInt64 is valid and positive; the
+	// round-up must not overflow into a negative retry field. Old formula
+	// (Retry+time.Millisecond-1)/time.Millisecond wraps here.
+	got, err := frame(t, sse.Retry(time.Duration(math.MaxInt64)))
+	require.NoError(t, err)
+	assert.Equal(t, "retry: 9223372036855\n\n", got)
 }
 
 func TestEventValidation(t *testing.T) {

--- a/realtime/sse/example_test.go
+++ b/realtime/sse/example_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 
 	"github.com/dmitrymomot/forge/realtime/fanout"
 	"github.com/dmitrymomot/forge/realtime/sse"
@@ -42,16 +43,23 @@ func Example() {
 	}
 
 	br := bufio.NewReader(resp.Body)
-	for range 3 { // id line, event line, data line
+	// The frame opens with an "id:" line — an opaque, per-instance resume cursor
+	// — which we skip here, followed by the event and data lines.
+	for {
 		line, err := br.ReadString('\n')
 		if err != nil {
 			panic(err)
 		}
+		if strings.HasPrefix(line, "id: ") {
+			continue
+		}
 		fmt.Print(line)
+		if strings.HasPrefix(line, "data: ") {
+			break
+		}
 	}
 
 	// Output:
-	// id: 1
 	// event: notifications.42
 	// data: {"unread":3}
 }
@@ -59,7 +67,10 @@ func Example() {
 func ExampleNewWriter() {
 	rec := httptest.NewRecorder() // any flushable http.ResponseWriter
 
-	w, err := sse.NewWriter(rec)
+	// A recorder cannot set write deadlines, so WithSendTimeout(0) opts out of
+	// the per-send bound; a real server connection supports it, so production
+	// code keeps the default.
+	w, err := sse.NewWriter(rec, sse.WithSendTimeout(0))
 	if err != nil {
 		panic(err) // ErrStreamingUnsupported: respond 500 instead
 	}

--- a/realtime/sse/handler.go
+++ b/realtime/sse/handler.go
@@ -1,10 +1,14 @@
 package sse
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dmitrymomot/forge/realtime/fanout"
@@ -20,6 +24,7 @@ type handler struct {
 	hub        *fanout.Hub
 	topics     TopicsFunc
 	encode     func(fanout.Message) (Event, error)
+	resume     func(raw string) (uint64, bool)
 	log        *slog.Logger
 	subOpts    []fanout.SubscribeOption
 	writerOpts []WriterOption
@@ -45,16 +50,59 @@ func NewHandler(hub *fanout.Hub, topics TopicsFunc, opts ...HandlerOption) (http
 	if len(c.errs) > 0 {
 		return nil, errors.Join(c.errs...)
 	}
-	return &handler{
+	h := &handler{
 		hub:        hub,
 		topics:     topics,
-		encode:     c.encode,
 		log:        c.log,
 		subOpts:    c.subOpts,
 		writerOpts: c.writerOpts,
 		keepAlive:  c.keepAlive,
 		retry:      c.retry,
-	}, nil
+	}
+	if c.encode != nil {
+		// A custom encoder owns the id: semantics (typically stable domain IDs),
+		// so resume trusts the raw cursor as before.
+		h.encode = c.encode
+		h.resume = rawCursor
+	} else {
+		// The default encoder maps the per-instance hub ID to the cursor. Those
+		// IDs reset on restart and differ per instance, so namespace them with a
+		// random epoch: a cursor minted by another instance or a previous boot
+		// carries a foreign epoch, is recognised as such, and degrades to a
+		// live-only stream instead of silently dropping the messages whose IDs
+		// numerically overlap it.
+		epoch := newEpoch()
+		h.encode = func(m fanout.Message) (Event, error) {
+			return Event{ID: epoch + "." + strconv.FormatUint(m.ID, 10), Name: m.Topic, Data: m.Payload}, nil
+		}
+		h.resume = func(raw string) (uint64, bool) {
+			ep, seq, ok := strings.Cut(raw, ".")
+			if !ok || ep != epoch {
+				return 0, false
+			}
+			id, err := strconv.ParseUint(seq, 10, 64)
+			return id, err == nil
+		}
+	}
+	return h, nil
+}
+
+// rawCursor parses a bare numeric Last-Event-ID, the resume cursor a custom
+// encoder is expected to emit when it wants Last-Event-ID resume.
+func rawCursor(raw string) (uint64, bool) {
+	id, err := strconv.ParseUint(raw, 10, 64)
+	return id, err == nil
+}
+
+// newEpoch returns a random per-instance token that namespaces this handler's
+// resume cursors so cursors from other instances or previous boots are
+// recognised as foreign.
+func newEpoch() string {
+	var b [8]byte
+	// crypto/rand.Read never returns an error on supported platforms; a zero
+	// token would only weaken foreign-cursor detection, never break safety.
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -118,6 +166,16 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			if err := wr.Send(ev); err != nil {
+				if errors.Is(err, ErrInvalidEvent) {
+					// Validation failed with nothing written (e.g. a topic
+					// carrying CR/LF becomes an invalid event name). Skip it and
+					// keep the stream alive; treating it as a transport failure
+					// would, with replay enabled, re-serve the same bad event on
+					// every reconnect and trap the client in a loop.
+					h.log.WarnContext(ctx, "sse: invalid event skipped",
+						slog.String("topic", msg.Topic), slog.Uint64("message_id", msg.ID), slog.Any("error", err))
+					continue
+				}
 				return
 			}
 		case <-heartbeat:
@@ -134,10 +192,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // failing the request.
 func (h *handler) subscribe(r *http.Request, topics []string) (*fanout.Subscription, error) {
 	if raw := r.Header.Get("Last-Event-ID"); raw != "" {
-		if id, err := strconv.ParseUint(raw, 10, 64); err == nil {
-			opts := make([]fanout.SubscribeOption, len(h.subOpts), len(h.subOpts)+1)
-			copy(opts, h.subOpts)
-			opts = append(opts, fanout.WithResumeAfter(id))
+		if id, ok := h.resume(raw); ok {
+			opts := append(slices.Clone(h.subOpts), fanout.WithResumeAfter(id))
 			sub, err := h.hub.Subscribe(r.Context(), topics, opts...)
 			if err == nil || !errors.Is(err, fanout.ErrReplayDisabled) {
 				return sub, err

--- a/realtime/sse/handler_test.go
+++ b/realtime/sse/handler_test.go
@@ -300,6 +300,30 @@ func TestHandlerResumeForeignEpoch(t *testing.T) {
 	assert.Equal(t, "live", got.data, "a foreign-epoch cursor must degrade to live-only, never replay another instance's IDs")
 }
 
+func TestHandlerResumeMalformedSequence(t *testing.T) {
+	t.Parallel()
+
+	hub := newHub(t, fanout.WithReplay(16))
+	h, err := sse.NewHandler(hub, staticTopics("feed"))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	// Learn this instance's epoch from a live event.
+	br := connect(t, srv, nil)
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("first")))
+	first, err := readEvent(br)
+	require.NoError(t, err)
+	epoch, _, _ := strings.Cut(first.id, ".")
+
+	// A cursor with the correct epoch but a non-numeric sequence must not be
+	// applied against the ring; it degrades to a live-only stream.
+	br = connect(t, srv, http.Header{"Last-Event-Id": {epoch + ".notanum"}})
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("live")))
+	got, err := readEvent(br)
+	require.NoError(t, err)
+	assert.Equal(t, "live", got.data, "a correct epoch with a malformed sequence degrades to live-only")
+}
+
 func TestHandlerInvalidEventSkipped(t *testing.T) {
 	t.Parallel()
 

--- a/realtime/sse/handler_test.go
+++ b/realtime/sse/handler_test.go
@@ -119,11 +119,17 @@ func TestHandlerStream(t *testing.T) {
 
 	got, err := readEvent(br)
 	require.NoError(t, err)
-	assert.Equal(t, event{id: "1", name: "notifications.42", data: "first"}, got)
+	assert.Equal(t, "notifications.42", got.name)
+	assert.Equal(t, "first", got.data)
+	epoch, seq, ok := strings.Cut(got.id, ".")
+	require.True(t, ok, "default cursor must be epoch-namespaced")
+	assert.NotEmpty(t, epoch)
+	assert.Equal(t, "1", seq)
 
 	got, err = readEvent(br)
 	require.NoError(t, err)
 	assert.Equal(t, "a\nb", got.data, "multi-line payloads must survive framing")
+	assert.Equal(t, epoch+".2", got.id, "same instance keeps its epoch and advances the cursor")
 }
 
 func TestHandlerMethodNotAllowed(t *testing.T) {
@@ -218,17 +224,26 @@ func TestHandlerResume(t *testing.T) {
 	require.NoError(t, err)
 	srv := newServer(t, h)
 
-	for _, payload := range []string{"one", "two", "three"} {
-		require.NoError(t, hub.Publish(t.Context(), "feed", []byte(payload)))
-	}
+	// Learn a real cursor from a live event, exactly as a browser does — the
+	// default cursor is epoch-namespaced, so a fabricated "1" would be foreign.
+	br := connect(t, srv, nil)
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("one")))
+	first, err := readEvent(br)
+	require.NoError(t, err)
+	require.Equal(t, "one", first.data)
+	epoch, _, _ := strings.Cut(first.id, ".")
 
-	br := connect(t, srv, http.Header{"Last-Event-Id": {"1"}})
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("two")))
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("three")))
+
+	// Reconnect resuming after the captured cursor: replay serves the rest.
+	br = connect(t, srv, http.Header{"Last-Event-Id": {first.id}})
 	got, err := readEvent(br)
 	require.NoError(t, err)
-	assert.Equal(t, event{id: "2", name: "feed", data: "two"}, got)
+	assert.Equal(t, event{id: epoch + ".2", name: "feed", data: "two"}, got)
 	got, err = readEvent(br)
 	require.NoError(t, err)
-	assert.Equal(t, event{id: "3", name: "feed", data: "three"}, got)
+	assert.Equal(t, event{id: epoch + ".3", name: "feed", data: "three"}, got)
 }
 
 func TestHandlerResumeWithoutReplay(t *testing.T) {
@@ -261,6 +276,48 @@ func TestHandlerInvalidLastEventID(t *testing.T) {
 	got, err := readEvent(br)
 	require.NoError(t, err)
 	assert.Equal(t, "live", got.data, "an unparseable cursor starts a fresh live stream, no replay")
+}
+
+func TestHandlerResumeForeignEpoch(t *testing.T) {
+	t.Parallel()
+
+	hub := newHub(t, fanout.WithReplay(16))
+	h, err := sse.NewHandler(hub, staticTopics("feed"))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	// Buffer history whose numeric cursors (1, 2) this instance would honor.
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("old1")))
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("old2")))
+
+	// A well-formed cursor from a different instance/boot: valid seq, foreign
+	// epoch. It must not be applied against this instance's IDs (which would
+	// replay old2); it degrades to a live-only stream instead.
+	br := connect(t, srv, http.Header{"Last-Event-Id": {"0000000000000000.1"}})
+	require.NoError(t, hub.Publish(t.Context(), "feed", []byte("live")))
+	got, err := readEvent(br)
+	require.NoError(t, err)
+	assert.Equal(t, "live", got.data, "a foreign-epoch cursor must degrade to live-only, never replay another instance's IDs")
+}
+
+func TestHandlerInvalidEventSkipped(t *testing.T) {
+	t.Parallel()
+
+	hub := newHub(t)
+	// A topic carrying a line break is legal for the hub but makes the default
+	// encoder produce an invalid event name.
+	h, err := sse.NewHandler(hub, staticTopics("bad\ntopic", "good"))
+	require.NoError(t, err)
+	srv := newServer(t, h)
+
+	br := connect(t, srv, nil)
+	require.NoError(t, hub.Publish(t.Context(), "bad\ntopic", []byte("dropped")))
+	require.NoError(t, hub.Publish(t.Context(), "good", []byte("kept")))
+
+	got, err := readEvent(br)
+	require.NoError(t, err)
+	assert.Equal(t, "good", got.name)
+	assert.Equal(t, "kept", got.data, "an invalid event is skipped, not treated as a transport failure")
 }
 
 func TestHandlerKeepAlive(t *testing.T) {

--- a/realtime/sse/options.go
+++ b/realtime/sse/options.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
-	"strconv"
 	"time"
 
 	"github.com/dmitrymomot/forge/ops/logger"
@@ -29,8 +28,11 @@ type WriterOption func(*writerConfig)
 // connected client that stopped reading would pin the goroutine and the
 // connection forever; with it the blocked Send fails and ends the stream.
 // Zero disables the bound; negative is an error. Defaults to 30s.
-// Best-effort: a middleware chain that cannot set deadlines falls back to
-// the server's own write timeout.
+//
+// When the bound is positive, NewWriter fails closed if the response writer
+// cannot set write deadlines (a flushable wrapper without Unwrap): the
+// protection cannot be enforced, so pass WithSendTimeout(0) to accept
+// unbounded writes explicitly.
 func WithSendTimeout(d time.Duration) WriterOption {
 	return func(c *writerConfig) {
 		if d < 0 {
@@ -53,16 +55,9 @@ type handlerConfig struct {
 
 func newHandlerConfig() *handlerConfig {
 	return &handlerConfig{
-		encode:    defaultEncode,
 		log:       logger.NewNope(),
 		keepAlive: defaultKeepAlive,
 	}
-}
-
-// defaultEncode maps a fanout message onto the wire: the message ID becomes
-// the resume cursor and the topic becomes the event name.
-func defaultEncode(m fanout.Message) (Event, error) {
-	return Event{ID: strconv.FormatUint(m.ID, 10), Name: m.Topic, Data: m.Payload}, nil
 }
 
 // HandlerOption configures NewHandler.
@@ -95,11 +90,15 @@ func WithRetry(d time.Duration) HandlerOption {
 	}
 }
 
-// WithEncoder replaces the default fanout.Message → Event mapping (message ID
-// as the "id:" resume cursor, topic as the event name, payload as data). An
-// encoder that clears Event.ID opts that message out of Last-Event-ID resume.
-// An encoder error skips the message — logged, never delivered — and the
-// stream continues.
+// WithEncoder replaces the default fanout.Message → Event mapping (an
+// epoch-namespaced message ID as the "id:" resume cursor, topic as the event
+// name, payload as data). An encoder that clears Event.ID opts that message out
+// of Last-Event-ID resume. An encoder error skips the message — logged, never
+// delivered — and the stream continues.
+//
+// A custom encoder owns the "id:" it emits, so the handler resumes on the raw
+// Last-Event-ID (a bare uint64) rather than the default epoch-namespaced form —
+// emit stable, cross-instance IDs if you want resume to survive restarts.
 func WithEncoder(fn func(fanout.Message) (Event, error)) HandlerOption {
 	return func(c *handlerConfig) {
 		if fn == nil {

--- a/realtime/sse/writer.go
+++ b/realtime/sse/writer.go
@@ -88,8 +88,10 @@ func (w *Writer) Send(e Event) error {
 	}
 	w.buf = buf
 	if w.sendTimeout > 0 {
-		// Best-effort: a chain that cannot set deadlines falls back to the
-		// server's own write timeout.
+		// NewWriter fails closed unless deadline control is available, so a
+		// positive sendTimeout guarantees this is supported; ignore the error
+		// because a genuine failure here (e.g. the connection already closed)
+		// surfaces on the Write/Flush below anyway.
 		_ = w.rc.SetWriteDeadline(time.Now().Add(w.sendTimeout))
 	}
 	if _, err := w.w.Write(buf); err != nil {

--- a/realtime/sse/writer.go
+++ b/realtime/sse/writer.go
@@ -48,13 +48,22 @@ func NewWriter(w http.ResponseWriter, opts ...WriterOption) (*Writer, error) {
 		h.Del("X-Accel-Buffering")
 	}
 	rc := http.NewResponseController(w)
-	// A wrapping middleware that does not implement Unwrap surfaces
-	// ErrNotSupported here even though the underlying connection has a
-	// deadline; that is the caller's cue to run the server with
-	// WriteTimeout=0 instead (see the package comment).
-	if err := rc.SetWriteDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
-		resetHeaders()
-		return nil, fmt.Errorf("sse: clear write deadline: %w", err)
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		if !errors.Is(err, http.ErrNotSupported) {
+			resetHeaders()
+			return nil, fmt.Errorf("sse: clear write deadline: %w", err)
+		}
+		// Deadline control is unavailable — a flushable middleware in the chain
+		// does not implement Unwrap. Per-send deadlines then cannot be armed, so
+		// a configured send timeout would be silently unenforced and a stalled
+		// client could pin the connection forever. Fail closed before committing
+		// unless the caller explicitly accepted unbounded writes with
+		// WithSendTimeout(0). A writer that also cannot flush is a more
+		// fundamental problem, reported as ErrStreamingUnsupported below.
+		if c.sendTimeout > 0 && canFlush(w) {
+			resetHeaders()
+			return nil, fmt.Errorf("sse: response writer lacks the deadline control the per-send timeout needs; make wrappers implement Unwrap, or pass WithSendTimeout(0): %w", err)
+		}
 	}
 	if err := rc.Flush(); err != nil {
 		resetHeaders()
@@ -90,4 +99,23 @@ func (w *Writer) Send(e Event) error {
 		return fmt.Errorf("sse: flush event: %w", err)
 	}
 	return nil
+}
+
+// canFlush reports whether w supports flushing, mirroring how
+// http.ResponseController resolves Flush along the Unwrap chain. It lets
+// NewWriter tell a flushable-but-deadline-less writer (fail closed on the send
+// timeout) apart from one that cannot stream at all (ErrStreamingUnsupported).
+func canFlush(w http.ResponseWriter) bool {
+	for {
+		switch t := w.(type) {
+		case interface{ FlushError() error }:
+			return true
+		case http.Flusher:
+			return true
+		case interface{ Unwrap() http.ResponseWriter }:
+			w = t.Unwrap()
+		default:
+			return false
+		}
+	}
 }

--- a/realtime/sse/writer_test.go
+++ b/realtime/sse/writer_test.go
@@ -48,7 +48,9 @@ func TestNewWriterHeaders(t *testing.T) {
 	t.Parallel()
 
 	rec := httptest.NewRecorder()
-	_, err := sse.NewWriter(rec)
+	// A recorder cannot set write deadlines, so opt out of the send-timeout
+	// bound explicitly; this test is about the stream headers.
+	_, err := sse.NewWriter(rec, sse.WithSendTimeout(0))
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -96,7 +98,7 @@ func TestSendFlushesEveryEvent(t *testing.T) {
 	t.Parallel()
 
 	cw := &countingFlusher{rec: httptest.NewRecorder()}
-	w, err := sse.NewWriter(cw)
+	w, err := sse.NewWriter(cw, sse.WithSendTimeout(0)) // recorder has no deadline control
 	require.NoError(t, err)
 	flushed := cw.flushes // header flush
 
@@ -110,7 +112,7 @@ func TestSendWriteError(t *testing.T) {
 	t.Parallel()
 
 	cw := &countingFlusher{rec: httptest.NewRecorder()}
-	w, err := sse.NewWriter(cw)
+	w, err := sse.NewWriter(cw, sse.WithSendTimeout(0)) // recorder has no deadline control
 	require.NoError(t, err)
 
 	cw.writeErr = errors.New("client gone")
@@ -161,11 +163,38 @@ func TestSendTimeoutValidation(t *testing.T) {
 	require.Error(t, err)
 }
 
+// deadlinelessFlusher flushes but cannot set write deadlines and does not
+// implement Unwrap — a middleware wrapper that forgot Unwrap.
+type deadlinelessFlusher struct {
+	header http.Header
+}
+
+func (w *deadlinelessFlusher) Header() http.Header         { return w.header }
+func (w *deadlinelessFlusher) Write(p []byte) (int, error) { return len(p), nil }
+func (w *deadlinelessFlusher) WriteHeader(int)             {}
+func (w *deadlinelessFlusher) Flush()                      {}
+
+func TestNewWriterSendTimeoutUnsupported(t *testing.T) {
+	t.Parallel()
+
+	// A positive send timeout that cannot be enforced fails closed before the
+	// response is committed, rather than silently dropping the protection.
+	w := &deadlinelessFlusher{header: make(http.Header)}
+	_, err := sse.NewWriter(w)
+	require.Error(t, err)
+	assert.Empty(t, w.header.Get("Content-Type"), "stream headers must be reset on failure")
+
+	// Opting out of the bound accepts unbounded writes and succeeds.
+	w2 := &deadlinelessFlusher{header: make(http.Header)}
+	_, err = sse.NewWriter(w2, sse.WithSendTimeout(0))
+	require.NoError(t, err)
+}
+
 func TestWriterConcurrentSend(t *testing.T) {
 	t.Parallel()
 
 	rec := httptest.NewRecorder()
-	w, err := sse.NewWriter(rec)
+	w, err := sse.NewWriter(rec, sse.WithSendTimeout(0)) // recorder has no deadline control
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Description

Fixes five issues from a review of `realtime/sse` (one dependency fix lands in `realtime/fanout`). A sixth reported issue — "idle stream fails after the first send timeout" — was verified as a **false positive** (the write deadline is re-armed before every write; empirically an idle-then-send succeeds) and is not addressed.

### `realtime/fanout` — cross-topic delivery ordering (High)
Hub IDs are a single global sequence but topics lock independently, so a subscriber multiplexing several topics could observe a higher ID enqueued ahead of a lower one and regress its `Last-Event-ID` cursor (skip on disconnect, or duplicate on reconnect). A hub-level `seqMu` now serializes ID allocation, ring insertion, and delivery. Single-topic publish is unaffected; concurrent multi-topic publish serializes what was parallel.

### `realtime/sse`
- **Stale cross-instance cursor (High).** The default resume cursor is now namespaced with a random per-instance epoch (`<epoch>.<seq>`). Hub IDs are per-instance and reset on restart, so a numeric cursor from another instance or a previous boot was mis-applied against this instance's ID space and silently dropped the messages it overlapped. A foreign epoch now degrades to a live-only stream, as the package docs already promised. Custom encoders keep raw-cursor resume.
- **Invalid event → reconnect loop (Medium).** `ErrInvalidEvent` from `Send` (e.g. a fanout topic containing CR/LF becomes an invalid event name) is logged-and-skipped instead of ending the stream; validation writes nothing, so the stream is intact. Previously, with replay enabled, the bad event was re-served on every reconnect and trapped clients in a loop.
- **Send-timeout silently unenforced (Medium).** When deadline control is unavailable (a flushable writer without `Unwrap`) and `sendTimeout > 0`, `NewWriter` now fails closed before committing rather than silently dropping stall protection. `WithSendTimeout(0)` opts into unbounded writes.
- **Retry rounding overflow (Low).** Divide-then-round-up so a duration near `MaxInt64` no longer overflows into a negative `retry:` field.

## Benchmarks (`realtime/fanout`, `-count=5`, 14 cores)

| bench | before | after | Δ |
|---|---|---|---|
| `Publish/1subs` | 122.4 ns | 121.3 ns | none |
| `Publish/8subs` | 684.8 ns | 685.6 ns | none |
| `Publish/64subs` | ~10.2 µs | ~9.6 µs | none (noise) |
| `PublishMultiTopic` (concurrent) | 260.7 ns | 413.6 ns | +153 ns (~1.6×) |

All 0 allocs. Single-topic publish (the common SSE shape) is unaffected — `seqMu` is uncontended there. Only concurrent multi-topic publishing pays, which is the cost of the monotonic cross-topic cursor.

## Reviewer notes
- The `seqMu` regression test (`TestMultiTopicDeliveryMonotonic`) was **proven to fail pre-fix** under `-race` (a higher ID delivered before a lower one); it passes with the fix.
- The fail-closed send-timeout is a behavior change: a plain `httptest.ResponseRecorder` (flushable, no deadline support) now requires `WithSendTimeout(0)`. Recorder-based tests and both examples were updated accordingly. Real server connections support deadlines, so production code keeps the default.
- Default resume cursors change format to `<epoch>.<seq>`; opaque to clients. In-flight clients holding old bare-numeric cursors degrade to live-only once on deploy, then resume normally.

## Checklist

- [x] `just lint` passes
- [x] `just test` passes
- [x] New code has tests
- [x] Commit messages follow conventional commits