### PR TITLE
fix(session): make revocation terminal and harden lifecycle

### DIFF
--- a/auth/session/config.go
+++ b/auth/session/config.go
@@ -35,7 +35,10 @@ func (c Config) Validate() error {
 	if c.RememberMax < 0 || (c.RememberMax > 0 && c.RememberMax < c.RememberIdle) {
 		return ErrBadMaxTTL
 	}
-	if c.Touch < 0 || c.Touch > c.Idle {
+	// A nonzero Touch must sit strictly below both idle windows: at Touch ==
+	// Idle the refresh lands exactly when the session expires, so sliding
+	// expiry never actually slides.
+	if c.Touch < 0 || (c.Touch > 0 && (c.Touch >= c.Idle || c.Touch >= c.RememberIdle)) {
 		return ErrBadTouch
 	}
 	return nil

--- a/auth/session/config_test.go
+++ b/auth/session/config_test.go
@@ -28,6 +28,14 @@ func TestConfigValidate(t *testing.T) {
 		{"remembermax below remember idle", func(c *session.Config) { c.RememberIdle = 60 * 24 * time.Hour; c.RememberMax = time.Hour }, session.ErrBadMaxTTL},
 		{"negative touch", func(c *session.Config) { c.Touch = -time.Second }, session.ErrBadTouch},
 		{"touch above idle", func(c *session.Config) { c.Touch = 48 * time.Hour }, session.ErrBadTouch},
+		// Touch == Idle would refresh exactly when the session expires, so
+		// sliding expiry never actually slides.
+		{"touch equal to idle", func(c *session.Config) { c.Touch = c.Idle }, session.ErrBadTouch},
+		{"touch at remember idle", func(c *session.Config) {
+			c.RememberIdle = 30 * time.Minute
+			c.RememberMax = 0
+			c.Touch = 30 * time.Minute
+		}, session.ErrBadTouch},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/auth/session/context_test.go
+++ b/auth/session/context_test.go
@@ -4,8 +4,10 @@ import (
 	"log/slog"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/core/clock"
 )
 
 func TestFromContextAbsent(t *testing.T) {
@@ -84,7 +86,8 @@ func TestInfoStaysStaleAfterFailedAuthenticate(t *testing.T) {
 }
 
 func TestInfoTracksMidRequestElevate(t *testing.T) {
-	mgr := newTestManager(t)
+	clk := clock.NewMock(time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC))
+	mgr := newTestManager(t, session.WithClock(clk))
 	sess := mgr.Start()
 	ctx := session.TestWithSession(t.Context(), sess)
 	info, ok := session.FromContext(ctx)
@@ -94,6 +97,13 @@ func TestInfoTracksMidRequestElevate(t *testing.T) {
 	if !info.ElevatedAt.IsZero() {
 		t.Fatal("a fresh session's Info must not report an elevation stamp")
 	}
+
+	// Elevate requires an identity to re-prove; authenticate, then age the
+	// stamp so the elevation actually changes it.
+	if err := mgr.Authenticate(ctx, sess, "u1"); err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	clk.Advance(20 * time.Minute)
 
 	if err := mgr.Elevate(ctx, sess); err != nil {
 		t.Fatalf("Elevate: %v", err)

--- a/auth/session/devices.go
+++ b/auth/session/devices.go
@@ -2,11 +2,12 @@ package session
 
 import (
 	"context"
+	"slices"
 
 	"github.com/dmitrymomot/forge/core/id"
 )
 
-// ListByUser returns every live session for userID, newest first. IP, user agent, and last-seen are columns, so a device list decodes no payload. Returns ErrUnsupported when the store has no user index. With a configured scope hook, results are confined to the resolved tenant.
+// ListByUser returns every live session for userID, newest first. Expired records the reaper has not removed yet are filtered out here, so the promise holds regardless of the driver. IP, user agent, and last-seen are columns, so a device list decodes no payload. Returns ErrUnsupported when the store has no user index. With a configured scope hook, results are confined to the resolved tenant.
 func (m *Manager) ListByUser(ctx context.Context, userID string) ([]Record, error) {
 	if m.index == nil {
 		return nil, ErrUnsupported
@@ -18,7 +19,14 @@ func (m *Manager) ListByUser(ctx context.Context, userID string) ([]Record, erro
 	if err != nil {
 		return nil, err
 	}
-	return m.index.ListByUser(ctx, tenant, userID)
+	recs, err := m.index.ListByUser(ctx, tenant, userID)
+	if err != nil {
+		return nil, err
+	}
+	now := m.now()
+	return slices.DeleteFunc(recs, func(r Record) bool {
+		return !r.ExpiresAt.IsZero() && !r.ExpiresAt.After(now)
+	}), nil
 }
 
 // Revoke removes one of userID's sessions. It is user-bound: passing another user's session id is a no-op, not a cross-account logout. With a configured scope hook, it is also tenant-bound the same way.

--- a/auth/session/devices_test.go
+++ b/auth/session/devices_test.go
@@ -17,8 +17,11 @@ type bareStore struct{ inner *session.MemoryStore }
 func (b bareStore) Load(ctx context.Context, tok string) (session.Record, error) {
 	return b.inner.Load(ctx, tok)
 }
-func (b bareStore) Save(ctx context.Context, tok string, r session.Record) (string, error) {
-	return b.inner.Save(ctx, tok, r)
+func (b bareStore) Create(ctx context.Context, tok string, r session.Record) (string, error) {
+	return b.inner.Create(ctx, tok, r)
+}
+func (b bareStore) Update(ctx context.Context, tok string, r session.Record) (string, error) {
+	return b.inner.Update(ctx, tok, r)
 }
 func (b bareStore) Delete(ctx context.Context, tok string) error { return b.inner.Delete(ctx, tok) }
 
@@ -118,6 +121,40 @@ func TestRevokeIsUserBound(t *testing.T) {
 	}
 }
 
+// TestListByUserFiltersExpiredRecords pins the "every live session" promise:
+// an expired record no reaper has removed yet must not show up in a device
+// list, whatever the driver returns.
+func TestListByUserFiltersExpiredRecords(t *testing.T) {
+	start := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	clk := clock.NewMock(start)
+	store := session.NewMemoryStore()
+	mgr, err := session.New(session.DefaultConfig(), session.WithStore(store), session.WithClock(clk))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx := t.Context()
+
+	live := mgr.Start()
+	if err := mgr.Authenticate(ctx, live, "u1"); err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if _, err := store.Create(ctx, "expired-device-tok", session.Record{
+		ID: id.NewUUID(), UserID: "u1",
+		CreatedAt: start.Add(-2 * time.Hour), LastSeenAt: start.Add(-2 * time.Hour),
+		ExpiresAt: start.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed expired record: %v", err)
+	}
+
+	list, err := mgr.ListByUser(ctx, "u1")
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != live.ID() {
+		t.Fatalf("ListByUser must return only live sessions: got %d records", len(list))
+	}
+}
+
 func TestReaperServiceName(t *testing.T) {
 	mgr := newTestManager(t)
 	svc := session.Reaper(mgr, time.Minute)
@@ -154,14 +191,14 @@ func TestReaperDeletesExpiredRecordsOnTick(t *testing.T) {
 	ctx := t.Context()
 
 	const expiredTok, liveTok = "reaper-expired-tok", "reaper-live-tok"
-	if _, err := store.Save(ctx, expiredTok, session.Record{
+	if _, err := store.Create(ctx, expiredTok, session.Record{
 		ID:        id.NewUUID(),
 		CreatedAt: time.Now().Add(-time.Hour),
 		ExpiresAt: time.Now().Add(-time.Minute),
 	}); err != nil {
 		t.Fatalf("seed expired record: %v", err)
 	}
-	if _, err := store.Save(ctx, liveTok, session.Record{
+	if _, err := store.Create(ctx, liveTok, session.Record{
 		ID:        id.NewUUID(),
 		CreatedAt: time.Now(),
 		ExpiresAt: time.Now().Add(time.Hour),
@@ -215,12 +252,12 @@ func TestDeleteExpiredUsesManagerClockAndBoundary(t *testing.T) {
 	ctx := t.Context()
 
 	const beforeTok, afterTok = "boundary-before-tok", "boundary-after-tok"
-	if _, err := store.Save(ctx, beforeTok, session.Record{
+	if _, err := store.Create(ctx, beforeTok, session.Record{
 		ID: id.NewUUID(), CreatedAt: start, ExpiresAt: start.Add(-time.Minute),
 	}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	if _, err := store.Save(ctx, afterTok, session.Record{
+	if _, err := store.Create(ctx, afterTok, session.Record{
 		ID: id.NewUUID(), CreatedAt: start, ExpiresAt: start.Add(time.Minute),
 	}); err != nil {
 		t.Fatalf("seed: %v", err)

--- a/auth/session/elevation.go
+++ b/auth/session/elevation.go
@@ -18,13 +18,20 @@ import (
 func RequireElevation(window time.Duration, actions ...access.Action) access.Decider {
 	guarded := slices.Clone(actions)
 	return access.Named("session.elevation", access.DeciderFunc(
-		func(ctx context.Context, _ access.Subject, a access.Action, _ access.Resource) (access.Decision, error) {
+		func(ctx context.Context, sub access.Subject, a access.Action, _ access.Resource) (access.Decision, error) {
 			if !slices.Contains(guarded, a) {
 				return access.Abstain.Because("action does not require elevation"), nil
 			}
 			inf, ok := FromContext(ctx)
 			if !ok || !inf.Authenticated() {
 				return access.Deny.Because("no authenticated session"), nil
+			}
+			// The session's elevation vouches only for the session's own user. In
+			// a mixed-auth chain (API key + session cookie in one request) the
+			// subject under decision may come from the other mechanism — a
+			// bystander session must not satisfy its step-up requirement.
+			if sub.ID != inf.UserID {
+				return access.Deny.Because("elevation belongs to a different principal"), nil
 			}
 			if inf.ElevatedAt.IsZero() {
 				return access.Deny.Because("identity has not been re-proved"), nil

--- a/auth/session/elevation_test.go
+++ b/auth/session/elevation_test.go
@@ -59,6 +59,30 @@ func TestRequireElevationDeniesWhenStale(t *testing.T) {
 	}
 }
 
+// TestRequireElevationDeniesAForeignSubject pins the principal binding: in a
+// mixed-auth chain the subject under decision can come from another mechanism
+// (an API key, say), and a bystander session's elevation must not vouch for it.
+func TestRequireElevationDeniesAForeignSubject(t *testing.T) {
+	mgr := newTestManager(t)
+	sess := mgr.Start()
+	if err := mgr.Authenticate(t.Context(), sess, "u1"); err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if err := mgr.Elevate(t.Context(), sess); err != nil {
+		t.Fatalf("Elevate: %v", err)
+	}
+	ctx := session.TestWithSession(t.Context(), sess)
+
+	d := session.RequireElevation(10*time.Minute, "tenant:delete")
+	dec, err := d.Decide(ctx, access.Subject{ID: "api-key-service-account"}, "tenant:delete", access.Resource{})
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if dec.Effect != access.Deny {
+		t.Fatalf("effect = %v for a subject that is not the session's user, want Deny", dec.Effect)
+	}
+}
+
 func TestRequireElevationDeniesWithoutASession(t *testing.T) {
 	d := session.RequireElevation(10*time.Minute, "tenant:delete")
 

--- a/auth/session/errors.go
+++ b/auth/session/errors.go
@@ -5,6 +5,8 @@ import "errors"
 var (
 	// ErrNotFound means no record exists for the presented token.
 	ErrNotFound = errors.New("session: not found")
+	// ErrExists means Create found a record already stored under the token.
+	ErrExists = errors.New("session: record already exists")
 	// ErrExpired means the record exists but its deadline has passed.
 	ErrExpired = errors.New("session: expired")
 	// ErrUnsupported means the configured Store lacks the capability this call needs.
@@ -17,6 +19,15 @@ var (
 	ErrNoStore = errors.New("session: no store configured")
 	// ErrAnonymous means the call requires an authenticated session.
 	ErrAnonymous = errors.New("session: session is anonymous")
+	// ErrUserMismatch means Authenticate was asked to switch an authenticated
+	// session to a different user. Log the first user out instead: carrying one
+	// user's payload into another's session leaks whatever the first cached.
+	ErrUserMismatch = errors.New("session: session is bound to another user")
+	// ErrDenied is what the middleware hands the responder when a policy denies:
+	// the policy's reason goes to logs, never into the response body.
+	ErrDenied = errors.New("session: denied by policy")
+	// ErrRevoked is the responder-facing counterpart of ErrDenied for revocations.
+	ErrRevoked = errors.New("session: revoked by policy")
 	// ErrScope means a configured scope hook errored or yielded an empty scope. A
 	// scoped operation fails closed rather than touching an unscoped bucket.
 	ErrScope = errors.New("session: scope resolution failed")
@@ -25,8 +36,6 @@ var (
 	ErrBadIdle = errors.New("session: idle ttl must be positive")
 	// ErrBadMaxTTL means an absolute lifetime is negative or below its idle ttl.
 	ErrBadMaxTTL = errors.New("session: max ttl must be zero or above the idle ttl")
-	// ErrBadTouch means Touch is negative or exceeds the idle ttl.
-	ErrBadTouch = errors.New("session: touch interval must be zero or within the idle ttl")
-	// ErrTouchUnsupported means Touch is configured but the Store has no Toucher.
-	ErrTouchUnsupported = errors.New("session: touch configured but store does not implement Toucher")
+	// ErrBadTouch means Touch is negative or not below both idle ttls.
+	ErrBadTouch = errors.New("session: touch interval must be zero or below both idle ttls")
 )

--- a/auth/session/guard.go
+++ b/auth/session/guard.go
@@ -30,7 +30,7 @@ type VerifierOption func(*verifierOptions)
 
 // WithIdentity maps a session to a guard.Identity, letting roles or scopes ride
 // a session namespace instead of a per-request store read. The default emits
-// Subject and Method only — session core knows nothing about roles.
+// Subject, Tenant, and Method only — session core knows nothing about roles.
 func WithIdentity(fn func(*Session) guard.Identity) VerifierOption {
 	return func(o *verifierOptions) { o.identity = fn }
 }
@@ -55,6 +55,8 @@ func Verifier(m *Manager, opts ...VerifierOption) guard.Verifier {
 		if o.identity != nil {
 			return o.identity(s), nil
 		}
-		return guard.Identity{Subject: s.rec.UserID, Method: guard.MethodSession}, nil
+		// Tenant rides along so access.SubjectFromIdentity sees it: dropping it
+		// here would silently disable tenant checks in downstream deciders.
+		return guard.Identity{Subject: s.rec.UserID, Tenant: s.rec.Tenant, Method: guard.MethodSession}, nil
 	})
 }

--- a/auth/session/guard_test.go
+++ b/auth/session/guard_test.go
@@ -65,6 +65,42 @@ func TestGuard401sAnAnonymousSession(t *testing.T) {
 	}
 }
 
+// TestDefaultIdentityCarriesTenant pins that a scoped session's tenant reaches
+// guard.Identity without WithIdentity: access.SubjectFromIdentity copies
+// Identity.Tenant, so dropping it here would silently blank tenant checks in
+// every downstream decider.
+func TestDefaultIdentityCarriesTenant(t *testing.T) {
+	mgr := newTestManager(t, session.WithScope(scopeFromCtx))
+	authed := mgr.Start()
+	if err := mgr.Authenticate(withTenant(t.Context(), "t1"), authed, "u1"); err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+
+	chain := middleware.Chain(
+		session.Middleware(mgr, session.WithTransport(headerTransport{})),
+		guard.New(session.Verifier(mgr), guard.WithExtractors(session.Extractor())),
+	)
+
+	var got guard.Identity
+	h := chain(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = guard.MustFrom(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r = r.WithContext(withTenant(r.Context(), "t1"))
+	r.Header.Set("X-Test-Token", authed.Token())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got.Tenant != "t1" {
+		t.Fatalf("Identity.Tenant = %q, want t1", got.Tenant)
+	}
+}
+
 func TestWithIdentityCarriesRoles(t *testing.T) {
 	mgr := newTestManager(t)
 	authed := mgr.Start()

--- a/auth/session/lifecycle_test.go
+++ b/auth/session/lifecycle_test.go
@@ -117,6 +117,67 @@ func TestAuthenticateRollsBackTokenOnFailedSave(t *testing.T) {
 	}
 }
 
+func TestRotateRollsBackTheWholeRecordOnFailedSave(t *testing.T) {
+	store := &failingSaveStore{MemoryStore: session.NewMemoryStore()}
+	mgr, err := session.New(session.DefaultConfig(), session.WithStore(store))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	sess := mgr.Start()
+	if err := mgr.Save(t.Context(), sess); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	oldToken, oldExpires := sess.Token(), sess.ExpiresAt()
+
+	store.failOn = store.calls + 1
+	if err := mgr.Rotate(t.Context(), sess); err == nil {
+		t.Fatal("Rotate must surface the store failure")
+	}
+
+	if sess.Token() != oldToken {
+		t.Fatal("a failed rotation must roll the token back")
+	}
+	if !sess.ExpiresAt().Equal(oldExpires) {
+		t.Fatal("a failed rotation must not leave a deadline the store never committed")
+	}
+	if _, err := mgr.Load(t.Context(), oldToken); err != nil {
+		t.Fatalf("the original session must still load after a failed Rotate: %v", err)
+	}
+}
+
+func TestElevateRollsBackTheWholeRecordOnFailedSave(t *testing.T) {
+	store := &failingSaveStore{MemoryStore: session.NewMemoryStore()}
+	mgr, err := session.New(session.DefaultConfig(), session.WithStore(store))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	sess := mgr.Start()
+	if err := mgr.Authenticate(t.Context(), sess, "u1"); err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	oldToken, oldElevated, oldExpires := sess.Token(), sess.ElevatedAt(), sess.ExpiresAt()
+
+	store.failOn = store.calls + 1
+	if err := mgr.Elevate(t.Context(), sess); err == nil {
+		t.Fatal("Elevate must surface the store failure")
+	}
+
+	if sess.Token() != oldToken {
+		t.Fatal("a failed elevation must roll the token back")
+	}
+	if !sess.ElevatedAt().Equal(oldElevated) {
+		t.Fatal("a failed elevation must not leave a fresher stamp than the store holds")
+	}
+	if !sess.ExpiresAt().Equal(oldExpires) {
+		t.Fatal("a failed elevation must not leave a deadline the store never committed")
+	}
+	if _, err := mgr.Load(t.Context(), oldToken); err != nil {
+		t.Fatalf("the original session must still load after a failed Elevate: %v", err)
+	}
+}
+
 func TestFailedAuthenticateKeepsPendingPayloadForRetry(t *testing.T) {
 	store := &failingSaveStore{MemoryStore: session.NewMemoryStore()}
 	mgr, err := session.New(session.DefaultConfig(), session.WithStore(store))

--- a/auth/session/lifecycle_test.go
+++ b/auth/session/lifecycle_test.go
@@ -10,19 +10,27 @@ import (
 	"github.com/dmitrymomot/forge/core/clock"
 )
 
-// failingSaveStore fails the Nth save, to prove rollback.
+// failingSaveStore fails the Nth write (Create or Update), to prove rollback.
 type failingSaveStore struct {
 	*session.MemoryStore
 	failOn int
 	calls  int
 }
 
-func (f *failingSaveStore) Save(ctx context.Context, token string, rec session.Record) (string, error) {
+func (f *failingSaveStore) Create(ctx context.Context, token string, rec session.Record) (string, error) {
 	f.calls++
 	if f.calls == f.failOn {
 		return "", errors.New("store unavailable")
 	}
-	return f.MemoryStore.Save(ctx, token, rec)
+	return f.MemoryStore.Create(ctx, token, rec)
+}
+
+func (f *failingSaveStore) Update(ctx context.Context, token string, rec session.Record) (string, error) {
+	f.calls++
+	if f.calls == f.failOn {
+		return "", errors.New("store unavailable")
+	}
+	return f.MemoryStore.Update(ctx, token, rec)
 }
 
 func TestAuthenticateRotatesTokenAndPreservesIdentity(t *testing.T) {
@@ -140,6 +148,117 @@ func TestFailedAuthenticateKeepsPendingPayloadForRetry(t *testing.T) {
 	}
 	if len(cart.Items) != 1 || cart.Items[0] != "guest-item" {
 		t.Fatalf("pending namespace write lost after a failed Authenticate: %+v", cart)
+	}
+}
+
+func TestAuthenticateRejectsSwitchingUsers(t *testing.T) {
+	mgr := newTestManager(t)
+	sess := mgr.Start()
+	nsCart.Set(sess, cartData{Items: []string{"user-a-item"}})
+	if err := mgr.Authenticate(t.Context(), sess, "user-a"); err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	// Same user re-authenticating is fine (e.g. password re-entry).
+	if err := mgr.Authenticate(t.Context(), sess, "user-a"); err != nil {
+		t.Fatalf("same-user re-authentication: %v", err)
+	}
+	tokenAfterA := sess.Token()
+
+	// A different user must be rejected: the payload still carries user-a's data.
+	if err := mgr.Authenticate(t.Context(), sess, "user-b"); !errors.Is(err, session.ErrUserMismatch) {
+		t.Fatalf("Authenticate(user-b) on user-a's session = %v, want ErrUserMismatch", err)
+	}
+	if sess.UserID() != "user-a" {
+		t.Fatalf("rejected switch must leave the binding intact: UserID = %q", sess.UserID())
+	}
+	if sess.Token() != tokenAfterA {
+		t.Fatal("a rejected switch must not rotate the credential")
+	}
+}
+
+func TestElevateRotatesTheToken(t *testing.T) {
+	mgr := newTestManager(t)
+	sess := mgr.Start()
+	if err := mgr.Authenticate(t.Context(), sess, "u1"); err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	stolen := sess.Token()
+
+	if err := mgr.Elevate(t.Context(), sess); err != nil {
+		t.Fatalf("Elevate: %v", err)
+	}
+	if sess.Token() == stolen {
+		t.Fatal("Elevate must rotate the token — a credential copied before step-up must not inherit the elevation")
+	}
+	if _, err := mgr.Load(t.Context(), stolen); !errors.Is(err, session.ErrNotFound) {
+		t.Fatal("the pre-elevation token must stop working")
+	}
+	reloaded, err := mgr.Load(t.Context(), sess.Token())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !reloaded.ElevatedWithin(time.Minute) {
+		t.Fatal("the rotated record must carry the fresh elevation stamp")
+	}
+}
+
+func TestElevateRejectsAnonymousSessions(t *testing.T) {
+	mgr := newTestManager(t)
+	sess := mgr.Start()
+	if err := mgr.Elevate(t.Context(), sess); !errors.Is(err, session.ErrAnonymous) {
+		t.Fatalf("Elevate on an anonymous session = %v, want ErrAnonymous — there is no identity to re-prove", err)
+	}
+}
+
+func TestDestroyDeauthenticatesTheInMemorySession(t *testing.T) {
+	mgr := newTestManager(t)
+	sess := mgr.Start()
+	if err := mgr.Authenticate(t.Context(), sess, "u1"); err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+
+	if err := mgr.Destroy(t.Context(), sess); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if sess.Authenticated() {
+		t.Fatal("code later in the request must not keep authorizing a destroyed session")
+	}
+	if err := mgr.Save(t.Context(), sess); !errors.Is(err, session.ErrNotFound) {
+		t.Fatalf("Save after Destroy = %v, want ErrNotFound — a destroyed session must not be resurrectable", err)
+	}
+}
+
+// TestStaleSnapshotCannotResurrectADestroyedSession is the manager-level
+// revocation-is-terminal proof: request A holds a loaded snapshot, request B
+// destroys the session, then A commits. The upsert contract this replaces
+// would recreate the record with a fresh deadline.
+func TestStaleSnapshotCannotResurrectADestroyedSession(t *testing.T) {
+	mgr := newTestManager(t)
+	sess := mgr.Start()
+	if err := mgr.Authenticate(t.Context(), sess, "u1"); err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	token := sess.Token()
+
+	snapshotA, err := mgr.Load(t.Context(), token)
+	if err != nil {
+		t.Fatalf("Load (request A): %v", err)
+	}
+	snapshotB, err := mgr.Load(t.Context(), token)
+	if err != nil {
+		t.Fatalf("Load (request B): %v", err)
+	}
+
+	if err := mgr.Destroy(t.Context(), snapshotB); err != nil {
+		t.Fatalf("Destroy (request B): %v", err)
+	}
+
+	nsCart.Set(snapshotA, cartData{Items: []string{"stale"}})
+	if err := mgr.Save(t.Context(), snapshotA); !errors.Is(err, session.ErrNotFound) {
+		t.Fatalf("stale Save after Destroy = %v, want ErrNotFound", err)
+	}
+	if _, err := mgr.Load(t.Context(), token); !errors.Is(err, session.ErrNotFound) {
+		t.Fatal("the destroyed record must stay destroyed")
 	}
 }
 

--- a/auth/session/manager.go
+++ b/auth/session/manager.go
@@ -48,10 +48,6 @@ func New(cfg Config, opts ...Option) (*Manager, error) {
 	m.toucher, _ = c.store.(Toucher)
 	m.index, _ = c.store.(UserIndex)
 	m.expirer, _ = c.store.(Expirer)
-
-	if m.cfg.Touch > 0 && m.toucher == nil {
-		return nil, ErrTouchUnsupported
-	}
 	return m, nil
 }
 
@@ -118,20 +114,44 @@ func (m *Manager) Load(ctx context.Context, token string) (*Session, error) {
 	storedSeenAt := rec.LastSeenAt
 	rec.LastSeenAt = now
 	rec.ExpiresAt = m.deadline(rec, now)
+	// The recomputed deadline reflects the CURRENT config. If an operator
+	// tightened MaxTTL/RememberMax since this record was written, the absolute
+	// cap can already be in the past even though the persisted ExpiresAt was
+	// not — enforce the new policy now instead of admitting one more request.
+	if !rec.ExpiresAt.After(now) {
+		if err := m.store.Delete(ctx, token); err != nil {
+			m.log.WarnContext(ctx, "session: deleting expired record failed", slog.Any("error", err))
+		}
+		return nil, ErrExpired
+	}
 	sess := newSession(rec, token, false, m.now)
 	sess.storedSeenAt = storedSeenAt
 	return sess, nil
 }
 
-// Save persists the session, encoding any dirty namespaces first. The token the
-// store returns becomes the session's token, which is what lets a stateless
-// store re-encode the record into a fresh credential. With a configured scope
-// hook, the tenant is resolved and stamped before anything else is touched, so
-// a hook error or empty scope aborts before any mutation or write.
+// Save persists the session, encoding any dirty namespaces first: Create for a
+// never-persisted session, Update otherwise. Update returns ErrNotFound when
+// the record was deleted or revoked mid-request — deliberately, so a stale
+// snapshot cannot resurrect it. A destroyed session fails the same way without
+// touching the store. With a configured scope hook, the tenant is resolved and
+// stamped before anything else is touched, so a hook error or empty scope
+// aborts before any mutation or write.
 func (m *Manager) Save(ctx context.Context, s *Session) error {
 	if s == nil {
 		return ErrNoSession
 	}
+	if s.deleted {
+		return ErrNotFound
+	}
+	return m.persist(ctx, s, s.isNew)
+}
+
+// persist stamps scope and timestamps, encodes dirty namespaces, and writes the
+// record — Create when the store has never seen this token (a new session or a
+// freshly-rotated credential), Update otherwise. The token the store returns
+// becomes the session's token, which is what lets a stateless store re-encode
+// the record into a fresh credential.
+func (m *Manager) persist(ctx context.Context, s *Session, create bool) error {
 	tenant, err := m.resolveScope(ctx)
 	if err != nil {
 		return err
@@ -144,7 +164,12 @@ func (m *Manager) Save(ctx context.Context, s *Session) error {
 	s.rec.LastSeenAt = now
 	s.rec.ExpiresAt = m.deadline(s.rec, now)
 
-	tok, err := m.store.Save(ctx, s.token, s.rec)
+	var tok string
+	if create {
+		tok, err = m.store.Create(ctx, s.token, s.rec)
+	} else {
+		tok, err = m.store.Update(ctx, s.token, s.rec)
+	}
 	if err != nil {
 		return err
 	}
@@ -173,13 +198,13 @@ func (m *Manager) deadline(rec Record, now time.Time) time.Time {
 	return exp
 }
 
-// touchDue reports whether enough time has passed since the LastSeenAt that
-// was actually persisted to justify a metadata-only write. It compares
+// touchDue reports whether the sliding deadline should be re-persisted for a
+// clean request. A zero Touch means every request refreshes. It compares
 // against storedSeenAt, not rec.LastSeenAt: Load refreshes the in-memory
 // LastSeenAt to now, so comparing against that would make the elapsed
 // interval always zero and no request would ever touch.
 func (m *Manager) touchDue(s *Session, now time.Time) bool {
-	if m.cfg.Touch <= 0 || m.toucher == nil || s.isNew {
+	if s.isNew || s.deleted {
 		return false
 	}
 	return now.Sub(s.storedSeenAt) >= m.cfg.Touch
@@ -209,6 +234,12 @@ func Remember(v bool) AuthOption { return func(o *authOptions) { o.remember = v 
 // session ID, CreatedAt, and payload survive; a failed save rolls every field
 // back so the client is never left holding a credential no record answers to.
 //
+// Only anonymous → authenticated and same-user re-authentication are allowed.
+// A session already bound to a different user gets ErrUserMismatch: the
+// payload carries whatever the first user's handlers cached (roles, tenant
+// membership, a cart), and silently rebinding it would hand all of that to the
+// second user. Destroy the old session and Start a fresh one instead.
+//
 // The new token is saved before the pre-rotation record is deleted. If that
 // delete fails it is only logged: the old token then remains loadable until it
 // expires on its own, so a store that can fail deletes weakens the "old token
@@ -219,6 +250,9 @@ func (m *Manager) Authenticate(ctx context.Context, s *Session, userID string, o
 	}
 	if userID == "" {
 		return ErrAnonymous
+	}
+	if s.rec.UserID != "" && s.rec.UserID != userID {
+		return ErrUserMismatch
 	}
 	var o authOptions
 	for _, opt := range opts {
@@ -234,7 +268,7 @@ func (m *Manager) Authenticate(ctx context.Context, s *Session, userID string, o
 	s.token = newToken()
 
 	wasNew := s.isNew
-	if err := m.Save(ctx, s); err != nil {
+	if err := m.persist(ctx, s, true); err != nil {
 		s.token, s.rec = oldToken, oldRec
 		return err
 	}
@@ -253,11 +287,12 @@ func (m *Manager) Rotate(ctx context.Context, s *Session) error {
 	}
 	oldToken := s.token
 	s.token = newToken()
-	if err := m.Save(ctx, s); err != nil {
+	wasNew := s.isNew
+	if err := m.persist(ctx, s, true); err != nil {
 		s.token = oldToken
 		return err
 	}
-	if oldToken != s.token {
+	if !wasNew && oldToken != s.token {
 		if err := m.store.Delete(ctx, oldToken); err != nil {
 			m.log.WarnContext(ctx, "session: deleting pre-rotation record failed", slog.Any("error", err))
 		}
@@ -265,7 +300,9 @@ func (m *Manager) Rotate(ctx context.Context, s *Session) error {
 	return nil
 }
 
-// Destroy removes the record. The caller's transport clears the credential.
+// Destroy removes the record and strips the in-memory identity, so code later
+// in the same request cannot keep authorizing a session that no longer exists.
+// The caller's transport clears the credential.
 func (m *Manager) Destroy(ctx context.Context, s *Session) error {
 	if s == nil {
 		return ErrNoSession
@@ -274,17 +311,38 @@ func (m *Manager) Destroy(ctx context.Context, s *Session) error {
 		return err
 	}
 	s.deleted = true
+	s.rec.UserID = ""
+	s.rec.ElevatedAt = time.Time{}
+	s.syncInfo()
 	return nil
 }
 
-// Elevate stamps a successful identity re-proof. Session records that it
-// happened; auth/access decides what it entitles the user to.
+// Elevate stamps a successful identity re-proof and rotates the token. Session
+// records that it happened; auth/access decides what it entitles the user to.
+// The rotation is what keeps a credential copied before the re-proof from
+// inheriting the elevation: the pre-elevation token stops working, so only the
+// client that actually completed step-up holds the elevated credential.
 func (m *Manager) Elevate(ctx context.Context, s *Session) error {
 	if s == nil {
 		return ErrNoSession
 	}
+	if s.rec.UserID == "" {
+		return ErrAnonymous
+	}
+	oldToken, oldElevated := s.token, s.rec.ElevatedAt
 	s.rec.ElevatedAt = m.now()
-	return m.Save(ctx, s)
+	s.token = newToken()
+	wasNew := s.isNew
+	if err := m.persist(ctx, s, true); err != nil {
+		s.token, s.rec.ElevatedAt = oldToken, oldElevated
+		return err
+	}
+	if !wasNew {
+		if err := m.store.Delete(ctx, oldToken); err != nil {
+			m.log.WarnContext(ctx, "session: deleting pre-rotation record failed", slog.Any("error", err))
+		}
+	}
+	return nil
 }
 
 // Bind carries the pinned device metadata Rebind writes.

--- a/auth/session/manager.go
+++ b/auth/session/manager.go
@@ -285,11 +285,14 @@ func (m *Manager) Rotate(ctx context.Context, s *Session) error {
 	if s == nil {
 		return ErrNoSession
 	}
-	oldToken := s.token
+	oldToken, oldRec := s.token, s.rec
 	s.token = newToken()
 	wasNew := s.isNew
 	if err := m.persist(ctx, s, true); err != nil {
-		s.token = oldToken
+		// persist stamps Tenant/LastSeenAt/ExpiresAt before the store write;
+		// restore the whole record so a failed rotation leaves no field the
+		// store never durably committed.
+		s.token, s.rec = oldToken, oldRec
 		return err
 	}
 	if !wasNew && oldToken != s.token {
@@ -329,12 +332,12 @@ func (m *Manager) Elevate(ctx context.Context, s *Session) error {
 	if s.rec.UserID == "" {
 		return ErrAnonymous
 	}
-	oldToken, oldElevated := s.token, s.rec.ElevatedAt
+	oldToken, oldRec := s.token, s.rec
 	s.rec.ElevatedAt = m.now()
 	s.token = newToken()
 	wasNew := s.isNew
 	if err := m.persist(ctx, s, true); err != nil {
-		s.token, s.rec.ElevatedAt = oldToken, oldElevated
+		s.token, s.rec = oldToken, oldRec
 		return err
 	}
 	if !wasNew {

--- a/auth/session/manager_test.go
+++ b/auth/session/manager_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // noTouchStore implements Store but not Toucher. It embeds the Store
-// interface, not the concrete *MemoryStore, so only Load/Save/Delete
+// interface, not the concrete *MemoryStore, so only Load/Create/Update/Delete
 // promote — embedding the concrete type would also promote MemoryStore's
 // Touch method and defeat the point of this type.
 type noTouchStore struct{ session.Store }
@@ -21,13 +21,48 @@ func TestNewRequiresStore(t *testing.T) {
 	}
 }
 
-func TestNewRejectsTouchWithoutToucher(t *testing.T) {
-	_, err := session.New(session.DefaultConfig(),
+func TestNewAcceptsTouchWithoutToucher(t *testing.T) {
+	if _, err := session.New(session.DefaultConfig(),
 		session.WithStore(noTouchStore{session.NewMemoryStore()}),
 		session.WithTouch(time.Minute),
-	)
-	if !errors.Is(err, session.ErrTouchUnsupported) {
-		t.Fatalf("New = %v, want ErrTouchUnsupported — a configured option whose capability is missing is a boot error", err)
+	); err != nil {
+		t.Fatalf("New = %v — without a Toucher the refresh falls back to a full save, not a boot error", err)
+	}
+}
+
+// TestLoadEnforcesTightenedAbsoluteLifetime pins that a config change applies
+// on the very next load: a record persisted under a generous MaxTTL, read by a
+// manager whose MaxTTL now puts CreatedAt+cap in the past, is expired — not
+// admitted one more time on the strength of its stored deadline.
+func TestLoadEnforcesTightenedAbsoluteLifetime(t *testing.T) {
+	start := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	clk := clock.NewMock(start)
+	store := session.NewMemoryStore()
+
+	generous, err := session.New(session.DefaultConfig(), session.WithStore(store),
+		session.WithClock(clk), session.WithIdle(4*time.Hour), session.WithMaxTTL(0))
+	if err != nil {
+		t.Fatalf("New (generous): %v", err)
+	}
+	sess := generous.Start()
+	if err := generous.Save(t.Context(), sess); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	tightened, err := session.New(session.DefaultConfig(), session.WithStore(store),
+		session.WithClock(clk), session.WithIdle(time.Hour), session.WithMaxTTL(time.Hour))
+	if err != nil {
+		t.Fatalf("New (tightened): %v", err)
+	}
+
+	// 90 minutes in: the stored deadline (start+4h) is alive, but the tightened
+	// cap (CreatedAt+1h) is already behind us.
+	clk.Advance(90 * time.Minute)
+	if _, err := tightened.Load(t.Context(), sess.Token()); !errors.Is(err, session.ErrExpired) {
+		t.Fatalf("Load under the tightened MaxTTL = %v, want ErrExpired", err)
+	}
+	if _, err := store.Load(t.Context(), sess.Token()); !errors.Is(err, session.ErrNotFound) {
+		t.Fatal("a record expired under the current policy must be deleted, not left for one more request")
 	}
 }
 

--- a/auth/session/memory.go
+++ b/auth/session/memory.go
@@ -41,12 +41,29 @@ func (m *MemoryStore) Load(_ context.Context, token string) (Record, error) {
 	return cloneRecord(rec), nil
 }
 
-// Save implements Store. The token is echoed back: this is a server-side store,
-// so the client's credential does not change unless the manager rotates it.
-func (m *MemoryStore) Save(_ context.Context, token string, rec Record) (string, error) {
+// Create implements Store. The token is echoed back: this is a server-side
+// store, so the client's credential does not change unless the manager rotates it.
+func (m *MemoryStore) Create(_ context.Context, token string, rec Record) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.byDigest[Digest(token)] = cloneRecord(rec)
+	d := Digest(token)
+	if _, ok := m.byDigest[d]; ok {
+		return "", ErrExists
+	}
+	m.byDigest[d] = cloneRecord(rec)
+	return token, nil
+}
+
+// Update implements Store. It never inserts: an absent record means the
+// session was deleted or revoked, and a stale snapshot must not resurrect it.
+func (m *MemoryStore) Update(_ context.Context, token string, rec Record) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d := Digest(token)
+	if _, ok := m.byDigest[d]; !ok {
+		return "", ErrNotFound
+	}
+	m.byDigest[d] = cloneRecord(rec)
 	return token, nil
 }
 
@@ -58,7 +75,8 @@ func (m *MemoryStore) Delete(_ context.Context, token string) error {
 	return nil
 }
 
-// Touch implements Toucher: metadata only, payload untouched.
+// Touch implements Toucher: metadata only, payload untouched, monotonic — a
+// racing request's older timestamps never move the deadline backward.
 func (m *MemoryStore) Touch(_ context.Context, token string, lastSeenAt, expiresAt time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -67,8 +85,12 @@ func (m *MemoryStore) Touch(_ context.Context, token string, lastSeenAt, expires
 	if !ok {
 		return ErrNotFound
 	}
-	rec.LastSeenAt = lastSeenAt
-	rec.ExpiresAt = expiresAt
+	if lastSeenAt.After(rec.LastSeenAt) {
+		rec.LastSeenAt = lastSeenAt
+	}
+	if expiresAt.After(rec.ExpiresAt) {
+		rec.ExpiresAt = expiresAt
+	}
 	m.byDigest[d] = rec
 	return nil
 }

--- a/auth/session/middleware.go
+++ b/auth/session/middleware.go
@@ -148,6 +148,9 @@ func runPolicies(m *Manager, o *mwOptions, w http.ResponseWriter, r *http.Reques
 		if err == nil {
 			continue
 		}
+		// The responder gets a static sentinel, never the policy error: reasons
+		// like "fingerprint mismatch" are for logs, and web/problem puts a 4xx
+		// error's text into the response body.
 		reason, revoke := IsRevoke(err)
 		if revoke {
 			if delErr := m.Destroy(r.Context(), s); delErr != nil {
@@ -156,12 +159,12 @@ func runPolicies(m *Manager, o *mwOptions, w http.ResponseWriter, r *http.Reques
 			}
 			clearCredential(o, w, r, matchedIdx)
 			o.logger.InfoContext(r.Context(), "session: revoked", slog.String("reason", reason))
-			o.responder(w, r, err)
+			o.responder(w, r, ErrRevoked)
 			return err
 		}
 		if reason, deny := IsDeny(err); deny {
 			o.logger.InfoContext(r.Context(), "session: denied", slog.String("reason", reason))
-			o.responder(w, r, err)
+			o.responder(w, r, ErrDenied)
 			return err
 		}
 		// Anything else is infrastructure: fail closed.
@@ -196,9 +199,19 @@ func commit(m *Manager, o *mwOptions, w http.ResponseWriter, r *http.Request, s 
 	if !s.isNew && s.token != presentedToken {
 		return embed(o, w, r, s, matchedIdx)
 	}
-	// Otherwise a metadata-only refresh, fail-open: a failed touch must not fail the request.
+	// Otherwise a sliding-deadline refresh, fail-open: a failed refresh must not
+	// fail the request. Metadata-only when the store implements Toucher, a full
+	// save otherwise — read-only traffic must still persist sliding expiry.
 	if m.touchDue(s, m.now()) {
-		if err := m.toucher.Touch(r.Context(), s.token, s.rec.LastSeenAt, s.rec.ExpiresAt); err != nil {
+		var err error
+		if m.toucher != nil {
+			err = m.toucher.Touch(r.Context(), s.token, s.rec.LastSeenAt, s.rec.ExpiresAt)
+		} else if err = m.Save(r.Context(), s); err == nil && s.token != presentedToken {
+			// A stateless store re-encodes on save; the fresh credential must
+			// still reach the client.
+			err = embed(o, w, r, s, matchedIdx)
+		}
+		if err != nil {
 			o.logger.WarnContext(r.Context(), "session: touch failed", slog.Any("error", err))
 		}
 	}

--- a/auth/session/middleware_test.go
+++ b/auth/session/middleware_test.go
@@ -5,9 +5,12 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/dmitrymomot/forge/auth/session"
+	"github.com/dmitrymomot/forge/core/clock"
 )
 
 func TestAnonymousRequestCostsNoStorage(t *testing.T) {
@@ -93,6 +96,43 @@ func TestPolicyRevokeDeletesTheRecord(t *testing.T) {
 	}
 	if _, err := mgr.Load(t.Context(), seed.Token()); !errors.Is(err, session.ErrNotFound) {
 		t.Fatal("Revoke must delete the record")
+	}
+}
+
+// TestPolicyReasonStaysOutOfTheResponseBody pins the sanitization: the default
+// responder puts a 4xx error's text into the body, so the middleware must hand
+// it ErrDenied/ErrRevoked, never the policy error whose reason explains what
+// tripped detection.
+func TestPolicyReasonStaysOutOfTheResponseBody(t *testing.T) {
+	const secret = "fingerprint-mismatch-from-known-botnet"
+	for name, policy := range map[string]session.Policy{
+		"deny":   func(context.Context, *http.Request, *session.Session) error { return session.Deny(secret) },
+		"revoke": func(context.Context, *http.Request, *session.Session) error { return session.Revoke(secret) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			mgr := newTestManager(t)
+			seed := mgr.Start()
+			if err := mgr.Save(t.Context(), seed); err != nil {
+				t.Fatalf("Save: %v", err)
+			}
+			mw := session.Middleware(mgr,
+				session.WithTransport(headerTransport{}),
+				session.WithPolicy(policy),
+			)
+			h := mw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+			r := httptest.NewRequest("GET", "/", nil)
+			r.Header.Set("X-Test-Token", seed.Token())
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, r)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401", rec.Code)
+			}
+			if strings.Contains(rec.Body.String(), secret) {
+				t.Fatalf("the policy reason leaked into the response body: %s", rec.Body.String())
+			}
+		})
 	}
 }
 
@@ -225,6 +265,72 @@ func TestClientInfoIsPinnedAtCreationOnly(t *testing.T) {
 	}
 	if after.IP() != "203.0.113.4" || after.UserAgent() != "Chrome" {
 		t.Fatalf("pinned metadata was overwritten on a later request: ip=%q ua=%q", after.IP(), after.UserAgent())
+	}
+}
+
+// TestReadOnlyRequestSlidesExpiryViaToucher pins that clean traffic persists
+// sliding expiry: after the touch interval, a request that dirties nothing
+// still moves the stored deadline forward.
+func TestReadOnlyRequestSlidesExpiryViaToucher(t *testing.T) {
+	start := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	clk := clock.NewMock(start)
+	store := session.NewMemoryStore()
+	mgr, err := session.New(session.DefaultConfig(), session.WithStore(store),
+		session.WithClock(clk), session.WithIdle(time.Hour), session.WithMaxTTL(0), session.WithTouch(5*time.Minute))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	seed := mgr.Start()
+	if err := mgr.Save(t.Context(), seed); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	clk.Advance(10 * time.Minute)
+	mw := session.Middleware(mgr, session.WithTransport(headerTransport{}))
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }))
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("X-Test-Token", seed.Token())
+	h.ServeHTTP(httptest.NewRecorder(), r)
+
+	rec, err := store.Load(t.Context(), seed.Token())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if want := start.Add(10*time.Minute + time.Hour); !rec.ExpiresAt.Equal(want) {
+		t.Fatalf("stored ExpiresAt = %v, want %v — a clean request past the touch interval must persist the slide", rec.ExpiresAt, want)
+	}
+}
+
+// TestReadOnlyRequestSlidesExpiryWithoutToucher pins the fallback: with no
+// Toucher capability the refresh is a full save, not a silent skip that lets
+// an active session expire under read-only traffic.
+func TestReadOnlyRequestSlidesExpiryWithoutToucher(t *testing.T) {
+	start := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	clk := clock.NewMock(start)
+	inner := session.NewMemoryStore()
+	mgr, err := session.New(session.DefaultConfig(), session.WithStore(noTouchStore{inner}),
+		session.WithClock(clk), session.WithIdle(time.Hour), session.WithMaxTTL(0), session.WithTouch(0))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	seed := mgr.Start()
+	if err := mgr.Save(t.Context(), seed); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	clk.Advance(10 * time.Minute)
+	mw := session.Middleware(mgr, session.WithTransport(headerTransport{}))
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }))
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("X-Test-Token", seed.Token())
+	h.ServeHTTP(httptest.NewRecorder(), r)
+
+	rec, err := inner.Load(t.Context(), seed.Token())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if want := start.Add(10*time.Minute + time.Hour); !rec.ExpiresAt.Equal(want) {
+		t.Fatalf("stored ExpiresAt = %v, want %v — WithTouch(0) and no Toucher must fall back to a full save", rec.ExpiresAt, want)
 	}
 }
 

--- a/auth/session/options.go
+++ b/auth/session/options.go
@@ -37,9 +37,10 @@ func WithRememberIdle(d time.Duration) Option { return func(c *config) { c.Remem
 // WithRememberMaxTTL sets the absolute lifetime for remembered sessions. Zero means no cap.
 func WithRememberMaxTTL(d time.Duration) Option { return func(c *config) { c.RememberMax = d } }
 
-// WithTouch sets the metadata-only refresh interval: a request whose deadline
-// moved by less than this does not write to the store. Zero disables touching,
-// which makes every request a full save.
+// WithTouch sets the sliding-deadline refresh interval: a clean request whose
+// last persisted activity is younger than this writes nothing. When the
+// refresh is due it is metadata-only where the store implements Toucher and a
+// full save otherwise. Zero refreshes on every request.
 func WithTouch(d time.Duration) Option { return func(c *config) { c.Touch = d } }
 
 // WithScope enables tenant scoping. Without it, session is single-tenant and

--- a/auth/session/policy.go
+++ b/auth/session/policy.go
@@ -21,7 +21,9 @@ type DenyError struct{ reason string }
 // Error implements error.
 func (e *DenyError) Error() string { return "session: denied: " + e.reason }
 
-// Reason returns the human-readable cause, surfaced to logs and the responder.
+// Reason returns the human-readable cause. It goes to logs only: the
+// middleware hands the responder ErrDenied, so a reason like "fingerprint
+// mismatch" never tells a rejected client what tripped the policy.
 func (e *DenyError) Reason() string { return e.reason }
 
 // RevokeError rejects the request and destroys the session.
@@ -30,7 +32,8 @@ type RevokeError struct{ reason string }
 // Error implements error.
 func (e *RevokeError) Error() string { return "session: revoked: " + e.reason }
 
-// Reason returns the human-readable cause, surfaced to logs and the responder.
+// Reason returns the human-readable cause. It goes to logs only: the
+// middleware hands the responder ErrRevoked.
 func (e *RevokeError) Reason() string { return e.reason }
 
 // Deny builds the "reject, keep the record" outcome.

--- a/auth/session/scope_test.go
+++ b/auth/session/scope_test.go
@@ -207,13 +207,13 @@ func TestScopeConfinesRevoke(t *testing.T) {
 
 	sameID := id.NewUUID()
 	now := time.Now().UTC()
-	if _, err := store.Save(t.Context(), "tok-t1", session.Record{
+	if _, err := store.Create(t.Context(), "tok-t1", session.Record{
 		ID: sameID, UserID: "u1", Tenant: "t1",
 		CreatedAt: now, LastSeenAt: now, ExpiresAt: now.Add(time.Hour),
 	}); err != nil {
 		t.Fatalf("seed t1: %v", err)
 	}
-	if _, err := store.Save(t.Context(), "tok-t2", session.Record{
+	if _, err := store.Create(t.Context(), "tok-t2", session.Record{
 		ID: sameID, UserID: "u1", Tenant: "t2",
 		CreatedAt: now, LastSeenAt: now, ExpiresAt: now.Add(time.Hour),
 	}); err != nil {

--- a/auth/session/store.go
+++ b/auth/session/store.go
@@ -31,20 +31,40 @@ type Record struct {
 
 // Store is the minimum a backend must implement. Implementations must be safe
 // for concurrent use and must never persist the raw token — key on Digest.
-// Save must persist Record.Tenant and Load must return it, so a configured
-// scope hook's post-filter in Manager.Load can compare against it.
+// Create and Update must persist Record.Tenant and Load must return it, so a
+// configured scope hook's post-filter in Manager.Load can compare against it.
+//
+// Create and Update are deliberately not one upsert: Update failing on an
+// absent record is what makes revocation terminal. A request that loaded a
+// session, lost a race with Destroy/Revoke, and then commits its stale
+// snapshot must get ErrNotFound — an upsert would silently resurrect the
+// revoked record with a fresh deadline.
+//
+// A stateless store (one that encodes the record into the credential itself)
+// cannot check existence server-side; it re-encodes on both calls and its
+// revocation guarantee is only as strong as the credential's own expiry.
 type Store interface {
 	// Load returns the record for token, or ErrNotFound.
 	Load(ctx context.Context, token string) (Record, error)
-	// Save writes rec and returns the token the client should present next.
-	// Server-side stores echo token back; a stateless store returns its fresh
-	// encoding of rec, which is what lets both satisfy this interface.
-	Save(ctx context.Context, token string, rec Record) (string, error)
+	// Create writes rec under a token no record exists for, returning the token
+	// the client should present next. Server-side stores insert and echo token
+	// back, and must fail (ErrExists) rather than overwrite if a record is
+	// already stored under it; a stateless store returns its fresh encoding of
+	// rec.
+	Create(ctx context.Context, token string, rec Record) (string, error)
+	// Update rewrites the existing record for token, returning the token the
+	// client should present next. It must return ErrNotFound when no record
+	// exists — never insert — so a stale snapshot cannot recreate a deleted
+	// record.
+	Update(ctx context.Context, token string, rec Record) (string, error)
 	// Delete removes the record for token. Deleting an absent record is not an error.
 	Delete(ctx context.Context, token string) error
 }
 
-// Toucher is the optional metadata-only refresh capability.
+// Toucher is the optional metadata-only refresh capability. Touch returns
+// ErrNotFound for an absent record and must be monotonic: a timestamp at or
+// before the stored one is dropped, never written, so two racing requests
+// cannot move LastSeenAt or ExpiresAt backward.
 type Toucher interface {
 	Touch(ctx context.Context, token string, lastSeenAt, expiresAt time.Time) error
 }
@@ -60,6 +80,8 @@ type Toucher interface {
 // an empty one, so a driver only ever receives "" from a single-tenant caller —
 // where matching any row is correct because every row's Tenant is also "".
 type UserIndex interface {
+	// ListByUser may include expired records that no reaper has removed yet;
+	// Manager.ListByUser filters them, so drivers need no expiry predicate.
 	ListByUser(ctx context.Context, tenant, userID string) ([]Record, error)
 	// DeleteByUser removes every record for tenant+userID except those in keep.
 	DeleteByUser(ctx context.Context, tenant, userID string, keep ...id.UUID) error

--- a/auth/session/storetest/storetest.go
+++ b/auth/session/storetest/storetest.go
@@ -19,11 +19,16 @@ import (
 func Run(t *testing.T, newStore func(*testing.T) session.Store) {
 	t.Helper()
 	t.Run("LoadMissing", func(t *testing.T) { testLoadMissing(t, newStore(t)) })
-	t.Run("SaveLoadDelete", func(t *testing.T) { testSaveLoadDelete(t, newStore(t)) })
-	t.Run("SaveReturnsToken", func(t *testing.T) { testSaveReturnsToken(t, newStore(t)) })
-	t.Run("SaveOverwritesToken", func(t *testing.T) { testSaveOverwritesToken(t, newStore(t)) })
+	t.Run("CreateLoadDelete", func(t *testing.T) { testCreateLoadDelete(t, newStore(t)) })
+	t.Run("CreateReturnsToken", func(t *testing.T) { testCreateReturnsToken(t, newStore(t)) })
+	t.Run("CreateExistingFails", func(t *testing.T) { testCreateExistingFails(t, newStore(t)) })
+	t.Run("UpdateOverwrites", func(t *testing.T) { testUpdateOverwrites(t, newStore(t)) })
+	t.Run("UpdateMissingFails", func(t *testing.T) { testUpdateMissingFails(t, newStore(t)) })
+	t.Run("UpdateAfterDeleteFails", func(t *testing.T) { testUpdateAfterDeleteFails(t, newStore(t)) })
 	t.Run("DeleteMissingIsNotAnError", func(t *testing.T) { testDeleteMissing(t, newStore(t)) })
 	t.Run("Toucher", func(t *testing.T) { testToucher(t, newStore(t)) })
+	t.Run("ToucherMonotonic", func(t *testing.T) { testToucherMonotonic(t, newStore(t)) })
+	t.Run("ToucherMissing", func(t *testing.T) { testToucherMissing(t, newStore(t)) })
 	t.Run("UserIndex", func(t *testing.T) { testUserIndex(t, newStore(t)) })
 	t.Run("UserIndexListOrder", func(t *testing.T) { testUserIndexOrder(t, newStore(t)) })
 	t.Run("UserIndexScoped", func(t *testing.T) { testUserIndexScoped(t, newStore(t)) })
@@ -70,13 +75,13 @@ func testLoadMissing(t *testing.T, st session.Store) {
 	}
 }
 
-func testSaveLoadDelete(t *testing.T, st session.Store) {
+func testCreateLoadDelete(t *testing.T, st session.Store) {
 	ctx := context.Background()
 	want := rec("u1", time.Now().Add(time.Hour))
 
-	tok, err := st.Save(ctx, "tok-1", want)
+	tok, err := st.Create(ctx, "tok-1", want)
 	if err != nil {
-		t.Fatalf("Save: %v", err)
+		t.Fatalf("Create: %v", err)
 	}
 
 	got, err := st.Load(ctx, tok)
@@ -125,35 +130,58 @@ func testSaveLoadDelete(t *testing.T, st session.Store) {
 	}
 }
 
-func testSaveReturnsToken(t *testing.T, st session.Store) {
-	tok, err := st.Save(context.Background(), "tok-2", rec("u1", time.Now().Add(time.Hour)))
+func testCreateReturnsToken(t *testing.T, st session.Store) {
+	tok, err := st.Create(context.Background(), "tok-2", rec("u1", time.Now().Add(time.Hour)))
 	if err != nil {
-		t.Fatalf("Save: %v", err)
+		t.Fatalf("Create: %v", err)
 	}
 	if tok == "" {
-		t.Fatal("Save must return the token the client should present next")
+		t.Fatal("Create must return the token the client should present next")
 	}
 }
 
-// testSaveOverwritesToken saves twice to the same token with different record
-// contents and confirms the second write wins with no duplicate left behind.
-// A driver that plain-INSERTs without upsert semantics either errors on the
-// second Save (caught directly) or leaves two rows reachable through the same
-// digest (caught via ListByUser, where the store supports it).
-func testSaveOverwritesToken(t *testing.T, st session.Store) {
+// testCreateExistingFails pins the insert-only half of the contract: Create
+// against an already-stored token must fail with ErrExists and must not
+// disturb the existing record.
+func testCreateExistingFails(t *testing.T, st session.Store) {
+	ctx := context.Background()
+	const tok = "tok-create-dup"
+
+	first := rec("u1", time.Now().Add(time.Hour))
+	if _, err := st.Create(ctx, tok, first); err != nil {
+		t.Fatalf("Create (first): %v", err)
+	}
+
+	second := rec("u1", time.Now().Add(2*time.Hour))
+	if _, err := st.Create(ctx, tok, second); !errors.Is(err, session.ErrExists) {
+		t.Fatalf("Create (second, same token) = %v, want ErrExists", err)
+	}
+
+	got, err := st.Load(ctx, tok)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.ID != first.ID {
+		t.Fatalf("failed Create must not disturb the stored record: got ID %v, want %v", got.ID, first.ID)
+	}
+}
+
+// testUpdateOverwrites updates an existing record with different contents and
+// confirms the rewrite wins with no duplicate left behind.
+func testUpdateOverwrites(t *testing.T, st session.Store) {
 	ctx := context.Background()
 	const tok = "tok-overwrite"
 
 	first := rec("u1", time.Now().Add(time.Hour))
-	if _, err := st.Save(ctx, tok, first); err != nil {
-		t.Fatalf("Save (first): %v", err)
+	if _, err := st.Create(ctx, tok, first); err != nil {
+		t.Fatalf("Create: %v", err)
 	}
 
 	second := rec("u1", time.Now().Add(2*time.Hour))
 	second.Payload = []byte(`{"k":{"v":2}}`)
-	gotTok, err := st.Save(ctx, tok, second)
+	gotTok, err := st.Update(ctx, tok, second)
 	if err != nil {
-		t.Fatalf("Save (second, same token): %v", err)
+		t.Fatalf("Update: %v", err)
 	}
 
 	got, err := st.Load(ctx, gotTok)
@@ -161,13 +189,13 @@ func testSaveOverwritesToken(t *testing.T, st session.Store) {
 		t.Fatalf("Load: %v", err)
 	}
 	if got.ID != second.ID {
-		t.Fatalf("second Save did not win: got ID %v, want %v", got.ID, second.ID)
+		t.Fatalf("Update did not win: got ID %v, want %v", got.ID, second.ID)
 	}
 	if string(got.Payload) != string(second.Payload) {
-		t.Fatalf("second Save did not win: got payload %s, want %s", got.Payload, second.Payload)
+		t.Fatalf("Update did not win: got payload %s, want %s", got.Payload, second.Payload)
 	}
 	if !got.ExpiresAt.Equal(second.ExpiresAt) {
-		t.Fatalf("second Save did not win: got ExpiresAt %v, want %v", got.ExpiresAt, second.ExpiresAt)
+		t.Fatalf("Update did not win: got ExpiresAt %v, want %v", got.ExpiresAt, second.ExpiresAt)
 	}
 
 	ix, ok := st.(session.UserIndex)
@@ -179,10 +207,47 @@ func testSaveOverwritesToken(t *testing.T, st session.Store) {
 		t.Fatalf("ListByUser: %v", err)
 	}
 	if len(list) != 1 {
-		t.Fatalf("Save on an existing token must not duplicate: ListByUser returned %d records, want 1", len(list))
+		t.Fatalf("Update must not duplicate: ListByUser returned %d records, want 1", len(list))
 	}
 	if list[0].ID != second.ID {
 		t.Fatalf("ListByUser returned a stale record: got %v, want %v", list[0].ID, second.ID)
+	}
+}
+
+// testUpdateMissingFails pins the update-only half of the contract: Update
+// must never insert.
+func testUpdateMissingFails(t *testing.T, st session.Store) {
+	ctx := context.Background()
+	if _, err := st.Update(ctx, "tok-never-created", rec("u1", time.Now().Add(time.Hour))); !errors.Is(err, session.ErrNotFound) {
+		t.Fatalf("Update(missing) = %v, want ErrNotFound", err)
+	}
+	if _, err := st.Load(ctx, "tok-never-created"); !errors.Is(err, session.ErrNotFound) {
+		t.Fatal("Update(missing) must not insert a record")
+	}
+}
+
+// testUpdateAfterDeleteFails is the revocation-is-terminal guarantee: a
+// snapshot that lost a race with Delete cannot resurrect the record by
+// committing after it. An upserting driver fails here.
+func testUpdateAfterDeleteFails(t *testing.T, st session.Store) {
+	ctx := context.Background()
+	const tok = "tok-revoked"
+
+	r := rec("u1", time.Now().Add(time.Hour))
+	if _, err := st.Create(ctx, tok, r); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := st.Delete(ctx, tok); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	stale := r
+	stale.ExpiresAt = time.Now().Add(2 * time.Hour)
+	if _, err := st.Update(ctx, tok, stale); !errors.Is(err, session.ErrNotFound) {
+		t.Fatalf("Update(deleted) = %v, want ErrNotFound — a stale snapshot must not resurrect a revoked session", err)
+	}
+	if _, err := st.Load(ctx, tok); !errors.Is(err, session.ErrNotFound) {
+		t.Fatal("Update(deleted) must not recreate the record")
 	}
 }
 
@@ -199,9 +264,9 @@ func testToucher(t *testing.T, st session.Store) {
 	}
 	ctx := context.Background()
 	r := rec("u1", time.Now().Add(time.Hour))
-	tok, err := st.Save(ctx, "tok-3", r)
+	tok, err := st.Create(ctx, "tok-3", r)
 	if err != nil {
-		t.Fatalf("Save: %v", err)
+		t.Fatalf("Create: %v", err)
 	}
 
 	newSeen := r.LastSeenAt.Add(10 * time.Minute)
@@ -225,6 +290,53 @@ func testToucher(t *testing.T, st session.Store) {
 	}
 }
 
+// testToucherMonotonic pins the Toucher doc's monotonicity requirement: a
+// racing request's older timestamps must never move LastSeenAt or ExpiresAt
+// backward.
+func testToucherMonotonic(t *testing.T, st session.Store) {
+	tc, ok := st.(session.Toucher)
+	if !ok {
+		t.Skip("store does not implement Toucher")
+	}
+	ctx := context.Background()
+	r := rec("u1", time.Now().Add(time.Hour))
+	tok, err := st.Create(ctx, "tok-monotonic", r)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	ahead := r.LastSeenAt.Add(10 * time.Minute)
+	aheadExp := r.ExpiresAt.Add(10 * time.Minute)
+	if err := tc.Touch(ctx, tok, ahead, aheadExp); err != nil {
+		t.Fatalf("Touch (forward): %v", err)
+	}
+	if err := tc.Touch(ctx, tok, r.LastSeenAt, r.ExpiresAt); err != nil {
+		t.Fatalf("Touch (stale): %v", err)
+	}
+
+	got, err := st.Load(ctx, tok)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !got.LastSeenAt.Equal(ahead) {
+		t.Fatalf("stale Touch moved LastSeenAt backward: got %v want %v", got.LastSeenAt, ahead)
+	}
+	if !got.ExpiresAt.Equal(aheadExp) {
+		t.Fatalf("stale Touch moved ExpiresAt backward: got %v want %v", got.ExpiresAt, aheadExp)
+	}
+}
+
+func testToucherMissing(t *testing.T, st session.Store) {
+	tc, ok := st.(session.Toucher)
+	if !ok {
+		t.Skip("store does not implement Toucher")
+	}
+	now := time.Now()
+	if err := tc.Touch(context.Background(), "tok-never-created", now, now.Add(time.Hour)); !errors.Is(err, session.ErrNotFound) {
+		t.Fatalf("Touch(missing) = %v, want ErrNotFound", err)
+	}
+}
+
 func testUserIndex(t *testing.T, st session.Store) {
 	ix, ok := st.(session.UserIndex)
 	if !ok {
@@ -234,8 +346,8 @@ func testUserIndex(t *testing.T, st session.Store) {
 	a, b, c := rec("u1", time.Now().Add(time.Hour)), rec("u1", time.Now().Add(time.Hour)), rec("u1", time.Now().Add(time.Hour))
 	other := rec("u2", time.Now().Add(time.Hour))
 	for tok, r := range map[string]session.Record{"ta": a, "tb": b, "tc": c, "to": other} {
-		if _, err := st.Save(ctx, tok, r); err != nil {
-			t.Fatalf("Save %s: %v", tok, err)
+		if _, err := st.Create(ctx, tok, r); err != nil {
+			t.Fatalf("Create %s: %v", tok, err)
 		}
 	}
 
@@ -305,14 +417,14 @@ func testUserIndexOrder(t *testing.T, st session.Store) {
 	newest := recAt("u1", base, base.Add(time.Hour))
 
 	// Save deliberately out of chronological order: middle, newest, oldest.
-	if _, err := st.Save(ctx, "order-middle", middle); err != nil {
-		t.Fatalf("Save: %v", err)
+	if _, err := st.Create(ctx, "order-middle", middle); err != nil {
+		t.Fatalf("Create: %v", err)
 	}
-	if _, err := st.Save(ctx, "order-newest", newest); err != nil {
-		t.Fatalf("Save: %v", err)
+	if _, err := st.Create(ctx, "order-newest", newest); err != nil {
+		t.Fatalf("Create: %v", err)
 	}
-	if _, err := st.Save(ctx, "order-oldest", oldest); err != nil {
-		t.Fatalf("Save: %v", err)
+	if _, err := st.Create(ctx, "order-oldest", oldest); err != nil {
+		t.Fatalf("Create: %v", err)
 	}
 
 	list, err := ix.ListByUser(ctx, "", "u1")
@@ -347,8 +459,8 @@ func testUserIndexScoped(t *testing.T, st session.Store) {
 	t2.Tenant = "t2"
 
 	for tok, r := range map[string]session.Record{"scoped-t1-a": t1a, "scoped-t1-b": t1b, "scoped-t2": t2} {
-		if _, err := st.Save(ctx, tok, r); err != nil {
-			t.Fatalf("Save %s: %v", tok, err)
+		if _, err := st.Create(ctx, tok, r); err != nil {
+			t.Fatalf("Create %s: %v", tok, err)
 		}
 	}
 
@@ -407,17 +519,17 @@ func testExpirer(t *testing.T, st session.Store) {
 	onBoundary := rec("u1", now)      // expires exactly at now: inclusive boundary, must be reaped
 	forever := rec("u1", time.Time{}) // zero ExpiresAt: never expires, must never be reaped
 
-	if _, err := st.Save(ctx, "expired", past); err != nil {
-		t.Fatalf("Save: %v", err)
+	if _, err := st.Create(ctx, "expired", past); err != nil {
+		t.Fatalf("Create: %v", err)
 	}
-	if _, err := st.Save(ctx, "live", future); err != nil {
-		t.Fatalf("Save: %v", err)
+	if _, err := st.Create(ctx, "live", future); err != nil {
+		t.Fatalf("Create: %v", err)
 	}
-	if _, err := st.Save(ctx, "boundary", onBoundary); err != nil {
-		t.Fatalf("Save: %v", err)
+	if _, err := st.Create(ctx, "boundary", onBoundary); err != nil {
+		t.Fatalf("Create: %v", err)
 	}
-	if _, err := st.Save(ctx, "forever", forever); err != nil {
-		t.Fatalf("Save: %v", err)
+	if _, err := st.Create(ctx, "forever", forever); err != nil {
+		t.Fatalf("Create: %v", err)
 	}
 
 	n, err := ex.DeleteExpired(ctx, now)
@@ -457,7 +569,7 @@ func testConcurrentAccess(t *testing.T, st session.Store) {
 			for i := range iterations {
 				tok := fmt.Sprintf("concurrent-%d-%d", worker, i)
 				r := rec("u-concurrent", time.Now().Add(time.Hour))
-				savedTok, err := st.Save(ctx, tok, r)
+				savedTok, err := st.Create(ctx, tok, r)
 				if err != nil {
 					errs <- fmt.Errorf("save: %w", err)
 					continue


### PR DESCRIPTION
## What

Fixes the confirmed findings from the auth/session package review, centered on one contract change: **`Store.Save` (upsert) is split into insert-only `Create` and update-only `Update`.**

### Store contract (breaking)

- `Create(ctx, token, rec)` fails with `ErrExists` on an existing digest, never overwrites.
- `Update(ctx, token, rec)` fails with `ErrNotFound` on an absent record, never inserts.
- This makes revocation terminal: a request that loaded a session, lost a race with Destroy/Revoke/LogoutOthers, and then commits its stale snapshot gets `ErrNotFound` — the old upsert would silently recreate the revoked record *with a fresh idle window*.
- Rotation (`Authenticate`/`Rotate`/`Elevate`) persists the new digest via `Create`, then deletes the old one.
- Deliberate non-goals, documented on the interface: no revisions/CAS (concurrent same-session payload writes stay last-write-wins), and rotation's create-then-delete leaves a narrow rotate-vs-revoke race until a driver can rotate atomically.
- No external consumers of `session.Store` exist yet; the four planned drivers (pgstore/mongostore/cookiestore/kvstore) inherit the new contract through `storetest`.

### Lifecycle hardening

- `Elevate` requires an authenticated session and **rotates the token** — a credential copied before step-up no longer inherits the elevation.
- `Authenticate` rejects switching an authenticated session to a different user (`ErrUserMismatch`); anonymous→user and same-user re-auth unchanged. Prevents user A's cached payload (roles, cart) from riding into user B's session.
- `Destroy` strips the in-memory identity (`Authenticated()` → false, `Info` synced), so code later in the same request cannot keep authorizing a destroyed session; a subsequent `Save` fails.
- `Load` enforces the deadline recomputed from *current* config: tightening `MaxTTL`/`RememberMax` now expires stale records on the next request instead of admitting one more.

### Request layer

- Policy `Deny`/`Revoke` reasons are logs-only. The responder receives static `ErrDenied`/`ErrRevoked` — `web/problem` puts a 4xx error's text into the response body, so reasons like "fingerprint mismatch" were telling rejected clients what tripped detection.
- `WithTouch(0)` now does what its doc always claimed: refresh on every request. When the store lacks `Toucher`, the refresh falls back to a full save (with credential re-embed for stateless stores), so read-only traffic persists sliding expiry. `ErrTouchUnsupported` and the boot-time Toucher requirement are removed.
- Default guard identity carries `Tenant` — `access.SubjectFromIdentity` copies it, so omitting it silently blanked tenant checks in downstream deciders.
- `RequireElevation` denies when the decision subject is not the session's own user (mixed-auth chains: a bystander session must not satisfy an API key's step-up).

### Stores and conformance

- `MemoryStore.Touch` is monotonic; monotonicity is now a documented `Toucher` requirement.
- `Manager.ListByUser` filters expired records, so the "live sessions" promise holds regardless of driver.
- `storetest` grew `CreateExistingFails`, `UpdateMissingFails`, `UpdateAfterDeleteFails` (an upserting driver fails here), `ToucherMonotonic`, `ToucherMissing`.
- `Config.Validate` requires a nonzero `Touch` strictly below both idle windows (`Touch == Idle` never actually slid).

## Testing

- `go test ./auth/session/... -race`: all pass, including new regression tests for every fix (stale-snapshot resurrection, user switch, elevate rotation, destroy de-auth, reason leak, tenant identity, foreign-subject elevation, tightened-TTL load, expired-device filtering, sliding expiry with and without Toucher).
- Key regression tests were red-green verified: the reason-leak and sliding-expiry tests fail against the pre-fix behavior.
- `just lint` clean; `modernize` clean.

## Benchmarks (Apple M3 Max, before → after)

| benchmark | before | after |
|---|---|---|
| NoOpRequest | 525.6 ns/op, 1312 B/op, 14 allocs | 489.3 ns/op, 1312 B/op, 14 allocs |
| CommitWithRotation | — | 1136 ns/op, 1104 B/op, 11 allocs |

The Create/Update split costs nothing measurable on the request path.